### PR TITLE
feat: add triangle_descriptor min_inlier_ratio + max_pairs ROS params

### DIFF
--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -264,6 +264,15 @@ private:
     // / hash params suppress most false buckets on their own.
     int triangle_descriptor_min_votes_ {6};
     int triangle_descriptor_min_inliers_ {4};
+    // Companion to min_inliers expressed as inliers / eval_n. Zero disables.
+    // Lets the operator combine a low absolute count with a meaningful
+    // relative-density floor (e.g. 4 inliers / max_pairs 64 = 6% vs the
+    // same 4 inliers / max_pairs 20 = 20%).
+    double triangle_descriptor_min_inlier_ratio_ {0.0};
+    // Cap on triangle pairs evaluated inside the RANSAC consensus check.
+    // Lower numbers make min_inlier_ratio more informative; default 64 keeps
+    // the previous behaviour.
+    int triangle_descriptor_max_pairs_ {64};
     double triangle_descriptor_inlier_translation_m_ {2.0};
     double triangle_descriptor_inlier_rotation_deg_ {5.0};
     int triangle_descriptor_exclude_recent_ {4};

--- a/graph_based_slam/include/graph_based_slam/triangle_descriptor_database.hpp
+++ b/graph_based_slam/include/graph_based_slam/triangle_descriptor_database.hpp
@@ -229,6 +229,11 @@ struct VerificationConfig
   float inlier_rotation_deg {5.0f};
   // Minimum inliers required to accept the candidate.
   int min_inliers {3};
+  // Minimum inlier ratio (inliers / eval_n) required when > 0. Useful to
+  // attach a relative-density floor to a low absolute count: with max_pairs
+  // 64 a count of 4 is only 6%, but at max_pairs 20 the same 4 is 20%. Set
+  // to 0.0 to disable.
+  float min_inlier_ratio {0.0f};
   // Cap on triangle pairs evaluated (top N by edge length descending).
   int max_pairs {64};
 };
@@ -352,7 +357,13 @@ inline LoopCandidate findLoopCandidate(
 
   result.inliers = best_inliers;
   result.transform = best_T;
-  result.accepted = best_inliers >= verify_cfg.min_inliers;
+  bool count_ok = best_inliers >= verify_cfg.min_inliers;
+  bool ratio_ok = true;
+  if (verify_cfg.min_inlier_ratio > 0.0f && eval_n > 0) {
+    const float ratio = static_cast<float>(best_inliers) / static_cast<float>(eval_n);
+    ratio_ok = ratio >= verify_cfg.min_inlier_ratio;
+  }
+  result.accepted = count_ok && ratio_ok;
   return result;
 }
 

--- a/graph_based_slam/param/graphbasedslam.yaml
+++ b/graph_based_slam/param/graphbasedslam.yaml
@@ -54,6 +54,11 @@ graph_based_slam:
       triangle_descriptor_edge_bin_m: 0.5
       triangle_descriptor_min_votes: 6
       triangle_descriptor_min_inliers: 4
+      # 0.0 disables the relative-density floor. Set to e.g. 0.15 in combination
+      # with triangle_descriptor_max_pairs: 20 if you want to insist on >=15%
+      # of evaluated triangle pairs agreeing on SE(3).
+      triangle_descriptor_min_inlier_ratio: 0.0
+      triangle_descriptor_max_pairs: 64
       triangle_descriptor_inlier_translation_m: 2.0
       triangle_descriptor_inlier_rotation_deg: 5.0
       triangle_descriptor_exclude_recent: 4

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -147,6 +147,12 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("triangle_descriptor_min_votes", triangle_descriptor_min_votes_);
   declare_parameter("triangle_descriptor_min_inliers", 4);
   get_parameter("triangle_descriptor_min_inliers", triangle_descriptor_min_inliers_);
+  declare_parameter("triangle_descriptor_min_inlier_ratio", 0.0);
+  get_parameter(
+    "triangle_descriptor_min_inlier_ratio",
+    triangle_descriptor_min_inlier_ratio_);
+  declare_parameter("triangle_descriptor_max_pairs", 64);
+  get_parameter("triangle_descriptor_max_pairs", triangle_descriptor_max_pairs_);
   declare_parameter("triangle_descriptor_inlier_translation_m", 2.0);
   get_parameter(
     "triangle_descriptor_inlier_translation_m",
@@ -524,6 +530,22 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   if (triangle_descriptor_min_inliers_ < 1) {
     triangle_descriptor_min_inliers_ = 1;
   }
+  if (triangle_descriptor_min_inlier_ratio_ < 0.0) {
+    triangle_descriptor_min_inlier_ratio_ = 0.0;
+  } else if (triangle_descriptor_min_inlier_ratio_ > 1.0) {
+    RCLCPP_WARN(
+      get_logger(),
+      "triangle_descriptor_min_inlier_ratio must be in [0, 1]; clamping %.3f to 1.0",
+      triangle_descriptor_min_inlier_ratio_);
+    triangle_descriptor_min_inlier_ratio_ = 1.0;
+  }
+  if (triangle_descriptor_max_pairs_ < 3) {
+    RCLCPP_WARN(
+      get_logger(),
+      "triangle_descriptor_max_pairs must be >= 3; clamping %d to 3",
+      triangle_descriptor_max_pairs_);
+    triangle_descriptor_max_pairs_ = 3;
+  }
   if (triangle_descriptor_inlier_translation_m_ <= 0.0) {
     triangle_descriptor_inlier_translation_m_ = 2.0;
   }
@@ -770,6 +792,10 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       triangle_descriptor_min_votes_ << std::endl;
     std::cout << "triangle_descriptor_min_inliers:" <<
       triangle_descriptor_min_inliers_ << std::endl;
+    std::cout << "triangle_descriptor_min_inlier_ratio:" <<
+      triangle_descriptor_min_inlier_ratio_ << std::endl;
+    std::cout << "triangle_descriptor_max_pairs:" <<
+      triangle_descriptor_max_pairs_ << std::endl;
     std::cout << "triangle_descriptor_inlier_translation_m:" <<
       triangle_descriptor_inlier_translation_m_ << std::endl;
     std::cout << "triangle_descriptor_inlier_rotation_deg:" <<
@@ -1851,6 +1877,9 @@ void GraphBasedSlamComponent::searchLoop()
       verify_cfg.inlier_rotation_deg =
         static_cast<float>(triangle_descriptor_inlier_rotation_deg_);
       verify_cfg.min_inliers = triangle_descriptor_min_inliers_;
+      verify_cfg.min_inlier_ratio =
+        static_cast<float>(triangle_descriptor_min_inlier_ratio_);
+      verify_cfg.max_pairs = triangle_descriptor_max_pairs_;
 
       // Mask out the latest_idx and any recent submaps so we don't loop on
       // ourselves. We do this by running the vote step first and dropping any

--- a/graph_based_slam/test/test_triangle_descriptor_database.cpp
+++ b/graph_based_slam/test/test_triangle_descriptor_database.cpp
@@ -391,3 +391,58 @@ TEST(TriangleLoopCandidate, RejectsUnrelatedQueries)
   const auto candidate = findLoopCandidate(db, kps_q, tris_q, cfg, vote_cfg, verify_cfg);
   EXPECT_FALSE(candidate.accepted);
 }
+
+TEST(TriangleLoopCandidate, InlierRatioGateRejectsLowRatio)
+{
+  // Reuse the identity-recovery setup: every triangle pair will produce the
+  // same SE(3), so inliers / eval_n approaches 1.0. A ratio threshold above
+  // 1.0 cannot be met, so the candidate must be rejected.
+  const auto kps = makeKeypointGrid(4, 4, 3.0f);
+  const auto tris = buildTriangles(kps, TriangleBuildConfig{});
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(11, kps, tris, cfg);
+
+  VoteConfig vote_cfg;
+  VerificationConfig verify_cfg;
+  verify_cfg.min_inlier_ratio = 1.5f;  // impossible: ratio is bounded by 1.0
+  const auto candidate = findLoopCandidate(db, kps, tris, cfg, vote_cfg, verify_cfg);
+  EXPECT_FALSE(candidate.accepted);
+  EXPECT_GT(candidate.inliers, 0);  // RANSAC still found inliers, just not enough
+}
+
+TEST(TriangleLoopCandidate, InlierRatioGateAcceptsAtZeroDisabled)
+{
+  const auto kps = makeKeypointGrid(4, 4, 3.0f);
+  const auto tris = buildTriangles(kps, TriangleBuildConfig{});
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(13, kps, tris, cfg);
+
+  VoteConfig vote_cfg;
+  VerificationConfig verify_cfg;
+  verify_cfg.min_inlier_ratio = 0.0f;  // default; disabled
+  const auto candidate = findLoopCandidate(db, kps, tris, cfg, vote_cfg, verify_cfg);
+  EXPECT_TRUE(candidate.accepted);
+}
+
+TEST(TriangleLoopCandidate, MaxPairsLimitsEvaluatedSet)
+{
+  // Cap max_pairs to 3 -- best-case inliers must not exceed that cap.
+  const auto kps = makeKeypointGrid(4, 4, 3.0f);
+  const auto tris = buildTriangles(kps, TriangleBuildConfig{});
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(17, kps, tris, cfg);
+
+  VoteConfig vote_cfg;
+  VerificationConfig verify_cfg;
+  verify_cfg.max_pairs = 3;
+  verify_cfg.min_inliers = 1;
+  const auto candidate = findLoopCandidate(db, kps, tris, cfg, vote_cfg, verify_cfg);
+  EXPECT_LE(candidate.inliers, 3);
+  EXPECT_GE(candidate.inliers, 0);
+}

--- a/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
+++ b/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
@@ -53,6 +53,8 @@ EXPECTED_PARAM_KEYS = {
     'triangle_descriptor_inlier_translation_m',
     'triangle_descriptor_inlier_rotation_deg',
     'triangle_descriptor_exclude_recent',
+    'triangle_descriptor_min_inlier_ratio',
+    'triangle_descriptor_max_pairs',
     'triangle_verify_with_bev',
     'triangle_verify_bev_max_distance',
 }

--- a/lidarslam/param/lidarslam_mid360_rko_graph.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph.yaml
@@ -55,6 +55,11 @@ graph_based_slam:
     triangle_descriptor_edge_bin_m: 0.5
     triangle_descriptor_min_votes: 8
     triangle_descriptor_min_inliers: 5
+    # MID-360 narrower FOV / fewer keypoints means evaluated pair counts are
+    # already lower than a spinning 360° LiDAR; cap max_pairs at 32 so
+    # min_inlier_ratio (when set) is more informative for the operator.
+    triangle_descriptor_min_inlier_ratio: 0.0
+    triangle_descriptor_max_pairs: 32
     triangle_descriptor_inlier_translation_m: 2.0
     triangle_descriptor_inlier_rotation_deg: 5.0
     triangle_descriptor_exclude_recent: 6


### PR DESCRIPTION
## Summary

Two more knobs on top of the absolute `min_inliers` floor (PR #143) and the v4 keypoint tightening (PR #145):

- **`triangle_descriptor_min_inlier_ratio`** (default 0.0 = disabled): relative-density floor on `inliers / eval_n`. The NTU v4 ablation accepted candidates with 4 inliers out of 64 evaluated pairs (~6%); operators can now insist on e.g. 15% to require a more meaningful consensus on top of the absolute count.
- **`triangle_descriptor_max_pairs`** (default 64, MID-360 preset 32): the previously-hardcoded RANSAC consensus cap is now configurable. Lowering it makes `min_inlier_ratio` more informative -- the same absolute inlier count becomes a larger share of evaluated pairs.

Both are validated on load (ratio clamped to `[0, 1]`, `max_pairs` floored at 3) and listed in the parameter banner. The yaml regression now requires both keys in both presets.

3 new gtests cover:
- ratio gate at `> 1.0` (impossible → rejected even on identity)
- ratio gate at `0.0` (disabled → identity accepts as usual)
- `max_pairs` caps the reported inlier count

## Test plan

- [x] `colcon test --packages-select graph_based_slam` -- **471 tests, 0 failures, 26 skipped** (test_triangle_descriptor_database grows from 15 to 18, yaml regression from 10 to 12)
- [x] uncrustify / cpplint / flake8 / pep257 / xmllint pass locally

## Follow-up

- Run a new NTU VIRAL ablation round with `max_pairs: 20` + `min_inlier_ratio: 0.20` to see if the higher relative-density floor weeds out the borderline triangle candidates that pass min_inliers but produce noisy SE(3).
- Same machinery is now available for the 4-point consensus follow-up: once that lands, max_pairs becomes the operative knob for tuning runtime.