### PR TITLE
feat: plumb triangle SE(3) as NDT initial guess; raise default thresholds

### DIFF
--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -250,8 +250,12 @@ private:
     double triangle_descriptor_max_edge_m_ {50.0};
     int triangle_descriptor_max_triangles_ {5000};
     double triangle_descriptor_edge_bin_m_ {1.0};
-    int triangle_descriptor_min_votes_ {6};
-    int triangle_descriptor_min_inliers_ {3};
+    // NTU VIRAL ablation showed min_inliers 3 / min_votes 6 let through too
+    // many weak triangle candidates that NDT then rejected. Tighten the
+    // defaults so the few candidates the descriptor does emit are more
+    // likely to survive geometric verification.
+    int triangle_descriptor_min_votes_ {10};
+    int triangle_descriptor_min_inliers_ {5};
     double triangle_descriptor_inlier_translation_m_ {2.0};
     double triangle_descriptor_inlier_rotation_deg_ {5.0};
     int triangle_descriptor_exclude_recent_ {4};

--- a/graph_based_slam/param/graphbasedslam.yaml
+++ b/graph_based_slam/param/graphbasedslam.yaml
@@ -52,8 +52,8 @@ graph_based_slam:
       triangle_descriptor_max_edge_m: 50.0
       triangle_descriptor_max_triangles: 5000
       triangle_descriptor_edge_bin_m: 1.0
-      triangle_descriptor_min_votes: 6
-      triangle_descriptor_min_inliers: 3
+      triangle_descriptor_min_votes: 10
+      triangle_descriptor_min_inliers: 5
       triangle_descriptor_inlier_translation_m: 2.0
       triangle_descriptor_inlier_rotation_deg: 5.0
       triangle_descriptor_exclude_recent: 4

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -143,9 +143,9 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("triangle_descriptor_max_triangles", triangle_descriptor_max_triangles_);
   declare_parameter("triangle_descriptor_edge_bin_m", 1.0);
   get_parameter("triangle_descriptor_edge_bin_m", triangle_descriptor_edge_bin_m_);
-  declare_parameter("triangle_descriptor_min_votes", 6);
+  declare_parameter("triangle_descriptor_min_votes", 10);
   get_parameter("triangle_descriptor_min_votes", triangle_descriptor_min_votes_);
-  declare_parameter("triangle_descriptor_min_inliers", 3);
+  declare_parameter("triangle_descriptor_min_inliers", 5);
   get_parameter("triangle_descriptor_min_inliers", triangle_descriptor_min_inliers_);
   declare_parameter("triangle_descriptor_inlier_translation_m", 2.0);
   get_parameter(
@@ -1059,6 +1059,11 @@ void GraphBasedSlamComponent::searchLoop()
     double selection_metric {std::numeric_limits<double>::max()};
     Source source {Source::DISTANCE};
     double yaw_rad {0.0};
+    // Recovered SE(3) from the descriptor that proposed this candidate
+    // (currently only triangle). Identity unless populated. Used as the NDT
+    // initial guess instead of the pose-derived guess when source matches.
+    Eigen::Matrix4f relative_transform {Eigen::Matrix4f::Identity()};
+    bool has_relative_transform {false};
   };
 
   struct LoopCandidateResult
@@ -1290,7 +1295,8 @@ void GraphBasedSlamComponent::searchLoop()
     int index,
     double selection_metric,
     LoopCandidate::Source source,
-    double yaw_rad = 0.0)
+    double yaw_rad = 0.0,
+    const Eigen::Matrix4f * relative_transform = nullptr)
     {
       if (index < 0) {
         return;
@@ -1301,6 +1307,10 @@ void GraphBasedSlamComponent::searchLoop()
         }
         candidate.selection_metric = std::min(candidate.selection_metric, selection_metric);
         candidate.yaw_rad = yaw_rad;
+        if (relative_transform != nullptr) {
+          candidate.relative_transform = *relative_transform;
+          candidate.has_relative_transform = true;
+        }
         return;
       }
 
@@ -1309,6 +1319,10 @@ void GraphBasedSlamComponent::searchLoop()
       candidate.selection_metric = selection_metric;
       candidate.source = source;
       candidate.yaw_rad = yaw_rad;
+      if (relative_transform != nullptr) {
+        candidate.relative_transform = *relative_transform;
+        candidate.has_relative_transform = true;
+      }
       candidates.push_back(candidate);
     };
 
@@ -1907,7 +1921,8 @@ void GraphBasedSlamComponent::searchLoop()
               chosen_submap_id,
               tri_metric,
               LoopCandidate::Source::TRIANGLE_DESCRIPTOR,
-              tri_yaw_rad);
+              tri_yaw_rad,
+              &cand.transform);
             std::cout << "Triangle loop candidate: id=" << chosen_submap_id
                       << " votes=" << chosen_votes
                       << " inliers=" << cand.inliers
@@ -2016,7 +2031,18 @@ void GraphBasedSlamComponent::searchLoop()
     double three_d_bbs_elapsed_msec = 0.0;
     Eigen::Matrix4f initial_guess =
       (candidate_affine.matrix() * latest_affine.inverse().matrix()).cast<float>();
-    if (std::abs(candidate.yaw_rad) > 1e-6) {
+    if (
+      candidate.source == LoopCandidate::Source::TRIANGLE_DESCRIPTOR &&
+      candidate.has_relative_transform)
+    {
+      // Triangle proposes a SE(3) that maps latest-submap-local points to
+      // chosen-submap-local points. NDT works in world frame, so chain in
+      // the two submap poses to recover the source -> target world guess.
+      initial_guess =
+        (candidate_affine.matrix() *
+        candidate.relative_transform.cast<double>() *
+        latest_affine.inverse().matrix()).cast<float>();
+    } else if (std::abs(candidate.yaw_rad) > 1e-6) {
       Eigen::Affine3d yaw_correction = Eigen::Affine3d::Identity();
       yaw_correction.rotate(Eigen::AngleAxisd(candidate.yaw_rad, Eigen::Vector3d::UnitZ()));
       initial_guess =

--- a/lidarslam/param/lidarslam_mid360_rko_graph.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph.yaml
@@ -53,8 +53,8 @@ graph_based_slam:
     triangle_descriptor_max_edge_m: 30.0
     triangle_descriptor_max_triangles: 3000
     triangle_descriptor_edge_bin_m: 1.0
-    triangle_descriptor_min_votes: 8
-    triangle_descriptor_min_inliers: 4
+    triangle_descriptor_min_votes: 12
+    triangle_descriptor_min_inliers: 6
     triangle_descriptor_inlier_translation_m: 2.0
     triangle_descriptor_inlier_rotation_deg: 5.0
     triangle_descriptor_exclude_recent: 6


### PR DESCRIPTION
## Summary

Follow-up to the first NTU VIRAL ablation. The previous run emitted 4 triangle candidates (id=0/12, votes 598-2784, inliers 3-4) and NDT verification rejected every one, contributing 0 accepted loops while pushing distance acceptances down 26 -> 21 via dedup.

Two changes target the root cause:

1. **Triangle SE(3) -> NDT initial guess.** Plumbs the recovered transform through `LoopCandidate.relative_transform` so NDT uses `candidate_pose * T_triangle * latest_pose^-1` as the initial guess for `TRIANGLE_DESCRIPTOR` candidates instead of the pose-difference + yaw fallback. The pose-derived guess assumes the existing graph poses are accurate -- exactly the wrong assumption for a loop-closure candidate. Triangle is the only current descriptor that produces an absolute relative transform between two submap-local frames; chaining it through the two submap poses recovers the source -> target world transform NDT expects.

2. **Tighten default thresholds.** `min_votes` 6 -> 10 and `min_inliers` 3 -> 5 in the generic preset (`graphbasedslam.yaml`), 8/4 -> 12/6 in the MID-360 preset (`lidarslam_mid360_rko_graph.yaml`). The NTU run showed 3-4 inliers out of 64 evaluated pairs is too lax: the resulting transforms are noisy enough that even a good initial guess won't save NDT.

The yaml regression already asserts both knobs exist with sane bounds and that MID-360 stays >= generic; both invariants hold (12 >= 10, 6 >= 5).

## Test plan

- [x] `colcon test --packages-select graph_based_slam` -- **468 tests, 0 failures, 26 skipped**
- [x] yaml regression confirms MID-360 stays at or above generic on the bumped knobs
- [x] uncrustify / cpplint / flake8 / pep257 / xmllint pass

## Follow-up (manual)

Rerun `bash scripts/run_triangle_ablation.sh ...` on NTU VIRAL with #142 + this PR; expect:
- fewer emitted triangle candidates (votes/inliers floor raised)
- the ones that do emit should hit NDT with a much closer initial guess and stand a chance of being accepted