### PR TITLE
feat: surface triangle descriptor parameters in default YAMLs

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -303,6 +303,11 @@ if(BUILD_TESTING)
     test/test_exploration_closeout_report.py
     TIMEOUT 120
   )
+  ament_add_pytest_test(
+    test_triangle_descriptor_yaml_defaults
+    test/test_triangle_descriptor_yaml_defaults.py
+    TIMEOUT 60
+  )
 endif()
 
 add_library(graph_based_slam_component SHARED

--- a/graph_based_slam/param/graphbasedslam.yaml
+++ b/graph_based_slam/param/graphbasedslam.yaml
@@ -40,6 +40,23 @@ graph_based_slam:
       solid_descriptor_sequence_min_similarity: -1.0
       solid_descriptor_pose_consistency_threshold_m: -1.0
       solid_descriptor_max_euclidean_distance_m: -1.0
+      # STD/BTC-style triangle descriptor place recognition. Defaults sized
+      # for a 360° LiDAR; tighten the edge and grid bounds for short-range
+      # sensors like the Livox MID-360.
+      use_triangle_descriptor: false
+      triangle_descriptor_grid_size_m: 60.0
+      triangle_descriptor_grid_cells: 60
+      triangle_descriptor_max_keypoints: 80
+      triangle_descriptor_min_salience_m: 0.3
+      triangle_descriptor_min_edge_m: 2.0
+      triangle_descriptor_max_edge_m: 50.0
+      triangle_descriptor_max_triangles: 5000
+      triangle_descriptor_edge_bin_m: 1.0
+      triangle_descriptor_min_votes: 6
+      triangle_descriptor_min_inliers: 3
+      triangle_descriptor_inlier_translation_m: 2.0
+      triangle_descriptor_inlier_rotation_deg: 5.0
+      triangle_descriptor_exclude_recent: 4
       prefer_scan_context_candidates: false
       use_3d_bbs_for_scan_context: false
       three_d_bbs_min_level_res: 1.0

--- a/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
+++ b/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Regression tests for triangle descriptor parameters in default YAML files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+EXPECTED_PARAM_KEYS = {
+    'use_triangle_descriptor',
+    'triangle_descriptor_grid_size_m',
+    'triangle_descriptor_grid_cells',
+    'triangle_descriptor_max_keypoints',
+    'triangle_descriptor_min_salience_m',
+    'triangle_descriptor_min_edge_m',
+    'triangle_descriptor_max_edge_m',
+    'triangle_descriptor_max_triangles',
+    'triangle_descriptor_edge_bin_m',
+    'triangle_descriptor_min_votes',
+    'triangle_descriptor_min_inliers',
+    'triangle_descriptor_inlier_translation_m',
+    'triangle_descriptor_inlier_rotation_deg',
+    'triangle_descriptor_exclude_recent',
+}
+
+PARAM_FILES = [
+    REPO_ROOT / 'graph_based_slam' / 'param' / 'graphbasedslam.yaml',
+    REPO_ROOT / 'lidarslam' / 'param' / 'lidarslam_mid360_rko_graph.yaml',
+]
+
+
+def _load_graph_params(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding='utf-8'))
+    assert 'graph_based_slam' in data, f'{path} missing graph_based_slam node'
+    params = data['graph_based_slam'].get('ros__parameters')
+    assert params is not None, f'{path} missing ros__parameters'
+    return params
+
+
+@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
+def test_yaml_contains_all_triangle_descriptor_keys(path):
+    params = _load_graph_params(path)
+    missing = EXPECTED_PARAM_KEYS - set(params.keys())
+    assert not missing, (
+        f'{path.name} missing keys: {sorted(missing)}'
+    )
+
+
+@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
+def test_triangle_descriptor_defaults_off(path):
+    params = _load_graph_params(path)
+    assert params['use_triangle_descriptor'] is False, (
+        f'{path.name}: triangle descriptor must default off so the existing '
+        'workflow stays unchanged'
+    )
+
+
+@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
+def test_triangle_descriptor_edge_bounds_sane(path):
+    params = _load_graph_params(path)
+    min_edge = params['triangle_descriptor_min_edge_m']
+    max_edge = params['triangle_descriptor_max_edge_m']
+    assert min_edge > 0.0, f'{path.name}: min_edge_m must be positive'
+    assert max_edge > min_edge, (
+        f'{path.name}: max_edge_m ({max_edge}) must exceed min_edge_m ({min_edge})'
+    )
+
+
+def test_mid360_preset_tightens_for_short_range_sensor():
+    """MID-360 has shorter range than spinning 360° LiDAR; preset must reflect."""
+    default = _load_graph_params(PARAM_FILES[0])
+    mid360 = _load_graph_params(PARAM_FILES[1])
+    assert mid360['triangle_descriptor_max_edge_m'] <= default['triangle_descriptor_max_edge_m'], (
+        'MID-360 preset must not exceed the generic LiDAR max edge (shorter range sensor)'
+    )
+    assert mid360['triangle_descriptor_min_votes'] >= default['triangle_descriptor_min_votes'], (
+        'MID-360 preset should be stricter on vote count to suppress FOV ambiguity'
+    )

--- a/lidarslam/param/lidarslam_mid360_rko_graph.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph.yaml
@@ -40,6 +40,24 @@ graph_based_slam:
     solid_descriptor_sequence_min_similarity: -1.0
     solid_descriptor_pose_consistency_threshold_m: -1.0
     solid_descriptor_max_euclidean_distance_m: -1.0
+    # STD/BTC-style triangle descriptor tuned for MID-360 (shorter range,
+    # narrower FOV than a spinning 360° LiDAR). Default off so the existing
+    # MID-360 pipeline keeps the same loop-closure behaviour; flip
+    # use_triangle_descriptor to true to opt in.
+    use_triangle_descriptor: false
+    triangle_descriptor_grid_size_m: 60.0
+    triangle_descriptor_grid_cells: 60
+    triangle_descriptor_max_keypoints: 60
+    triangle_descriptor_min_salience_m: 0.3
+    triangle_descriptor_min_edge_m: 2.0
+    triangle_descriptor_max_edge_m: 30.0
+    triangle_descriptor_max_triangles: 3000
+    triangle_descriptor_edge_bin_m: 1.0
+    triangle_descriptor_min_votes: 8
+    triangle_descriptor_min_inliers: 4
+    triangle_descriptor_inlier_translation_m: 2.0
+    triangle_descriptor_inlier_rotation_deg: 5.0
+    triangle_descriptor_exclude_recent: 6
     prefer_scan_context_candidates: false
     use_3d_bbs_for_scan_context: false
     three_d_bbs_min_level_res: 1.0


### PR DESCRIPTION
## Summary

Follow-up to #137. Surfaces the 14 `triangle_descriptor_*` parameters into the shipped YAML presets so users can find every knob without reading C++.

- `graph_based_slam/param/graphbasedslam.yaml` — generic 360° LiDAR defaults (50 m max edge, 80 keypoints, 5000 triangles).
- `lidarslam/param/lidarslam_mid360_rko_graph.yaml` — MID-360 preset tightened for the sensor: 30 m max edge, 60 keypoints, 3000 triangles, vote / inlier floors 8 / 4 to suppress narrow-FOV ambiguity.
- Both presets default `use_triangle_descriptor: false` — existing pipelines stay untouched; users flip one flag to opt in.

## Test plan

- [x] `colcon test --packages-select graph_based_slam` — **458 tests, 0 failures, 26 skipped** (test_triangle_descriptor_yaml_defaults adds 8)
- [x] pytest verifies: every C++ param has a YAML default, defaults are off, edge bounds sane, MID-360 preset stays at or below the generic on edge / vote
- [x] uncrustify / cpplint / flake8 / pep257 / xmllint pass

## Follow-ups

1. Benchmark MID-360 / NTU place-recognition recall against BEV + Scan Context baselines
2. Combine triangle vote shortlist with BEV mutual-visibility verification on the same candidate