### PR TITLE
Rosdep entry is called libg2o

### DIFF
--- a/graph_based_slam/package.xml
+++ b/graph_based_slam/package.xml
@@ -20,7 +20,7 @@
   <depend>pcl_conversions</depend>
   <depend>lidarslam_msgs</depend>
   <depend>ndt_omp_ros2</depend>
-  <depend>g2o</depend>
+  <depend>libg2o</depend>
   <depend>libpcl-all-dev</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
Same fix as https://github.com/rsasaki0109/lidarslam_ros2/commit/a17312d68e2cd1a71c420410b4f4334ac8caf4e5
