### PR TITLE
feat: track triangle descriptor in place-recognition report

### DIFF
--- a/graph_based_slam/test/test_place_recognition_report.py
+++ b/graph_based_slam/test/test_place_recognition_report.py
@@ -268,3 +268,77 @@ def test_place_recognition_report_supports_bev_rerank_label(tmp_path):
     payload = json.loads(out_json.read_text(encoding='utf-8'))
     assert payload['candidate']['kind'] == 'bev_rerank'
     assert payload['candidate']['log_summary']['bev_rerank_hint_count'] == 1
+
+
+def test_place_recognition_report_counts_triangle_candidates(tmp_path):
+    """Triangle candidate logs + accepted source must surface in the report."""
+    baseline_metrics = tmp_path / 'baseline' / 'metrics.json'
+    candidate_metrics = tmp_path / 'candidate' / 'metrics.json'
+    baseline_log = tmp_path / 'baseline' / 'run.log'
+    candidate_log = tmp_path / 'candidate' / 'run.log'
+    out_path = tmp_path / 'triangle_report.md'
+    out_json = tmp_path / 'triangle_report.json'
+
+    _write_metrics(baseline_metrics, rmse=2.50, loop_count=0, attempted=0)
+    _write_metrics(candidate_metrics, rmse=2.10, loop_count=2, attempted=3)
+    baseline_log.write_text(
+        '\n'.join(
+            [
+                'use_scan_context:false',
+            ],
+        ) + '\n',
+        encoding='utf-8',
+    )
+    candidate_log.write_text(
+        '\n'.join(
+            [
+                'use_scan_context:false',
+                'Triangle loop candidate: id=12 votes=10 inliers=5 yaw_deg=12.0',
+                'Triangle loop candidate: id=20 votes=8 inliers=4 yaw_deg=-5.0',
+                'loop_candidate_source:triangle_descriptor',
+                'loop_candidate_source:triangle_descriptor',
+            ],
+        ) + '\n',
+        encoding='utf-8',
+    )
+
+    result = subprocess.run(
+        [
+            'python3',
+            str(SCRIPT),
+            '--baseline-metrics',
+            str(baseline_metrics),
+            '--baseline-log',
+            str(baseline_log),
+            '--candidate-metrics',
+            str(candidate_metrics),
+            '--candidate-log',
+            str(candidate_log),
+            '--baseline-label',
+            'distance baseline',
+            '--candidate-label',
+            'triangle descriptor',
+            '--candidate-kind',
+            'triangle_descriptor',
+            '--out',
+            str(out_path),
+            '--write-json',
+            str(out_json),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = out_path.read_text(encoding='utf-8')
+    assert 'triangle descriptor' in report
+    assert 'Accepted Triangle loops' in report
+    assert 'Observed Triangle candidates' in report
+    assert 'accepted loop closures from triangle descriptor hashing' in report
+    payload = json.loads(out_json.read_text(encoding='utf-8'))
+    assert payload['candidate']['kind'] == 'triangle_descriptor'
+    counts = payload['candidate']['log_summary']['accepted_source_counts']
+    assert counts['triangle_descriptor'] == 2
+    assert payload['candidate']['log_summary']['triangle_candidate_count'] == 2

--- a/scripts/generate_place_recognition_report.py
+++ b/scripts/generate_place_recognition_report.py
@@ -81,10 +81,12 @@ def parse_log_summary(log_path: Path) -> dict[str, object]:
             'scan_context': 0,
             'bev_descriptor': 0,
             'solid_descriptor': 0,
+            'triangle_descriptor': 0,
         },
         'scan_context_candidate_count': 0,
         'bev_rerank_hint_count': 0,
         'solid_rerank_candidate_count': 0,
+        'triangle_candidate_count': 0,
     }
     if not log_path.is_file():
         return summary
@@ -102,6 +104,9 @@ def parse_log_summary(log_path: Path) -> dict[str, object]:
     )
     summary['solid_rerank_candidate_count'] = len(
         re.findall(r'SOLiD rerank candidate:', text),
+    )
+    summary['triangle_candidate_count'] = len(
+        re.findall(r'Triangle loop candidate:', text),
     )
     for source in re.findall(r'loop_candidate_source:([a-z_]+)', text):
         counts = summary['accepted_source_counts']
@@ -184,6 +189,17 @@ def _conclusion(
             source_text = 'SOLiD produced rerank candidates, but none survived geometric validation'
         else:
             source_text = 'no SOLiD rerank candidate made it into the accepted loop set'
+    elif candidate_kind == 'triangle_descriptor':
+        accepted = int(accepted_counts.get('triangle_descriptor', 0))
+        observed = int(candidate_log.get('triangle_candidate_count', 0))
+        if accepted > 0:
+            source_text = 'accepted loop closures from triangle descriptor hashing'
+        elif observed > 0:
+            source_text = (
+                'triangle descriptor emitted candidates, but none survived NDT/GICP validation'
+            )
+        else:
+            source_text = 'no triangle descriptor candidate made it into the accepted loop set'
     else:
         source_text = f'{candidate_label} completed'
 
@@ -241,7 +257,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         '--candidate-kind',
         default='scan_context',
-        choices=['scan_context', 'bev_rerank', 'solid_descriptor', 'generic'],
+        choices=[
+            'scan_context', 'bev_rerank', 'solid_descriptor',
+            'triangle_descriptor', 'generic',
+        ],
         help='Descriptor family used by the candidate run.',
     )
     parser.add_argument(
@@ -335,10 +354,10 @@ experimental place-recognition candidate run.
 
 ## Summary
 
-| Run | Runtime `use_scan_context` | APE RMSE (m) | Accepted loops | Attempted loops | Accepted distance loops | Accepted Scan Context loops | Accepted BEV loops | Accepted SOLiD loops | Observed Scan Context candidates | Observed BEV rerank hints | Observed SOLiD rerank candidates |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| {args.baseline_label} | `{baseline_log_summary.get("use_scan_context")}` | `{_fmt(baseline_rmse)}` | `{_loop_count(baseline, "loop_count")}` | `{_loop_count(baseline, "loop_count_attempted")}` | `{baseline_log_summary["accepted_source_counts"].get("distance", 0)}` | `{baseline_log_summary["accepted_source_counts"].get("scan_context", 0)}` | `{baseline_log_summary["accepted_source_counts"].get("bev_descriptor", 0)}` | `{baseline_log_summary["accepted_source_counts"].get("solid_descriptor", 0)}` | `{baseline_log_summary.get("scan_context_candidate_count", 0)}` | `{baseline_log_summary.get("bev_rerank_hint_count", 0)}` | `{baseline_log_summary.get("solid_rerank_candidate_count", 0)}` |
-| {args.candidate_label} | `{candidate_log_summary.get("use_scan_context")}` | `{_fmt(candidate_rmse)}` | `{_loop_count(candidate, "loop_count")}` | `{_loop_count(candidate, "loop_count_attempted")}` | `{candidate_log_summary["accepted_source_counts"].get("distance", 0)}` | `{candidate_log_summary["accepted_source_counts"].get("scan_context", 0)}` | `{candidate_log_summary["accepted_source_counts"].get("bev_descriptor", 0)}` | `{candidate_log_summary["accepted_source_counts"].get("solid_descriptor", 0)}` | `{candidate_log_summary.get("scan_context_candidate_count", 0)}` | `{candidate_log_summary.get("bev_rerank_hint_count", 0)}` | `{candidate_log_summary.get("solid_rerank_candidate_count", 0)}` |
+| Run | Runtime `use_scan_context` | APE RMSE (m) | Accepted loops | Attempted loops | Accepted distance loops | Accepted Scan Context loops | Accepted BEV loops | Accepted SOLiD loops | Accepted Triangle loops | Observed Scan Context candidates | Observed BEV rerank hints | Observed SOLiD rerank candidates | Observed Triangle candidates |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| {args.baseline_label} | `{baseline_log_summary.get("use_scan_context")}` | `{_fmt(baseline_rmse)}` | `{_loop_count(baseline, "loop_count")}` | `{_loop_count(baseline, "loop_count_attempted")}` | `{baseline_log_summary["accepted_source_counts"].get("distance", 0)}` | `{baseline_log_summary["accepted_source_counts"].get("scan_context", 0)}` | `{baseline_log_summary["accepted_source_counts"].get("bev_descriptor", 0)}` | `{baseline_log_summary["accepted_source_counts"].get("solid_descriptor", 0)}` | `{baseline_log_summary["accepted_source_counts"].get("triangle_descriptor", 0)}` | `{baseline_log_summary.get("scan_context_candidate_count", 0)}` | `{baseline_log_summary.get("bev_rerank_hint_count", 0)}` | `{baseline_log_summary.get("solid_rerank_candidate_count", 0)}` | `{baseline_log_summary.get("triangle_candidate_count", 0)}` |
+| {args.candidate_label} | `{candidate_log_summary.get("use_scan_context")}` | `{_fmt(candidate_rmse)}` | `{_loop_count(candidate, "loop_count")}` | `{_loop_count(candidate, "loop_count_attempted")}` | `{candidate_log_summary["accepted_source_counts"].get("distance", 0)}` | `{candidate_log_summary["accepted_source_counts"].get("scan_context", 0)}` | `{candidate_log_summary["accepted_source_counts"].get("bev_descriptor", 0)}` | `{candidate_log_summary["accepted_source_counts"].get("solid_descriptor", 0)}` | `{candidate_log_summary["accepted_source_counts"].get("triangle_descriptor", 0)}` | `{candidate_log_summary.get("scan_context_candidate_count", 0)}` | `{candidate_log_summary.get("bev_rerank_hint_count", 0)}` | `{candidate_log_summary.get("solid_rerank_candidate_count", 0)}` | `{candidate_log_summary.get("triangle_candidate_count", 0)}` |
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary

Extends `generate_place_recognition_report.py` so MID-360 / NTU runs using `use_triangle_descriptor:=true` can be diffed against a distance-only baseline with the same shell pipeline used for Scan Context / BEV / SOLiD ablations.

- Parses `Triangle loop candidate:` lines from the launch log → `triangle_candidate_count`.
- Counts `loop_candidate_source:triangle_descriptor` acceptances into `accepted_source_counts['triangle_descriptor']`.
- Adds *Accepted Triangle loops* + *Observed Triangle candidates* columns to the markdown summary.
- New `--candidate-kind triangle_descriptor` choice with its own conclusion phrasing.

## Test plan

- [x] `colcon test --packages-select graph_based_slam` — **459 tests, 0 failures, 26 skipped** (test_place_recognition_report grows from 4 cases to 5)
- [x] Synthetic test feeds 2x `Triangle loop candidate:` + 2x `loop_candidate_source:triangle_descriptor` and asserts the report + JSON pick them up
- [x] uncrustify / cpplint / flake8 / pep257 / xmllint pass locally

## Follow-ups

Real-bag ablation: rerun MID-360 demo bag with `use_triangle_descriptor:=true`, diff against the latest distance-only baseline, attach the generated markdown to a v0.4 progress note.