### PR TITLE
feat: optional BEV cross-verification for triangle loop candidates

### DIFF
--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -255,6 +255,13 @@ private:
     double triangle_descriptor_inlier_translation_m_ {2.0};
     double triangle_descriptor_inlier_rotation_deg_ {5.0};
     int triangle_descriptor_exclude_recent_ {4};
+    // Cross-verification: when both use_triangle_descriptor and
+    // use_bev_descriptor are true, gate the triangle candidate by also
+    // requiring the BEV mutual-visibility distance to clear an upper bound.
+    // Helps filter false positives caused by repeated geometry (corridors,
+    // facades) at the cost of triangle-only recall.
+    bool triangle_verify_with_bev_ {false};
+    double triangle_verify_bev_max_distance_ {0.30};
     graphslam::triangle::TriangleDatabase triangle_descriptor_db_;
     struct TrianglePerSubmap
     {

--- a/graph_based_slam/param/graphbasedslam.yaml
+++ b/graph_based_slam/param/graphbasedslam.yaml
@@ -57,6 +57,11 @@ graph_based_slam:
       triangle_descriptor_inlier_translation_m: 2.0
       triangle_descriptor_inlier_rotation_deg: 5.0
       triangle_descriptor_exclude_recent: 4
+      # Optional: gate triangle candidates by BEV mutual-visibility distance
+      # to suppress false positives from repeated geometry. Requires
+      # use_bev_descriptor: true to have any effect.
+      triangle_verify_with_bev: false
+      triangle_verify_bev_max_distance: 0.30
       prefer_scan_context_candidates: false
       use_3d_bbs_for_scan_context: false
       three_d_bbs_min_level_res: 1.0

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -157,6 +157,10 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     triangle_descriptor_inlier_rotation_deg_);
   declare_parameter("triangle_descriptor_exclude_recent", 4);
   get_parameter("triangle_descriptor_exclude_recent", triangle_descriptor_exclude_recent_);
+  declare_parameter("triangle_verify_with_bev", false);
+  get_parameter("triangle_verify_with_bev", triangle_verify_with_bev_);
+  declare_parameter("triangle_verify_bev_max_distance", 0.30);
+  get_parameter("triangle_verify_bev_max_distance", triangle_verify_bev_max_distance_);
   declare_parameter("use_pcd_cache", false);
   get_parameter("use_pcd_cache", use_pcd_cache_);
   declare_parameter("pcd_cache_dir", std::string("/tmp/graph_slam_pcd_cache"));
@@ -528,6 +532,9 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   }
   if (triangle_descriptor_exclude_recent_ < 0) {
     triangle_descriptor_exclude_recent_ = 0;
+  }
+  if (triangle_verify_bev_max_distance_ <= 0.0) {
+    triangle_verify_bev_max_distance_ = 0.30;
   }
   if (
     solid_descriptor_min_similarity_ <= -1.0 ||
@@ -1865,7 +1872,30 @@ void GraphBasedSlamComponent::searchLoop()
         if (cand.accepted) {
           const double travel_distance =
             latest_moving_distance - map_array_msg.submaps[chosen_submap_id].distance;
-          if (travel_distance > distance_loop_closure_) {
+          bool bev_cross_verify_ok = true;
+          double bev_cross_verify_distance = std::numeric_limits<double>::infinity();
+          if (
+            triangle_verify_with_bev_ &&
+            use_bev_descriptor_ &&
+            chosen_submap_id < bev_descriptor_db_.size() &&
+            !bev_descriptor_db_.descriptors.empty())
+          {
+            graphslam::bev::MutualVisibilityConfig mv_cfg;
+            mv_cfg.min_overlap_ratio = bev_mutual_visibility_min_overlap_ratio_;
+            mv_cfg.occupancy_eps =
+              static_cast<float>(bev_mutual_visibility_occupancy_eps_);
+            const auto fov = graphslam::bev::mutualVisibilityWithYawSearch(
+              bev_descriptor_db_.descriptors.back(),
+              bev_descriptor_db_.descriptors[chosen_submap_id],
+              chosen_submap_id,
+              bev_descriptor_yaw_bins_,
+              mv_cfg);
+            bev_cross_verify_distance = fov.valid ?
+              fov.distance : std::numeric_limits<double>::infinity();
+            bev_cross_verify_ok =
+              fov.valid && fov.distance <= triangle_verify_bev_max_distance_;
+          }
+          if (travel_distance > distance_loop_closure_ && bev_cross_verify_ok) {
             const Eigen::Matrix3f R = cand.transform.block<3, 3>(0, 0);
             const Eigen::Vector3f euler = R.eulerAngles(2, 1, 0);
             double tri_yaw_rad = static_cast<double>(euler[0]);
@@ -1881,7 +1911,17 @@ void GraphBasedSlamComponent::searchLoop()
             std::cout << "Triangle loop candidate: id=" << chosen_submap_id
                       << " votes=" << chosen_votes
                       << " inliers=" << cand.inliers
-                      << " yaw_deg=" << tri_yaw_rad * 180.0 / M_PI << std::endl;
+                      << " yaw_deg=" << tri_yaw_rad * 180.0 / M_PI;
+            if (triangle_verify_with_bev_) {
+              std::cout << " bev_xv_dist=" << bev_cross_verify_distance;
+            }
+            std::cout << std::endl;
+          } else if (!bev_cross_verify_ok && debug_flag_) {
+            RCLCPP_INFO(
+              get_logger(),
+              "Skip Triangle candidate %d: BEV cross-verify distance %.3f > %.3f",
+              chosen_submap_id, bev_cross_verify_distance,
+              triangle_verify_bev_max_distance_);
           } else if (debug_flag_) {
             RCLCPP_INFO(
               get_logger(),

--- a/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
+++ b/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
@@ -53,6 +53,8 @@ EXPECTED_PARAM_KEYS = {
     'triangle_descriptor_inlier_translation_m',
     'triangle_descriptor_inlier_rotation_deg',
     'triangle_descriptor_exclude_recent',
+    'triangle_verify_with_bev',
+    'triangle_verify_bev_max_distance',
 }
 
 PARAM_FILES = [
@@ -108,3 +110,11 @@ def test_mid360_preset_tightens_for_short_range_sensor():
     assert mid360['triangle_descriptor_min_votes'] >= default['triangle_descriptor_min_votes'], (
         'MID-360 preset should be stricter on vote count to suppress FOV ambiguity'
     )
+
+
+@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
+def test_bev_cross_verify_defaults_off(path):
+    """Cross-verification must be opt-in so default workflows stay unchanged."""
+    params = _load_graph_params(path)
+    assert params['triangle_verify_with_bev'] is False
+    assert params['triangle_verify_bev_max_distance'] > 0.0

--- a/lidarslam/param/lidarslam_mid360_rko_graph.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph.yaml
@@ -58,6 +58,11 @@ graph_based_slam:
     triangle_descriptor_inlier_translation_m: 2.0
     triangle_descriptor_inlier_rotation_deg: 5.0
     triangle_descriptor_exclude_recent: 6
+    # Optional: gate triangle candidates by BEV mutual-visibility distance to
+    # suppress false positives in repeated MID-360 geometry. Requires
+    # use_bev_descriptor: true to have any effect.
+    triangle_verify_with_bev: false
+    triangle_verify_bev_max_distance: 0.30
     prefer_scan_context_candidates: false
     use_3d_bbs_for_scan_context: false
     three_d_bbs_min_level_res: 1.0


### PR DESCRIPTION
## Summary

Adds an opt-in safety net for triangle-descriptor loop candidates: when both `use_triangle_descriptor` and `use_bev_descriptor` are on and `triangle_verify_with_bev` is set, a triangle-accepted candidate also has to clear a BEV mutual-visibility distance bound (`triangle_verify_bev_max_distance`, default 0.30) before joining the candidate list.

Motivation: STD-style triangle hashing can produce strong RANSAC inliers on repeated geometry (corridors, facades, parking lots, urban grids) where BEV visibly disagrees. Cross-verification drops those before they reach NDT/GICP.

- 2 new ROS parameters (default off). YAML presets ship them commented as opt-in.
- Yaml regression now requires both keys exist in both presets and default off.
- The triangle candidate log gains `bev_xv_dist=<value>` when the gate is on, so the place-recognition report can attribute drops back to BEV.

## Test plan

- [x] `colcon test --packages-select graph_based_slam` — **460 tests, 0 failures, 26 skipped** (yaml regression grows from 8 to 10 cases)
- [x] uncrustify / cpplint / flake8 / pep257 / xmllint pass locally

## Follow-ups

- Once #139 lands, extend the place-recognition report to surface `bev_xv_dist` skips.
- Real-bag ablation: rerun MID-360 with `use_triangle_descriptor:=true` and `triangle_verify_with_bev:=true` to confirm the gate cuts false positives without killing recall.