### PR TITLE
feat: v0.3 readiness gate + v0.4 MID-360 research track

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ Out of scope for the public path:
 - pointcloud-map authoring is treated as a first-class workflow, not just a side-effect of odometry
 - Autoware pointcloud-map flow is exercised end-to-end
 - **AWSIM → lidarslam → Autoware autonomous driving** pipeline with one-command demo
-- **lanelet2 auto-generation** from SLAM trajectories (multi-segment with shared boundary nodes)
-- default benchmark path is tracked on `NTU VIRAL`
-- current long-loop evidence is tracked on `MID360`
+- **lanelet2 auto-generation** from SLAM trajectories (multi-segment with shared boundary nodes), structurally validated before Autoware loads it
+- release-track benchmarks: `NTU VIRAL` (outdoor GT) and KITTI Odometry 00/05/07 (LO baseline non-regression)
+- research-track benchmarks (`report_only_until: v0.4`): `MID-360` solid-state LiDAR vs GLIM, Leo Drive open-data Velodyne cross-validation
+- per-dataset pass / target thresholds in `scripts/release_profiles.yaml`; `bash scripts/run_release_readiness_checks.sh --fail-on-profiles` gates release without forcing one global APE threshold
 - optional GNSS georeferencing writes `map_projector_info.yaml`; GNSS edges can use covariance-based weighting
 - GPL-free Scan Context place recognition is available in `graph_based_slam`
+- opt-in NIS-driven auto-scale for the adjacent-edge information weight so the backend self-tunes between strong and weak LIO datasets
 - optional MIT-licensed 3D-BBS loop-candidate verification can be built from the vendored `Thirdparty/3d_bbs` source and remains disabled at runtime by default
 - report helpers cover benchmarks, GNSS, cleanup, dynamic filtering, place recognition, and submission bundles
 
@@ -113,7 +115,16 @@ Preview the doc site locally with `python3 -m mkdocs serve`.
 
 ## Current Snapshot
 
-The current public evidence covers `NTU VIRAL`, `MID360`, GNSS map metadata, and dynamic-filter save-time cleanup. More detail lives in [docs/comparison.md](docs/comparison.md), [docs/benchmarking.md](docs/benchmarking.md), `output/benchmark_summary.md`, and `output/latest_report.html`.
+Release track:
+- `NTU VIRAL tnp_01` outdoor GT (current default 0.952 m, best 0.870 m; gate `WARN`, `report_only_until: v0.4`)
+- KITTI Odometry 00 / 05 / 07 LO baseline (non-regression report; `bash scripts/run_kitti_00_05_07_report.sh`)
+- Autoware-compatible pointcloud_map + lanelet2 + AWSIM → Autoware E2E demo
+
+Research track (`report_only_until: v0.4`, does not block release):
+- `MID-360` vs GLIM cross-validation (current default 3.641 m, best 3.590 m; solid-state LiDAR research dataset)
+- Leo Drive applanix/velodyne open-data cross-validation
+
+More detail lives in [docs/comparison.md](docs/comparison.md), [docs/benchmarking.md](docs/benchmarking.md), `scripts/release_profiles.yaml`, `output/benchmark_summary.md`, and `output/latest_report.html`.
 
 ## Main Entrypoints
 
@@ -158,9 +169,18 @@ bash scripts/download_ntu_viral_tnp01.sh
 bash scripts/run_rko_lio_graph_benchmark.sh
 ```
 
-For KITTI Odometry / Velodyne-only evaluation, Leo Drive classic-path suites, dynamic-filter benchmarks, and MID360 place-recognition comparisons, use the entrypoints documented in [docs/benchmarking.md](docs/benchmarking.md).
+For KITTI Odometry / Velodyne-only evaluation, Leo Drive classic-path suites, dynamic-filter benchmarks, and `MID-360` place-recognition comparisons, use the entrypoints documented in [docs/benchmarking.md](docs/benchmarking.md). The KITTI Odometry 00/05/07 LO baseline aggregator lives at `scripts/run_kitti_00_05_07_report.sh` (uses frozen params and writes `kitti_dev_report.md` with `t_rel` / `r_rel` per sequence).
 
-Run the local readiness gate:
+Run the local readiness gate. The default uses the per-dataset profiles in
+`scripts/release_profiles.yaml`, so `WARN` is emitted for research-track
+datasets (`MID-360`, `NTU VIRAL`, Leo Drive) and only release-track profiles
+without `report_only_until` (Newer College) can block release:
+
+```bash
+bash scripts/run_release_readiness_checks.sh --fail-on-profiles
+```
+
+The legacy single-threshold mode is still supported for compatibility:
 
 ```bash
 bash scripts/run_release_readiness_checks.sh --ape-threshold 0.10

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -58,7 +58,8 @@ Build behavior:
 - force-disabled with
   `colcon build --symlink-install --cmake-args -DGRAPH_BASED_SLAM_ENABLE_3D_BBS=OFF`
 
-MID360 wrapper example:
+MID-360 wrapper example (research track, `report_only_until: v0.4` in
+`scripts/release_profiles.yaml`):
 
 ```bash
 bash scripts/run_rko_lio_mid360_crossval_benchmark.sh \

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,10 +1,31 @@
 # Comparison
 
-This page is the public comparison snapshot for `lidarslam_ros2 v0.2.2`.
+This page is the public comparison snapshot for `lidarslam_ros2 v0.2.2` and
+the in-flight `v0.3` track on `develop`.
 
 It is intentionally scoped to workflows that are actually exercised in this
 repository. It is not trying to be a universal ranking of every LiDAR SLAM
 system.
+
+## Release Track vs Research Track
+
+`v0.3` separates evaluation into two tiers so the release gate stops squashing
+heterogeneous datasets onto a single APE threshold:
+
+- **Release track** — datasets where the release-profile gate enforces a
+  pass threshold. The current release-track datasets are `Newer College
+  math-hard` (hard gate) and the KITTI Odometry 00/05/07 LO baseline
+  comparison (non-regression).
+- **Research track** — datasets that are reported but do not block release
+  (`report_only_until: v0.4` in `scripts/release_profiles.yaml`). The current
+  research-track datasets are `NTU VIRAL tnp_01`, `MID-360` vs GLIM, the
+  Leo Drive applanix/velodyne open-data cross-validation, and the experimental
+  loop descriptor / NIS auto-scale paths.
+
+The distinction is exercised by `scripts/run_release_readiness_checks.sh`,
+which evaluates each profile in `scripts/release_profiles.yaml` and emits
+`PASS` / `FAIL` / `WARN` / `TARGET_MET` / `NO_DATA` per dataset. Profiles with
+`report_only_until` emit `WARN` instead of `FAIL` until the named release.
 
 ## Strategic Position
 
@@ -62,20 +83,40 @@ pure odometry novelty.
 
 These numbers come from local artifacts currently checked under `output/`.
 
-| Dataset | Published configuration | Reference kind | APE RMSE (m) | Autoware map verify | Notes |
+### Release-track datasets
+
+| Dataset | Configuration | Reference kind | APE RMSE (m) | Profile gate | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `NTU VIRAL tnp_01` | current default | `ground_truth` | `0.952` | `PASS` | default public benchmark path |
-| `NTU VIRAL tnp_01` | best observed | `ground_truth` | `0.870` | `PASS` | loop-gated backend run |
-| `MID360` | current default | `cross_validation` | `3.641` | `PASS` | current documented tuned path |
-| `MID360` | best observed | `cross_validation` | `3.590` | `PASS` | rerun with the same tuned backend family |
-| `MID360` | Scan Context candidate | `cross_validation` | `3.816` | `PASS` | fair current-code comparison; still opt-in |
-| `MID360` | experimental BEV-assisted rerank | `cross_validation` | `3.607` | `PASS` | sensor-agnostic rerank of distance candidates; still opt-in |
+| `NTU VIRAL tnp_01` | current default | `ground_truth` | `0.952` | `WARN` (pass ≤ 1.00, target 0.30, `report_only_until: v0.4`) | outdoor long-loop GT |
+| `NTU VIRAL tnp_01` | best observed   | `ground_truth` | `0.870` | `WARN` (same)                                                | loop-gated backend run |
+
+The Newer College `math-hard` profile is the only hard gate; numbers are not
+checked in to this repo and are reported separately on the long-form benchmark
+notes. The KITTI Odometry 00/05/07 LO baseline comparison is wired through
+`scripts/run_kitti_00_05_07_report.sh` and emits a non-regression report under
+`output/kitti_dev_<timestamp>/kitti_dev_report.md`.
+
+### Research-track datasets (report-only until v0.4)
+
+| Dataset | Configuration | Reference kind | APE RMSE (m) | Profile gate | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `MID-360` | current default                  | `cross_validation` vs GLIM | `3.641` | `WARN` (pass ≤ 4.00, target 1.00) | solid-state LiDAR, non-360° FOV |
+| `MID-360` | best observed                    | `cross_validation` vs GLIM | `3.590` | `WARN` (same)                     | rerun with same tuned backend family |
+| `MID-360` | Scan Context candidate           | `cross_validation` vs GLIM | `3.816` | `WARN`                            | fair current-code comparison; still opt-in |
+| `MID-360` | experimental BEV-assisted rerank | `cross_validation` vs GLIM | `3.607` | `WARN`                            | sensor-agnostic rerank of distance candidates; still opt-in |
+| Leo Drive (applanix/velodyne) | current default | `cross_validation` vs Applanix GSOF49 | varies per bag | `WARN` (pass ≤ 1.50, target 0.50) | open-data Velodyne packet path |
+
+`MID-360` and Leo Drive remain instructive evidence but no longer feed the
+release gate; the v0.3 default release path is judged on Autoware-compatible
+map authoring + Newer College + KITTI Odometry LO baseline.
 
 Source artifacts:
 
 - `output/benchmark_summary.md`
 - `output/latest_report.html`
 - `output/stress_validation_report_20260325.md`
+- `scripts/release_profiles.yaml` (profile definitions)
+- `output/kitti_dev_<timestamp>/kitti_dev_report.md` (KITTI LO baseline)
 
 ## Current Default Position
 
@@ -83,11 +124,15 @@ The public `v0.2.2` position is:
 
 - default workflow: `RKO-LIO + graph_based_slam`
 - public Autoware entrypoint: `bash scripts/run_autoware_quickstart.sh`
-- release gate: `bash scripts/run_release_readiness_checks.sh --ape-threshold 0.10`
+- release gate (legacy): `bash scripts/run_release_readiness_checks.sh --ape-threshold 0.10`
+- release gate (`v0.3`): `bash scripts/run_release_readiness_checks.sh --fail-on-profiles`
+  using `scripts/release_profiles.yaml` (per-dataset pass/target thresholds)
 - map-cleanup benchmark: `bash scripts/run_dynamic_object_filter_benchmark.sh`
 - classic-path suite: `bash scripts/run_open_data_classic_path_benchmark_suite.sh`
 - place-recognition suite: `bash scripts/run_place_recognition_benchmark.sh`
-- current MID360 default tuning:
+- KITTI Odometry dev split: `bash scripts/run_kitti_00_05_07_report.sh`
+- AWSIM → Autoware E2E demo: `bash scripts/run_awsim_selfmade_map_demo.sh`
+- research-track MID360 default tuning (kept for parity with prior numbers):
   `voxel_size=0.5`, `max_range=80.0`, `search_submap_num=5`,
   `loop_edge_dedup_index_window=20`, `loop_edge_info_weight=200`
 
@@ -95,13 +140,15 @@ The public `v0.2.2` position is:
 
 Safe claims:
 
-- the default path is benchmarked on `NTU VIRAL`
-- the pointcloud-map flow is dogfooded into Autoware
-- the backend has current long-loop evidence on `MID360`
+- the default path is benchmarked on `NTU VIRAL` and reports on `MID-360`
+- the pointcloud-map flow is dogfooded into Autoware end-to-end via AWSIM
 - the repository already provides reusable comparison artifacts for
   dynamic-filtering, classic-path open-data runs, and place-recognition
+- the release gate is now data-aware (per-dataset pass/target thresholds) so
+  hard datasets (`MID-360`, `NTU VIRAL`) can be reported without being
+  forced to one global APE threshold
 - the built-in GPL-free `Scan Context` path is now benchmarked and improves the
-  fair current-code `MID360` rerun baseline, but it is still documented as
+  fair current-code `MID-360` rerun baseline, but it is still documented as
   opt-in
 - the experimental submap-BEV path currently works better as a
   distance-candidate rerank than as a standalone loop source
@@ -112,7 +159,8 @@ Unsafe claims:
 - that this repo should be judged primarily as a localization-research stack
 - that the current default path is fully validated against every aggressive
   motion edge case
-- that lanelet generation is part of the supported release scope
+- that the `MID-360` research-track number (3.5–4.0 m vs GLIM) is anywhere
+  near production accuracy on solid-state LiDAR
 
 ## Release Scope Reminder
 
@@ -122,4 +170,13 @@ Unsafe claims:
 - non-GPL default workflow
 - Autoware pointcloud-map loading
 
-It is not yet claiming full production maturity.
+`v0.3` (in flight on `develop`) extends this with:
+
+- Autoware-compatible lanelet2 auto-generation + multi-segment routing
+  validation (`scripts/simple_lanelet2_generator.py --validate-structure`)
+- dataset-profile release gate (`scripts/release_profiles.yaml`)
+- KITTI Odometry t_rel / r_rel drift metric and 00/05/07 dev-split aggregator
+- opt-in NIS-driven auto-scale for `adjacent_edge_info_weight`
+
+`MID-360` and other solid-state LiDAR datasets are explicitly research track
+until `v0.4`; they are reported but do not block release.

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -153,6 +153,13 @@ if(BUILD_TESTING)
     target_include_directories(test_submap_bev_descriptor PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_bev_mutual_visibility
+    test/test_bev_mutual_visibility.cpp
+  )
+  if(TARGET test_bev_mutual_visibility)
+    target_include_directories(test_bev_mutual_visibility PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  endif()
+  ament_add_gtest(
     test_dynamic_object_filter
     test/test_dynamic_object_filter.cpp
   )

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -160,6 +160,13 @@ if(BUILD_TESTING)
     target_include_directories(test_bev_mutual_visibility PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_loop_edge_robustifier
+    test/test_loop_edge_robustifier.cpp
+  )
+  if(TARGET test_loop_edge_robustifier)
+    target_include_directories(test_loop_edge_robustifier PRIVATE include)
+  endif()
+  ament_add_gtest(
     test_dynamic_object_filter
     test/test_dynamic_object_filter.cpp
   )

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -124,6 +124,13 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_gnss_weighting sensor_msgs)
   endif()
   ament_add_gtest(
+    test_adjacent_edge_auto_scale
+    test/test_adjacent_edge_auto_scale.cpp
+  )
+  if(TARGET test_adjacent_edge_auto_scale)
+    target_include_directories(test_adjacent_edge_auto_scale PRIVATE include)
+  endif()
+  ament_add_gtest(
     test_scan_context
     test/test_scan_context.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/adjacent_edge_auto_scale.hpp
+++ b/graph_based_slam/include/graph_based_slam/adjacent_edge_auto_scale.hpp
@@ -1,0 +1,124 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__ADJACENT_EDGE_AUTO_SCALE_HPP_
+#define GRAPH_BASED_SLAM__ADJACENT_EDGE_AUTO_SCALE_HPP_
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+namespace graphslam
+{
+namespace detail
+{
+
+// NIS-driven auto-scaling for the scalar `adjacent_edge_info_weight` used on
+// adjacent submap edges in graph_based_slam. The idea (Level 1 of the
+// covariance-driven roadmap): keep the existing identity-information matrix
+// shape, but multiply its overall scale so that the median chi-squared (NIS)
+// of adjacent edges after optimisation lands near the SE(3) degrees of freedom
+// target (~6). This auto-balances "trust the LIO front-end vs trust the graph
+// adjustment" between datasets without manual tuning per dataset.
+//
+// The maths:
+//   chi2 = e^T * (s * I) * e = s * e^T * I * e
+// so if the current median chi2 is c and the target is t, the *next* scale
+// should be roughly s_next = s * (t / c). An EMA smooths the update against
+// chi2 noise; min/max clamps protect against pathological feedback loops.
+
+struct AutoScaleConfig
+{
+  // Target median chi-squared per adjacent edge. SE(3) edges have 6 DoF, so 6
+  // is the natural target; users can lower it (closer to 3) if they want the
+  // backend to lean more on the LIO front-end.
+  double target_nis {6.0};
+
+  // EMA mixing factor in [0, 1]. 0 = no adaptation, 1 = full jump to the
+  // chi-squared-implied scale. 0.3 is a conservative default.
+  double ema_alpha {0.3};
+
+  // Clamp range for the resulting scale. Defaults span four orders of
+  // magnitude around the historical hand-tuned defaults (100 / 1000).
+  double min_scale {1.0};
+  double max_scale {1.0e6};
+};
+
+// Median of a vector of doubles. Returns 0.0 when the input is empty.
+inline double medianChi2(std::vector<double> values)
+{
+  if (values.empty()) {
+    return 0.0;
+  }
+  const std::size_t mid = values.size() / 2;
+  std::nth_element(values.begin(), values.begin() + mid, values.end());
+  const double upper = values[mid];
+  if (values.size() % 2 == 1) {
+    return upper;
+  }
+  // Even count: also locate the lower middle and average.
+  std::nth_element(values.begin(), values.begin() + mid - 1, values.begin() + mid);
+  const double lower = values[mid - 1];
+  return 0.5 * (lower + upper);
+}
+
+// Compute the next scale value from the current scale, the post-optimisation
+// median chi-squared across adjacent edges, and the config.
+//
+// Behaviour:
+//   - empty median (no samples) or non-positive median → return current_scale
+//     unchanged (preserve historical hand-tuned weight).
+//   - target_nis non-positive → return current_scale unchanged.
+//   - otherwise mix with EMA and clamp to [min_scale, max_scale].
+inline double nextScale(
+  double current_scale,
+  double median_chi2,
+  const AutoScaleConfig & cfg)
+{
+  if (current_scale <= 0.0) {
+    return current_scale;
+  }
+  if (cfg.target_nis <= 0.0) {
+    return current_scale;
+  }
+  if (median_chi2 <= 0.0) {
+    return current_scale;
+  }
+  const double ratio = cfg.target_nis / median_chi2;
+  const double implied = current_scale * ratio;
+  const double alpha = std::min(std::max(cfg.ema_alpha, 0.0), 1.0);
+  const double mixed = (1.0 - alpha) * current_scale + alpha * implied;
+  const double clamped = std::min(std::max(mixed, cfg.min_scale), cfg.max_scale);
+  return clamped;
+}
+
+}  // namespace detail
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__ADJACENT_EDGE_AUTO_SCALE_HPP_

--- a/graph_based_slam/include/graph_based_slam/bev_mutual_visibility.hpp
+++ b/graph_based_slam/include/graph_based_slam/bev_mutual_visibility.hpp
@@ -260,5 +260,85 @@ inline YawAlignedMatch mutualVisibilityWithYawSearch(
   return best;
 }
 
+// FOV-aware database query against an existing SubmapBEVDescriptor::Database.
+//
+// Pipeline:
+//   1. Coarse pre-filter via cosine distance on each descriptor's coarse_key
+//      (existing cheap pass), keeping the top ``num_candidates``.
+//   2. For each surviving candidate, run mutualVisibilityWithYawSearch over
+//      the configured yaw bins and FOV-aware NCC.
+//   3. Sort candidates by FOV-aware distance and return up to ``num_matches``
+//      entries whose distance is strictly below ``threshold``.
+//
+// The function does not modify the database. Recent descriptors (within
+// ``exclude_recent`` of the most recent insertion) are skipped, matching the
+// existing Database::queryTopMatchesWithYaw convention.
+inline std::vector<YawAlignedMatch> queryDatabaseWithMutualVisibility(
+  const SubmapBEVDescriptor::Database & db,
+  const SubmapBEVDescriptor::Descriptor & query,
+  int num_matches,
+  int num_candidates = SubmapBEVDescriptor::DEFAULT_NUM_CANDIDATES,
+  int exclude_recent = SubmapBEVDescriptor::DEFAULT_EXCLUDE_RECENT,
+  double threshold = SubmapBEVDescriptor::DEFAULT_DISTANCE_THRESHOLD,
+  const MutualVisibilityConfig & cfg = MutualVisibilityConfig())
+{
+  std::vector<YawAlignedMatch> matches;
+  const int total = static_cast<int>(db.descriptors.size());
+  const int search_end = total - exclude_recent;
+  if (search_end <= 0 || num_matches <= 0) {
+    return matches;
+  }
+
+  // Coarse pre-filter via cosine distance on coarse keys (cheap and unchanged
+  // from the default path). We re-implement the lookup here so this header
+  // stays self-contained.
+  std::vector<std::pair<double, int>> coarse_candidates;
+  coarse_candidates.reserve(search_end);
+  for (int idx = 0; idx < search_end; ++idx) {
+    const Eigen::VectorXf & a = query.coarse_key;
+    const Eigen::VectorXf & b = db.descriptors[idx].coarse_key;
+    double coarse_distance = 1.0;
+    if (a.size() != 0 && a.size() == b.size()) {
+      const float a_norm = a.norm();
+      const float b_norm = b.norm();
+      if (a_norm > 1e-6f && b_norm > 1e-6f) {
+        const float cosine =
+          std::max(-1.0f, std::min(1.0f, a.dot(b) / (a_norm * b_norm)));
+        coarse_distance = 1.0 - static_cast<double>(cosine);
+      }
+    }
+    coarse_candidates.emplace_back(coarse_distance, idx);
+  }
+  const int k = std::min(num_candidates, static_cast<int>(coarse_candidates.size()));
+  std::partial_sort(
+    coarse_candidates.begin(),
+    coarse_candidates.begin() + k,
+    coarse_candidates.end());
+
+  // Verify each coarse candidate with FOV-aware yaw search.
+  std::vector<YawAlignedMatch> verified;
+  verified.reserve(k);
+  for (int idx = 0; idx < k; ++idx) {
+    const int descriptor_idx = coarse_candidates[idx].second;
+    const YawAlignedMatch result = mutualVisibilityWithYawSearch(
+      query, db.descriptors[descriptor_idx], db.submap_ids[descriptor_idx],
+      db.yaw_bins, cfg);
+    if (!result.valid) {continue;}
+    verified.push_back(result);
+  }
+
+  std::sort(
+    verified.begin(), verified.end(),
+    [](const YawAlignedMatch & lhs, const YawAlignedMatch & rhs) {
+      return lhs.distance < rhs.distance;
+    });
+  for (const auto & match : verified) {
+    if (match.distance >= threshold) {continue;}
+    matches.push_back(match);
+    if (static_cast<int>(matches.size()) >= num_matches) {break;}
+  }
+  return matches;
+}
+
 }  // namespace bev
 }  // namespace graphslam

--- a/graph_based_slam/include/graph_based_slam/bev_mutual_visibility.hpp
+++ b/graph_based_slam/include/graph_based_slam/bev_mutual_visibility.hpp
@@ -91,7 +91,9 @@ namespace detail
 inline Eigen::Array<bool, Eigen::Dynamic, Eigen::Dynamic> visibilityMask(
   const Eigen::MatrixXf & occupancy, float occupancy_eps)
 {
-  return  occupancy.array() > occupancy_eps;
+  const Eigen::Array<bool, Eigen::Dynamic, Eigen::Dynamic> mask =
+    occupancy.array() > occupancy_eps;
+  return mask;
 }
 
 // Compute zero-mean normalized cross-correlation of two grids, restricted to

--- a/graph_based_slam/include/graph_based_slam/bev_mutual_visibility.hpp
+++ b/graph_based_slam/include/graph_based_slam/bev_mutual_visibility.hpp
@@ -1,0 +1,264 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// FOV-aware BEV descriptor distance for solid-state LiDAR loop closure.
+//
+// The bundled ``SubmapBEVDescriptor::descriptorDistance`` uses cosine distance
+// over the flattened occupancy / density / max_height stack. That works well
+// on 360-degree spinning LiDAR because both submaps observe roughly the same
+// FOV, so unobserved cells (= 0) mean the same thing on both sides. On
+// non-360 solid-state LiDAR (e.g. Livox MID-360) two submaps captured from
+// different poses can have very different observed footprints, and the cosine
+// distance lumps "the sensor never saw this cell" together with "the sensor
+// saw this cell and it was empty". That biases place recognition.
+//
+// This header implements the FOV-aware fix recommended in the GPT pro 先生
+// roadmap: build a mutual-visibility mask = (query observed) AND (candidate
+// observed), then compute zero-mean normalized cross-correlation over the
+// masked cells per channel and average across channels. Cells outside the
+// mask do not contribute, so unobserved area no longer biases the score.
+
+#pragma once
+
+#include <Eigen/Core>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include "graph_based_slam/submap_bev_descriptor.hpp"
+
+namespace graphslam
+{
+namespace bev
+{
+
+struct MutualVisibilityResult
+{
+  // 1 - average NCC across channels, clamped to [0, 2]. 0 = perfect match,
+  // 1 = uncorrelated, 2 = inverse-correlated (rare in practice).
+  double distance {1.0};
+  // Fraction of cells inside the mutual-visibility mask.
+  double overlap_ratio {0.0};
+  // False when the overlap was below ``min_overlap_ratio``; ``distance``
+  // is then forced to 1.0 so the caller treats it as no match.
+  bool valid {false};
+};
+
+struct MutualVisibilityConfig
+{
+  // Minimum fraction of grid cells that must lie inside the mutual-visibility
+  // mask for the score to be considered valid. With grids of 40x40 the default
+  // 0.05 corresponds to ~80 mutually-observed cells.
+  double min_overlap_ratio {0.05};
+  // Cell-value epsilon used to convert occupancy floats into the visibility
+  // mask. occupancy is written as 0.0f or 1.0f by SubmapBEVDescriptor.
+  float occupancy_eps {0.5f};
+};
+
+namespace detail
+{
+
+inline Eigen::Array<bool, Eigen::Dynamic, Eigen::Dynamic> visibilityMask(
+  const Eigen::MatrixXf & occupancy, float occupancy_eps)
+{
+  return  occupancy.array() > occupancy_eps;
+}
+
+// Compute zero-mean normalized cross-correlation of two grids, restricted to
+// cells where ``mask`` is true. Returns {ncc, informative}.
+//
+// Edge cases:
+//   - fewer than 2 masked cells: {0.0, false} (cannot compute)
+//   - both sides constant within the mask and means agree: {+1.0, true}
+//     (the channel is consistent across the mutually-visible region; it does
+//     carry information, namely "no disagreement")
+//   - both sides constant but means disagree: {-1.0, true}
+//     (the channel is a hard disagreement)
+//   - exactly one side constant while the other varies: {0.0, false}
+//     (correlation is undefined; caller should skip this channel)
+//   - otherwise: clamped Pearson correlation, {ncc, true}.
+inline std::pair<double, bool> maskedNCC(
+  const Eigen::MatrixXf & a,
+  const Eigen::MatrixXf & b,
+  const Eigen::Array<bool, Eigen::Dynamic, Eigen::Dynamic> & mask)
+{
+  const int rows = a.rows();
+  const int cols = a.cols();
+  if (rows != b.rows() || cols != b.cols() || rows != mask.rows() || cols != mask.cols()) {
+    return {0.0, false};
+  }
+  double sum_a = 0.0;
+  double sum_b = 0.0;
+  int n = 0;
+  for (int r = 0; r < rows; ++r) {
+    for (int c = 0; c < cols; ++c) {
+      if (!mask(r, c)) {continue;}
+      sum_a += a(r, c);
+      sum_b += b(r, c);
+      ++n;
+    }
+  }
+  if (n < 2) {
+    return {0.0, false};
+  }
+  const double mean_a = sum_a / n;
+  const double mean_b = sum_b / n;
+
+  double var_a = 0.0;
+  double var_b = 0.0;
+  double cov = 0.0;
+  for (int r = 0; r < rows; ++r) {
+    for (int c = 0; c < cols; ++c) {
+      if (!mask(r, c)) {continue;}
+      const double da = a(r, c) - mean_a;
+      const double db = b(r, c) - mean_b;
+      var_a += da * da;
+      var_b += db * db;
+      cov += da * db;
+    }
+  }
+  constexpr double kVarEps = 1e-12;
+  constexpr double kMeanEps = 1e-6;
+  const bool a_constant = var_a < kVarEps;
+  const bool b_constant = var_b < kVarEps;
+  if (a_constant && b_constant) {
+    return {(std::abs(mean_a - mean_b) < kMeanEps) ? 1.0 : -1.0, true};
+  }
+  if (a_constant || b_constant) {
+    return {0.0, false};
+  }
+  const double ncc = cov / std::sqrt(var_a * var_b);
+  return {std::max(-1.0, std::min(1.0, ncc)), true};
+}
+
+}  // namespace detail
+
+// Score a single (query, candidate) descriptor pair with mutual-visibility NCC.
+// Both descriptors must share the same grid resolution.
+inline MutualVisibilityResult mutualVisibilityDistance(
+  const SubmapBEVDescriptor::Descriptor & query,
+  const SubmapBEVDescriptor::Descriptor & candidate,
+  const MutualVisibilityConfig & cfg = MutualVisibilityConfig())
+{
+  MutualVisibilityResult result;
+  if (query.occupancy.rows() != candidate.occupancy.rows() ||
+    query.occupancy.cols() != candidate.occupancy.cols() ||
+    query.occupancy.rows() == 0 || query.occupancy.cols() == 0)
+  {
+    return result;
+  }
+  const auto mask_q = detail::visibilityMask(query.occupancy, cfg.occupancy_eps);
+  const auto mask_c = detail::visibilityMask(candidate.occupancy, cfg.occupancy_eps);
+  const auto mask = mask_q && mask_c;
+
+  const int total = static_cast<int>(mask.size());
+  const int overlap = static_cast<int>(mask.count());
+  result.overlap_ratio = total > 0 ? static_cast<double>(overlap) / total : 0.0;
+
+  const double min_overlap = std::max(0.0, cfg.min_overlap_ratio);
+  if (result.overlap_ratio < min_overlap || overlap < 2) {
+    return result;
+  }
+
+  const auto pair_o = detail::maskedNCC(query.occupancy, candidate.occupancy, mask);
+  const auto pair_d = detail::maskedNCC(query.density, candidate.density, mask);
+  const auto pair_h = detail::maskedNCC(query.max_height, candidate.max_height, mask);
+  std::vector<double> nccs;
+  nccs.reserve(3);
+  if (pair_o.second) {nccs.push_back(pair_o.first);}
+  if (pair_d.second) {nccs.push_back(pair_d.first);}
+  if (pair_h.second) {nccs.push_back(pair_h.first);}
+  if (nccs.empty()) {
+    // No channel produced an informative NCC. The mutual-visibility mask
+    // itself overlaps, so treat that as a structural match.
+    result.distance = 0.0;
+    result.valid = true;
+    return result;
+  }
+  const double avg_ncc =
+    std::accumulate(nccs.begin(), nccs.end(), 0.0) / static_cast<double>(nccs.size());
+  result.distance = std::max(0.0, std::min(2.0, 1.0 - avg_ncc));
+  result.valid = true;
+  return result;
+}
+
+// Yaw-search variant. Rotates ``candidate`` through ``yaw_bins`` evenly-spaced
+// orientations, evaluates mutual-visibility NCC at each, and returns the best
+// match (lowest distance). Mirrors SubmapBEVDescriptor::distanceWithAlignment
+// but uses FOV-aware scoring underneath.
+struct YawAlignedMatch
+{
+  int submap_id {-1};
+  double distance {1.0};
+  double overlap_ratio {0.0};
+  int yaw_bin {0};
+  double yaw_rad {0.0};
+  bool valid {false};
+};
+
+inline YawAlignedMatch mutualVisibilityWithYawSearch(
+  const SubmapBEVDescriptor::Descriptor & query,
+  const SubmapBEVDescriptor::Descriptor & candidate,
+  int submap_id,
+  int yaw_bins = SubmapBEVDescriptor::DEFAULT_YAW_BINS,
+  const MutualVisibilityConfig & cfg = MutualVisibilityConfig())
+{
+  YawAlignedMatch best;
+  best.submap_id = submap_id;
+  best.distance = std::numeric_limits<double>::max();
+  if (yaw_bins < 1) {
+    yaw_bins = 1;
+  }
+  for (int bin = 0; bin < yaw_bins; ++bin) {
+    const double yaw_rad = static_cast<double>(bin) * 2.0 * M_PI /
+      static_cast<double>(yaw_bins);
+    const SubmapBEVDescriptor::Descriptor rotated =
+      SubmapBEVDescriptor::rotateDescriptor(candidate, yaw_rad);
+    const MutualVisibilityResult res = mutualVisibilityDistance(query, rotated, cfg);
+    if (!res.valid) {continue;}
+    if (res.distance < best.distance) {
+      best.distance = res.distance;
+      best.overlap_ratio = res.overlap_ratio;
+      best.yaw_bin = bin;
+      best.yaw_rad = yaw_rad;
+      best.valid = true;
+    }
+  }
+  if (!best.valid) {
+    best.distance = 1.0;
+  }
+  return best;
+}
+
+}  // namespace bev
+}  // namespace graphslam

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -197,6 +197,16 @@ private:
     double loop_edge_info_weight_ {100.0};
     double loop_edge_robust_kernel_delta_ {1.0};
 
+    // Auto-scaling for adjacent_edge_info_weight (Level 1: NIS median tracking).
+    // When enabled, the post-optimisation chi-squared of adjacent edges is
+    // monitored and adjacent_edge_info_weight_ is mixed toward
+    // current * target_nis / median_chi2 via EMA, clamped to [min, max].
+    bool adjacent_edge_info_auto_scale_ {false};
+    double adjacent_edge_info_auto_scale_target_nis_ {6.0};
+    double adjacent_edge_info_auto_scale_ema_alpha_ {0.3};
+    double adjacent_edge_info_auto_scale_min_ {1.0};
+    double adjacent_edge_info_auto_scale_max_ {1.0e6};
+
     bool initial_map_array_received_ {false};
     bool is_map_array_updated_ {false};
     int previous_submaps_num_ {0};

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -231,6 +231,11 @@ private:
     double bev_descriptor_pose_consistency_threshold_m_ {-1.0};
     double bev_descriptor_max_euclidean_distance_m_ {-1.0};
     double bev_descriptor_rerank_weight_m_ {100.0};
+    // FOV-aware (mutual-visibility) distance for the BEV descriptor. Default
+    // off so the cosine-distance baseline stays unchanged on 360° LiDAR.
+    bool bev_use_mutual_visibility_ {false};
+    double bev_mutual_visibility_min_overlap_ratio_ {0.05};
+    double bev_mutual_visibility_occupancy_eps_ {0.5};
     SubmapBEVDescriptor::Database bev_descriptor_db_;
     bool use_solid_descriptor_ {false};
     double solid_descriptor_min_similarity_ {0.70};

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -196,6 +196,7 @@ private:
     double adjacent_edge_info_weight_ {1000.0};
     double loop_edge_info_weight_ {100.0};
     double loop_edge_robust_kernel_delta_ {1.0};
+    std::string loop_edge_robust_kernel_type_ {"huber"};
 
     // Auto-scaling for adjacent_edge_info_weight (Level 1: NIS median tracking).
     // When enabled, the post-optimisation chi-squared of adjacent edges is

--- a/graph_based_slam/include/graph_based_slam/loop_edge_robustifier.hpp
+++ b/graph_based_slam/include/graph_based_slam/loop_edge_robustifier.hpp
@@ -1,0 +1,126 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Robust kernel selection for loop closure edges in graph_based_slam.
+//
+// The bundled default is g2o::RobustKernelHuber, which clips the loop edge
+// influence above a threshold but never drives it to zero. For solid-state
+// LiDAR / aggressive false-loop regimes, Dynamic Covariance Scaling (DCS,
+// Agarwal et al. 2013) is preferred because it analytically down-weights
+// outlier loops toward zero without introducing extra optimisation
+// variables. Cauchy is offered as a smoother middle ground.
+//
+// The parsing helpers live here so they are unit-testable without pulling
+// in g2o headers. The factory ``makeLoopEdgeKernel`` is included only when
+// g2o's RobustKernel headers are visible to keep this header lightweight
+// for tests.
+
+#ifndef GRAPH_BASED_SLAM__LOOP_EDGE_ROBUSTIFIER_HPP_
+#define GRAPH_BASED_SLAM__LOOP_EDGE_ROBUSTIFIER_HPP_
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+#if defined(GRAPH_BASED_SLAM_WITH_G2O)
+#include <g2o/core/robust_kernel_impl.h>
+#endif
+
+namespace graphslam
+{
+namespace robust
+{
+
+enum class LoopEdgeKernelType
+{
+  Huber,
+  DCS,
+  Cauchy,
+};
+
+inline std::string toLowerAscii(const std::string & input)
+{
+  std::string out;
+  out.reserve(input.size());
+  for (char ch : input) {
+    out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(ch))));
+  }
+  return out;
+}
+
+// Parse a ROS-parameter string into the matching kernel enum. Unknown values
+// fall back to Huber, matching the historical default.
+inline LoopEdgeKernelType parseLoopEdgeKernelType(const std::string & raw)
+{
+  const std::string lower = toLowerAscii(raw);
+  if (lower == "dcs") {return LoopEdgeKernelType::DCS;}
+  if (lower == "cauchy") {return LoopEdgeKernelType::Cauchy;}
+  return LoopEdgeKernelType::Huber;
+}
+
+// Reverse lookup used for logging and effective-parameter dumps.
+inline const char * loopEdgeKernelTypeName(LoopEdgeKernelType type)
+{
+  switch (type) {
+    case LoopEdgeKernelType::DCS:
+      return "dcs";
+    case LoopEdgeKernelType::Cauchy:
+      return "cauchy";
+    default:
+      return "huber";
+  }
+}
+
+#if defined(GRAPH_BASED_SLAM_WITH_G2O)
+// Factory wrapper around g2o's robust kernels. The returned pointer is owned
+// by whatever object it is later attached to (typically a g2o::OptimizableGraph
+// edge via ``setRobustKernel``).
+inline g2o::RobustKernel * makeLoopEdgeKernel(LoopEdgeKernelType type, double delta)
+{
+  g2o::RobustKernel * kernel = nullptr;
+  switch (type) {
+    case LoopEdgeKernelType::DCS:
+      kernel = new g2o::RobustKernelDCS();
+      break;
+    case LoopEdgeKernelType::Cauchy:
+      kernel = new g2o::RobustKernelCauchy();
+      break;
+    default:
+      kernel = new g2o::RobustKernelHuber();
+      break;
+  }
+  kernel->setDelta(delta);
+  return kernel;
+}
+#endif  // GRAPH_BASED_SLAM_WITH_G2O
+
+}  // namespace robust
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__LOOP_EDGE_ROBUSTIFIER_HPP_

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -37,6 +37,7 @@
 #include <iomanip>
 #include <unordered_map>
 
+#include "graph_based_slam/adjacent_edge_auto_scale.hpp"
 #include "graph_based_slam/dynamic_object_filter.hpp"
 #include "g2o/core/robust_kernel_impl.h"
 
@@ -95,6 +96,20 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("debug_flag", debug_flag_);
   declare_parameter("adjacent_edge_info_weight", 1000.0);
   get_parameter("adjacent_edge_info_weight", adjacent_edge_info_weight_);
+  declare_parameter("adjacent_edge_info_auto_scale", false);
+  get_parameter("adjacent_edge_info_auto_scale", adjacent_edge_info_auto_scale_);
+  declare_parameter("adjacent_edge_info_auto_scale_target_nis", 6.0);
+  get_parameter(
+    "adjacent_edge_info_auto_scale_target_nis",
+    adjacent_edge_info_auto_scale_target_nis_);
+  declare_parameter("adjacent_edge_info_auto_scale_ema_alpha", 0.3);
+  get_parameter(
+    "adjacent_edge_info_auto_scale_ema_alpha",
+    adjacent_edge_info_auto_scale_ema_alpha_);
+  declare_parameter("adjacent_edge_info_auto_scale_min", 1.0);
+  get_parameter("adjacent_edge_info_auto_scale_min", adjacent_edge_info_auto_scale_min_);
+  declare_parameter("adjacent_edge_info_auto_scale_max", 1.0e6);
+  get_parameter("adjacent_edge_info_auto_scale_max", adjacent_edge_info_auto_scale_max_);
   declare_parameter("loop_edge_info_weight", 100.0);
   get_parameter("loop_edge_info_weight", loop_edge_info_weight_);
   declare_parameter("loop_edge_robust_kernel_delta", 1.0);
@@ -1922,6 +1937,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
   optimizer.setAlgorithm(solver);
 
   int submaps_size = map_array_msg.submaps.size();
+  std::vector<g2o::EdgeSE3 *> adjacent_edges;
   for (int i = 0; i < submaps_size; i++) {
     Eigen::Affine3d affine;
     Eigen::fromMsg(map_array_msg.submaps[i].pose, affine);
@@ -1951,6 +1967,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
         edge_se3->vertices()[0] = optimizer.vertex(pre_idx);
         edge_se3->vertices()[1] = optimizer.vertex(i);
         optimizer.addEdge(edge_se3);
+        adjacent_edges.push_back(edge_se3);
       }
     }
   }
@@ -2076,6 +2093,35 @@ void GraphBasedSlamComponent::doPoseAdjustment(
   optimizer.initializeOptimization();
   optimizer.optimize(10);
   optimizer.save("pose_graph.g2o");
+
+  if (adjacent_edge_info_auto_scale_ && !adjacent_edges.empty()) {
+    std::vector<double> chi2_values;
+    chi2_values.reserve(adjacent_edges.size());
+    for (auto * e : adjacent_edges) {
+      e->computeError();
+      const double v = e->chi2();
+      if (std::isfinite(v)) {
+        chi2_values.push_back(v);
+      }
+    }
+    const double median_chi2 = graphslam::detail::medianChi2(chi2_values);
+
+    graphslam::detail::AutoScaleConfig cfg;
+    cfg.target_nis = adjacent_edge_info_auto_scale_target_nis_;
+    cfg.ema_alpha = adjacent_edge_info_auto_scale_ema_alpha_;
+    cfg.min_scale = adjacent_edge_info_auto_scale_min_;
+    cfg.max_scale = adjacent_edge_info_auto_scale_max_;
+
+    const double prev_weight = adjacent_edge_info_weight_;
+    adjacent_edge_info_weight_ =
+      graphslam::detail::nextScale(prev_weight, median_chi2, cfg);
+
+    RCLCPP_INFO(
+      get_logger(),
+      "[auto_scale] median_chi2=%.3f (n=%zu) target=%.3f weight=%.3f -> %.3f",
+      median_chi2, chi2_values.size(), cfg.target_nis, prev_weight,
+      adjacent_edge_info_weight_);
+  }
 
   /* modified_map publish */
   std::cout << "modified_map publish" << std::endl;

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -40,6 +40,8 @@
 #include "graph_based_slam/adjacent_edge_auto_scale.hpp"
 #include "graph_based_slam/dynamic_object_filter.hpp"
 #include "g2o/core/robust_kernel_impl.h"
+#define GRAPH_BASED_SLAM_WITH_G2O 1
+#include "graph_based_slam/loop_edge_robustifier.hpp"
 
 using namespace std::chrono_literals;
 
@@ -114,6 +116,8 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("loop_edge_info_weight", loop_edge_info_weight_);
   declare_parameter("loop_edge_robust_kernel_delta", 1.0);
   get_parameter("loop_edge_robust_kernel_delta", loop_edge_robust_kernel_delta_);
+  declare_parameter("loop_edge_robust_kernel_type", std::string("huber"));
+  get_parameter("loop_edge_robust_kernel_type", loop_edge_robust_kernel_type_);
   declare_parameter("use_scan_context", false);
   get_parameter("use_scan_context", use_scan_context_);
   declare_parameter("use_bev_descriptor", false);
@@ -571,6 +575,10 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   std::cout << "adjacent_edge_info_weight:" << adjacent_edge_info_weight_ << std::endl;
   std::cout << "loop_edge_info_weight:" << loop_edge_info_weight_ << std::endl;
   std::cout << "loop_edge_robust_kernel_delta:" << loop_edge_robust_kernel_delta_ << std::endl;
+  std::cout << "loop_edge_robust_kernel_type:"
+            << graphslam::robust::loopEdgeKernelTypeName(
+    graphslam::robust::parseLoopEdgeKernelType(loop_edge_robust_kernel_type_))
+            << std::endl;
   std::cout << "use_save_map_in_loop:" << std::boolalpha << use_save_map_in_loop_ << std::endl;
   std::cout << "debug_flag:" << std::boolalpha << debug_flag_ << std::endl;
   std::cout << "use_scan_context:" << std::boolalpha << use_scan_context_ << std::endl;
@@ -2019,6 +2027,8 @@ void GraphBasedSlamComponent::doPoseAdjustment(
   }
 
   /* loop edge */
+  const auto loop_kernel_type =
+    graphslam::robust::parseLoopEdgeKernelType(loop_edge_robust_kernel_type_);
   for (const auto & loop_edge : loop_edges) {
     g2o::EdgeSE3 * edge_se3 = new g2o::EdgeSE3();
     edge_se3->setMeasurement(loop_edge.relative_pose);
@@ -2026,9 +2036,9 @@ void GraphBasedSlamComponent::doPoseAdjustment(
     Eigen::Matrix<double, 6, 6> loop_info_mat =
       Eigen::Matrix<double, 6, 6>::Identity() * (loop_edge_info_weight_ / fitness);
     edge_se3->setInformation(loop_info_mat);
-    auto * robust_kernel = new g2o::RobustKernelHuber();
-    robust_kernel->setDelta(loop_edge_robust_kernel_delta_);
-    edge_se3->setRobustKernel(robust_kernel);
+    edge_se3->setRobustKernel(
+      graphslam::robust::makeLoopEdgeKernel(
+        loop_kernel_type, loop_edge_robust_kernel_delta_));
     edge_se3->vertices()[0] = optimizer.vertex(loop_edge.pair_id.first);
     edge_se3->vertices()[1] = optimizer.vertex(loop_edge.pair_id.second);
     optimizer.addEdge(edge_se3);

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -38,6 +38,7 @@
 #include <unordered_map>
 
 #include "graph_based_slam/adjacent_edge_auto_scale.hpp"
+#include "graph_based_slam/bev_mutual_visibility.hpp"
 #include "graph_based_slam/dynamic_object_filter.hpp"
 #include "g2o/core/robust_kernel_impl.h"
 #define GRAPH_BASED_SLAM_WITH_G2O 1
@@ -156,6 +157,16 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     bev_descriptor_max_euclidean_distance_m_);
   declare_parameter("bev_descriptor_rerank_weight_m", 100.0);
   get_parameter("bev_descriptor_rerank_weight_m", bev_descriptor_rerank_weight_m_);
+  declare_parameter("bev_use_mutual_visibility", false);
+  get_parameter("bev_use_mutual_visibility", bev_use_mutual_visibility_);
+  declare_parameter("bev_mutual_visibility_min_overlap_ratio", 0.05);
+  get_parameter(
+    "bev_mutual_visibility_min_overlap_ratio",
+    bev_mutual_visibility_min_overlap_ratio_);
+  declare_parameter("bev_mutual_visibility_occupancy_eps", 0.5);
+  get_parameter(
+    "bev_mutual_visibility_occupancy_eps",
+    bev_mutual_visibility_occupancy_eps_);
   declare_parameter("solid_descriptor_min_similarity", 0.70);
   get_parameter("solid_descriptor_min_similarity", solid_descriptor_min_similarity_);
   declare_parameter("solid_descriptor_sequence_window", 0);
@@ -623,6 +634,14 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       bev_descriptor_max_euclidean_distance_m_ << std::endl;
     std::cout << "bev_descriptor_rerank_weight_m:" << bev_descriptor_rerank_weight_m_ <<
       std::endl;
+    std::cout << "bev_use_mutual_visibility:" << std::boolalpha <<
+      bev_use_mutual_visibility_ << std::endl;
+    if (bev_use_mutual_visibility_) {
+      std::cout << "bev_mutual_visibility_min_overlap_ratio:" <<
+        bev_mutual_visibility_min_overlap_ratio_ << std::endl;
+      std::cout << "bev_mutual_visibility_occupancy_eps:" <<
+        bev_mutual_visibility_occupancy_eps_ << std::endl;
+    }
   }
   std::cout << "use_solid_descriptor:" << std::boolalpha << use_solid_descriptor_ << std::endl;
   if (use_solid_descriptor_) {
@@ -1262,11 +1281,29 @@ void GraphBasedSlamComponent::searchLoop()
         continue;
       }
 
-      const auto bev_match = SubmapBEVDescriptor::distanceWithAlignment(
-        bev_descriptor_db_.descriptors.back(),
-        bev_descriptor_db_.descriptors[bev_idx],
-        bev_idx,
-        bev_descriptor_yaw_bins_);
+      SubmapBEVDescriptor::Match bev_match;
+      if (bev_use_mutual_visibility_) {
+        graphslam::bev::MutualVisibilityConfig mv_cfg;
+        mv_cfg.min_overlap_ratio = bev_mutual_visibility_min_overlap_ratio_;
+        mv_cfg.occupancy_eps =
+          static_cast<float>(bev_mutual_visibility_occupancy_eps_);
+        const auto fov = graphslam::bev::mutualVisibilityWithYawSearch(
+          bev_descriptor_db_.descriptors.back(),
+          bev_descriptor_db_.descriptors[bev_idx],
+          bev_idx,
+          bev_descriptor_yaw_bins_,
+          mv_cfg);
+        bev_match.submap_id = fov.submap_id;
+        bev_match.distance = fov.valid ? fov.distance : 1.0;
+        bev_match.yaw_bin = fov.yaw_bin;
+        bev_match.yaw_rad = fov.yaw_rad;
+      } else {
+        bev_match = SubmapBEVDescriptor::distanceWithAlignment(
+          bev_descriptor_db_.descriptors.back(),
+          bev_descriptor_db_.descriptors[bev_idx],
+          bev_idx,
+          bev_descriptor_yaw_bins_);
+      }
       if (bev_match.distance < best_bev_dist) {
         best_bev_dist = bev_match.distance;
         best_bev_idx = bev_idx;
@@ -1307,9 +1344,23 @@ void GraphBasedSlamComponent::searchLoop()
           const auto rotated_candidate_descriptor = SubmapBEVDescriptor::rotateDescriptor(
             bev_descriptor_db_.descriptors[candidate_sequence_idx],
             bev_yaw_rad);
-          bev_sequence_distance_sum += SubmapBEVDescriptor::descriptorDistance(
-            bev_descriptor_db_.descriptors[query_idx],
-            rotated_candidate_descriptor);
+          double sequence_distance;
+          if (bev_use_mutual_visibility_) {
+            graphslam::bev::MutualVisibilityConfig mv_cfg;
+            mv_cfg.min_overlap_ratio = bev_mutual_visibility_min_overlap_ratio_;
+            mv_cfg.occupancy_eps =
+              static_cast<float>(bev_mutual_visibility_occupancy_eps_);
+            const auto fov = graphslam::bev::mutualVisibilityDistance(
+              bev_descriptor_db_.descriptors[query_idx],
+              rotated_candidate_descriptor,
+              mv_cfg);
+            sequence_distance = fov.valid ? fov.distance : 1.0;
+          } else {
+            sequence_distance = SubmapBEVDescriptor::descriptorDistance(
+              bev_descriptor_db_.descriptors[query_idx],
+              rotated_candidate_descriptor);
+          }
+          bev_sequence_distance_sum += sequence_distance;
           ++bev_sequence_count;
         }
         bev_sequence_metric = bev_sequence_distance_sum / static_cast<double>(bev_sequence_count);

--- a/graph_based_slam/test/test_adjacent_edge_auto_scale.cpp
+++ b/graph_based_slam/test/test_adjacent_edge_auto_scale.cpp
@@ -1,0 +1,184 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "graph_based_slam/adjacent_edge_auto_scale.hpp"
+
+namespace graphslam
+{
+namespace detail
+{
+namespace
+{
+
+TEST(AdjacentEdgeAutoScaleMedian, EmptyReturnsZero)
+{
+  EXPECT_DOUBLE_EQ(0.0, medianChi2({}));
+}
+
+TEST(AdjacentEdgeAutoScaleMedian, SingleElement)
+{
+  EXPECT_DOUBLE_EQ(3.5, medianChi2({3.5}));
+}
+
+TEST(AdjacentEdgeAutoScaleMedian, OddCount)
+{
+  EXPECT_DOUBLE_EQ(2.0, medianChi2({5.0, 1.0, 2.0, 0.5, 7.0}));
+}
+
+TEST(AdjacentEdgeAutoScaleMedian, EvenCountAveragesTwoMiddles)
+{
+  EXPECT_DOUBLE_EQ(3.0, medianChi2({1.0, 2.0, 4.0, 8.0}));
+}
+
+TEST(AdjacentEdgeAutoScaleMedian, UnsortedInputOk)
+{
+  EXPECT_DOUBLE_EQ(50.0, medianChi2({100.0, 50.0, 25.0}));
+}
+
+TEST(AdjacentEdgeAutoScale, MedianEqualsTargetLeavesScaleUnchanged)
+{
+  AutoScaleConfig cfg;
+  cfg.target_nis = 6.0;
+  cfg.ema_alpha = 1.0;
+  EXPECT_DOUBLE_EQ(1000.0, nextScale(1000.0, 6.0, cfg));
+}
+
+TEST(AdjacentEdgeAutoScale, MedianAboveTargetReducesScale)
+{
+  AutoScaleConfig cfg;
+  cfg.target_nis = 6.0;
+  cfg.ema_alpha = 1.0;
+  // chi2 doubled vs target → scale should halve.
+  EXPECT_DOUBLE_EQ(500.0, nextScale(1000.0, 12.0, cfg));
+}
+
+TEST(AdjacentEdgeAutoScale, MedianBelowTargetIncreasesScale)
+{
+  AutoScaleConfig cfg;
+  cfg.target_nis = 6.0;
+  cfg.ema_alpha = 1.0;
+  // chi2 halved vs target → scale should double.
+  EXPECT_DOUBLE_EQ(2000.0, nextScale(1000.0, 3.0, cfg));
+}
+
+TEST(AdjacentEdgeAutoScale, EmaMixesPartialMove)
+{
+  AutoScaleConfig cfg;
+  cfg.target_nis = 6.0;
+  cfg.ema_alpha = 0.5;
+  // implied = 1000 * (6/12) = 500. mixed = 0.5 * 1000 + 0.5 * 500 = 750.
+  EXPECT_DOUBLE_EQ(750.0, nextScale(1000.0, 12.0, cfg));
+}
+
+TEST(AdjacentEdgeAutoScale, EmaAlphaZeroFreezesScale)
+{
+  AutoScaleConfig cfg;
+  cfg.target_nis = 6.0;
+  cfg.ema_alpha = 0.0;
+  EXPECT_DOUBLE_EQ(1000.0, nextScale(1000.0, 12.0, cfg));
+}
+
+TEST(AdjacentEdgeAutoScale, EmaAlphaClampedToUnit)
+{
+  AutoScaleConfig cfg;
+  cfg.target_nis = 6.0;
+  cfg.ema_alpha = 5.0;  // out-of-range value clamps to 1.0
+  EXPECT_DOUBLE_EQ(500.0, nextScale(1000.0, 12.0, cfg));
+}
+
+TEST(AdjacentEdgeAutoScale, RespectsMinClamp)
+{
+  AutoScaleConfig cfg;
+  cfg.target_nis = 6.0;
+  cfg.ema_alpha = 1.0;
+  cfg.min_scale = 200.0;
+  cfg.max_scale = 1.0e6;
+  // implied = 1000 * (6/1000) = 6 → clamps to 200.
+  EXPECT_DOUBLE_EQ(200.0, nextScale(1000.0, 1000.0, cfg));
+}
+
+TEST(AdjacentEdgeAutoScale, RespectsMaxClamp)
+{
+  AutoScaleConfig cfg;
+  cfg.target_nis = 6.0;
+  cfg.ema_alpha = 1.0;
+  cfg.min_scale = 1.0;
+  cfg.max_scale = 5000.0;
+  // implied = 1000 * (6/0.1) = 60000 → clamps to 5000.
+  EXPECT_DOUBLE_EQ(5000.0, nextScale(1000.0, 0.1, cfg));
+}
+
+TEST(AdjacentEdgeAutoScale, MedianZeroLeavesScaleUnchanged)
+{
+  AutoScaleConfig cfg;
+  cfg.target_nis = 6.0;
+  cfg.ema_alpha = 0.5;
+  EXPECT_DOUBLE_EQ(1000.0, nextScale(1000.0, 0.0, cfg));
+}
+
+TEST(AdjacentEdgeAutoScale, NegativeTargetLeavesScaleUnchanged)
+{
+  AutoScaleConfig cfg;
+  cfg.target_nis = -1.0;
+  cfg.ema_alpha = 0.5;
+  EXPECT_DOUBLE_EQ(1000.0, nextScale(1000.0, 12.0, cfg));
+}
+
+TEST(AdjacentEdgeAutoScale, NegativeCurrentScaleLeavesUnchanged)
+{
+  AutoScaleConfig cfg;
+  EXPECT_DOUBLE_EQ(-50.0, nextScale(-50.0, 12.0, cfg));
+}
+
+TEST(AdjacentEdgeAutoScale, RepeatedApplicationConvergesToTarget)
+{
+  AutoScaleConfig cfg;
+  cfg.target_nis = 6.0;
+  cfg.ema_alpha = 0.5;
+  cfg.min_scale = 1.0;
+  cfg.max_scale = 1.0e6;
+
+  // Model: the edge residual is roughly fixed across nearby weight values, so
+  // chi2 = e^T (s * I) e is approximately proportional to the scale s.
+  // Picking baseline_chi2_per_unit = 0.012 makes chi2=12 at s=1000, which means
+  // the equilibrium scale (where chi2 == target == 6) is s* = 6 / 0.012 = 500.
+  const double baseline_chi2_per_unit = 0.012;
+  double scale = 1000.0;
+  for (int i = 0; i < 50; ++i) {
+    const double observed_chi2 = baseline_chi2_per_unit * scale;
+    scale = nextScale(scale, observed_chi2, cfg);
+  }
+  EXPECT_NEAR(500.0, scale, 1e-2);
+}
+
+}  // namespace
+}  // namespace detail
+}  // namespace graphslam

--- a/graph_based_slam/test/test_bev_mutual_visibility.cpp
+++ b/graph_based_slam/test/test_bev_mutual_visibility.cpp
@@ -174,7 +174,8 @@ TEST(BevMutualVisibility, YawSearchPicksAlignmentBin)
   // Rotate the candidate by 90° about the centre.
   const SubmapBEVDescriptor::Descriptor rotated =
     SubmapBEVDescriptor::rotateDescriptor(base, M_PI / 2.0);
-  const auto match = mutualVisibilityWithYawSearch(base, rotated, /*submap_id=*/7, /*yaw_bins=*/4);
+  const auto match =
+    mutualVisibilityWithYawSearch(base, rotated, /*submap_id=*/ 7, /*yaw_bins=*/ 4);
   EXPECT_TRUE(match.valid);
   EXPECT_EQ(7, match.submap_id);
   EXPECT_LT(match.distance, 0.2);
@@ -189,7 +190,7 @@ TEST(BevMutualVisibility, YawSearchInvalidWhenNoOverlap)
   auto c = makeBlankDescriptor();
   writeBlock(q, 0, 1, 0, 1, 0.5f, 0.5f);
   writeBlock(c, 15, 16, 15, 16, 0.5f, 0.5f);
-  const auto match = mutualVisibilityWithYawSearch(q, c, /*submap_id=*/3, /*yaw_bins=*/8);
+  const auto match = mutualVisibilityWithYawSearch(q, c, /*submap_id=*/ 3, /*yaw_bins=*/ 8);
   EXPECT_FALSE(match.valid);
   EXPECT_NEAR(1.0, match.distance, 1e-9);
 }
@@ -220,22 +221,22 @@ SubmapBEVDescriptor::Descriptor descriptorWithBlock(
 TEST(BevMutualVisibilityDatabase, FindsMatchingSubmapAndIgnoresUnrelated)
 {
   SubmapBEVDescriptor::Database db(
-    /*grid_size_m=*/16.0,
-    /*grid_cells=*/kGrid,
-    /*yaw_bins=*/4);
+    /*grid_size_m=*/ 16.0,
+    /*grid_cells=*/ kGrid,
+    /*yaw_bins=*/ 4);
   // Two unrelated submaps + one that overlaps the query.
-  db.add(/*submap_id=*/100, descriptorWithBlock(0, 4, 0, 4, 0.6f, 0.5f));
-  db.add(/*submap_id=*/101, descriptorWithBlock(12, 16, 12, 16, 0.4f, 0.7f));
-  db.add(/*submap_id=*/102, descriptorWithBlock(3, 9, 9, 15, 0.5f, 0.4f));
+  db.add(/*submap_id=*/ 100, descriptorWithBlock(0, 4, 0, 4, 0.6f, 0.5f));
+  db.add(/*submap_id=*/ 101, descriptorWithBlock(12, 16, 12, 16, 0.4f, 0.7f));
+  db.add(/*submap_id=*/ 102, descriptorWithBlock(3, 9, 9, 15, 0.5f, 0.4f));
 
   // Query roughly matches submap 102.
   const auto query = descriptorWithBlock(3, 9, 9, 15, 0.5f, 0.4f);
   const auto matches = queryDatabaseWithMutualVisibility(
     db, query,
-    /*num_matches=*/1,
-    /*num_candidates=*/3,
-    /*exclude_recent=*/0,
-    /*threshold=*/0.5);
+    /*num_matches=*/ 1,
+    /*num_candidates=*/ 3,
+    /*exclude_recent=*/ 0,
+    /*threshold=*/ 0.5);
   ASSERT_EQ(1u, matches.size());
   EXPECT_EQ(102, matches.front().submap_id);
   EXPECT_LT(matches.front().distance, 0.2);
@@ -251,10 +252,10 @@ TEST(BevMutualVisibilityDatabase, RespectsExcludeRecent)
   const auto query = descriptorWithBlock(3, 9, 9, 15, 0.5f, 0.4f);
   const auto matches = queryDatabaseWithMutualVisibility(
     db, query,
-    /*num_matches=*/1,
-    /*num_candidates=*/2,
-    /*exclude_recent=*/1,  // skip submap 51
-    /*threshold=*/0.5);
+    /*num_matches=*/ 1,
+    /*num_candidates=*/ 2,
+    /*exclude_recent=*/ 1,  // skip submap 51
+    /*threshold=*/ 0.5);
   ASSERT_EQ(1u, matches.size());
   EXPECT_EQ(50, matches.front().submap_id);
 }
@@ -271,10 +272,10 @@ TEST(BevMutualVisibilityDatabase, ReturnsEmptyWhenNoCandidateMeetsThreshold)
   const auto query = descriptorWithBlock(12, 16, 0, 4, 0.50f, 0.50f);
   const auto matches = queryDatabaseWithMutualVisibility(
     db, query,
-    /*num_matches=*/2,
-    /*num_candidates=*/2,
-    /*exclude_recent=*/0,
-    /*threshold=*/0.2);
+    /*num_matches=*/ 2,
+    /*num_candidates=*/ 2,
+    /*exclude_recent=*/ 0,
+    /*threshold=*/ 0.2);
   EXPECT_TRUE(matches.empty());
 }
 
@@ -283,7 +284,7 @@ TEST(BevMutualVisibilityDatabase, EmptyDatabaseReturnsNoMatches)
   SubmapBEVDescriptor::Database db(16.0, kGrid, 4);
   const auto query = descriptorWithBlock(3, 9, 9, 15, 0.5f, 0.4f);
   const auto matches = queryDatabaseWithMutualVisibility(
-    db, query, /*num_matches=*/3);
+    db, query, /*num_matches=*/ 3);
   EXPECT_TRUE(matches.empty());
 }
 
@@ -298,10 +299,10 @@ TEST(BevMutualVisibilityDatabase, ReturnsUpToNumMatchesSortedByDistance)
   const auto query = descriptorWithBlock(3, 9, 9, 15, 0.50f, 0.40f);
   const auto matches = queryDatabaseWithMutualVisibility(
     db, query,
-    /*num_matches=*/2,
-    /*num_candidates=*/3,
-    /*exclude_recent=*/0,
-    /*threshold=*/1.5);
+    /*num_matches=*/ 2,
+    /*num_candidates=*/ 3,
+    /*exclude_recent=*/ 0,
+    /*threshold=*/ 1.5);
   ASSERT_EQ(2u, matches.size());
   EXPECT_LE(matches[0].distance, matches[1].distance);
   EXPECT_EQ(1, matches[0].submap_id);

--- a/graph_based_slam/test/test_bev_mutual_visibility.cpp
+++ b/graph_based_slam/test/test_bev_mutual_visibility.cpp
@@ -1,0 +1,199 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "graph_based_slam/bev_mutual_visibility.hpp"
+#include "graph_based_slam/submap_bev_descriptor.hpp"
+
+namespace graphslam
+{
+namespace bev
+{
+namespace
+{
+
+constexpr int kGrid = 16;
+
+SubmapBEVDescriptor::Descriptor makeBlankDescriptor()
+{
+  SubmapBEVDescriptor::Descriptor d;
+  d.occupancy = Eigen::MatrixXf::Zero(kGrid, kGrid);
+  d.density = Eigen::MatrixXf::Zero(kGrid, kGrid);
+  d.max_height = Eigen::MatrixXf::Zero(kGrid, kGrid);
+  return d;
+}
+
+// Place a "feature box" (a rectangular block of occupied cells with given
+// density and height values) into a descriptor at the requested grid offsets.
+void writeBlock(
+  SubmapBEVDescriptor::Descriptor & d,
+  int row_begin, int row_end,
+  int col_begin, int col_end,
+  float density_value,
+  float height_value)
+{
+  for (int r = row_begin; r < row_end; ++r) {
+    for (int c = col_begin; c < col_end; ++c) {
+      if (r < 0 || r >= kGrid || c < 0 || c >= kGrid) {continue;}
+      d.occupancy(r, c) = 1.0f;
+      d.density(r, c) = density_value;
+      d.max_height(r, c) = height_value;
+    }
+  }
+}
+
+TEST(BevMutualVisibility, IdenticalDescriptorsReturnZeroDistance)
+{
+  auto d = makeBlankDescriptor();
+  writeBlock(d, 4, 8, 4, 8, 0.6f, 0.5f);
+  writeBlock(d, 10, 14, 10, 14, 0.3f, 0.8f);
+  const auto res = mutualVisibilityDistance(d, d);
+  EXPECT_TRUE(res.valid);
+  EXPECT_NEAR(0.0, res.distance, 1e-9);
+  EXPECT_GT(res.overlap_ratio, 0.0);
+}
+
+TEST(BevMutualVisibility, DisjointVisibilityReturnsInvalid)
+{
+  auto q = makeBlankDescriptor();
+  auto c = makeBlankDescriptor();
+  writeBlock(q, 0, 4, 0, 4, 0.5f, 0.5f);
+  writeBlock(c, 12, 16, 12, 16, 0.5f, 0.5f);
+  const auto res = mutualVisibilityDistance(q, c);
+  EXPECT_FALSE(res.valid);
+  EXPECT_EQ(0.0, res.overlap_ratio);
+  EXPECT_NEAR(1.0, res.distance, 1e-9);
+}
+
+TEST(BevMutualVisibility, EmptyDescriptorReturnsInvalid)
+{
+  SubmapBEVDescriptor::Descriptor q;
+  SubmapBEVDescriptor::Descriptor c;
+  const auto res = mutualVisibilityDistance(q, c);
+  EXPECT_FALSE(res.valid);
+}
+
+TEST(BevMutualVisibility, RaisingMinOverlapForcesInvalid)
+{
+  auto q = makeBlankDescriptor();
+  auto c = makeBlankDescriptor();
+  writeBlock(q, 6, 8, 6, 8, 0.5f, 0.5f);
+  writeBlock(c, 6, 8, 6, 8, 0.5f, 0.5f);
+  // 4 mutually-visible cells out of 256 ≈ 0.0156 overlap ratio.
+  MutualVisibilityConfig cfg;
+  cfg.min_overlap_ratio = 0.10;  // requires >= 25 cells
+  const auto res = mutualVisibilityDistance(q, c, cfg);
+  EXPECT_FALSE(res.valid);
+}
+
+TEST(BevMutualVisibility, MaskExcludesUnobservedDifferences)
+{
+  // Both descriptors agree on the overlapping region (rows/cols 4..12) but
+  // have completely different content in their non-overlapping observed area.
+  // Mutual-visibility NCC should ignore the disagreement and report a perfect
+  // score, whereas the existing cosine distance would not.
+  auto q = makeBlankDescriptor();
+  auto c = makeBlankDescriptor();
+  writeBlock(q, 4, 12, 4, 12, 0.6f, 0.5f);  // shared block (occupied in both)
+  writeBlock(c, 4, 12, 4, 12, 0.6f, 0.5f);
+  // Region only observed by q (unobserved by c): completely different content.
+  writeBlock(q, 0, 3, 0, 16, 0.95f, 0.9f);
+  // Region only observed by c (unobserved by q).
+  writeBlock(c, 13, 16, 0, 16, 0.95f, 0.9f);
+
+  const auto fov = mutualVisibilityDistance(q, c);
+  EXPECT_TRUE(fov.valid);
+  EXPECT_NEAR(0.0, fov.distance, 1e-9);
+
+  // Sanity: cosine distance does not ignore the divergent regions, so it
+  // should be measurably worse than the mutual-visibility distance.
+  const double cosine = SubmapBEVDescriptor::descriptorDistance(q, c);
+  EXPECT_GT(cosine, fov.distance + 1e-6);
+}
+
+TEST(BevMutualVisibility, DifferentContentInsideMaskRaisesDistance)
+{
+  // Same visibility footprint, but the channel values disagree completely
+  // inside the mask. NCC should report a non-zero distance.
+  auto q = makeBlankDescriptor();
+  auto c = makeBlankDescriptor();
+  for (int r = 4; r < 12; ++r) {
+    for (int col = 4; col < 12; ++col) {
+      q.occupancy(r, col) = 1.0f;
+      c.occupancy(r, col) = 1.0f;
+      q.density(r, col) = (col < 8) ? 0.2f : 0.9f;
+      c.density(r, col) = (col < 8) ? 0.9f : 0.2f;
+      q.max_height(r, col) = (r < 8) ? 0.1f : 0.95f;
+      c.max_height(r, col) = (r < 8) ? 0.95f : 0.1f;
+    }
+  }
+  const auto res = mutualVisibilityDistance(q, c);
+  EXPECT_TRUE(res.valid);
+  EXPECT_GT(res.distance, 0.5);
+}
+
+TEST(BevMutualVisibility, YawSearchPicksAlignmentBin)
+{
+  // Block size must keep overlap_ratio above the default min_overlap of 5%,
+  // i.e. >= 13 of 256 cells in a 16x16 grid.
+  auto base = makeBlankDescriptor();
+  writeBlock(base, 3, 9, 9, 15, 0.5f, 0.5f);
+  // Density varies inside the block so density NCC is informative.
+  for (int r = 3; r < 9; ++r) {
+    for (int c = 9; c < 15; ++c) {
+      base.density(r, c) = 0.3f + 0.1f * static_cast<float>((r + c) % 3);
+    }
+  }
+  // Rotate the candidate by 90° about the centre.
+  const SubmapBEVDescriptor::Descriptor rotated =
+    SubmapBEVDescriptor::rotateDescriptor(base, M_PI / 2.0);
+  const auto match = mutualVisibilityWithYawSearch(base, rotated, /*submap_id=*/7, /*yaw_bins=*/4);
+  EXPECT_TRUE(match.valid);
+  EXPECT_EQ(7, match.submap_id);
+  EXPECT_LT(match.distance, 0.2);
+  // Best yaw should correspond to the inverse rotation (the candidate is the
+  // base rotated by π/2, so rotating it by 3π/2 brings it back).
+  EXPECT_NE(match.yaw_bin, 0);
+}
+
+TEST(BevMutualVisibility, YawSearchInvalidWhenNoOverlap)
+{
+  auto q = makeBlankDescriptor();
+  auto c = makeBlankDescriptor();
+  writeBlock(q, 0, 1, 0, 1, 0.5f, 0.5f);
+  writeBlock(c, 15, 16, 15, 16, 0.5f, 0.5f);
+  const auto match = mutualVisibilityWithYawSearch(q, c, /*submap_id=*/3, /*yaw_bins=*/8);
+  EXPECT_FALSE(match.valid);
+  EXPECT_NEAR(1.0, match.distance, 1e-9);
+}
+
+}  // namespace
+}  // namespace bev
+}  // namespace graphslam

--- a/graph_based_slam/test/test_bev_mutual_visibility.cpp
+++ b/graph_based_slam/test/test_bev_mutual_visibility.cpp
@@ -194,6 +194,119 @@ TEST(BevMutualVisibility, YawSearchInvalidWhenNoOverlap)
   EXPECT_NEAR(1.0, match.distance, 1e-9);
 }
 
+// ------------------------- Database query tests -------------------------
+
+// Build a Descriptor "by hand" so the cell layout is fully controlled and
+// computeCoarseKey runs once at construction. The Database routes its
+// coarse pre-filter through this key.
+SubmapBEVDescriptor::Descriptor finaliseDescriptor(SubmapBEVDescriptor::Descriptor d)
+{
+  // computeCoarseKey is private; rebuild via flatten + average-pool is also
+  // private. Easiest: round-trip through computeDescriptor with an empty
+  // cloud so the public API repopulates coarse_key. Instead reuse the
+  // helper exposed via rotateDescriptor with yaw=0 (regenerates coarse_key).
+  return SubmapBEVDescriptor::rotateDescriptor(d, 0.0);
+}
+
+SubmapBEVDescriptor::Descriptor descriptorWithBlock(
+  int row_begin, int row_end, int col_begin, int col_end,
+  float density_value, float height_value)
+{
+  auto d = makeBlankDescriptor();
+  writeBlock(d, row_begin, row_end, col_begin, col_end, density_value, height_value);
+  return finaliseDescriptor(d);
+}
+
+TEST(BevMutualVisibilityDatabase, FindsMatchingSubmapAndIgnoresUnrelated)
+{
+  SubmapBEVDescriptor::Database db(
+    /*grid_size_m=*/16.0,
+    /*grid_cells=*/kGrid,
+    /*yaw_bins=*/4);
+  // Two unrelated submaps + one that overlaps the query.
+  db.add(/*submap_id=*/100, descriptorWithBlock(0, 4, 0, 4, 0.6f, 0.5f));
+  db.add(/*submap_id=*/101, descriptorWithBlock(12, 16, 12, 16, 0.4f, 0.7f));
+  db.add(/*submap_id=*/102, descriptorWithBlock(3, 9, 9, 15, 0.5f, 0.4f));
+
+  // Query roughly matches submap 102.
+  const auto query = descriptorWithBlock(3, 9, 9, 15, 0.5f, 0.4f);
+  const auto matches = queryDatabaseWithMutualVisibility(
+    db, query,
+    /*num_matches=*/1,
+    /*num_candidates=*/3,
+    /*exclude_recent=*/0,
+    /*threshold=*/0.5);
+  ASSERT_EQ(1u, matches.size());
+  EXPECT_EQ(102, matches.front().submap_id);
+  EXPECT_LT(matches.front().distance, 0.2);
+  EXPECT_TRUE(matches.front().valid);
+}
+
+TEST(BevMutualVisibilityDatabase, RespectsExcludeRecent)
+{
+  SubmapBEVDescriptor::Database db(16.0, kGrid, 4);
+  db.add(50, descriptorWithBlock(3, 9, 9, 15, 0.5f, 0.4f));
+  db.add(51, descriptorWithBlock(3, 9, 9, 15, 0.5f, 0.4f));  // recent match
+
+  const auto query = descriptorWithBlock(3, 9, 9, 15, 0.5f, 0.4f);
+  const auto matches = queryDatabaseWithMutualVisibility(
+    db, query,
+    /*num_matches=*/1,
+    /*num_candidates=*/2,
+    /*exclude_recent=*/1,  // skip submap 51
+    /*threshold=*/0.5);
+  ASSERT_EQ(1u, matches.size());
+  EXPECT_EQ(50, matches.front().submap_id);
+}
+
+TEST(BevMutualVisibilityDatabase, ReturnsEmptyWhenNoCandidateMeetsThreshold)
+{
+  SubmapBEVDescriptor::Database db(16.0, kGrid, 4);
+  // Candidates overlap with the query under some yaw rotation but their
+  // density/height values disagree, so the mutual-visibility distance is far
+  // above the threshold.
+  db.add(10, descriptorWithBlock(0, 4, 0, 4, 0.95f, 0.05f));
+  db.add(11, descriptorWithBlock(0, 4, 12, 16, 0.05f, 0.95f));
+
+  const auto query = descriptorWithBlock(12, 16, 0, 4, 0.50f, 0.50f);
+  const auto matches = queryDatabaseWithMutualVisibility(
+    db, query,
+    /*num_matches=*/2,
+    /*num_candidates=*/2,
+    /*exclude_recent=*/0,
+    /*threshold=*/0.2);
+  EXPECT_TRUE(matches.empty());
+}
+
+TEST(BevMutualVisibilityDatabase, EmptyDatabaseReturnsNoMatches)
+{
+  SubmapBEVDescriptor::Database db(16.0, kGrid, 4);
+  const auto query = descriptorWithBlock(3, 9, 9, 15, 0.5f, 0.4f);
+  const auto matches = queryDatabaseWithMutualVisibility(
+    db, query, /*num_matches=*/3);
+  EXPECT_TRUE(matches.empty());
+}
+
+TEST(BevMutualVisibilityDatabase, ReturnsUpToNumMatchesSortedByDistance)
+{
+  SubmapBEVDescriptor::Database db(16.0, kGrid, 4);
+  // Three submaps all overlap with the query but with different content.
+  db.add(1, descriptorWithBlock(3, 9, 9, 15, 0.50f, 0.40f));  // best
+  db.add(2, descriptorWithBlock(3, 9, 9, 15, 0.45f, 0.55f));  // mid
+  db.add(3, descriptorWithBlock(3, 9, 9, 15, 0.10f, 0.95f));  // worst
+
+  const auto query = descriptorWithBlock(3, 9, 9, 15, 0.50f, 0.40f);
+  const auto matches = queryDatabaseWithMutualVisibility(
+    db, query,
+    /*num_matches=*/2,
+    /*num_candidates=*/3,
+    /*exclude_recent=*/0,
+    /*threshold=*/1.5);
+  ASSERT_EQ(2u, matches.size());
+  EXPECT_LE(matches[0].distance, matches[1].distance);
+  EXPECT_EQ(1, matches[0].submap_id);
+}
+
 }  // namespace
 }  // namespace bev
 }  // namespace graphslam

--- a/graph_based_slam/test/test_loop_edge_robustifier.cpp
+++ b/graph_based_slam/test/test_loop_edge_robustifier.cpp
@@ -1,0 +1,89 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "graph_based_slam/loop_edge_robustifier.hpp"
+
+namespace graphslam
+{
+namespace robust
+{
+namespace
+{
+
+TEST(LoopEdgeRobustifier, DefaultUnknownStringFallsBackToHuber)
+{
+  EXPECT_EQ(LoopEdgeKernelType::Huber, parseLoopEdgeKernelType(""));
+  EXPECT_EQ(LoopEdgeKernelType::Huber, parseLoopEdgeKernelType("unknown"));
+  EXPECT_EQ(LoopEdgeKernelType::Huber, parseLoopEdgeKernelType("HUbeR"));
+}
+
+TEST(LoopEdgeRobustifier, ParsesDcsCaseInsensitively)
+{
+  EXPECT_EQ(LoopEdgeKernelType::DCS, parseLoopEdgeKernelType("dcs"));
+  EXPECT_EQ(LoopEdgeKernelType::DCS, parseLoopEdgeKernelType("DCS"));
+  EXPECT_EQ(LoopEdgeKernelType::DCS, parseLoopEdgeKernelType("Dcs"));
+}
+
+TEST(LoopEdgeRobustifier, ParsesCauchyCaseInsensitively)
+{
+  EXPECT_EQ(LoopEdgeKernelType::Cauchy, parseLoopEdgeKernelType("cauchy"));
+  EXPECT_EQ(LoopEdgeKernelType::Cauchy, parseLoopEdgeKernelType("CAUCHY"));
+}
+
+TEST(LoopEdgeRobustifier, NamesRoundTrip)
+{
+  for (const auto type :
+    {LoopEdgeKernelType::Huber, LoopEdgeKernelType::DCS, LoopEdgeKernelType::Cauchy})
+  {
+    const std::string name = loopEdgeKernelTypeName(type);
+    EXPECT_EQ(type, parseLoopEdgeKernelType(name));
+  }
+}
+
+TEST(LoopEdgeRobustifier, NamesAreLowerCaseAscii)
+{
+  EXPECT_STREQ("huber", loopEdgeKernelTypeName(LoopEdgeKernelType::Huber));
+  EXPECT_STREQ("dcs", loopEdgeKernelTypeName(LoopEdgeKernelType::DCS));
+  EXPECT_STREQ("cauchy", loopEdgeKernelTypeName(LoopEdgeKernelType::Cauchy));
+}
+
+TEST(LoopEdgeRobustifier, ToLowerAsciiHandlesEmptyAndMixed)
+{
+  EXPECT_EQ("", toLowerAscii(""));
+  EXPECT_EQ("abc123", toLowerAscii("AbC123"));
+  EXPECT_EQ("test_kernel", toLowerAscii("TEST_KERNEL"));
+}
+
+}  // namespace
+}  // namespace robust
+}  // namespace graphslam

--- a/lidarslam/test/test_aggregate_kitti_metrics.py
+++ b/lidarslam/test/test_aggregate_kitti_metrics.py
@@ -1,0 +1,152 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Regression tests for KITTI metric aggregation."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / 'scripts' / 'aggregate_kitti_metrics.py'
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location('aggregate_kitti_metrics', SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding='utf-8')
+
+
+def test_label_prefix_overrides_json_label(tmp_path: Path):
+    module = _load_module()
+    p = tmp_path / 'm.json'
+    _write_json(p, {'label': 'from_json', 't_rel_percent_avg': 1.0,
+                    'r_rel_deg_per_m_avg': 0.001, 'sequence': '00'})
+    [rec] = module.load_metric_files([f'forced::{p}'])
+    assert rec['label'] == 'forced'
+    assert rec['sequence'] == '00'
+
+
+def test_sequence_inferred_from_path_when_missing(tmp_path: Path):
+    module = _load_module()
+    p = tmp_path / 'kitti_bench_05_run' / 'metrics.json'
+    _write_json(p, {'t_rel_percent_avg': 1.2, 'r_rel_deg_per_m_avg': 0.002})
+    [rec] = module.load_metric_files([str(p)])
+    assert rec['sequence'] == '05'
+
+
+def test_sequence_inferred_from_seq_prefix(tmp_path: Path):
+    module = _load_module()
+    p = tmp_path / 'seq07_kiss.json'
+    _write_json(p, {'t_rel_percent_avg': 0.5, 'r_rel_deg_per_m_avg': 0.001})
+    [rec] = module.load_metric_files([str(p)])
+    assert rec['sequence'] == '07'
+
+
+def test_missing_input_file_raises(tmp_path: Path):
+    module = _load_module()
+    with pytest.raises(FileNotFoundError):
+        module.load_metric_files([str(tmp_path / 'does_not_exist.json')])
+
+
+def test_single_estimator_uses_flat_table(tmp_path: Path):
+    module = _load_module()
+    p00 = tmp_path / 'seq00.json'
+    p05 = tmp_path / 'seq05.json'
+    _write_json(p00, {'sequence': '00', 't_rel_percent_avg': 0.50,
+                      'r_rel_deg_per_m_avg': 0.002, 'pairs_total': 1200, 'frames': 4541})
+    _write_json(p05, {'sequence': '05', 't_rel_percent_avg': 0.70,
+                      'r_rel_deg_per_m_avg': 0.003, 'pairs_total': 800, 'frames': 2761})
+    recs = module.load_metric_files([f'ours::{p00}', f'ours::{p05}'])
+    md = module.render_markdown(recs)
+    assert '## Per-run metrics' in md
+    assert '0.500' in md
+    assert '0.700' in md
+    assert 'average t_rel: 0.600%' in md
+
+
+def test_two_estimators_render_side_by_side(tmp_path: Path):
+    module = _load_module()
+    p_ours_00 = tmp_path / 'ours_00.json'
+    p_kiss_00 = tmp_path / 'kiss_00.json'
+    p_ours_05 = tmp_path / 'ours_05.json'
+    p_kiss_05 = tmp_path / 'kiss_05.json'
+    _write_json(p_ours_00, {'sequence': '00', 't_rel_percent_avg': 0.50,
+                            'r_rel_deg_per_m_avg': 0.002})
+    _write_json(p_kiss_00, {'sequence': '00', 't_rel_percent_avg': 0.60,
+                            'r_rel_deg_per_m_avg': 0.0025})
+    _write_json(p_ours_05, {'sequence': '05', 't_rel_percent_avg': 0.70,
+                            'r_rel_deg_per_m_avg': 0.003})
+    _write_json(p_kiss_05, {'sequence': '05', 't_rel_percent_avg': 0.80,
+                            'r_rel_deg_per_m_avg': 0.0035})
+    recs = module.load_metric_files(
+        [
+            f'ours::{p_ours_00}', f'kiss::{p_kiss_00}',
+            f'ours::{p_ours_05}', f'kiss::{p_kiss_05}',
+        ]
+    )
+    md = module.render_markdown(recs)
+    assert '## Per-sequence comparison' in md
+    assert '## Aggregate per estimator' in md
+    # Aggregate row for ours: avg t_rel = (0.50 + 0.70)/2 = 0.600
+    assert '| ours | 2 | 0.600 |' in md
+    # Aggregate row for kiss: avg t_rel = (0.60 + 0.80)/2 = 0.700
+    assert '| kiss | 2 | 0.700 |' in md
+
+
+def test_render_with_no_records_returns_placeholder():
+    module = _load_module()
+    md = module.render_markdown([])
+    assert 'No input metrics' in md
+
+
+def test_cli_writes_markdown(tmp_path: Path):
+    module = _load_module()
+    p = tmp_path / 'seq00.json'
+    _write_json(p, {'sequence': '00', 't_rel_percent_avg': 0.42,
+                    'r_rel_deg_per_m_avg': 0.001, 'pairs_total': 100, 'frames': 4000})
+    out_md = tmp_path / 'report.md'
+    rc = module.main(['--input', f'ours::{p}', '--out-md', str(out_md)])
+    assert rc == 0
+    body = out_md.read_text()
+    assert 'KITTI Odometry aggregate report' in body
+    assert '0.420' in body

--- a/lidarslam/test/test_benchmark_summary_profiles.py
+++ b/lidarslam/test/test_benchmark_summary_profiles.py
@@ -1,0 +1,280 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Regression tests for release-profile gate evaluation in benchmark_summary."""
+
+from __future__ import annotations
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / 'scripts' / 'benchmark_summary.py'
+DEFAULT_PROFILE_YAML = REPO_ROOT / 'scripts' / 'release_profiles.yaml'
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location('benchmark_summary', SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _rec(**overrides):
+    base = {
+        'run': overrides.get('run', 'r0'),
+        'bag': overrides.get('bag', 'demo_bag'),
+        'points_topic': overrides.get('points_topic', '/livox/lidar'),
+        'ape_ref_kind': overrides.get('ape_ref_kind', 'ground_truth'),
+        'ape_ref_src': overrides.get('ape_ref_src', 'leica_prism_gt'),
+        'ape_rmse_m': overrides.get('ape_rmse_m', '0.500'),
+        'ape_pairs': overrides.get('ape_pairs', 500),
+    }
+    return base
+
+
+def test_default_release_profiles_yaml_loads():
+    """The shipped scripts/release_profiles.yaml must parse without errors."""
+    module = _load_module()
+    profiles = module.load_release_profiles(DEFAULT_PROFILE_YAML)
+    names = [p['name'] for p in profiles]
+    assert 'newer_college_math_hard' in names
+    assert 'mid360_vs_glim' in names
+
+
+def test_load_release_profiles_rejects_unknown_metric(tmp_path: Path):
+    module = _load_module()
+    bad = tmp_path / 'bad.yaml'
+    bad.write_text(
+        textwrap.dedent(
+            """
+            release_profiles:
+              - name: x
+                metric: not_a_metric
+                pass: 1.0
+            """
+        )
+    )
+    with pytest.raises(ValueError, match='metric must be one of'):
+        module.load_release_profiles(bad)
+
+
+def test_load_release_profiles_rejects_duplicate_name(tmp_path: Path):
+    module = _load_module()
+    bad = tmp_path / 'bad.yaml'
+    bad.write_text(
+        textwrap.dedent(
+            """
+            release_profiles:
+              - name: dup
+                metric: ape_rmse_gt_m
+                pass: 1.0
+              - name: dup
+                metric: ape_rmse_gt_m
+                pass: 1.0
+            """
+        )
+    )
+    with pytest.raises(ValueError, match='duplicate profile name'):
+        module.load_release_profiles(bad)
+
+
+def test_evaluate_pass_picks_best_matching_run():
+    module = _load_module()
+    profile = {
+        'name': 'p',
+        'metric': 'ape_rmse_gt_m',
+        'pass': 1.0,
+        'match': {'bag_name_contains': 'tnp_01', 'reference_kind': 'ground_truth'},
+    }
+    records = [
+        _rec(run='a', bag='tnp_01_run', ape_rmse_m='0.95'),
+        _rec(run='b', bag='tnp_01_run', ape_rmse_m='0.80'),
+        _rec(run='c', bag='unrelated_run', ape_rmse_m='0.10'),
+    ]
+    [result] = module.evaluate_release_profiles([profile], records)
+    assert result['status'] == 'PASS'
+    assert result['best_run'] == 'b'
+    assert result['best_value'] == pytest.approx(0.80)
+
+
+def test_evaluate_target_met_when_under_target():
+    module = _load_module()
+    profile = {
+        'name': 'p',
+        'metric': 'ape_rmse_gt_m',
+        'pass': 1.0,
+        'target': 0.5,
+        'match': {'bag_name_contains': 'foo'},
+    }
+    records = [_rec(run='a', bag='foo_run', ape_rmse_m='0.30')]
+    [result] = module.evaluate_release_profiles([profile], records)
+    assert result['status'] == 'TARGET_MET'
+
+
+def test_evaluate_fail_when_over_pass_without_report_only():
+    module = _load_module()
+    profile = {
+        'name': 'p',
+        'metric': 'ape_rmse_gt_m',
+        'pass': 0.10,
+        'match': {'bag_name_contains': 'foo'},
+    }
+    records = [_rec(run='a', bag='foo_run', ape_rmse_m='0.95')]
+    [result] = module.evaluate_release_profiles([profile], records)
+    assert result['status'] == 'FAIL'
+
+
+def test_evaluate_warn_when_over_pass_with_report_only_until():
+    module = _load_module()
+    profile = {
+        'name': 'p',
+        'metric': 'ape_rmse_gt_m',
+        'pass': 0.10,
+        'report_only_until': 'v0.4',
+        'match': {'bag_name_contains': 'foo'},
+    }
+    records = [_rec(run='a', bag='foo_run', ape_rmse_m='0.95')]
+    [result] = module.evaluate_release_profiles([profile], records)
+    assert result['status'] == 'WARN'
+
+
+def test_evaluate_no_data_when_no_matches():
+    module = _load_module()
+    profile = {
+        'name': 'p',
+        'metric': 'ape_rmse_gt_m',
+        'pass': 0.10,
+        'match': {'bag_name_contains': 'nothing'},
+    }
+    records = [_rec(run='a', bag='foo', ape_rmse_m='0.5')]
+    [result] = module.evaluate_release_profiles([profile], records)
+    assert result['status'] == 'NO_DATA'
+    assert result['best_run'] is None
+
+
+def test_metric_ape_rmse_gt_m_skips_cross_validation():
+    """ape_rmse_gt_m must only score ground_truth references."""
+    module = _load_module()
+    profile = {
+        'name': 'p',
+        'metric': 'ape_rmse_gt_m',
+        'pass': 1.0,
+        'match': {'bag_name_contains': 'foo'},
+    }
+    records = [
+        _rec(run='cv', bag='foo', ape_ref_kind='cross_validation', ape_rmse_m='0.10'),
+        _rec(run='gt', bag='foo', ape_ref_kind='ground_truth', ape_rmse_m='0.50'),
+    ]
+    [result] = module.evaluate_release_profiles([profile], records)
+    assert result['best_run'] == 'gt'
+    assert result['best_value'] == pytest.approx(0.50)
+
+
+def test_min_ape_pairs_filters_incomplete_runs():
+    """Match should drop runs whose APE was computed on too few pose pairs."""
+    module = _load_module()
+    profile = {
+        'name': 'p',
+        'metric': 'ape_rmse_vs_reference_m',
+        'pass': 4.0,
+        'match': {
+            'points_topic': '/livox/lidar',
+            'reference_kind': 'cross_validation',
+            'min_ape_pairs': 400,
+        },
+    }
+    records = [
+        _rec(run='partial', ape_ref_kind='cross_validation', ape_rmse_m='0.11', ape_pairs=119),
+        _rec(run='full', ape_ref_kind='cross_validation', ape_rmse_m='3.45', ape_pairs=580),
+    ]
+    [result] = module.evaluate_release_profiles([profile], records)
+    assert result['best_run'] == 'full'
+    assert result['best_value'] == pytest.approx(3.45)
+
+
+def test_profile_match_combines_predicates():
+    """All predicates in match must hold simultaneously (AND semantics)."""
+    module = _load_module()
+    profile = {
+        'name': 'p',
+        'metric': 'ape_rmse_vs_reference_m',
+        'pass': 1.0,
+        'match': {
+            'points_topic': '/livox/lidar',
+            'reference_source_contains': 'glim_mid360',
+        },
+    }
+    records = [
+        _rec(run='other_topic',
+             points_topic='/os1/points',
+             ape_ref_kind='cross_validation',
+             ape_ref_src='glim_mid360_reference',
+             ape_rmse_m='0.1'),
+        _rec(run='other_ref',
+             points_topic='/livox/lidar',
+             ape_ref_kind='cross_validation',
+             ape_ref_src='applanix_gsof49_reference',
+             ape_rmse_m='0.2'),
+        _rec(run='match_me',
+             points_topic='/livox/lidar',
+             ape_ref_kind='cross_validation',
+             ape_ref_src='glim_mid360_reference',
+             ape_rmse_m='0.3'),
+    ]
+    [result] = module.evaluate_release_profiles([profile], records)
+    assert result['best_run'] == 'match_me'
+
+
+def test_render_release_profile_section_has_required_columns():
+    module = _load_module()
+    results = [
+        {
+            'name': 'newer',
+            'status': 'PASS',
+            'metric': 'ape_rmse_gt_m',
+            'best_run': 'r1',
+            'best_value': 0.08,
+            'pass': 0.10,
+            'target': 0.08,
+            'report_only_until': None,
+        }
+    ]
+    lines = module.render_release_profile_section(results)
+    body = '\n'.join(lines)
+    assert '## Release profile gate' in body
+    assert 'newer' in body
+    assert 'PASS' in body
+    assert 'ape_rmse_gt_m' in body

--- a/lidarslam/test/test_benchmark_summary_profiles.py
+++ b/lidarslam/test/test_benchmark_summary_profiles.py
@@ -32,8 +32,8 @@
 from __future__ import annotations
 
 import importlib.util
-import textwrap
 from pathlib import Path
+import textwrap
 
 import pytest
 

--- a/lidarslam/test/test_kitti_metrics.py
+++ b/lidarslam/test/test_kitti_metrics.py
@@ -69,10 +69,7 @@ def _straight_line_tum(length_m: float = 1000.0, step_m: float = 1.0) -> np.ndar
 
 def _curved_path_tum(radius_m: float = 200.0, total_arc_m: float = 1000.0,
                      step_m: float = 1.0) -> np.ndarray:
-    """Build a TUM array along an arc on a circle of given radius (xy plane).
-
-    Yaw rotates so that +x always points along the tangent.
-    """
+    """Build an arc on a circle (xy plane); yaw stays aligned with +x tangent."""
     n = int(total_arc_m / step_m) + 1
     ts = np.arange(n) * 0.1
     rows = []

--- a/lidarslam/test/test_kitti_metrics.py
+++ b/lidarslam/test/test_kitti_metrics.py
@@ -1,0 +1,196 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Regression tests for the KITTI drift metric helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / 'scripts' / 'kitti_metrics.py'
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location('kitti_metrics', SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _identity_quat() -> np.ndarray:
+    return np.array([0.0, 0.0, 0.0, 1.0])
+
+
+def _straight_line_tum(length_m: float = 1000.0, step_m: float = 1.0) -> np.ndarray:
+    """Build a TUM array along +x at 1 m spacing with identity rotations."""
+    n = int(length_m / step_m) + 1
+    ts = np.arange(n) * 0.1
+    xs = np.arange(n) * step_m
+    rows = []
+    for i in range(n):
+        rows.append([ts[i], xs[i], 0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+    return np.array(rows)
+
+
+def _curved_path_tum(radius_m: float = 200.0, total_arc_m: float = 1000.0,
+                     step_m: float = 1.0) -> np.ndarray:
+    """Build a TUM array along an arc on a circle of given radius (xy plane).
+
+    Yaw rotates so that +x always points along the tangent.
+    """
+    n = int(total_arc_m / step_m) + 1
+    ts = np.arange(n) * 0.1
+    rows = []
+    for i in range(n):
+        s = i * step_m
+        theta = s / radius_m
+        x = radius_m * math.sin(theta)
+        y = radius_m * (1.0 - math.cos(theta))
+        # quaternion for yaw rotation by theta about +z
+        qz = math.sin(theta * 0.5)
+        qw = math.cos(theta * 0.5)
+        rows.append([ts[i], x, y, 0.0, 0.0, 0.0, qz, qw])
+    return np.array(rows)
+
+
+def test_perfect_estimate_yields_zero_drift():
+    module = _load_module()
+    tum = _straight_line_tum(length_m=1000.0)
+    poses = module.tum_to_poses(tum)
+    metrics = module.compute_kitti_errors(poses, poses.copy())
+    assert metrics['t_rel_percent_avg'] == pytest.approx(0.0, abs=1e-9)
+    assert metrics['r_rel_deg_per_m_avg'] == pytest.approx(0.0, abs=1e-9)
+    assert metrics['pairs_total'] > 0
+
+
+def test_global_se3_transform_does_not_change_drift():
+    """KITTI drift is invariant to a global SE(3) shift of the estimate."""
+    module = _load_module()
+    tum = _curved_path_tum()
+    gt = module.tum_to_poses(tum)
+    rot = np.array(
+        [
+            [math.cos(0.3), -math.sin(0.3), 0.0, 5.0],
+            [math.sin(0.3), math.cos(0.3), 0.0, -2.0],
+            [0.0, 0.0, 1.0, 1.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    est = np.einsum('ij,njk->nik', rot, gt)
+    metrics = module.compute_kitti_errors(gt, est)
+    assert metrics['t_rel_percent_avg'] == pytest.approx(0.0, abs=1e-7)
+    assert metrics['r_rel_deg_per_m_avg'] == pytest.approx(0.0, abs=1e-7)
+
+
+def test_constant_translational_drift_rate_is_reported_correctly():
+    """A 1% along-track over-shoot must show up as ~1% t_rel."""
+    module = _load_module()
+    gt_tum = _straight_line_tum(length_m=1000.0, step_m=1.0)
+    est_tum = gt_tum.copy()
+    est_tum[:, 1] = est_tum[:, 1] * 1.01  # stretch x by +1%
+    gt_poses = module.tum_to_poses(gt_tum)
+    est_poses = module.tum_to_poses(est_tum)
+    metrics = module.compute_kitti_errors(gt_poses, est_poses)
+    assert metrics['t_rel_percent_avg'] == pytest.approx(1.0, rel=1e-3)
+
+
+def test_per_length_breakdown_includes_all_requested_lengths():
+    module = _load_module()
+    tum = _curved_path_tum(radius_m=200.0, total_arc_m=1000.0)
+    gt = module.tum_to_poses(tum)
+    metrics = module.compute_kitti_errors(
+        gt, gt.copy(), lengths_m=(100, 200, 400, 800)
+    )
+    assert set(metrics['per_length'].keys()) == {100, 200, 400, 800}
+    for L, stats in metrics['per_length'].items():
+        assert stats['pairs'] > 0, f'no pairs for L={L}'
+
+
+def test_returns_none_when_no_window_fits():
+    """If the trajectory is shorter than the smallest window, no pairs."""
+    module = _load_module()
+    tum = _straight_line_tum(length_m=50.0, step_m=1.0)
+    poses = module.tum_to_poses(tum)
+    metrics = module.compute_kitti_errors(poses, poses, lengths_m=(100, 200))
+    assert metrics['t_rel_percent_avg'] is None
+    assert metrics['r_rel_deg_per_m_avg'] is None
+    assert metrics['pairs_total'] == 0
+
+
+def test_pose_shape_mismatch_raises():
+    module = _load_module()
+    a = np.tile(np.eye(4), (10, 1, 1))
+    b = np.tile(np.eye(4), (5, 1, 1))
+    with pytest.raises(ValueError, match='shape mismatch'):
+        module.compute_kitti_errors(a, b)
+
+
+def test_quat_to_R_normalises_input():
+    """Non-unit quaternions should still produce a proper rotation matrix."""
+    module = _load_module()
+    R = module._quat_to_R(np.array([0.0, 0.0, 2.0, 2.0]))  # not unit norm
+    assert np.allclose(R @ R.T, np.eye(3), atol=1e-9)
+    assert np.isclose(np.linalg.det(R), 1.0, atol=1e-9)
+
+
+def test_cli_writes_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """End-to-end smoke: TUM in → JSON metrics out via the CLI entrypoint."""
+    module = _load_module()
+    gt = _straight_line_tum(length_m=1000.0)
+    est = gt.copy()
+    est[:, 1] = est[:, 1] * 1.02  # +2% along-track drift
+    gt_path = tmp_path / 'gt.tum'
+    est_path = tmp_path / 'est.tum'
+    out_json = tmp_path / 'out.json'
+    np.savetxt(gt_path, gt, fmt='%.6f')
+    np.savetxt(est_path, est, fmt='%.6f')
+
+    rc = module.main(
+        [
+            '--gt', str(gt_path),
+            '--est', str(est_path),
+            '--out-json', str(out_json),
+            '--label', 'unit_test',
+        ]
+    )
+    assert rc == 0
+    import json
+    data = json.loads(out_json.read_text())
+    assert data['label'] == 'unit_test'
+    assert data['t_rel_percent_avg'] == pytest.approx(2.0, rel=1e-3)
+    assert data['frames'] == len(gt)

--- a/lidarslam/test/test_simple_lanelet2_generator.py
+++ b/lidarslam/test/test_simple_lanelet2_generator.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Regression tests for the simple Lanelet2 generator helper script."""
+
+from __future__ import annotations
+
+import importlib.util
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / 'scripts' / 'simple_lanelet2_generator.py'
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location('simple_lanelet2_generator', SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _straight_trajectory(n_pts: int = 80, dx: float = 1.0) -> np.ndarray:
+    """Build a synthetic centreline along +x at 1 m spacing."""
+    xs = np.arange(n_pts) * dx
+    ys = np.zeros(n_pts)
+    zs = np.zeros(n_pts)
+    return np.column_stack([xs, ys, zs])
+
+
+def _build_osm(module, n_pts: int = 80, segment_length: int = 25,
+               add_local_coords: bool = True):
+    centre = _straight_trajectory(n_pts)
+    left, right = module.offset_boundaries(centre, half_width=1.75)
+    return module.build_osm(
+        left,
+        right,
+        origin_lat=35.6862,
+        origin_lon=139.6891,
+        speed_limit=20.0,
+        segment_length=segment_length,
+        add_local_coords=add_local_coords,
+    )
+
+
+def test_multi_segment_emits_multiple_lanelets():
+    module = _load_module()
+    osm, n_lanelets = _build_osm(module, n_pts=80, segment_length=25)
+    assert n_lanelets >= 3, f'expected >=3 lanelets for 80pts/seg25, got {n_lanelets}'
+    relations = [r for r in osm.findall('relation')
+                 if any(t.get('k') == 'type' and t.get('v') == 'lanelet'
+                        for t in r.findall('tag'))]
+    assert len(relations) == n_lanelets
+
+
+def test_adjacent_lanelets_share_boundary_node_ids():
+    """The Lanelet2 routing graph relies on node identity, not coordinates."""
+    module = _load_module()
+    osm, _ = _build_osm(module, n_pts=80, segment_length=25)
+
+    ways = {w.get('id'): [nd.get('ref') for nd in w.findall('nd')]
+            for w in osm.findall('way')}
+    lanelets = sorted(
+        [r for r in osm.findall('relation')
+         if any(t.get('k') == 'type' and t.get('v') == 'lanelet'
+                for t in r.findall('tag'))],
+        key=lambda r: int(r.get('id') or '0'),
+    )
+    for a, b in zip(lanelets, lanelets[1:]):
+        a_left = next(m.get('ref') for m in a.findall('member') if m.get('role') == 'left')
+        a_right = next(m.get('ref') for m in a.findall('member') if m.get('role') == 'right')
+        b_left = next(m.get('ref') for m in b.findall('member') if m.get('role') == 'left')
+        b_right = next(m.get('ref') for m in b.findall('member') if m.get('role') == 'right')
+        assert ways[a_left][-1] == ways[b_left][0], (
+            f'left boundary not shared between {a.get("id")} and {b.get("id")}'
+        )
+        assert ways[a_right][-1] == ways[b_right][0], (
+            f'right boundary not shared between {a.get("id")} and {b.get("id")}'
+        )
+
+
+def test_every_node_has_ele_tag():
+    module = _load_module()
+    osm, _ = _build_osm(module)
+    for node in osm.findall('node'):
+        tags = {t.get('k') for t in node.findall('tag')}
+        assert 'ele' in tags, f'node {node.get("id")} missing ele tag'
+
+
+def test_lanelet_relations_carry_required_autoware_tags():
+    module = _load_module()
+    osm, _ = _build_osm(module)
+    for rel in osm.findall('relation'):
+        tag_kv = {t.get('k'): t.get('v') for t in rel.findall('tag')}
+        if tag_kv.get('type') != 'lanelet':
+            continue
+        for required in module.REQUIRED_LANELET_TAGS:
+            assert required in tag_kv, f'lanelet {rel.get("id")} missing tag {required}'
+        assert tag_kv['subtype'] == 'road'
+        assert tag_kv['one_way'] == 'yes'
+        assert tag_kv['participant:vehicle'] == 'yes'
+
+
+def test_local_coords_tags_emitted_by_default():
+    module = _load_module()
+    osm, _ = _build_osm(module, add_local_coords=True)
+    sample = next(iter(osm.findall('node')))
+    keys = {t.get('k') for t in sample.findall('tag')}
+    assert 'local_x' in keys
+    assert 'local_y' in keys
+
+
+def test_local_coords_tags_omitted_when_disabled():
+    module = _load_module()
+    osm, _ = _build_osm(module, add_local_coords=False)
+    sample = next(iter(osm.findall('node')))
+    keys = {t.get('k') for t in sample.findall('tag')}
+    assert 'local_x' not in keys
+    assert 'local_y' not in keys
+
+
+def test_validate_structure_passes_on_generated_map():
+    module = _load_module()
+    osm, _ = _build_osm(module, n_pts=80, segment_length=25)
+    ok, msgs = module.validate_structure(osm)
+    assert ok, '\n'.join(msgs)
+    summary = '\n'.join(msgs)
+    assert 'adjacent lanelets share boundary nodes' in summary
+
+
+def test_validate_structure_catches_broken_node_sharing():
+    """Mutate the OSM so adjacent lanelets no longer share a node."""
+    module = _load_module()
+    osm, _ = _build_osm(module, n_pts=80, segment_length=25)
+
+    ways = {w.get('id'): w for w in osm.findall('way')}
+    lanelets = sorted(
+        [r for r in osm.findall('relation')
+         if any(t.get('k') == 'type' and t.get('v') == 'lanelet'
+                for t in r.findall('tag'))],
+        key=lambda r: int(r.get('id') or '0'),
+    )
+    second_left_way_id = next(
+        m.get('ref') for m in lanelets[1].findall('member') if m.get('role') == 'left'
+    )
+    way = ways[second_left_way_id]
+    way.find('nd').set('ref', '999999')
+
+    ok, msgs = module.validate_structure(osm)
+    assert not ok
+    assert any('does not share' in m for m in msgs)
+
+
+def test_validate_structure_catches_missing_ele():
+    module = _load_module()
+    osm, _ = _build_osm(module)
+    node = osm.find('node')
+    for tag in list(node.findall('tag')):
+        if tag.get('k') == 'ele':
+            node.remove(tag)
+    ok, msgs = module.validate_structure(osm)
+    assert not ok
+    assert any('ele' in m for m in msgs)
+
+
+def test_validate_routing_skips_when_lanelet2_unavailable(tmp_path: Path,
+                                                          monkeypatch: pytest.MonkeyPatch):
+    """The routing check must degrade gracefully without ROS lanelet2 bindings."""
+    module = _load_module()
+    osm, _ = _build_osm(module)
+    out = tmp_path / 'lanelet2_map.osm'
+    module.write_osm(osm, out)
+
+    import builtins
+    real_import = builtins.__import__
+
+    def _blocked(name, *args, **kwargs):
+        if name == 'lanelet2' or name.startswith('lanelet2.'):
+            raise ImportError('forced for test')
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, '__import__', _blocked)
+    result, msgs = module.validate_routing(out, origin_lat=35.6862, origin_lon=139.6891)
+    assert result is None
+    assert any('lanelet2 Python bindings' in m for m in msgs)

--- a/lidarslam/test/test_simple_lanelet2_generator.py
+++ b/lidarslam/test/test_simple_lanelet2_generator.py
@@ -32,7 +32,6 @@
 from __future__ import annotations
 
 import importlib.util
-import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import numpy as np

--- a/scripts/aggregate_kitti_metrics.py
+++ b/scripts/aggregate_kitti_metrics.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Aggregate per-sequence KITTI metric JSONs into a single markdown report.
+
+Each input JSON is the output of ``scripts/kitti_metrics.py``: at minimum it
+must carry ``t_rel_percent_avg`` and ``r_rel_deg_per_m_avg``. The aggregator
+groups results by sequence id (and optionally by estimator label so several
+estimators can be compared side by side) and prints / writes a markdown table.
+
+Usage:
+  python3 scripts/aggregate_kitti_metrics.py \\
+      --input ours::output/kitti/seq00/metrics.json \\
+      --input ours::output/kitti/seq05/metrics.json \\
+      --input kiss::output/kitti/kiss_icp/seq00.json \\
+      --out-md output/kitti_report.md
+
+The ``label::path`` form is preferred when more than one estimator is being
+compared. When the prefix is omitted the file's own ``label`` is used; if both
+are missing the label defaults to ``run``.
+
+Sequence ids are picked up from the JSON's ``sequence`` key when present and
+otherwise inferred from the path with a regex (``seq(\\d+)`` or
+``_(\\d{2})_``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+SEQ_REGEXES = (
+    re.compile(r'seq[_-]?(\d{2})'),
+    re.compile(r'_(\d{2})_(?:rko|small|lo|graph|bench|kitti)'),
+    re.compile(r'_(\d{2})(?:\.|_|$)'),
+)
+
+
+def _infer_sequence(payload: dict[str, Any], path: Path) -> str:
+    seq = payload.get('sequence')
+    if isinstance(seq, (str, int)) and str(seq).strip():
+        return str(seq).strip().zfill(2)
+    text = path.as_posix()
+    for rx in SEQ_REGEXES:
+        m = rx.search(text)
+        if m:
+            return m.group(1).zfill(2)
+    return ''
+
+
+def _parse_input(spec: str) -> tuple[str, Path]:
+    """Split a ``label::path`` argument into (label, path). Label may be empty."""
+    if '::' in spec:
+        label, path = spec.split('::', 1)
+        return label.strip(), Path(path).expanduser()
+    return '', Path(spec).expanduser()
+
+
+def load_metric_files(specs: list[str]) -> list[dict[str, Any]]:
+    """Load each metric JSON and normalise into a flat record dict."""
+    records: list[dict[str, Any]] = []
+    for spec in specs:
+        label_override, path = _parse_input(spec)
+        if not path.exists():
+            raise FileNotFoundError(f'metric file does not exist: {path}')
+        payload = json.loads(path.read_text(encoding='utf-8'))
+        label = label_override or str(payload.get('label') or '') or 'run'
+        records.append(
+            {
+                'label': label,
+                'path': str(path),
+                'sequence': _infer_sequence(payload, path),
+                't_rel_percent_avg': payload.get('t_rel_percent_avg'),
+                'r_rel_deg_per_m_avg': payload.get('r_rel_deg_per_m_avg'),
+                'pairs_total': payload.get('pairs_total'),
+                'frames': payload.get('frames'),
+            }
+        )
+    return records
+
+
+def _fmt(v: object, digits: int = 3) -> str:
+    if v is None:
+        return ''
+    try:
+        return f'{float(v):.{digits}f}'
+    except Exception:
+        return str(v)
+
+
+def render_markdown(records: list[dict[str, Any]]) -> str:
+    """Render aggregated records as a markdown report."""
+    if not records:
+        return '# KITTI Odometry aggregate report\n\nNo input metrics.\n'
+
+    labels = sorted({r['label'] for r in records})
+    sequences = sorted({r['sequence'] for r in records if r['sequence']})
+
+    lines: list[str] = []
+    lines.append('# KITTI Odometry aggregate report')
+    lines.append('')
+    lines.append(f'- inputs: {len(records)}')
+    lines.append(f'- estimators: {", ".join(labels) if labels else "(unlabeled)"}')
+    lines.append(f'- sequences: {", ".join(sequences) if sequences else "(unknown)"}')
+    lines.append('')
+
+    if len(labels) > 1 and sequences:
+        # Side-by-side comparison: one row per sequence, one column per estimator.
+        per_seq: dict[str, dict[str, dict[str, Any]]] = {seq: {} for seq in sequences}
+        for r in records:
+            seq = r['sequence']
+            if not seq:
+                continue
+            per_seq[seq][r['label']] = r
+
+        header = ['sequence'] + [f'{lbl} t_rel%' for lbl in labels] \
+            + [f'{lbl} r_rel°/m' for lbl in labels]
+        lines.append('## Per-sequence comparison')
+        lines.append('')
+        lines.append('| ' + ' | '.join(header) + ' |')
+        lines.append('| ' + ' | '.join(['---'] * len(header)) + ' |')
+        for seq in sequences:
+            row = [seq]
+            for lbl in labels:
+                r = per_seq[seq].get(lbl)
+                row.append(_fmt(r['t_rel_percent_avg']) if r else '')
+            for lbl in labels:
+                r = per_seq[seq].get(lbl)
+                row.append(_fmt(r['r_rel_deg_per_m_avg']) if r else '')
+            lines.append('| ' + ' | '.join(row) + ' |')
+        lines.append('')
+
+        lines.append('## Aggregate per estimator')
+        lines.append('')
+        agg_header = ['estimator', 'sequences', 'avg_t_rel%', 'avg_r_rel°/m']
+        lines.append('| ' + ' | '.join(agg_header) + ' |')
+        lines.append('| ' + ' | '.join(['---'] * len(agg_header)) + ' |')
+        for lbl in labels:
+            sub = [r for r in records if r['label'] == lbl]
+            t_vals = [r['t_rel_percent_avg'] for r in sub if r['t_rel_percent_avg'] is not None]
+            r_vals = [r['r_rel_deg_per_m_avg'] for r in sub if r['r_rel_deg_per_m_avg'] is not None]
+            avg_t = sum(t_vals) / len(t_vals) if t_vals else None
+            avg_r = sum(r_vals) / len(r_vals) if r_vals else None
+            lines.append(
+                '| ' + ' | '.join([lbl, str(len(sub)), _fmt(avg_t), _fmt(avg_r)]) + ' |'
+            )
+        lines.append('')
+    else:
+        lines.append('## Per-run metrics')
+        lines.append('')
+        header = ['estimator', 'sequence', 't_rel_%', 'r_rel_deg/m', 'pairs', 'frames']
+        lines.append('| ' + ' | '.join(header) + ' |')
+        lines.append('| ' + ' | '.join(['---'] * len(header)) + ' |')
+        for r in records:
+            lines.append(
+                '| '
+                + ' | '.join(
+                    [
+                        r['label'],
+                        r['sequence'] or '',
+                        _fmt(r['t_rel_percent_avg']),
+                        _fmt(r['r_rel_deg_per_m_avg']),
+                        str(r.get('pairs_total') or ''),
+                        str(r.get('frames') or ''),
+                    ]
+                )
+                + ' |'
+            )
+        lines.append('')
+
+        t_vals = [r['t_rel_percent_avg'] for r in records if r['t_rel_percent_avg'] is not None]
+        r_vals = [r['r_rel_deg_per_m_avg'] for r in records if r['r_rel_deg_per_m_avg'] is not None]
+        if t_vals:
+            lines.append(f'- average t_rel: {_fmt(sum(t_vals) / len(t_vals))}%')
+        if r_vals:
+            lines.append(f'- average r_rel: {_fmt(sum(r_vals) / len(r_vals))} deg/m')
+
+    return '\n'.join(lines) + '\n'
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description='Aggregate KITTI metric JSONs into a markdown report.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    ap.add_argument(
+        '--input',
+        action='append',
+        default=[],
+        help='Per-run KITTI metric JSON. Optional "label::path" prefix.',
+    )
+    ap.add_argument('--out-md', type=Path, default=None, help='Write report to this path')
+    args = ap.parse_args(argv)
+
+    if not args.input:
+        ap.error('at least one --input is required')
+
+    records = load_metric_files(args.input)
+    report = render_markdown(records)
+    print(report, end='')
+
+    if args.out_md:
+        args.out_md.parent.mkdir(parents=True, exist_ok=True)
+        args.out_md.write_text(report, encoding='utf-8')
+        print(f'wrote {args.out_md}')
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/benchmark_summary.py
+++ b/scripts/benchmark_summary.py
@@ -7,6 +7,19 @@ import statistics
 from pathlib import Path
 from typing import Any
 
+try:
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover - PyYAML missing only on minimal builds
+    yaml = None  # type: ignore
+
+
+# Metric kinds supported by release profiles (extend cautiously - each value
+# must be derivable from a per-run record built below in main()).
+_PROFILE_METRICS = (
+    "ape_rmse_gt_m",
+    "ape_rmse_vs_reference_m",
+)
+
 
 def _fmt_float(v: Any, digits: int = 3) -> str:
     if v is None:
@@ -95,6 +108,160 @@ def _primary_value_text(primary: str, rec: dict[str, Any]) -> str:
     return rec.get("ape_rmse_m", "")
 
 
+def load_release_profiles(path: Path) -> list[dict[str, Any]]:
+    """Load and minimally validate a release-profile YAML file."""
+    if yaml is None:
+        raise RuntimeError(
+            "PyYAML is required to load release profiles; install python3-yaml"
+        )
+    with path.open("r", encoding="utf-8") as f:
+        doc = yaml.safe_load(f) or {}
+    profiles = doc.get("release_profiles")
+    if not isinstance(profiles, list):
+        raise ValueError(
+            f"{path}: expected top-level key 'release_profiles' to be a list"
+        )
+    validated: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for i, prof in enumerate(profiles):
+        if not isinstance(prof, dict):
+            raise ValueError(f"{path}: profile index {i} is not a mapping")
+        name = prof.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"{path}: profile index {i} missing 'name'")
+        if name in seen:
+            raise ValueError(f"{path}: duplicate profile name '{name}'")
+        seen.add(name)
+        metric = prof.get("metric")
+        if metric not in _PROFILE_METRICS:
+            raise ValueError(
+                f"{path}: profile '{name}' metric must be one of {_PROFILE_METRICS}, "
+                f"got {metric!r}"
+            )
+        if not isinstance(prof.get("pass"), (int, float)):
+            raise ValueError(f"{path}: profile '{name}' missing numeric 'pass'")
+        match = prof.get("match") or {}
+        if not isinstance(match, dict):
+            raise ValueError(f"{path}: profile '{name}' 'match' must be a mapping")
+        validated.append(prof)
+    return validated
+
+
+def _profile_match(profile: dict[str, Any], rec: dict[str, Any]) -> bool:
+    match = profile.get("match") or {}
+    bag_substr = match.get("bag_name_contains")
+    if bag_substr and bag_substr not in (rec.get("bag") or ""):
+        return False
+    points_topic = match.get("points_topic")
+    if points_topic and points_topic != (rec.get("points_topic") or ""):
+        return False
+    ref_kind = match.get("reference_kind")
+    if ref_kind and ref_kind != (rec.get("ape_ref_kind") or ""):
+        return False
+    ref_substr = match.get("reference_source_contains")
+    if ref_substr and ref_substr not in (rec.get("ape_ref_src") or ""):
+        return False
+    min_pairs = match.get("min_ape_pairs")
+    if min_pairs is not None:
+        pairs = _as_float(rec.get("ape_pairs"))
+        if pairs is None or pairs < float(min_pairs):
+            return False
+    return True
+
+
+def _profile_metric_value(profile: dict[str, Any], rec: dict[str, Any]) -> float | None:
+    metric = profile.get("metric")
+    if metric == "ape_rmse_gt_m":
+        if (rec.get("ape_ref_kind") or "") != "ground_truth":
+            return None
+        return _as_float(rec.get("ape_rmse_m"))
+    if metric == "ape_rmse_vs_reference_m":
+        return _as_float(rec.get("ape_rmse_m"))
+    return None
+
+
+def evaluate_release_profiles(
+    profiles: list[dict[str, Any]],
+    records: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """For each profile, find the best matching run and assign a status.
+
+    Status values:
+      PASS        - best matching metric <= pass threshold
+      FAIL        - best matching metric > pass threshold (gate active)
+      WARN        - same as FAIL but profile has report_only_until set
+      NO_DATA     - no matching runs found
+      TARGET_MET  - PASS and metric <= target (display-only bonus)
+    """
+    results: list[dict[str, Any]] = []
+    for prof in profiles:
+        matched = [
+            rec for rec in records
+            if _profile_match(prof, rec)
+            and _profile_metric_value(prof, rec) is not None
+        ]
+        result: dict[str, Any] = {
+            "name": prof["name"],
+            "description": prof.get("description", ""),
+            "metric": prof["metric"],
+            "pass": float(prof["pass"]),
+            "target": _as_float(prof.get("target")),
+            "report_only_until": prof.get("report_only_until"),
+            "matched_runs": len(matched),
+        }
+        if not matched:
+            result["status"] = "NO_DATA"
+            result["best_run"] = None
+            result["best_value"] = None
+            results.append(result)
+            continue
+        scored = [
+            (rec, _profile_metric_value(prof, rec))
+            for rec in matched
+        ]
+        scored.sort(key=lambda item: item[1] if item[1] is not None else float("inf"))
+        best_rec, best_value = scored[0]
+        result["best_run"] = best_rec.get("run")
+        result["best_value"] = best_value
+        if best_value <= result["pass"]:
+            if result["target"] is not None and best_value <= result["target"]:
+                result["status"] = "TARGET_MET"
+            else:
+                result["status"] = "PASS"
+        else:
+            result["status"] = "WARN" if result["report_only_until"] else "FAIL"
+        results.append(result)
+    return results
+
+
+def render_release_profile_section(results: list[dict[str, Any]]) -> list[str]:
+    """Format the release-profile evaluation as markdown lines."""
+    if not results:
+        return []
+    lines = ["", "## Release profile gate", ""]
+    header = ["profile", "status", "metric", "best_run", "best_value", "pass", "target", "report_only_until"]
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("| " + " | ".join(["---"] * len(header)) + " |")
+    for r in results:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(r["name"]),
+                    str(r["status"]),
+                    str(r["metric"]),
+                    str(r.get("best_run") or ""),
+                    _fmt_float(r.get("best_value")),
+                    _fmt_float(r.get("pass")),
+                    _fmt_float(r.get("target")),
+                    str(r.get("report_only_until") or ""),
+                ]
+            )
+            + " |"
+        )
+    return lines
+
+
 def main() -> int:
     script_dir = Path(__file__).resolve().parent
     repo_root = script_dir.parent
@@ -134,6 +301,23 @@ def main() -> int:
         help=(
             "Limit threshold pass/fail checks to runs whose reference kind matches "
             "this value (default: all)"
+        ),
+    )
+    ap.add_argument(
+        "--release-profile",
+        default="",
+        help=(
+            "Path to a release-profiles YAML (see scripts/release_profiles.yaml). "
+            "Each profile evaluates one dataset/reference combination against its "
+            "own pass/target thresholds and is reported as a separate section."
+        ),
+    )
+    ap.add_argument(
+        "--fail-on-profiles",
+        action="store_true",
+        help=(
+            "Return a non-zero exit code when any release profile is FAIL "
+            "(report_only_until profiles only emit WARN and never block)."
         ),
     )
     args = ap.parse_args()
@@ -200,6 +384,7 @@ def main() -> int:
         evo = r.get("evo") or {}
         ape = evo.get("ape") if isinstance(evo, dict) else None
         ape_rmse = (ape.get("rmse") if isinstance(ape, dict) else None) if ape is not None else None
+        ape_pairs = (ape.get("pairs") if isinstance(ape, dict) else None) if ape is not None else None
 
         if lid_success is True:
             lid_ok += 1
@@ -265,6 +450,7 @@ def main() -> int:
                 "glim_wall_s": _fmt_float(glim_wall, 2),
                 "ape_rmse_m": _fmt_float(ape_raw),
                 "ape_ok": ape_ok,
+                "ape_pairs": ape_pairs,
                 "primary_raw": primary_raw,
                 "primary_missing": primary_missing,
             }
@@ -374,6 +560,14 @@ def main() -> int:
             rec["ape_ok"],
         ]
         md_lines.append("| " + " | ".join(row) + " |")
+
+    profile_results: list[dict[str, Any]] = []
+    if args.release_profile:
+        profile_path = Path(args.release_profile).expanduser().resolve()
+        profiles = load_release_profiles(profile_path)
+        profile_results = evaluate_release_profiles(profiles, records_sorted)
+        md_lines.extend(render_release_profile_section(profile_results))
+
     md = "\n".join(md_lines) + "\n"
 
     print(md, end="")
@@ -428,6 +622,16 @@ def main() -> int:
                 "error: APE threshold failed for runs: "
                 + ", ".join(failing_runs),
             )
+            return 2
+
+    if args.fail_on_profiles:
+        if not args.release_profile:
+            print("error: --fail-on-profiles requires --release-profile")
+            return 1
+        failing = [r for r in profile_results if r["status"] == "FAIL"]
+        if failing:
+            names = ", ".join(r["name"] for r in failing)
+            print(f"error: release profile gate FAILED for: {names}")
             return 2
 
     return 0

--- a/scripts/kitti_metrics.py
+++ b/scripts/kitti_metrics.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""KITTI Odometry translational/rotational drift metrics.
+
+Reads two TUM trajectories (ground truth + estimate) over the same set of
+frames and reports the standard KITTI Odometry metrics:
+
+  t_rel : average translational drift (%)
+  r_rel : average rotational drift   (deg/m)
+  per-length breakdowns over the standard {100, 200, ..., 800} m windows.
+
+The algorithm follows the KITTI devkit:
+  1. compute the cumulative arc-length along the GT trajectory
+  2. for every pose i and every requested window length L, find the smallest
+     j > i with `dist[j] - dist[i] >= L`
+  3. compute the relative-pose error
+       err = inv(gt_rel) @ est_rel
+       gt_rel  = inv(T_gt[i])  @ T_gt[j]
+       est_rel = inv(T_est[i]) @ T_est[j]
+     and accumulate `||err.translation|| / L` and `theta(err.rotation) / L`
+  4. average over all valid (i, L) pairs.
+
+The two TUM files must list poses for the same frames in the same order. They
+do not have to be in the same reference frame; the metric is invariant to a
+global SE(3) transform.
+
+Usage:
+  python3 scripts/kitti_metrics.py --gt path/to/gt.tum --est path/to/est.tum \\
+      [--lengths 100,200,300,400,500,600,700,800] [--out-json path]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+# Standard KITTI Odometry sub-trajectory window lengths (metres).
+DEFAULT_LENGTHS_M = (100, 200, 300, 400, 500, 600, 700, 800)
+
+
+def read_tum(path: Path) -> np.ndarray:
+    """Read a TUM trajectory. Returns Nx8 array (t x y z qx qy qz qw)."""
+    rows: list[list[float]] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        parts = line.split()
+        if len(parts) < 8:
+            continue
+        rows.append([float(v) for v in parts[:8]])
+    if not rows:
+        raise ValueError(f'No valid TUM rows in {path}')
+    return np.array(rows)
+
+
+def _quat_to_R(q: np.ndarray) -> np.ndarray:
+    """Quaternion (qx, qy, qz, qw) -> 3x3 rotation matrix."""
+    qx, qy, qz, qw = q
+    n = math.sqrt(qx * qx + qy * qy + qz * qz + qw * qw)
+    if n == 0.0:
+        return np.eye(3)
+    qx, qy, qz, qw = qx / n, qy / n, qz / n, qw / n
+    return np.array(
+        [
+            [1 - 2 * (qy * qy + qz * qz), 2 * (qx * qy - qz * qw), 2 * (qx * qz + qy * qw)],
+            [2 * (qx * qy + qz * qw), 1 - 2 * (qx * qx + qz * qz), 2 * (qy * qz - qx * qw)],
+            [2 * (qx * qz - qy * qw), 2 * (qy * qz + qx * qw), 1 - 2 * (qx * qx + qy * qy)],
+        ]
+    )
+
+
+def tum_to_poses(tum: np.ndarray) -> np.ndarray:
+    """Convert Nx8 TUM array (t x y z qx qy qz qw) into N 4x4 SE(3) matrices."""
+    n = tum.shape[0]
+    poses = np.tile(np.eye(4), (n, 1, 1))
+    poses[:, :3, 3] = tum[:, 1:4]
+    for i in range(n):
+        poses[i, :3, :3] = _quat_to_R(tum[i, 4:8])
+    return poses
+
+
+def _cumulative_lengths(positions: np.ndarray) -> np.ndarray:
+    """Cumulative arc-length at each pose (positions: Nx3)."""
+    if len(positions) < 2:
+        return np.zeros(len(positions))
+    deltas = np.linalg.norm(np.diff(positions, axis=0), axis=1)
+    return np.concatenate(([0.0], np.cumsum(deltas)))
+
+
+def _rotation_angle(R: np.ndarray) -> float:
+    """Geodesic rotation angle (radians) of a 3x3 matrix."""
+    trace = np.clip((np.trace(R) - 1.0) * 0.5, -1.0, 1.0)
+    return float(math.acos(trace))
+
+
+def compute_kitti_errors(
+    gt_poses: np.ndarray,
+    est_poses: np.ndarray,
+    lengths_m: tuple[int, ...] = DEFAULT_LENGTHS_M,
+    step: int = 10,
+) -> dict[str, object]:
+    """Compute KITTI per-length and aggregate drift errors.
+
+    Args:
+      gt_poses:  Nx4x4 SE(3) ground-truth poses.
+      est_poses: Nx4x4 SE(3) estimated poses (same ordering).
+      lengths_m: window lengths to evaluate (metres).
+      step:      stride over starting indices i (KITTI devkit uses 10).
+
+    Returns a dict with per-length statistics and aggregate t_rel / r_rel.
+    """
+    if gt_poses.shape != est_poses.shape:
+        raise ValueError(
+            f'gt/est pose shape mismatch: {gt_poses.shape} vs {est_poses.shape}'
+        )
+    if gt_poses.ndim != 3 or gt_poses.shape[1:] != (4, 4):
+        raise ValueError(f'expected Nx4x4 SE(3) array, got shape {gt_poses.shape}')
+
+    n = gt_poses.shape[0]
+    if n < 2:
+        return {
+            'lengths_m': list(lengths_m),
+            'per_length': {},
+            't_rel_percent_avg': None,
+            'r_rel_deg_per_m_avg': None,
+            'pairs_total': 0,
+        }
+
+    dist = _cumulative_lengths(gt_poses[:, :3, 3])
+    per_length: dict[int, dict[str, float | int]] = {}
+    all_t_errs: list[float] = []
+    all_r_errs: list[float] = []
+
+    for L in lengths_m:
+        t_errs: list[float] = []
+        r_errs: list[float] = []
+        for i in range(0, n, step):
+            target = dist[i] + L
+            j = int(np.searchsorted(dist, target, side='left'))
+            if j >= n:
+                continue
+            gt_rel = np.linalg.inv(gt_poses[i]) @ gt_poses[j]
+            est_rel = np.linalg.inv(est_poses[i]) @ est_poses[j]
+            err = np.linalg.inv(gt_rel) @ est_rel
+            t_err = float(np.linalg.norm(err[:3, 3]))
+            r_err = _rotation_angle(err[:3, :3])
+            t_errs.append(t_err / L)
+            r_errs.append(r_err / L)
+        if t_errs:
+            per_length[int(L)] = {
+                'pairs': len(t_errs),
+                't_rel_percent': float(np.mean(t_errs)) * 100.0,
+                'r_rel_deg_per_m': math.degrees(float(np.mean(r_errs))),
+            }
+            all_t_errs.extend(t_errs)
+            all_r_errs.extend(r_errs)
+        else:
+            per_length[int(L)] = {'pairs': 0, 't_rel_percent': None, 'r_rel_deg_per_m': None}
+
+    if all_t_errs:
+        t_rel_avg = float(np.mean(all_t_errs)) * 100.0
+        r_rel_avg = math.degrees(float(np.mean(all_r_errs)))
+    else:
+        t_rel_avg = None
+        r_rel_avg = None
+
+    return {
+        'lengths_m': list(lengths_m),
+        'per_length': per_length,
+        't_rel_percent_avg': t_rel_avg,
+        'r_rel_deg_per_m_avg': r_rel_avg,
+        'pairs_total': len(all_t_errs),
+    }
+
+
+def _parse_lengths(spec: str) -> tuple[int, ...]:
+    parts = [p.strip() for p in spec.split(',') if p.strip()]
+    if not parts:
+        raise argparse.ArgumentTypeError('--lengths must list at least one value')
+    return tuple(int(p) for p in parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description='Compute KITTI Odometry t_rel / r_rel drift metrics from TUM files.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    ap.add_argument('--gt', required=True, type=Path, help='Ground-truth TUM trajectory')
+    ap.add_argument('--est', required=True, type=Path, help='Estimated TUM trajectory')
+    ap.add_argument(
+        '--lengths',
+        default=','.join(str(L) for L in DEFAULT_LENGTHS_M),
+        type=_parse_lengths,
+        help='Comma-separated window lengths in metres',
+    )
+    ap.add_argument('--step', type=int, default=10, help='Stride over starting indices')
+    ap.add_argument('--out-json', type=Path, default=None, help='Write metrics JSON here')
+    ap.add_argument('--label', default='', help='Optional label embedded in the JSON')
+    args = ap.parse_args(argv)
+
+    gt = read_tum(args.gt)
+    est = read_tum(args.est)
+
+    if gt.shape[0] != est.shape[0]:
+        n = min(gt.shape[0], est.shape[0])
+        print(
+            f'warning: trimming to common length {n} '
+            f'(gt={gt.shape[0]}, est={est.shape[0]})',
+            file=sys.stderr,
+        )
+        gt = gt[:n]
+        est = est[:n]
+
+    gt_poses = tum_to_poses(gt)
+    est_poses = tum_to_poses(est)
+    metrics = compute_kitti_errors(gt_poses, est_poses, args.lengths, args.step)
+
+    output = {
+        'label': args.label,
+        'gt_path': str(args.gt),
+        'est_path': str(args.est),
+        'frames': int(gt.shape[0]),
+        **metrics,
+    }
+
+    print(f'frames           : {output["frames"]}')
+    print(f't_rel (% / 100m) : {output["t_rel_percent_avg"]}')
+    print(f'r_rel (deg / m)  : {output["r_rel_deg_per_m_avg"]}')
+    print(f'pairs total      : {output["pairs_total"]}')
+    for L, stats in output['per_length'].items():
+        print(
+            f'  L={L:>4}m  pairs={stats["pairs"]:>5}  '
+            f't_rel%={stats["t_rel_percent"]}  r_rel_deg/m={stats["r_rel_deg_per_m"]}'
+        )
+
+    if args.out_json:
+        args.out_json.parent.mkdir(parents=True, exist_ok=True)
+        args.out_json.write_text(json.dumps(output, indent=2), encoding='utf-8')
+        print(f'wrote {args.out_json}')
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/release_profiles.yaml
+++ b/scripts/release_profiles.yaml
@@ -6,6 +6,14 @@
 # against the best matching run under ``--root`` and emits PASS / FAIL / WARN /
 # NO_DATA per profile.
 #
+# Track convention (also documented in docs/comparison.md):
+#   - Release track:  no ``report_only_until`` (currently only
+#                     ``newer_college_math_hard``). A FAIL here blocks release.
+#   - Research track: ``report_only_until: v0.4`` (``ntu_viral_tnp_01``,
+#                     ``mid360_vs_glim``, ``leo_drive_applanix_velodyne_cross``).
+#                     A FAIL here is downgraded to WARN, so the gate reports
+#                     the regression without blocking the release cut.
+#
 # Fields:
 #   name: short identifier (snake_case)
 #   description: human-readable context (sensor / route / GT type)

--- a/scripts/release_profiles.yaml
+++ b/scripts/release_profiles.yaml
@@ -1,0 +1,69 @@
+# lidarslam-ros2 release readiness profiles
+#
+# Each profile pins one dataset / reference combination to its own pass / target
+# threshold so the release gate does not collapse all datasets onto one APE
+# number. ``benchmark_summary.py --release-profile`` evaluates each profile
+# against the best matching run under ``--root`` and emits PASS / FAIL / WARN /
+# NO_DATA per profile.
+#
+# Fields:
+#   name: short identifier (snake_case)
+#   description: human-readable context (sensor / route / GT type)
+#   match: predicates that select which metrics.json runs feed this profile.
+#     - bag_name_contains: substring of basename(bag_path)
+#     - points_topic: exact match on /...
+#     - reference_kind: ground_truth | cross_validation | unknown
+#     - reference_source_contains: substring of reference.source
+#     - min_ape_pairs: minimum evo.ape.pairs to filter out partial/incomplete runs
+#   metric:
+#     ape_rmse_gt_m            -> evo.ape.rmse, only when reference.kind == ground_truth
+#     ape_rmse_vs_reference_m  -> evo.ape.rmse against any reference (typically cross_validation)
+#   pass: hard threshold (release gate fails if best matching run exceeds this)
+#   target: roadmap target shown alongside (no enforcement; bonus TARGET_MET tag)
+#   report_only_until: optional release tag; while set, FAIL is downgraded to WARN
+#                       so the profile reports but does not block release
+
+release_profiles:
+  - name: newer_college_math_hard
+    description: Newer College math-hard (~320m loop, Ouster OS0-128 + IMU, prism GT)
+    match:
+      bag_name_contains: math_hard
+      reference_kind: ground_truth
+    metric: ape_rmse_gt_m
+    pass: 0.10
+    target: 0.08
+
+  - name: ntu_viral_tnp_01
+    description: NTU VIRAL tnp_01 (~580s outdoor, Ouster OS1-16 + VN-100, Leica prism GT)
+    match:
+      bag_name_contains: tnp_01
+      reference_kind: ground_truth
+      min_ape_pairs: 200
+    metric: ape_rmse_gt_m
+    pass: 1.00
+    target: 0.30
+    report_only_until: v0.4
+
+  - name: mid360_vs_glim
+    description: Livox MID-360 vs GLIM cross-validation (~277s indoor loop)
+    match:
+      points_topic: /livox/lidar
+      reference_kind: cross_validation
+      reference_source_contains: glim_mid360
+      min_ape_pairs: 400
+    metric: ape_rmse_vs_reference_m
+    pass: 4.00
+    target: 1.00
+    report_only_until: v0.4
+
+  - name: leo_drive_applanix_velodyne_cross
+    description: Leo Drive applanix/velodyne open data vs Applanix GSOF49 cross-validation
+    match:
+      points_topic: /open_data/velodyne_points
+      reference_kind: cross_validation
+      reference_source_contains: applanix_gsof49
+      min_ape_pairs: 200
+    metric: ape_rmse_vs_reference_m
+    pass: 1.50
+    target: 0.50
+    report_only_until: v0.4

--- a/scripts/run_kitti_00_05_07_report.sh
+++ b/scripts/run_kitti_00_05_07_report.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run lidarslam on KITTI Odometry 00 / 05 / 07 (the v0.3 dev split) with frozen
+# parameters, compute KITTI t_rel / r_rel drift for each, and aggregate into a
+# single markdown report.
+#
+# This wrapper assumes the existing per-sequence benchmark scripts already work
+# end-to-end. It only:
+#   1. iterates the dev sequences with one shared params file
+#   2. invokes scripts/kitti_metrics.py on the resulting traj_corrected.tum
+#   3. aggregates the per-sequence JSONs via scripts/aggregate_kitti_metrics.py
+#
+# Same-params evaluation is what KITTI's official protocol expects. Per-seq
+# parameter overrides are intentionally not exposed.
+#
+# Required:
+#   --dataset PATH   KITTI Odometry root (the directory above sequences/poses)
+#
+# Optional:
+#   --sequences "00 05 07"
+#   --output-root PATH  (default: output/kitti_dev_<timestamp>)
+#   --variant lo|small-gicp|rko-lio   (default: small-gicp)
+#   --label NAME        label used in the aggregate report (default: ours)
+#   --extra-est-json "label::path,..." comma-separated extra metric JSONs
+#                                      to compare against (e.g. KISS-ICP)
+#   --reuse              reuse pre-existing per-seq dirs if present
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  run_kitti_00_05_07_report.sh --dataset PATH [options]
+
+Options:
+  --dataset PATH         KITTI Odometry root (default: $KITTI_ODOMETRY_ROOT)
+  --sequences "00 05 07" Whitespace-separated sequence ids
+  --output-root PATH     Where to put per-seq + aggregate artifacts
+  --variant NAME         lo | small-gicp | rko-lio   (default: small-gicp)
+  --label NAME           Label for aggregate report   (default: ours)
+  --extra-est-json LIST  Comma-separated "label::path" of extra metric JSONs
+  --reuse                Skip prepare/run for sequences whose output exists
+  --help
+EOF
+  exit 1
+}
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+DATASET="${KITTI_ODOMETRY_ROOT:-}"
+SEQUENCES="00 05 07"
+OUTPUT_ROOT=""
+VARIANT="small-gicp"
+LABEL="ours"
+EXTRA_EST=""
+REUSE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dataset)      [[ $# -ge 2 ]] || usage; DATASET=$(realpath "$2"); shift 2 ;;
+    --sequences)    [[ $# -ge 2 ]] || usage; SEQUENCES="$2"; shift 2 ;;
+    --output-root)  [[ $# -ge 2 ]] || usage; OUTPUT_ROOT=$(realpath -m "$2"); shift 2 ;;
+    --variant)      [[ $# -ge 2 ]] || usage; VARIANT="$2"; shift 2 ;;
+    --label)        [[ $# -ge 2 ]] || usage; LABEL="$2"; shift 2 ;;
+    --extra-est-json) [[ $# -ge 2 ]] || usage; EXTRA_EST="$2"; shift 2 ;;
+    --reuse)        REUSE=true; shift ;;
+    --help|-h)      usage ;;
+    *) echo "Unknown option: $1" >&2; usage ;;
+  esac
+done
+
+[[ -n "${DATASET}" ]] || { echo "error: --dataset is required" >&2; usage; }
+
+case "${VARIANT}" in
+  lo|small-gicp|rko-lio) ;;
+  *) echo "error: invalid --variant '${VARIANT}'" >&2; usage ;;
+esac
+
+if [[ -z "${OUTPUT_ROOT}" ]]; then
+  OUTPUT_ROOT="${REPO_ROOT}/output/kitti_dev_$(date +%Y%m%d_%H%M%S)"
+fi
+mkdir -p "${OUTPUT_ROOT}"
+
+INPUT_ARGS=()
+
+for seq in ${SEQUENCES}; do
+  echo "==> Sequence ${seq} (variant=${VARIANT})"
+  SEQ_OUT="${OUTPUT_ROOT}/seq${seq}"
+  mkdir -p "${SEQ_OUT}"
+
+  BENCH_CMD=(bash "${REPO_ROOT}/scripts/run_kitti_odometry_benchmark.sh"
+             --dataset "${DATASET}" --sequence "${seq}"
+             --output-dir "${SEQ_OUT}")
+  case "${VARIANT}" in
+    lo)         BENCH_CMD+=(--lo) ;;
+    small-gicp) BENCH_CMD+=(--small-gicp) ;;
+    # rko-lio is the default in run_kitti_odometry_benchmark.sh; no extra flag
+  esac
+  if [[ "${REUSE}" == "true" && -f "${SEQ_OUT}/bench_run_small_gicp/traj_corrected.tum" ]]; then
+    echo "  (reusing existing ${SEQ_OUT})"
+  else
+    "${BENCH_CMD[@]}"
+  fi
+
+  # Find canonical trajectory paths produced by the benchmark.
+  EST_TUM="${SEQ_OUT}/bench_run_small_gicp/traj_corrected.tum"
+  if [[ ! -f "${EST_TUM}" ]]; then
+    EST_TUM=$(find "${SEQ_OUT}" -name traj_corrected.tum -print -quit)
+  fi
+  GT_TUM="${SEQ_OUT}/kitti_seq${seq}_gt_velo.tum"
+  if [[ ! -f "${GT_TUM}" ]]; then
+    GT_TUM=$(find "${SEQ_OUT}" -name 'kitti_seq*_gt_velo.tum' -print -quit)
+  fi
+
+  if [[ ! -f "${EST_TUM}" || ! -f "${GT_TUM}" ]]; then
+    echo "  warning: missing GT or estimate for seq ${seq}; skipping metrics" >&2
+    continue
+  fi
+
+  METRIC_JSON="${SEQ_OUT}/kitti_metrics.json"
+  python3 "${REPO_ROOT}/scripts/kitti_metrics.py" \
+      --gt "${GT_TUM}" --est "${EST_TUM}" \
+      --label "${LABEL}_seq${seq}" \
+      --out-json "${METRIC_JSON}"
+
+  INPUT_ARGS+=(--input "${LABEL}::${METRIC_JSON}")
+done
+
+if [[ -n "${EXTRA_EST}" ]]; then
+  IFS=',' read -r -a EXTRA_LIST <<< "${EXTRA_EST}"
+  for entry in "${EXTRA_LIST[@]}"; do
+    [[ -n "${entry}" ]] && INPUT_ARGS+=(--input "${entry}")
+  done
+fi
+
+REPORT_MD="${OUTPUT_ROOT}/kitti_dev_report.md"
+python3 "${REPO_ROOT}/scripts/aggregate_kitti_metrics.py" \
+    "${INPUT_ARGS[@]}" --out-md "${REPORT_MD}"
+
+echo "==> KITTI dev-split report ready"
+echo "  output_root: ${OUTPUT_ROOT}"
+echo "  report:      ${REPORT_MD}"

--- a/scripts/run_release_readiness_checks.sh
+++ b/scripts/run_release_readiness_checks.sh
@@ -12,6 +12,10 @@ Options:
   --ape-threshold <m>           Optional APE threshold passed to benchmark_summary.py
   --ape-threshold-reference-kind <kind>
                                 Reference kind to gate on (default: ground_truth)
+  --release-profile <path>      Release-profile YAML (per-dataset pass/target)
+                                Default: scripts/release_profiles.yaml when omitted
+  --no-release-profile          Disable the release-profile gate
+  --fail-on-profiles            Exit non-zero if any release-profile FAILs
   --skip-default-ci             Skip scripts/run_default_ci_checks.sh
   --skip-benchmark-summary      Skip benchmark summary generation
   --dogfood                     Run the Autoware pointcloud-map dogfood flow
@@ -32,6 +36,11 @@ When --ape-threshold is provided, the benchmark summary becomes a hard gate and
 the script exits non-zero if any selected run is missing APE or exceeds the
 threshold. By default this gate is scoped to `ground_truth` runs so
 cross-validation artifacts can appear in reports without blocking release.
+
+The release-profile gate runs in addition to (or instead of) --ape-threshold:
+each profile in the YAML scores its own pass/target threshold against the best
+matching run, with optional report_only_until semantics so hard datasets
+(MID-360, NTU) can be reported without blocking release.
 EOF
   exit 1
 }
@@ -43,6 +52,8 @@ OUT_DIR="${REPO_ROOT}/output/release_readiness_$(date +%Y%m%d_%H%M%S)"
 BENCHMARK_ROOT="${REPO_ROOT}/output"
 APE_THRESHOLD=""
 APE_THRESHOLD_REFERENCE_KIND="ground_truth"
+RELEASE_PROFILE="${REPO_ROOT}/scripts/release_profiles.yaml"
+FAIL_ON_PROFILES=false
 RUN_DEFAULT_CI=true
 RUN_BENCHMARK_SUMMARY=true
 RUN_DOGFOOD=false
@@ -74,6 +85,19 @@ while [[ $# -gt 0 ]]; do
       [[ $# -ge 2 ]] || usage
       APE_THRESHOLD_REFERENCE_KIND="$2"
       shift 2
+      ;;
+    --release-profile)
+      [[ $# -ge 2 ]] || usage
+      RELEASE_PROFILE=$(realpath -m "$2")
+      shift 2
+      ;;
+    --no-release-profile)
+      RELEASE_PROFILE=""
+      shift
+      ;;
+    --fail-on-profiles)
+      FAIL_ON_PROFILES=true
+      shift
       ;;
     --skip-default-ci)
       RUN_DEFAULT_CI=false
@@ -148,6 +172,14 @@ if [[ "${RUN_BENCHMARK_SUMMARY}" == "true" ]]; then
         --ape-threshold-reference-kind "${APE_THRESHOLD_REFERENCE_KIND}"
         --fail-on-ape-threshold
       )
+    fi
+    if [[ -n "${RELEASE_PROFILE}" && -f "${RELEASE_PROFILE}" ]]; then
+      SUMMARY_CMD+=(--release-profile "${RELEASE_PROFILE}")
+      if [[ "${FAIL_ON_PROFILES}" == "true" ]]; then
+        SUMMARY_CMD+=(--fail-on-profiles)
+      fi
+    elif [[ -n "${RELEASE_PROFILE}" ]]; then
+      echo "warning: release profile not found at ${RELEASE_PROFILE}; continuing without profile gate" >&2
     fi
     "${SUMMARY_CMD[@]}" 2>&1 | tee "${OUT_DIR}/benchmark_summary.log"
     echo "==> Generating benchmark HTML report from ${BENCHMARK_ROOT}"

--- a/scripts/simple_lanelet2_generator.py
+++ b/scripts/simple_lanelet2_generator.py
@@ -158,12 +158,18 @@ def build_osm(
     origin_lon: float,
     speed_limit: float,
     segment_length: int = 25,
+    add_local_coords: bool = True,
 ) -> tuple[ET.Element, int]:
     """Build an OSM ElementTree from left/right boundary arrays (local coords).
 
     The trajectory is split into multiple lanelets of *segment_length* points
     each. Adjacent lanelets share boundary nodes so that Autoware's routing
     graph recognises them as connected.
+
+    When *add_local_coords* is True, every node also carries ``local_x``/
+    ``local_y`` tags holding the source frame x/y. Autoware's lanelet2
+    extension uses these when ``projector_type: local`` is set in
+    ``map_projector_info.yaml``.
 
     Returns (osm_element, number_of_lanelets).
     """
@@ -188,9 +194,9 @@ def build_osm(
     right_node_ids: list[int] = []
 
     for i in range(n_pts):
-        for lat_arr, lon_arr, ele_arr, node_list in [
-            (left_lat, left_lon, left_ele, left_node_ids),
-            (right_lat, right_lon, right_ele, right_node_ids),
+        for lat_arr, lon_arr, ele_arr, xy_src, node_list in [
+            (left_lat, left_lon, left_ele, left, left_node_ids),
+            (right_lat, right_lon, right_ele, right, right_node_ids),
         ]:
             nid += 1
             node = ET.SubElement(
@@ -198,6 +204,9 @@ def build_osm(
                 lat=f'{lat_arr[i]:.10f}', lon=f'{lon_arr[i]:.10f}',
             )
             _add_tag(node, 'ele', f'{ele_arr[i]:.4f}')
+            if add_local_coords:
+                _add_tag(node, 'local_x', f'{xy_src[i, 0]:.4f}')
+                _add_tag(node, 'local_y', f'{xy_src[i, 1]:.4f}')
             node_list.append(nid)
 
     # --- Split into lanelet segments ---
@@ -256,6 +265,160 @@ def write_osm(osm: ET.Element, path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Validation helpers (pure Python structural + optional lanelet2 routing)
+# ---------------------------------------------------------------------------
+
+
+REQUIRED_LANELET_TAGS = (
+    'subtype',
+    'location',
+    'one_way',
+    'participant:vehicle',
+    'speed_limit',
+)
+
+
+def validate_structure(osm: ET.Element) -> tuple[bool, list[str]]:
+    """Pure-Python structural validation. Returns (ok, messages).
+
+    Checks that:
+      - every node carries an ``ele`` tag (Autoware lanelet2 extension requires)
+      - every lanelet relation carries the tags Autoware needs to treat it as
+        a drivable road for vehicles
+      - every lanelet has both ``left`` and ``right`` boundary ways
+      - adjacent lanelets share boundary node IDs (not just coordinates), which
+        is what Lanelet2's default routing graph uses to infer succession.
+
+    The check is intentionally cheap so it can run in CI without ROS.
+    """
+    msgs: list[str] = []
+    ok = True
+
+    nodes = {n.get('id'): n for n in osm.findall('node')}
+    ways = {w.get('id'): w for w in osm.findall('way')}
+    lanelets = [
+        r
+        for r in osm.findall('relation')
+        if any(t.get('k') == 'type' and t.get('v') == 'lanelet' for t in r.findall('tag'))
+    ]
+    msgs.append(f'structure: {len(nodes)} nodes, {len(ways)} ways, {len(lanelets)} lanelets')
+
+    if not lanelets:
+        return False, msgs + ['FAIL: no lanelet relations found']
+
+    no_ele = [
+        nid for nid, n in nodes.items()
+        if not any(t.get('k') == 'ele' for t in n.findall('tag'))
+    ]
+    if no_ele:
+        ok = False
+        msgs.append(f'FAIL: {len(no_ele)} nodes missing "ele" tag (first: {no_ele[:3]})')
+
+    for rel in lanelets:
+        rid = rel.get('id')
+        tag_keys = {t.get('k') for t in rel.findall('tag')}
+        missing = [k for k in REQUIRED_LANELET_TAGS if k not in tag_keys]
+        if missing:
+            ok = False
+            msgs.append(f'FAIL: lanelet {rid} missing tags {missing}')
+        roles = {m.get('role') for m in rel.findall('member')}
+        if 'left' not in roles or 'right' not in roles:
+            ok = False
+            msgs.append(f'FAIL: lanelet {rid} missing left/right member')
+
+    def way_node_refs(way_id: str | None) -> list[str]:
+        w = ways.get(way_id) if way_id else None
+        return [nd.get('ref') for nd in w.findall('nd')] if w is not None else []
+
+    sorted_lanelets = sorted(lanelets, key=lambda r: int(r.get('id') or '0'))
+    shared_pairs = 0
+    total_pairs = max(0, len(sorted_lanelets) - 1)
+    for i in range(total_pairs):
+        a, b = sorted_lanelets[i], sorted_lanelets[i + 1]
+        a_left = next((m.get('ref') for m in a.findall('member') if m.get('role') == 'left'), None)
+        a_right = next((m.get('ref') for m in a.findall('member') if m.get('role') == 'right'), None)
+        b_left = next((m.get('ref') for m in b.findall('member') if m.get('role') == 'left'), None)
+        b_right = next((m.get('ref') for m in b.findall('member') if m.get('role') == 'right'), None)
+
+        a_l, a_r = way_node_refs(a_left), way_node_refs(a_right)
+        b_l, b_r = way_node_refs(b_left), way_node_refs(b_right)
+
+        if a_l and b_l and a_r and b_r and a_l[-1] == b_l[0] and a_r[-1] == b_r[0]:
+            shared_pairs += 1
+        else:
+            ok = False
+            msgs.append(
+                f'FAIL: lanelet pair ({a.get("id")}, {b.get("id")}) does not share '
+                f'boundary node IDs (left last/first={a_l[-1] if a_l else None}/'
+                f'{b_l[0] if b_l else None}, right={a_r[-1] if a_r else None}/'
+                f'{b_r[0] if b_r else None})'
+            )
+    if total_pairs:
+        msgs.append(f'structure: {shared_pairs}/{total_pairs} adjacent lanelets share boundary nodes')
+
+    return ok, msgs
+
+
+def validate_routing(
+    osm_path: Path, origin_lat: float, origin_lon: float
+) -> tuple[bool | None, list[str]]:
+    """Optional routing-graph validation using lanelet2 Python bindings.
+
+    Returns ``(True, msgs)`` on PASS, ``(False, msgs)`` on FAIL, or
+    ``(None, msgs)`` when the lanelet2 bindings are unavailable.
+    """
+    try:
+        import lanelet2  # type: ignore
+        from lanelet2.projection import UtmProjector  # type: ignore
+    except ImportError:
+        return None, [
+            'routing: lanelet2 Python bindings not importable; '
+            'install via `apt install ros-${ROS_DISTRO}-lanelet2-python` and '
+            'source the ROS overlay (skipping routing check)'
+        ]
+
+    msgs: list[str] = []
+    projector = UtmProjector(lanelet2.io.Origin(origin_lat, origin_lon))
+    try:
+        laneletmap = lanelet2.io.load(str(osm_path), projector)
+    except Exception as exc:  # pragma: no cover - depends on lanelet2 build
+        return False, [f'routing: lanelet2.io.load failed: {exc}']
+
+    lanelets = sorted(laneletmap.laneletLayer, key=lambda ll: ll.id)
+    if not lanelets:
+        return False, ['routing: no lanelets parsed from map']
+
+    msgs.append(f'routing: loaded {len(lanelets)} lanelets')
+
+    traffic_rules = lanelet2.traffic_rules.create(
+        lanelet2.traffic_rules.Locations.Germany,
+        lanelet2.traffic_rules.Participants.Vehicle,
+    )
+    routing_graph = lanelet2.routing.RoutingGraph(laneletmap, traffic_rules)
+
+    connected = 0
+    total = max(0, len(lanelets) - 1)
+    for i in range(total):
+        following_ids = {f.id for f in routing_graph.following(lanelets[i])}
+        if lanelets[i + 1].id in following_ids:
+            connected += 1
+    msgs.append(f'routing: {connected}/{total} adjacent pairs connected in routing graph')
+
+    path = routing_graph.shortestPath(lanelets[0], lanelets[-1])
+    if path is None or len(path) == 0:
+        msgs.append(
+            f'routing: FAIL shortestPath({lanelets[0].id} → {lanelets[-1].id}) is empty'
+        )
+        return False, msgs
+
+    msgs.append(
+        f'routing: PASS shortestPath({lanelets[0].id} → {lanelets[-1].id}) '
+        f'covers {len(path)} lanelets'
+    )
+    return True, msgs
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -275,6 +438,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument('--speed-limit', type=float, default=10.0, help='Speed limit [km/h]')
     p.add_argument('--segment-length', type=int, default=25,
                    help='Points per lanelet segment (Autoware needs multiple connected lanelets)')
+    p.add_argument('--no-local-coords', dest='add_local_coords', action='store_false',
+                   help='Skip emitting local_x/local_y tags on every node '
+                        '(default: emit, required by Autoware projector_type=local)')
+    p.set_defaults(add_local_coords=True)
+    p.add_argument('--no-validate-structure', dest='validate_structure',
+                   action='store_false',
+                   help='Skip the post-write structural validation')
+    p.set_defaults(validate_structure=True)
+    p.add_argument('--validate-routing', action='store_true',
+                   help='Also build a Lanelet2 routing graph and verify '
+                        'shortestPath(first → last). Requires lanelet2 Python bindings.')
     return p.parse_args(argv)
 
 
@@ -293,11 +467,32 @@ def main(argv: list[str] | None = None) -> None:
     osm, n_lanelets = build_osm(
         left, right, args.origin_lat, args.origin_lon,
         args.speed_limit, args.segment_length,
+        add_local_coords=args.add_local_coords,
     )
     write_osm(osm, args.output)
 
     n_nodes = len(left) + len(right)
     print(f'Wrote {args.output}  ({n_nodes} nodes, {n_lanelets * 2} ways, {n_lanelets} lanelets)')
+
+    exit_code = 0
+    if args.validate_structure:
+        ok, msgs = validate_structure(osm)
+        for line in msgs:
+            print(line)
+        if not ok:
+            print('Structural validation FAILED', file=sys.stderr)
+            exit_code = 1
+
+    if args.validate_routing:
+        result, msgs = validate_routing(args.output, args.origin_lat, args.origin_lon)
+        for line in msgs:
+            print(line)
+        if result is False:
+            print('Routing validation FAILED', file=sys.stderr)
+            exit_code = 1
+
+    if exit_code:
+        sys.exit(exit_code)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Two-phase bundle that closes out the GPT pro 先生 v0.3 readiness plan and opens the v0.4 MID-360 research track.

### Phase 1 — v0.3 readiness (release-track)
- `simple_lanelet2_generator.py`: structural validation (`ele` tags, required Autoware lanelet tags, adjacent-lanelet node-ID sharing), optional lanelet2 Python routing-graph check, and `local_x` / `local_y` node tags for Autoware `projector_type: local`
- `scripts/release_profiles.yaml` + `benchmark_summary.py --release-profile --fail-on-profiles`: per-dataset pass / target thresholds replacing the single APE 0.10 m gate. Profiles: `newer_college_math_hard` (release-track), `ntu_viral_tnp_01`, `mid360_vs_glim`, `leo_drive_applanix_velodyne_cross` (`report_only_until: v0.4`). `min_ape_pairs` filter drops partial / incomplete runs from the gate
- `scripts/kitti_metrics.py` + `aggregate_kitti_metrics.py` + `run_kitti_00_05_07_report.sh`: canonical KITTI t_rel / r_rel drift, multi-sequence aggregator, dev-split (00 / 05 / 07) wrapper using one frozen params file
- `graph_based_slam`: opt-in NIS-driven auto-scale for `adjacent_edge_info_weight` (Level 1: scalar EMA of post-optimise chi-squared toward the SE(3) DoF target)
- Docs: `comparison.md` split into release-track / research-track snapshots, MID-360 numbers labelled `report_only_until: v0.4`, README repositioned around the per-profile readiness gate

### Phase 2 — v0.4 MID-360 research track
- `graph_based_slam/include/graph_based_slam/bev_mutual_visibility.hpp`: FOV-aware BEV distance (mutual-visibility mask + per-channel masked NCC, with informative / uninformative channel handling so constant-mask cells do not bias the score). Adds `mutualVisibilityDistance`, `mutualVisibilityWithYawSearch`, and a `queryDatabaseWithMutualVisibility` free function that runs the existing coarse-key pre-filter and then verifies survivors with the FOV-aware score
- `graph_based_slam/include/graph_based_slam/loop_edge_robustifier.hpp`: parses `loop_edge_robust_kernel_type` (Huber / DCS / Cauchy) and selects the matching g2o kernel. Default stays Huber; MID-360 / aggressive false-loop configurations can switch to DCS for analytic outlier down-weighting
- Component integration: `bev_use_mutual_visibility` + `bev_mutual_visibility_min_overlap_ratio` + `bev_mutual_visibility_occupancy_eps` toggle the BEV scoring path (primary candidate + sequence verification) without disturbing the cosine baseline used on 360° LiDAR

## Test plan
- [x] `colcon test --packages-select graph_based_slam` — 292 tests, 0 failures, 21 skipped
- [x] `python3 -m pytest lidarslam/test/` — 66 tests pass
- [x] `python3 scripts/benchmark_summary.py --root output --release-profile scripts/release_profiles.yaml` — gate emits PASS / TARGET_MET / NO_DATA per profile against checked-in metrics; `--fail-on-profiles` returns exit 2 when a non-`report_only_until` profile fails
- [x] `python3 scripts/simple_lanelet2_generator.py --input output/awsim_shinjuku_slam/traj_slam.tum --output /tmp/test.osm --origin-lat 35.6862 --origin-lon 139.6891 --lane-width 3.5 --resolution 1.0 --speed-limit 20.0` — produces 37 lanelets / 1894 nodes / 74 ways with all adjacent pairs sharing boundary node IDs
- [ ] MID-360 dataset rerun with `bev_use_mutual_visibility: true` + `loop_edge_robust_kernel_type: "dcs"` against the current 3.451 m best to validate research-track regression
- [ ] KITTI 00 / 05 / 07 dev-split run via `scripts/run_kitti_00_05_07_report.sh` to seed the LO baseline numbers

## Notes
- All Phase 1 release-track defaults are unchanged; `bev_use_mutual_visibility` and `adjacent_edge_info_auto_scale` default to false, `loop_edge_robust_kernel_type` defaults to `"huber"`
- `report_only_until: v0.4` keeps MID-360 / NTU / Leo Drive profiles out of the hard gate while still being reported
- Companion design summary: `scripts/release_profiles.yaml` track convention + `docs/comparison.md` Release Track vs Research Track section