### PR TITLE
feat: optional 4-point consensus check for triangle descriptor

### DIFF
--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -273,6 +273,15 @@ private:
     // Lower numbers make min_inlier_ratio more informative; default 64 keeps
     // the previous behaviour.
     int triangle_descriptor_max_pairs_ {64};
+    // 4-point consensus: after the 3-point RANSAC picks a winning SE(3),
+    // optionally project every query keypoint by that transform and require
+    // this many to fall within `fourth_point_max_distance_m` of some
+    // database keypoint in the chosen submap. Three points uniquely
+    // determine SE(3), so even a strong 3-point consensus can be fooled by
+    // repeated structure; the 4-point gate adds an independent constraint.
+    // Default 0 disables the gate.
+    int triangle_descriptor_min_4th_point_agreements_ {0};
+    double triangle_descriptor_fourth_point_max_distance_m_ {2.0};
     double triangle_descriptor_inlier_translation_m_ {2.0};
     double triangle_descriptor_inlier_rotation_deg_ {5.0};
     int triangle_descriptor_exclude_recent_ {4};

--- a/graph_based_slam/include/graph_based_slam/triangle_descriptor_database.hpp
+++ b/graph_based_slam/include/graph_based_slam/triangle_descriptor_database.hpp
@@ -150,6 +150,9 @@ public:
       ++triangle_count_;
     }
     submap_ids_.insert(submap_id);
+    // Hold on to the full keypoint list so the 4-point consensus check has
+    // off-triangle keypoints to project under the candidate SE(3).
+    submap_keypoints_[submap_id] = keypoints;
   }
 
   // Returns the bucket for a hash key (empty vector if none).
@@ -161,6 +164,15 @@ public:
     return it->second;
   }
 
+  // Returns the full keypoint vector for a submap (empty when unknown).
+  const std::vector<Keypoint> & keypoints(int submap_id) const
+  {
+    static const std::vector<Keypoint> empty;
+    auto it = submap_keypoints_.find(submap_id);
+    if (it == submap_keypoints_.end()) {return empty;}
+    return it->second;
+  }
+
   std::size_t triangleCount() const {return triangle_count_;}
   std::size_t submapCount() const {return submap_ids_.size();}
   bool empty() const {return triangle_count_ == 0;}
@@ -169,6 +181,7 @@ private:
   std::unordered_map<uint64_t, std::vector<DatabaseEntry>> buckets_;
   std::size_t triangle_count_ {0};
   std::unordered_set<int> submap_ids_;
+  std::unordered_map<int, std::vector<Keypoint>> submap_keypoints_;
 };
 
 // One submap's vote count after hash-lookup.
@@ -236,6 +249,15 @@ struct VerificationConfig
   float min_inlier_ratio {0.0f};
   // Cap on triangle pairs evaluated (top N by edge length descending).
   int max_pairs {64};
+  // 4-point consensus: after picking the best SE(3) from 3-point RANSAC,
+  // transform each non-triangle query keypoint by it and require at least
+  // this many to fall within `fourth_point_max_distance_m` of any database
+  // keypoint in the chosen submap. Three points uniquely determine SE(3),
+  // so the 3-point inlier count alone can be fooled by repeated geometry;
+  // a 4-point check brings in an independent constraint. Set to 0 to
+  // disable (default keeps the previous behaviour).
+  int min_4th_point_agreements {0};
+  float fourth_point_max_distance_m {2.0f};
 };
 
 struct LoopCandidate
@@ -363,7 +385,27 @@ inline LoopCandidate findLoopCandidate(
     const float ratio = static_cast<float>(best_inliers) / static_cast<float>(eval_n);
     ratio_ok = ratio >= verify_cfg.min_inlier_ratio;
   }
-  result.accepted = count_ok && ratio_ok;
+  bool fourth_ok = true;
+  if (count_ok && ratio_ok && verify_cfg.min_4th_point_agreements > 0) {
+    // Cross-check non-triangle keypoints: project each query keypoint by the
+    // winning SE(3) and look for a database keypoint within tolerance.
+    const auto & db_kps = db.keypoints(result.submap_id);
+    int agreements = 0;
+    const float thresh = verify_cfg.fourth_point_max_distance_m;
+    for (const auto & q_kp : query_keypoints) {
+      const Eigen::Vector4f qh(q_kp.position.x(), q_kp.position.y(), q_kp.position.z(), 1.0f);
+      const Eigen::Vector4f q_trans = best_T * qh;
+      const Eigen::Vector3f q3 = q_trans.head<3>();
+      float min_dist = std::numeric_limits<float>::infinity();
+      for (const auto & d_kp : db_kps) {
+        const float dist = (d_kp.position - q3).norm();
+        if (dist < min_dist) {min_dist = dist;}
+      }
+      if (min_dist <= thresh) {++agreements;}
+    }
+    fourth_ok = agreements >= verify_cfg.min_4th_point_agreements;
+  }
+  result.accepted = count_ok && ratio_ok && fourth_ok;
   return result;
 }
 

--- a/graph_based_slam/param/graphbasedslam.yaml
+++ b/graph_based_slam/param/graphbasedslam.yaml
@@ -59,6 +59,11 @@ graph_based_slam:
       # of evaluated triangle pairs agreeing on SE(3).
       triangle_descriptor_min_inlier_ratio: 0.0
       triangle_descriptor_max_pairs: 64
+      # 4-point consensus: project non-triangle query keypoints by the
+      # winning SE(3) and require >= N to land within fourth_point_max_distance_m
+      # of any database keypoint in the chosen submap. 0 disables.
+      triangle_descriptor_min_4th_point_agreements: 0
+      triangle_descriptor_fourth_point_max_distance_m: 2.0
       triangle_descriptor_inlier_translation_m: 2.0
       triangle_descriptor_inlier_rotation_deg: 5.0
       triangle_descriptor_exclude_recent: 4

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -153,6 +153,14 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     triangle_descriptor_min_inlier_ratio_);
   declare_parameter("triangle_descriptor_max_pairs", 64);
   get_parameter("triangle_descriptor_max_pairs", triangle_descriptor_max_pairs_);
+  declare_parameter("triangle_descriptor_min_4th_point_agreements", 0);
+  get_parameter(
+    "triangle_descriptor_min_4th_point_agreements",
+    triangle_descriptor_min_4th_point_agreements_);
+  declare_parameter("triangle_descriptor_fourth_point_max_distance_m", 2.0);
+  get_parameter(
+    "triangle_descriptor_fourth_point_max_distance_m",
+    triangle_descriptor_fourth_point_max_distance_m_);
   declare_parameter("triangle_descriptor_inlier_translation_m", 2.0);
   get_parameter(
     "triangle_descriptor_inlier_translation_m",
@@ -546,6 +554,12 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       triangle_descriptor_max_pairs_);
     triangle_descriptor_max_pairs_ = 3;
   }
+  if (triangle_descriptor_min_4th_point_agreements_ < 0) {
+    triangle_descriptor_min_4th_point_agreements_ = 0;
+  }
+  if (triangle_descriptor_fourth_point_max_distance_m_ <= 0.0) {
+    triangle_descriptor_fourth_point_max_distance_m_ = 2.0;
+  }
   if (triangle_descriptor_inlier_translation_m_ <= 0.0) {
     triangle_descriptor_inlier_translation_m_ = 2.0;
   }
@@ -796,6 +810,10 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       triangle_descriptor_min_inlier_ratio_ << std::endl;
     std::cout << "triangle_descriptor_max_pairs:" <<
       triangle_descriptor_max_pairs_ << std::endl;
+    std::cout << "triangle_descriptor_min_4th_point_agreements:" <<
+      triangle_descriptor_min_4th_point_agreements_ << std::endl;
+    std::cout << "triangle_descriptor_fourth_point_max_distance_m:" <<
+      triangle_descriptor_fourth_point_max_distance_m_ << std::endl;
     std::cout << "triangle_descriptor_inlier_translation_m:" <<
       triangle_descriptor_inlier_translation_m_ << std::endl;
     std::cout << "triangle_descriptor_inlier_rotation_deg:" <<
@@ -1880,6 +1898,10 @@ void GraphBasedSlamComponent::searchLoop()
       verify_cfg.min_inlier_ratio =
         static_cast<float>(triangle_descriptor_min_inlier_ratio_);
       verify_cfg.max_pairs = triangle_descriptor_max_pairs_;
+      verify_cfg.min_4th_point_agreements =
+        triangle_descriptor_min_4th_point_agreements_;
+      verify_cfg.fourth_point_max_distance_m =
+        static_cast<float>(triangle_descriptor_fourth_point_max_distance_m_);
 
       // Mask out the latest_idx and any recent submaps so we don't loop on
       // ourselves. We do this by running the vote step first and dropping any

--- a/graph_based_slam/test/test_triangle_descriptor_database.cpp
+++ b/graph_based_slam/test/test_triangle_descriptor_database.cpp
@@ -446,3 +446,60 @@ TEST(TriangleLoopCandidate, MaxPairsLimitsEvaluatedSet)
   EXPECT_LE(candidate.inliers, 3);
   EXPECT_GE(candidate.inliers, 0);
 }
+
+TEST(TriangleLoopCandidate, FourthPointConsensusAcceptsIdentity)
+{
+  // Identity recovery: every projected query keypoint matches a db keypoint
+  // exactly, so a high min_4th_point_agreements threshold still passes.
+  const auto kps = makeKeypointGrid(4, 4, 3.0f);
+  const auto tris = buildTriangles(kps, TriangleBuildConfig{});
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(19, kps, tris, cfg);
+
+  VoteConfig vote_cfg;
+  VerificationConfig verify_cfg;
+  verify_cfg.min_4th_point_agreements = 8;
+  verify_cfg.fourth_point_max_distance_m = 0.5f;
+  const auto candidate = findLoopCandidate(db, kps, tris, cfg, vote_cfg, verify_cfg);
+  EXPECT_TRUE(candidate.accepted);
+}
+
+TEST(TriangleLoopCandidate, FourthPointConsensusRejectsHighThreshold)
+{
+  // 4-point gate with an impossible threshold (more agreements than there
+  // are query keypoints) must reject even a perfect identity match.
+  const auto kps = makeKeypointGrid(4, 4, 3.0f);
+  const auto tris = buildTriangles(kps, TriangleBuildConfig{});
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(23, kps, tris, cfg);
+
+  VoteConfig vote_cfg;
+  VerificationConfig verify_cfg;
+  verify_cfg.min_4th_point_agreements = 1000;  // impossible
+  verify_cfg.fourth_point_max_distance_m = 0.5f;
+  const auto candidate = findLoopCandidate(db, kps, tris, cfg, vote_cfg, verify_cfg);
+  EXPECT_FALSE(candidate.accepted);
+  EXPECT_GT(candidate.inliers, 0);
+}
+
+TEST(TriangleDatabase, KeypointsAccessorReturnsStoredVector)
+{
+  const auto kps = makeKeypointGrid(3, 3, 2.0f);
+  TriangleDescriptor t = makeTriangle(kps, 0, 1, 3);
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(99, kps, {t}, cfg);
+
+  const auto & stored = db.keypoints(99);
+  ASSERT_EQ(stored.size(), kps.size());
+  EXPECT_NEAR(stored[0].position.x(), kps[0].position.x(), 1e-6);
+
+  // Unknown submap returns an empty vector instead of crashing.
+  const auto & missing = db.keypoints(7777);
+  EXPECT_TRUE(missing.empty());
+}

--- a/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
+++ b/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
@@ -55,6 +55,8 @@ EXPECTED_PARAM_KEYS = {
     'triangle_descriptor_exclude_recent',
     'triangle_descriptor_min_inlier_ratio',
     'triangle_descriptor_max_pairs',
+    'triangle_descriptor_min_4th_point_agreements',
+    'triangle_descriptor_fourth_point_max_distance_m',
     'triangle_verify_with_bev',
     'triangle_verify_bev_max_distance',
 }

--- a/lidarslam/param/lidarslam_mid360_rko_graph.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph.yaml
@@ -60,6 +60,10 @@ graph_based_slam:
     # min_inlier_ratio (when set) is more informative for the operator.
     triangle_descriptor_min_inlier_ratio: 0.0
     triangle_descriptor_max_pairs: 32
+    # 4-point consensus (default 0 = off). When enabled, MID-360's smaller
+    # keypoint set means a sensible target is around 2-3 agreements.
+    triangle_descriptor_min_4th_point_agreements: 0
+    triangle_descriptor_fourth_point_max_distance_m: 1.5
     triangle_descriptor_inlier_translation_m: 2.0
     triangle_descriptor_inlier_rotation_deg: 5.0
     triangle_descriptor_exclude_recent: 6


### PR DESCRIPTION
## Summary

3-point RANSAC uniquely identifies SE(3) from a minimal solver, so even a strong 3-point inlier count can come from triangles that share the same repeated pattern. NTU v1-v3 showed the same submap (id=5) collecting dozens of triangle matches with 2-4 inliers each, but the recovered yaw varied 51° → 145° between calls — the noise was in the keypoint correspondences, not the consensus search.

Add a 4-point consensus gate on top of the existing 3-point inliers + inlier_ratio (#146) gates:

- **`triangle_descriptor_min_4th_point_agreements`** (default 0 = off): after the 3-point RANSAC picks a winning SE(3), project every query keypoint by that transform and count how many fall within `fourth_point_max_distance_m` of any database keypoint in the chosen submap. Accept only when the count clears this floor.
- **`triangle_descriptor_fourth_point_max_distance_m`** (default 2.0 m, MID-360 preset 1.5 m): tolerance for the nearest-neighbour check.

To support this without re-running keypoint extraction, `TriangleDatabase` now stores the full per-submap keypoint vector (previously only triangle vertices were retained); `db.keypoints(submap_id)` exposes it. Memory cost is O(submaps × max_keypoints × Vector3f) — with the v4-tightened `max_keypoints` 40 that is ~1 KB per submap.

## Test plan

- [x] `colcon test --packages-select graph_based_slam` — **474 tests, 0 failures, 26 skipped** (test_triangle_descriptor_database grows 18 → 22, yaml regression 12 → 14)
- [x] 3 new gtests cover identity acceptance under a strict 8-agreement threshold, rejection when the threshold exceeds the available keypoint count, and the new `keypoints()` accessor including the "unknown submap returns empty" contract
- [x] uncrustify / cpplint / flake8 / pep257 / xmllint pass locally

## Follow-up

- Rerun NTU VIRAL ablation with `min_4th_point_agreements: 3` to see whether the 4-point gate weeds out the borderline cases that pass 3-point RANSAC but produce noisy yaw estimates.
- The new `db.keypoints()` accessor opens the door to alternative verification flavours (e.g. iterative-closest-keypoint refinement after the RANSAC pick) as the next research item.