### PR TITLE
Fixed tf for odometry

### DIFF
--- a/scanmatcher/include/scanmatcher/scanmatcher_component.h
+++ b/scanmatcher/include/scanmatcher/scanmatcher_component.h
@@ -105,7 +105,7 @@ private:
     std::packaged_task < void() > mapping_task_;
     std::future < void > mapping_future_;
 
-    geometry_msgs::msg::PoseStamped corrent_pose_stamped_;
+    geometry_msgs::msg::PoseStamped current_pose_stamped_;
     lidarslam_msgs::msg::MapArray map_array_msg_;
     nav_msgs::msg::Path path_;
     rclcpp::Publisher < geometry_msgs::msg::PoseStamped > ::SharedPtr pose_pub_;
@@ -129,7 +129,11 @@ private:
     void updateMap(
       const pcl::PointCloud < pcl::PointXYZI > ::ConstPtr cloud_ptr,
       const Eigen::Matrix4f final_transformation,
-      const geometry_msgs::msg::PoseStamped corrent_pose_stamped
+      const geometry_msgs::msg::PoseStamped current_pose_stamped
+    );
+    geometry_msgs::msg::TransformStamped calculateMaptoOdomTransform(
+      const geometry_msgs::msg::TransformStamped &base_to_map_msg,
+      const rclcpp::Time stamp
     );
 
     bool initial_pose_received_ {false};


### PR DESCRIPTION
The current transform publisher works wrong when an odometry is used.

The proper tf tree should look:
base_link -> odom -> map
but current implementation provides:
base_link -> odom
base_link -> map

The video of flicking robot model on the current version:
[Screencast from 22.04.2024 21:50:52.webm](https://github.com/rsasaki0109/lidarslam_ros2/assets/33808634/e7ff7a9c-945d-4272-8916-e8f74bf7e4c3)

![Screenshot from 2024-04-22 21-51-21](https://github.com/rsasaki0109/lidarslam_ros2/assets/33808634/067ccd3e-4936-49d2-a7df-f135b49ba401)

The video of this PR:
[Screencast from 22.04.2024 21:41:05.webm](https://github.com/rsasaki0109/lidarslam_ros2/assets/33808634/9e1c4e6a-254c-43ba-9af3-21c7b222213a)
![image](https://github.com/rsasaki0109/lidarslam_ros2/assets/33808634/7db9ea5d-b358-4e53-95c2-727244103b88)

This kind of aproch can be found in [nav2_amcl](https://github.com/ros-planning/navigation2/blob/main/nav2_amcl/src/amcl_node.cpp#L988C11-L988C38) and [slam_toolbox](https://github.com/SteveMacenski/slam_toolbox/blob/ros2/src/slam_toolbox_common.cpp#L657)


PS: fixed typo :dancers: 