### PR TITLE
feat: triangle descriptor hash database with vote-based loop lookup

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -175,6 +175,16 @@ if(BUILD_TESTING)
     target_link_libraries(test_triangle_descriptor ${PCL_LIBRARIES})
   endif()
   ament_add_gtest(
+    test_triangle_descriptor_database
+    test/test_triangle_descriptor_database.cpp
+  )
+  if(TARGET test_triangle_descriptor_database)
+    target_include_directories(
+      test_triangle_descriptor_database PRIVATE include ${EIGEN3_INCLUDE_DIR}
+    )
+    target_link_libraries(test_triangle_descriptor_database ${PCL_LIBRARIES})
+  endif()
+  ament_add_gtest(
     test_dynamic_object_filter
     test/test_dynamic_object_filter.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/triangle_descriptor_database.hpp
+++ b/graph_based_slam/include/graph_based_slam/triangle_descriptor_database.hpp
@@ -1,0 +1,362 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Triangle descriptor hashing, in-memory database, and vote-based loop
+// candidate lookup. Implemented from scratch under BSD-2 so the default
+// workflow can include it without GPL contamination.
+//
+// Pipeline contract:
+//   1. quantizeEdges: sorted triangle edges (m) -> integer (le, me, ge) key
+//      that places nearby triangles into the same bucket.
+//   2. TriangleDatabase: stores per-submap (TriangleDescriptor, vertex
+//      positions) indexed by the hash key. Vertices are kept so geometric
+//      verification can run without going back to the original keypoints.
+//   3. accumulateVotes: hash-lookup each query triangle and count votes
+//      per candidate submap (one vote per matching triangle, capped).
+//   4. findLoopCandidate: pick the top-voted submap, then verify by
+//      enumerating matching triangle pairs and looking for a consensus
+//      SE(3) via RANSAC over estimateRigidFromTriangle output.
+
+#ifndef GRAPH_BASED_SLAM__TRIANGLE_DESCRIPTOR_DATABASE_HPP_
+#define GRAPH_BASED_SLAM__TRIANGLE_DESCRIPTOR_DATABASE_HPP_
+
+#include "graph_based_slam/triangle_descriptor.hpp"
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace graphslam
+{
+namespace triangle
+{
+
+struct HashConfig
+{
+  // Edge bin width (m). Edges within +-edge_bin_m / 2 fall in the same bin.
+  float edge_bin_m {1.0f};
+  // Hard upper bound on the quantized bin index (clipped at this value).
+  // Default keeps the packed key small (uint64) for triangles up to ~80 m.
+  int max_bin {255};
+};
+
+// (le, me, ge) integer bin tuple, le <= me <= ge.
+struct TriangleHash
+{
+  uint16_t le {0};
+  uint16_t me {0};
+  uint16_t ge {0};
+
+  bool operator==(const TriangleHash & other) const
+  {
+    return le == other.le && me == other.me && ge == other.ge;
+  }
+};
+
+inline TriangleHash quantizeEdges(const TriangleDescriptor & t, const HashConfig & cfg)
+{
+  TriangleHash h;
+  const float bin = std::max(1e-3f, cfg.edge_bin_m);
+  auto q = [&](float v) -> uint16_t {
+      const int idx = static_cast<int>(std::floor(v / bin));
+      const int clipped = std::max(0, std::min(cfg.max_bin, idx));
+      return static_cast<uint16_t>(clipped);
+    };
+  h.le = q(t.edges[0]);
+  h.me = q(t.edges[1]);
+  h.ge = q(t.edges[2]);
+  return h;
+}
+
+inline uint64_t packHash(const TriangleHash & h)
+{
+  return (static_cast<uint64_t>(h.le) << 32) |
+         (static_cast<uint64_t>(h.me) << 16) |
+         static_cast<uint64_t>(h.ge);
+}
+
+struct DatabaseEntry
+{
+  int submap_id {-1};
+  // Vertex positions in submap-local frame, in the order that matches
+  // TriangleDescriptor::keypoint_ids (vertex opposite edges[k] is index k).
+  std::array<Eigen::Vector3f, 3> vertices {{
+    Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero(), Eigen::Vector3f::Zero()
+  }};
+};
+
+class TriangleDatabase
+{
+public:
+  // Stash all triangles from a submap. ``keypoints`` is the keypoint vector
+  // that was passed to buildTriangles; the function looks up each
+  // ``keypoint_ids`` entry to copy the position into the database.
+  void addSubmap(
+    int submap_id,
+    const std::vector<Keypoint> & keypoints,
+    const std::vector<TriangleDescriptor> & triangles,
+    const HashConfig & cfg)
+  {
+    for (const auto & t : triangles) {
+      DatabaseEntry e;
+      e.submap_id = submap_id;
+      bool ok = true;
+      for (int k = 0; k < 3; ++k) {
+        const int idx = t.keypoint_ids[k];
+        if (idx < 0 || idx >= static_cast<int>(keypoints.size())) {
+          ok = false;
+          break;
+        }
+        e.vertices[k] = keypoints[idx].position;
+      }
+      if (!ok) {continue;}
+      const uint64_t key = packHash(quantizeEdges(t, cfg));
+      buckets_[key].push_back(e);
+      ++triangle_count_;
+    }
+    submap_ids_.insert(submap_id);
+  }
+
+  // Returns the bucket for a hash key (empty vector if none).
+  const std::vector<DatabaseEntry> & lookup(const TriangleHash & h) const
+  {
+    static const std::vector<DatabaseEntry> empty;
+    auto it = buckets_.find(packHash(h));
+    if (it == buckets_.end()) {return empty;}
+    return it->second;
+  }
+
+  std::size_t triangleCount() const {return triangle_count_;}
+  std::size_t submapCount() const {return submap_ids_.size();}
+  bool empty() const {return triangle_count_ == 0;}
+
+private:
+  std::unordered_map<uint64_t, std::vector<DatabaseEntry>> buckets_;
+  std::size_t triangle_count_ {0};
+  std::unordered_set<int> submap_ids_;
+};
+
+// One submap's vote count after hash-lookup.
+struct SubmapVote
+{
+  int submap_id {-1};
+  int votes {0};
+};
+
+struct VoteConfig
+{
+  // Cap on votes contributed by a single query triangle (avoids dominance
+  // when many database triangles share an unusual bucket).
+  int max_votes_per_query {3};
+  // Submap id to exclude from voting (typically the query submap itself).
+  int exclude_submap_id {-1};
+};
+
+inline std::vector<SubmapVote> accumulateVotes(
+  const TriangleDatabase & db,
+  const std::vector<TriangleDescriptor> & query_triangles,
+  const HashConfig & cfg,
+  const VoteConfig & vote_cfg)
+{
+  std::unordered_map<int, int> counts;
+  for (const auto & t : query_triangles) {
+    const auto & bucket = db.lookup(quantizeEdges(t, cfg));
+    if (bucket.empty()) {continue;}
+    // Per-query cap: dedupe by submap id and cap the contribution count.
+    std::unordered_map<int, int> per_query;
+    for (const auto & e : bucket) {
+      if (e.submap_id == vote_cfg.exclude_submap_id) {continue;}
+      ++per_query[e.submap_id];
+    }
+    for (const auto & kv : per_query) {
+      const int contribution = std::min(kv.second, std::max(1, vote_cfg.max_votes_per_query));
+      counts[kv.first] += contribution;
+    }
+  }
+
+  std::vector<SubmapVote> result;
+  result.reserve(counts.size());
+  for (const auto & kv : counts) {
+    result.push_back({kv.first, kv.second});
+  }
+  std::sort(
+    result.begin(), result.end(),
+    [](const SubmapVote & a, const SubmapVote & b) {return a.votes > b.votes;});
+  return result;
+}
+
+struct VerificationConfig
+{
+  // Triangle pair is treated as an inlier if every other matching pair agrees
+  // with the proposed SE(3) up to this translation tolerance (m).
+  float inlier_translation_m {2.0f};
+  // ...and this rotation tolerance (deg).
+  float inlier_rotation_deg {5.0f};
+  // Minimum inliers required to accept the candidate.
+  int min_inliers {3};
+  // Cap on triangle pairs evaluated (top N by edge length descending).
+  int max_pairs {64};
+};
+
+struct LoopCandidate
+{
+  int submap_id {-1};
+  int votes {0};
+  int inliers {0};
+  Eigen::Matrix4f transform {Eigen::Matrix4f::Identity()};
+  bool accepted {false};
+};
+
+namespace detail
+{
+
+inline float rotationAngleDeg(const Eigen::Matrix3f & R)
+{
+  const float trace = R.trace();
+  const float arg = std::max(-1.0f, std::min(1.0f, (trace - 1.0f) * 0.5f));
+  return std::acos(arg) * 180.0f / static_cast<float>(M_PI);
+}
+
+inline bool transformAgrees(
+  const Eigen::Matrix4f & a, const Eigen::Matrix4f & b,
+  float trans_tol_m, float rot_tol_deg)
+{
+  const Eigen::Vector3f dt = a.block<3, 1>(0, 3) - b.block<3, 1>(0, 3);
+  if (dt.norm() > trans_tol_m) {return false;}
+  const Eigen::Matrix3f Ra = a.block<3, 3>(0, 0);
+  const Eigen::Matrix3f Rb = b.block<3, 3>(0, 0);
+  const Eigen::Matrix3f Rdelta = Ra.transpose() * Rb;
+  return rotationAngleDeg(Rdelta) <= rot_tol_deg;
+}
+
+// Pull (src, dst) vertex arrays for a single query/db triangle pair.
+inline void packTrianglePair(
+  const TriangleDescriptor & query_tri,
+  const std::vector<Keypoint> & query_keypoints,
+  const DatabaseEntry & db_entry,
+  std::array<Eigen::Vector3f, 3> & src,
+  std::array<Eigen::Vector3f, 3> & dst)
+{
+  for (int k = 0; k < 3; ++k) {
+    const int qid = query_tri.keypoint_ids[k];
+    src[k] = (qid >= 0 && qid < static_cast<int>(query_keypoints.size())) ?
+      query_keypoints[qid].position : Eigen::Vector3f::Zero();
+    dst[k] = db_entry.vertices[k];
+  }
+}
+
+}  // namespace detail
+
+// Find the best loop candidate for the query (keypoints + triangles) against
+// the database. Returns LoopCandidate with accepted=false if no inlier set
+// meets the verification threshold.
+inline LoopCandidate findLoopCandidate(
+  const TriangleDatabase & db,
+  const std::vector<Keypoint> & query_keypoints,
+  const std::vector<TriangleDescriptor> & query_triangles,
+  const HashConfig & cfg,
+  const VoteConfig & vote_cfg,
+  const VerificationConfig & verify_cfg)
+{
+  LoopCandidate result;
+  const auto votes = accumulateVotes(db, query_triangles, cfg, vote_cfg);
+  if (votes.empty()) {return result;}
+
+  result.submap_id = votes.front().submap_id;
+  result.votes = votes.front().votes;
+
+  // Collect (query_tri, db_entry) pairs that touch the winning submap, then
+  // run RANSAC: each pair proposes a transform, count how many other pairs
+  // agree.
+  struct Pair
+  {
+    const TriangleDescriptor * query_tri;
+    const DatabaseEntry * db_entry;
+    float largest_edge;
+  };
+  std::vector<Pair> pairs;
+  pairs.reserve(query_triangles.size());
+  for (const auto & qt : query_triangles) {
+    const auto & bucket = db.lookup(quantizeEdges(qt, cfg));
+    for (const auto & e : bucket) {
+      if (e.submap_id != result.submap_id) {continue;}
+      pairs.push_back({&qt, &e, qt.edges[2]});
+    }
+  }
+  if (pairs.empty()) {return result;}
+
+  std::sort(
+    pairs.begin(), pairs.end(),
+    [](const Pair & a, const Pair & b) {return a.largest_edge > b.largest_edge;});
+  const int eval_n = std::min<int>(verify_cfg.max_pairs, static_cast<int>(pairs.size()));
+
+  int best_inliers = 0;
+  Eigen::Matrix4f best_T = Eigen::Matrix4f::Identity();
+  for (int i = 0; i < eval_n; ++i) {
+    std::array<Eigen::Vector3f, 3> src;
+    std::array<Eigen::Vector3f, 3> dst;
+    detail::packTrianglePair(*pairs[i].query_tri, query_keypoints, *pairs[i].db_entry, src, dst);
+    const Eigen::Matrix4f T_i = estimateRigidFromTriangle(src, dst);
+    int inliers = 0;
+    for (int j = 0; j < eval_n; ++j) {
+      std::array<Eigen::Vector3f, 3> sj;
+      std::array<Eigen::Vector3f, 3> dj;
+      detail::packTrianglePair(*pairs[j].query_tri, query_keypoints, *pairs[j].db_entry, sj, dj);
+      const Eigen::Matrix4f T_j = estimateRigidFromTriangle(sj, dj);
+      if (detail::transformAgrees(
+          T_i, T_j, verify_cfg.inlier_translation_m, verify_cfg.inlier_rotation_deg))
+      {
+        ++inliers;
+      }
+    }
+    if (inliers > best_inliers) {
+      best_inliers = inliers;
+      best_T = T_i;
+    }
+  }
+
+  result.inliers = best_inliers;
+  result.transform = best_T;
+  result.accepted = best_inliers >= verify_cfg.min_inliers;
+  return result;
+}
+
+}  // namespace triangle
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__TRIANGLE_DESCRIPTOR_DATABASE_HPP_

--- a/graph_based_slam/test/test_triangle_descriptor_database.cpp
+++ b/graph_based_slam/test/test_triangle_descriptor_database.cpp
@@ -1,0 +1,393 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <random>
+#include <vector>
+
+#include "graph_based_slam/triangle_descriptor_database.hpp"
+
+using graphslam::triangle::DatabaseEntry;
+using graphslam::triangle::HashConfig;
+using graphslam::triangle::Keypoint;
+using graphslam::triangle::TriangleBuildConfig;
+using graphslam::triangle::TriangleDatabase;
+using graphslam::triangle::TriangleDescriptor;
+using graphslam::triangle::TriangleHash;
+using graphslam::triangle::VerificationConfig;
+using graphslam::triangle::VoteConfig;
+using graphslam::triangle::accumulateVotes;
+using graphslam::triangle::buildTriangles;
+using graphslam::triangle::estimateRigidFromTriangle;
+using graphslam::triangle::findLoopCandidate;
+using graphslam::triangle::packHash;
+using graphslam::triangle::quantizeEdges;
+
+namespace
+{
+
+std::vector<Keypoint> makeKeypointGrid(int n_x, int n_y, float spacing)
+{
+  std::vector<Keypoint> kps;
+  kps.reserve(static_cast<std::size_t>(n_x * n_y));
+  for (int iy = 0; iy < n_y; ++iy) {
+    for (int ix = 0; ix < n_x; ++ix) {
+      Keypoint k;
+      k.position = Eigen::Vector3f(
+        static_cast<float>(ix) * spacing,
+        static_cast<float>(iy) * spacing,
+        0.0f);
+      k.salience = 1.0f;
+      kps.push_back(k);
+    }
+  }
+  return kps;
+}
+
+// A regular grid has 180° rotational symmetry, so two transforms (T_gt and
+// T_gt * R180) are both valid loop-edge solutions. Break the symmetry by
+// adding an off-axis marker so SE(3) recovery has a unique answer.
+std::vector<Keypoint> makeAsymmetricKeypointSet()
+{
+  auto kps = makeKeypointGrid(4, 4, 3.0f);
+  Keypoint marker;
+  marker.position = Eigen::Vector3f(13.5f, 6.0f, 0.0f);
+  marker.salience = 1.0f;
+  kps.push_back(marker);
+  return kps;
+}
+
+std::vector<Keypoint> transformKeypoints(
+  const std::vector<Keypoint> & src, const Eigen::Matrix4f & T)
+{
+  std::vector<Keypoint> out;
+  out.reserve(src.size());
+  for (const auto & k : src) {
+    Keypoint kt = k;
+    const Eigen::Vector4f hp(k.position.x(), k.position.y(), k.position.z(), 1.0f);
+    const Eigen::Vector4f tp = T * hp;
+    kt.position = tp.head<3>();
+    out.push_back(kt);
+  }
+  return out;
+}
+
+TriangleDescriptor makeTriangle(
+  const std::vector<Keypoint> & kps, int i, int j, int k)
+{
+  const float l_ij = (kps[i].position - kps[j].position).norm();
+  const float l_jk = (kps[j].position - kps[k].position).norm();
+  const float l_ik = (kps[i].position - kps[k].position).norm();
+  struct EdgeRef
+  {
+    float length;
+    int opposite_kp;
+  };
+  std::array<EdgeRef, 3> e = {{
+    {l_jk, i}, {l_ik, j}, {l_ij, k},
+  }};
+  std::sort(
+    e.begin(), e.end(),
+    [](const EdgeRef & a, const EdgeRef & b) {return a.length < b.length;});
+  TriangleDescriptor t;
+  t.edges = {{e[0].length, e[1].length, e[2].length}};
+  t.keypoint_ids = {{e[0].opposite_kp, e[1].opposite_kp, e[2].opposite_kp}};
+  return t;
+}
+
+}  // namespace
+
+TEST(TriangleHash, QuantizesEdgesIntoExpectedBins)
+{
+  TriangleDescriptor t;
+  t.edges = {{3.4f, 5.0f, 7.9f}};
+  HashConfig cfg;
+  cfg.edge_bin_m = 1.0f;
+  cfg.max_bin = 255;
+  const auto h = quantizeEdges(t, cfg);
+  EXPECT_EQ(h.le, 3);
+  EXPECT_EQ(h.me, 5);
+  EXPECT_EQ(h.ge, 7);
+}
+
+TEST(TriangleHash, IsDeterministic)
+{
+  TriangleDescriptor t;
+  t.edges = {{4.1f, 6.2f, 8.3f}};
+  HashConfig cfg;
+  cfg.edge_bin_m = 1.0f;
+  EXPECT_EQ(packHash(quantizeEdges(t, cfg)), packHash(quantizeEdges(t, cfg)));
+}
+
+TEST(TriangleHash, RobustToSmallEdgeNoise)
+{
+  TriangleDescriptor t1;
+  t1.edges = {{3.2f, 5.4f, 7.7f}};
+  TriangleDescriptor t2;
+  t2.edges = {{3.8f, 5.1f, 7.2f}};
+  HashConfig cfg;
+  cfg.edge_bin_m = 1.0f;
+  EXPECT_EQ(quantizeEdges(t1, cfg), quantizeEdges(t2, cfg));
+}
+
+TEST(TriangleHash, ClipsAtMaxBin)
+{
+  TriangleDescriptor t;
+  t.edges = {{500.0f, 600.0f, 700.0f}};
+  HashConfig cfg;
+  cfg.edge_bin_m = 1.0f;
+  cfg.max_bin = 255;
+  const auto h = quantizeEdges(t, cfg);
+  EXPECT_EQ(h.le, 255);
+  EXPECT_EQ(h.me, 255);
+  EXPECT_EQ(h.ge, 255);
+}
+
+TEST(TriangleDatabase, AddSubmapStoresAllValidTriangles)
+{
+  const auto kps = makeKeypointGrid(4, 4, 3.0f);
+  TriangleBuildConfig build_cfg;
+  const auto tris = buildTriangles(kps, build_cfg);
+  ASSERT_FALSE(tris.empty());
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(7, kps, tris, cfg);
+  EXPECT_EQ(db.submapCount(), 1U);
+  EXPECT_EQ(db.triangleCount(), tris.size());
+}
+
+TEST(TriangleDatabase, AddSubmapSkipsInvalidKeypointIds)
+{
+  const auto kps = makeKeypointGrid(3, 3, 2.0f);
+  TriangleDescriptor bad;
+  bad.edges = {{2.0f, 2.0f, 2.83f}};
+  bad.keypoint_ids = {{0, 1, 99}};  // out of range
+  TriangleDescriptor good;
+  good.edges = {{2.0f, 2.0f, 2.83f}};
+  good.keypoint_ids = {{0, 1, 3}};
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(1, kps, {bad, good}, cfg);
+  EXPECT_EQ(db.triangleCount(), 1U);
+}
+
+TEST(TriangleDatabase, LookupReturnsAddedEntries)
+{
+  const auto kps = makeKeypointGrid(3, 3, 2.0f);
+  TriangleDescriptor t = makeTriangle(kps, 0, 1, 3);
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(42, kps, {t}, cfg);
+
+  const auto & bucket = db.lookup(quantizeEdges(t, cfg));
+  ASSERT_EQ(bucket.size(), 1U);
+  EXPECT_EQ(bucket[0].submap_id, 42);
+}
+
+TEST(TriangleVotes, ReturnsHighestForExactMatch)
+{
+  const auto kps = makeKeypointGrid(4, 4, 3.0f);
+  TriangleBuildConfig build_cfg;
+  const auto tris = buildTriangles(kps, build_cfg);
+  ASSERT_GE(tris.size(), 10U);
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(3, kps, tris, cfg);
+
+  VoteConfig vote_cfg;
+  const auto votes = accumulateVotes(db, tris, cfg, vote_cfg);
+  ASSERT_FALSE(votes.empty());
+  EXPECT_EQ(votes.front().submap_id, 3);
+  EXPECT_GT(votes.front().votes, 0);
+}
+
+TEST(TriangleVotes, ExcludesRequestedSubmap)
+{
+  const auto kps = makeKeypointGrid(4, 4, 3.0f);
+  const auto tris = buildTriangles(kps, TriangleBuildConfig{});
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(5, kps, tris, cfg);
+
+  VoteConfig vote_cfg;
+  vote_cfg.exclude_submap_id = 5;
+  const auto votes = accumulateVotes(db, tris, cfg, vote_cfg);
+  for (const auto & v : votes) {
+    EXPECT_NE(v.submap_id, 5);
+  }
+}
+
+TEST(TriangleVotes, MultiSubmapPicksMostSimilar)
+{
+  const auto kps_a = makeKeypointGrid(4, 4, 3.0f);
+  TriangleBuildConfig build_cfg;
+  const auto tris_a = buildTriangles(kps_a, build_cfg);
+
+  // Submap B: same shape (so it should win) at a different absolute position.
+  Eigen::Matrix4f T_b = Eigen::Matrix4f::Identity();
+  T_b.block<3, 1>(0, 3) = Eigen::Vector3f(50.0f, 0.0f, 0.0f);
+  const auto kps_b = transformKeypoints(kps_a, T_b);
+  const auto tris_b = buildTriangles(kps_b, build_cfg);
+
+  // Submap C: completely different geometry (sparse 3-point setup).
+  std::vector<Keypoint> kps_c;
+  kps_c.push_back({Eigen::Vector3f(0.0f, 0.0f, 0.0f), 1.0f});
+  kps_c.push_back({Eigen::Vector3f(40.0f, 0.0f, 0.0f), 1.0f});
+  kps_c.push_back({Eigen::Vector3f(40.0f, 40.0f, 0.0f), 1.0f});
+  kps_c.push_back({Eigen::Vector3f(0.0f, 40.0f, 0.0f), 1.0f});
+  const auto tris_c = buildTriangles(kps_c, build_cfg);
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(101, kps_b, tris_b, cfg);
+  db.addSubmap(202, kps_c, tris_c, cfg);
+
+  VoteConfig vote_cfg;
+  const auto votes = accumulateVotes(db, tris_a, cfg, vote_cfg);
+  ASSERT_FALSE(votes.empty());
+  EXPECT_EQ(votes.front().submap_id, 101);
+}
+
+TEST(TriangleVotes, HoldsUpUnderRotation)
+{
+  const auto kps_a = makeKeypointGrid(4, 4, 3.0f);
+  const auto tris_a = buildTriangles(kps_a, TriangleBuildConfig{});
+
+  Eigen::Matrix4f T = Eigen::Matrix4f::Identity();
+  const float yaw = static_cast<float>(M_PI) * 0.37f;
+  T.block<3, 3>(0, 0) = Eigen::AngleAxisf(yaw, Eigen::Vector3f::UnitZ()).toRotationMatrix();
+  T.block<3, 1>(0, 3) = Eigen::Vector3f(12.0f, -7.0f, 0.0f);
+  const auto kps_b = transformKeypoints(kps_a, T);
+  const auto tris_b = buildTriangles(kps_b, TriangleBuildConfig{});
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(9, kps_b, tris_b, cfg);
+
+  VoteConfig vote_cfg;
+  const auto votes = accumulateVotes(db, tris_a, cfg, vote_cfg);
+  ASSERT_FALSE(votes.empty());
+  EXPECT_EQ(votes.front().submap_id, 9);
+}
+
+TEST(TriangleLoopCandidate, RecoversIdentity)
+{
+  const auto kps = makeKeypointGrid(4, 4, 3.0f);
+  const auto tris = buildTriangles(kps, TriangleBuildConfig{});
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(11, kps, tris, cfg);
+
+  VoteConfig vote_cfg;
+  VerificationConfig verify_cfg;
+  const auto candidate = findLoopCandidate(db, kps, tris, cfg, vote_cfg, verify_cfg);
+  ASSERT_TRUE(candidate.accepted);
+  EXPECT_EQ(candidate.submap_id, 11);
+  EXPECT_GT(candidate.inliers, verify_cfg.min_inliers);
+  const Eigen::Matrix4f T = candidate.transform;
+  const Eigen::Matrix3f R = T.block<3, 3>(0, 0);
+  const Eigen::Vector3f t = T.block<3, 1>(0, 3);
+  EXPECT_LT((R - Eigen::Matrix3f::Identity()).norm(), 1e-3f);
+  EXPECT_LT(t.norm(), 1e-3f);
+}
+
+TEST(TriangleLoopCandidate, RecoversYawAndTranslation)
+{
+  const auto kps_a = makeAsymmetricKeypointSet();
+  const auto tris_a = buildTriangles(kps_a, TriangleBuildConfig{});
+
+  Eigen::Matrix4f T_gt = Eigen::Matrix4f::Identity();
+  const float yaw = static_cast<float>(M_PI) * 0.21f;
+  T_gt.block<3, 3>(0, 0) = Eigen::AngleAxisf(yaw, Eigen::Vector3f::UnitZ()).toRotationMatrix();
+  T_gt.block<3, 1>(0, 3) = Eigen::Vector3f(8.0f, 4.5f, 0.0f);
+  const auto kps_b = transformKeypoints(kps_a, T_gt);
+  const auto tris_b = buildTriangles(kps_b, TriangleBuildConfig{});
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(77, kps_b, tris_b, cfg);
+
+  VoteConfig vote_cfg;
+  VerificationConfig verify_cfg;
+  const auto candidate = findLoopCandidate(db, kps_a, tris_a, cfg, vote_cfg, verify_cfg);
+  ASSERT_TRUE(candidate.accepted);
+  EXPECT_EQ(candidate.submap_id, 77);
+
+  const Eigen::Matrix4f T = candidate.transform;
+  const Eigen::Matrix4f delta = T_gt.inverse() * T;
+  const Eigen::Vector3f dt = delta.block<3, 1>(0, 3);
+  EXPECT_LT(dt.norm(), 0.2f);
+  const Eigen::Matrix3f R_delta = delta.block<3, 3>(0, 0);
+  const float trace = R_delta.trace();
+  const float arg = std::max(-1.0f, std::min(1.0f, (trace - 1.0f) * 0.5f));
+  const float angle_deg = std::acos(arg) * 180.0f / static_cast<float>(M_PI);
+  EXPECT_LT(angle_deg, 1.0f);
+}
+
+TEST(TriangleLoopCandidate, RejectsWhenDatabaseEmpty)
+{
+  TriangleDatabase db;
+  HashConfig cfg;
+  const auto candidate = findLoopCandidate(
+    db, std::vector<Keypoint>{}, std::vector<TriangleDescriptor>{},
+    cfg, VoteConfig{}, VerificationConfig{});
+  EXPECT_FALSE(candidate.accepted);
+  EXPECT_EQ(candidate.submap_id, -1);
+}
+
+TEST(TriangleLoopCandidate, RejectsUnrelatedQueries)
+{
+  // DB: a regular grid.
+  const auto kps_db = makeKeypointGrid(4, 4, 3.0f);
+  const auto tris_db = buildTriangles(kps_db, TriangleBuildConfig{});
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(50, kps_db, tris_db, cfg);
+
+  // Query: very different geometry (1.0f spacing -> all edges shrunk; should
+  // produce no overlap in hash buckets at edge_bin_m=1.0).
+  const auto kps_q = makeKeypointGrid(4, 4, 0.8f);
+  const auto tris_q = buildTriangles(kps_q, TriangleBuildConfig{});
+
+  VoteConfig vote_cfg;
+  VerificationConfig verify_cfg;
+  const auto candidate = findLoopCandidate(db, kps_q, tris_q, cfg, vote_cfg, verify_cfg);
+  EXPECT_FALSE(candidate.accepted);
+}


### PR DESCRIPTION
## Summary

Follow-up to #135. Adds `triangle_descriptor_database.hpp` so the STD-style
triangle primitives can drive actual place recognition:

- **Hashing** (`quantizeEdges` + `packHash`): sorted edges → uint64 bucket key. Edges within `edge_bin_m` share a bucket so noisy descriptors still match.
- **TriangleDatabase**: hash → list of `(submap_id, vertex positions)` so geometric verification works without re-reading keypoints.
- **`accumulateVotes`**: per-query hash lookup with `max_votes_per_query` cap (avoid dominance from one degenerate bucket) and `exclude_submap_id` for adjacent-frame suppression.
- **`findLoopCandidate`**: top-voted submap → RANSAC over matching triangle pairs using `estimateRigidFromTriangle`. Accepts when `min_inliers` proposals agree on SE(3) within `inlier_translation_m` / `inlier_rotation_deg`.

All under BSD-2 so the default workflow keeps it (vs GPLv2 STD).

## Test plan

- [x] `colcon test --packages-select graph_based_slam` → 448 tests, 0 failures, 26 skipped (test_triangle_descriptor_database adds 15)
- [x] hash determinism + edge-bin alignment + max-bin clipping
- [x] add / lookup, invalid keypoint-id skip
- [x] vote ranking under: exact match, exclude submap, multi-submap competition, yaw rotation
- [x] `findLoopCandidate` recovers identity transform
- [x] `findLoopCandidate` recovers yaw + translation on asymmetric keypoint set (regular grid 180°-symmetric so test breaks it with off-axis marker)
- [x] `findLoopCandidate` rejects empty DB and unrelated queries
- [x] cpplint / uncrustify / flake8 / pep257 / xmllint pass

## Follow-ups

1. Component-level opt-in (`use_triangle_descriptor` mirroring `use_bev_descriptor`)
2. Combine triangle vote shortlist with BEV mutual-visibility verification
3. Benchmark MID-360 against existing BEV / Scan Context paths