### PR TITLE
fix: pick slam.launch.log in ablation runner; degenericize report header

### DIFF
--- a/scripts/generate_place_recognition_report.py
+++ b/scripts/generate_place_recognition_report.py
@@ -342,8 +342,9 @@ def main() -> int:
 
     report = f"""# Place Recognition Report
 
-This report compares a fair current-code MID360 baseline rerun against an
-experimental place-recognition candidate run.
+This report compares a current-code baseline run against an experimental
+place-recognition candidate run (same bag, same params except the candidate
+descriptor toggle).
 
 ## Inputs
 

--- a/scripts/run_triangle_ablation.sh
+++ b/scripts/run_triangle_ablation.sh
@@ -176,8 +176,19 @@ run_one "candidate (use_triangle_descriptor:=true)" \
 
 BASELINE_METRICS="${BASELINE_DIR}/metrics.json"
 CANDIDATE_METRICS="${CANDIDATE_DIR}/metrics.json"
-BASELINE_LOG=$(find "$BASELINE_DIR" -maxdepth 2 -name "*.log" | head -n 1)
-CANDIDATE_LOG=$(find "$CANDIDATE_DIR" -maxdepth 2 -name "*.log" | head -n 1)
+# Prefer slam.launch.log because that's where the graph_based_slam component
+# emits the candidate / loop_candidate_source counters the report parses.
+# Fall back to any *.log only when the canonical launch log is missing.
+pick_launch_log() {
+  local dir="$1"
+  if [[ -f "${dir}/slam.launch.log" ]]; then
+    echo "${dir}/slam.launch.log"
+  else
+    find "$dir" -maxdepth 2 -name "*.log" | head -n 1
+  fi
+}
+BASELINE_LOG="$(pick_launch_log "$BASELINE_DIR")"
+CANDIDATE_LOG="$(pick_launch_log "$CANDIDATE_DIR")"
 
 if [[ -z "$REPORT_OUT" ]]; then
   REPORT_OUT="${OUTPUT_DIR}/triangle_ablation_report.md"


### PR DESCRIPTION
## Summary

Two small follow-ups from the first NTU VIRAL ablation run (#141):

1. `run_triangle_ablation.sh` used `find -name '*.log' | head -n 1` to pick the launch log per run. `find` returned `map_save.log` first (alphabetical), which has none of the `loop_candidate_source:` or `Triangle loop candidate:` lines the report parses — so the generated table showed `accepted distance loops: 0` on a run that actually accepted 26.

   Add a `pick_launch_log` helper that prefers `slam.launch.log` when present and only falls back to the find-first-log heuristic when it is missing. Empirically: on the NTU VIRAL ablation this turned the parsed accepted-distance count from `0` (wrong log) to `26 vs 21` (correct log).

2. `generate_place_recognition_report.py` opened with hardcoded *"a fair current-code MID360 baseline rerun"*. The same generator is now used for NTU VIRAL / Leo Drive / Newer College ablations, so the wording was actively wrong. Reworded to *"a current-code baseline run against an experimental place-recognition candidate run (same bag, same params except the candidate descriptor toggle)."*

## Test plan

- [x] `colcon test --packages-select graph_based_slam` — **468 tests, 0 failures, 26 skipped**; `test_place_recognition_report` still passes (no assertion was on the MID360 phrasing).
- [x] Manual: regenerated the NTU VIRAL ablation report with the fixed runner — accepted-source counts now reflect reality.

## Follow-up

A separate PR will tighten triangle descriptor defaults + plumb the recovered SE(3) as NDT initial guess so the candidates the triangle path emits actually survive NDT verification (current run: 4 candidates emitted, 0 accepted).