### PR TITLE
Fix compilation for jazzy, fix #107

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -19,6 +19,9 @@ endif()
 SET(CMAKE_CXX_FLAGS "-O2 -g ${CMAKE_CXX_FLAGS}")
 add_compile_definitions(G2O_USE_VENDORED_CERES)
 
+# Find missing symbols during link time
+add_link_options(-Wl,--no-undefined)
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -75,16 +78,18 @@ ament_target_dependencies(graph_based_slam_component
   ndt_omp_ros2
 )
 
+target_link_libraries(graph_based_slam_component
+  g2o::core
+  g2o::types_slam3d
+  g2o::solver_eigen
+)
+
 add_executable(graph_based_slam_node
 src/graph_based_slam_node.cpp
 )
 
 target_link_libraries(graph_based_slam_node
-graph_based_slam_component 
-${PCL_LIBRARIES}
-g2o::core
-g2o::types_slam3d
-g2o::solver_eigen
+  graph_based_slam_component
 )
 
 ament_target_dependencies(graph_based_slam_node


### PR DESCRIPTION
I've also added a linker flag to detect missing symbols during link time, instead of when running the executable. That makes debugging these issues much easier.