### PR TITLE
Port package to ROS iron

### DIFF
--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -267,9 +267,9 @@ void GraphBasedSlamComponent::doPoseAdjustment(
   g2o::SparseOptimizer optimizer;
   optimizer.setVerbose(false);
   std::unique_ptr<g2o::BlockSolver_6_3::LinearSolverType> linear_solver =
-    g2o::make_unique<g2o::LinearSolverEigen<g2o::BlockSolver_6_3::PoseMatrixType>>();
+    std::make_unique<g2o::LinearSolverEigen<g2o::BlockSolver_6_3::PoseMatrixType>>();
   g2o::OptimizationAlgorithmLevenberg * solver = new g2o::OptimizationAlgorithmLevenberg(
-    g2o::make_unique<g2o::BlockSolver_6_3>(std::move(linear_solver)));
+    std::make_unique<g2o::BlockSolver_6_3>(std::move(linear_solver)));
 
   optimizer.setAlgorithm(solver);
 


### PR DESCRIPTION
Hey,

This PR ports this package to ROS iron because the function `g2o::make_unique` was removed. The changes should be backwards compatible