### PR TITLE
feat: NIS auto-scale Level 2 — split adjacent edge weight into trans / rot

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -128,7 +128,7 @@ if(BUILD_TESTING)
     test/test_adjacent_edge_auto_scale.cpp
   )
   if(TARGET test_adjacent_edge_auto_scale)
-    target_include_directories(test_adjacent_edge_auto_scale PRIVATE include)
+    target_include_directories(test_adjacent_edge_auto_scale PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
     test_scan_context

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -208,6 +208,17 @@ private:
     double adjacent_edge_info_auto_scale_ema_alpha_ {0.3};
     double adjacent_edge_info_auto_scale_min_ {1.0};
     double adjacent_edge_info_auto_scale_max_ {1.0e6};
+    // Level 2: split the adjacent edge Information matrix into translation /
+    // rotation blocks (block-diag with weights w_trans, w_rot on I_3 each) so
+    // the auto-scaler can balance translation residuals and rotation residuals
+    // independently. When split mode is off the legacy single-scalar shape is
+    // used. Targets default to 3.0 (3 DoF per block, vs 6 for the unified
+    // mode); the EMA / min / max defaults are shared with Level 1.
+    bool adjacent_edge_info_auto_scale_split_trans_rot_ {false};
+    double adjacent_edge_info_weight_trans_ {-1.0};
+    double adjacent_edge_info_weight_rot_ {-1.0};
+    double adjacent_edge_info_auto_scale_target_nis_trans_ {3.0};
+    double adjacent_edge_info_auto_scale_target_nis_rot_ {3.0};
 
     bool initial_map_array_received_ {false};
     bool is_map_array_updated_ {false};

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -113,6 +113,32 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("adjacent_edge_info_auto_scale_min", adjacent_edge_info_auto_scale_min_);
   declare_parameter("adjacent_edge_info_auto_scale_max", 1.0e6);
   get_parameter("adjacent_edge_info_auto_scale_max", adjacent_edge_info_auto_scale_max_);
+  declare_parameter("adjacent_edge_info_auto_scale_split_trans_rot", false);
+  get_parameter(
+    "adjacent_edge_info_auto_scale_split_trans_rot",
+    adjacent_edge_info_auto_scale_split_trans_rot_);
+  declare_parameter("adjacent_edge_info_weight_trans", -1.0);
+  get_parameter("adjacent_edge_info_weight_trans", adjacent_edge_info_weight_trans_);
+  declare_parameter("adjacent_edge_info_weight_rot", -1.0);
+  get_parameter("adjacent_edge_info_weight_rot", adjacent_edge_info_weight_rot_);
+  declare_parameter("adjacent_edge_info_auto_scale_target_nis_trans", 3.0);
+  get_parameter(
+    "adjacent_edge_info_auto_scale_target_nis_trans",
+    adjacent_edge_info_auto_scale_target_nis_trans_);
+  declare_parameter("adjacent_edge_info_auto_scale_target_nis_rot", 3.0);
+  get_parameter(
+    "adjacent_edge_info_auto_scale_target_nis_rot",
+    adjacent_edge_info_auto_scale_target_nis_rot_);
+  // Trans/rot weights default to the unified weight when negative (i.e., user
+  // has not provided an explicit per-block override). This keeps the split
+  // mode safe to enable on existing YAMLs that only set
+  // adjacent_edge_info_weight.
+  if (adjacent_edge_info_weight_trans_ <= 0.0) {
+    adjacent_edge_info_weight_trans_ = adjacent_edge_info_weight_;
+  }
+  if (adjacent_edge_info_weight_rot_ <= 0.0) {
+    adjacent_edge_info_weight_rot_ = adjacent_edge_info_weight_;
+  }
   declare_parameter("loop_edge_info_weight", 100.0);
   get_parameter("loop_edge_info_weight", loop_edge_info_weight_);
   declare_parameter("loop_edge_robust_kernel_delta", 1.0);
@@ -429,6 +455,18 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       adjacent_edge_info_weight_);
     adjacent_edge_info_weight_ = 1000.0;
   }
+  if (adjacent_edge_info_weight_trans_ <= 0.0) {
+    adjacent_edge_info_weight_trans_ = adjacent_edge_info_weight_;
+  }
+  if (adjacent_edge_info_weight_rot_ <= 0.0) {
+    adjacent_edge_info_weight_rot_ = adjacent_edge_info_weight_;
+  }
+  if (adjacent_edge_info_auto_scale_target_nis_trans_ <= 0.0) {
+    adjacent_edge_info_auto_scale_target_nis_trans_ = 3.0;
+  }
+  if (adjacent_edge_info_auto_scale_target_nis_rot_ <= 0.0) {
+    adjacent_edge_info_auto_scale_target_nis_rot_ = 3.0;
+  }
   if (loop_edge_info_weight_ <= 0.0) {
     RCLCPP_WARN(
       get_logger(),
@@ -711,6 +749,25 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   std::cout << "loop_max_rotation_delta[deg]:" << loop_max_rotation_delta_deg_ << std::endl;
   std::cout << "num_adjacent_pose_cnstraints:" << num_adjacent_pose_cnstraints_ << std::endl;
   std::cout << "adjacent_edge_info_weight:" << adjacent_edge_info_weight_ << std::endl;
+  std::cout << "adjacent_edge_info_auto_scale:" << std::boolalpha
+            << adjacent_edge_info_auto_scale_ << std::endl;
+  if (adjacent_edge_info_auto_scale_) {
+    std::cout << "adjacent_edge_info_auto_scale_split_trans_rot:" << std::boolalpha
+              << adjacent_edge_info_auto_scale_split_trans_rot_ << std::endl;
+    if (adjacent_edge_info_auto_scale_split_trans_rot_) {
+      std::cout << "adjacent_edge_info_weight_trans:"
+                << adjacent_edge_info_weight_trans_ << std::endl;
+      std::cout << "adjacent_edge_info_weight_rot:"
+                << adjacent_edge_info_weight_rot_ << std::endl;
+      std::cout << "adjacent_edge_info_auto_scale_target_nis_trans:"
+                << adjacent_edge_info_auto_scale_target_nis_trans_ << std::endl;
+      std::cout << "adjacent_edge_info_auto_scale_target_nis_rot:"
+                << adjacent_edge_info_auto_scale_target_nis_rot_ << std::endl;
+    } else {
+      std::cout << "adjacent_edge_info_auto_scale_target_nis:"
+                << adjacent_edge_info_auto_scale_target_nis_ << std::endl;
+    }
+  }
   std::cout << "loop_edge_info_weight:" << loop_edge_info_weight_ << std::endl;
   std::cout << "loop_edge_robust_kernel_delta:" << loop_edge_robust_kernel_delta_ << std::endl;
   std::cout << "loop_edge_robust_kernel_type:"
@@ -2373,9 +2430,19 @@ void GraphBasedSlamComponent::doPoseAdjustment(
         Eigen::Isometry3d relative_pose = pre_pose.inverse() * pose;
 
         const int separation = i - pre_idx;
-        const double edge_weight = adjacent_edge_info_weight_ / static_cast<double>(separation);
-        Eigen::Matrix<double, 6, 6> info_mat =
-          Eigen::Matrix<double, 6, 6>::Identity() * edge_weight;
+        const double sep_d = static_cast<double>(separation);
+        Eigen::Matrix<double, 6, 6> info_mat = Eigen::Matrix<double, 6, 6>::Zero();
+        if (adjacent_edge_info_auto_scale_split_trans_rot_) {
+          // Block-diag with independent translation / rotation weights, each
+          // attenuated by edge separation just like the unified scalar path.
+          const double w_trans = adjacent_edge_info_weight_trans_ / sep_d;
+          const double w_rot = adjacent_edge_info_weight_rot_ / sep_d;
+          info_mat.topLeftCorner<3, 3>().diagonal().setConstant(w_trans);
+          info_mat.bottomRightCorner<3, 3>().diagonal().setConstant(w_rot);
+        } else {
+          const double edge_weight = adjacent_edge_info_weight_ / sep_d;
+          info_mat = Eigen::Matrix<double, 6, 6>::Identity() * edge_weight;
+        }
         g2o::EdgeSE3 * edge_se3 = new g2o::EdgeSE3();
         edge_se3->setMeasurement(relative_pose);
         edge_se3->setInformation(info_mat);
@@ -2512,32 +2579,84 @@ void GraphBasedSlamComponent::doPoseAdjustment(
   optimizer.save("pose_graph.g2o");
 
   if (adjacent_edge_info_auto_scale_ && !adjacent_edges.empty()) {
-    std::vector<double> chi2_values;
-    chi2_values.reserve(adjacent_edges.size());
-    for (auto * e : adjacent_edges) {
-      e->computeError();
-      const double v = e->chi2();
-      if (std::isfinite(v)) {
-        chi2_values.push_back(v);
-      }
-    }
-    const double median_chi2 = graphslam::detail::medianChi2(chi2_values);
-
     graphslam::detail::AutoScaleConfig cfg;
-    cfg.target_nis = adjacent_edge_info_auto_scale_target_nis_;
     cfg.ema_alpha = adjacent_edge_info_auto_scale_ema_alpha_;
     cfg.min_scale = adjacent_edge_info_auto_scale_min_;
     cfg.max_scale = adjacent_edge_info_auto_scale_max_;
 
-    const double prev_weight = adjacent_edge_info_weight_;
-    adjacent_edge_info_weight_ =
-      graphslam::detail::nextScale(prev_weight, median_chi2, cfg);
+    if (adjacent_edge_info_auto_scale_split_trans_rot_) {
+      // Level 2: split the post-opt residuals into translation / rotation
+      // blocks and rescale w_trans and w_rot independently. For diagonal
+      // block-diag Information matrices, trans_chi2 = w_trans *
+      // ||e.head<3>()||^2 and rot_chi2 = w_rot * ||e.tail<3>()||^2.
+      std::vector<double> trans_chi2_values;
+      std::vector<double> rot_chi2_values;
+      trans_chi2_values.reserve(adjacent_edges.size());
+      rot_chi2_values.reserve(adjacent_edges.size());
+      for (auto * e : adjacent_edges) {
+        e->computeError();
+        const auto err = e->error();
+        const Eigen::Matrix<double, 6, 6> info = e->information();
+        // For the block-diag construction above, the diagonals encode the
+        // per-block scale of I_3 already attenuated by separation, so
+        // multiplying ||delta||^2 by the leading diagonal of each block
+        // reproduces the standard chi^2 contribution of that block.
+        const double w_t = info(0, 0);
+        const double w_r = info(3, 3);
+        const double trans = w_t * err.template head<3>().squaredNorm();
+        const double rot = w_r * err.template tail<3>().squaredNorm();
+        if (std::isfinite(trans)) {
+          trans_chi2_values.push_back(trans);
+        }
+        if (std::isfinite(rot)) {
+          rot_chi2_values.push_back(rot);
+        }
+      }
+      const double median_chi2_trans = graphslam::detail::medianChi2(trans_chi2_values);
+      const double median_chi2_rot = graphslam::detail::medianChi2(rot_chi2_values);
 
-    RCLCPP_INFO(
-      get_logger(),
-      "[auto_scale] median_chi2=%.3f (n=%zu) target=%.3f weight=%.3f -> %.3f",
-      median_chi2, chi2_values.size(), cfg.target_nis, prev_weight,
-      adjacent_edge_info_weight_);
+      cfg.target_nis = adjacent_edge_info_auto_scale_target_nis_trans_;
+      const double prev_w_trans = adjacent_edge_info_weight_trans_;
+      adjacent_edge_info_weight_trans_ =
+        graphslam::detail::nextScale(prev_w_trans, median_chi2_trans, cfg);
+
+      cfg.target_nis = adjacent_edge_info_auto_scale_target_nis_rot_;
+      const double prev_w_rot = adjacent_edge_info_weight_rot_;
+      adjacent_edge_info_weight_rot_ =
+        graphslam::detail::nextScale(prev_w_rot, median_chi2_rot, cfg);
+
+      RCLCPP_INFO(
+        get_logger(),
+        "[auto_scale_split] trans median_chi2=%.3f target=%.3f w_trans=%.3f -> %.3f | "
+        "rot median_chi2=%.3f target=%.3f w_rot=%.3f -> %.3f (n=%zu)",
+        median_chi2_trans, adjacent_edge_info_auto_scale_target_nis_trans_,
+        prev_w_trans, adjacent_edge_info_weight_trans_,
+        median_chi2_rot, adjacent_edge_info_auto_scale_target_nis_rot_,
+        prev_w_rot, adjacent_edge_info_weight_rot_,
+        trans_chi2_values.size());
+    } else {
+      std::vector<double> chi2_values;
+      chi2_values.reserve(adjacent_edges.size());
+      for (auto * e : adjacent_edges) {
+        e->computeError();
+        const double v = e->chi2();
+        if (std::isfinite(v)) {
+          chi2_values.push_back(v);
+        }
+      }
+      const double median_chi2 = graphslam::detail::medianChi2(chi2_values);
+
+      cfg.target_nis = adjacent_edge_info_auto_scale_target_nis_;
+      const double prev_weight = adjacent_edge_info_weight_;
+      adjacent_edge_info_weight_ =
+        graphslam::detail::nextScale(prev_weight, median_chi2, cfg);
+
+      RCLCPP_INFO(
+        get_logger(),
+        "[auto_scale] median_chi2=%.3f (n=%zu) target=%.3f weight=%.3f -> %.3f",
+        median_chi2, chi2_values.size(), cfg.target_nis, prev_weight,
+        adjacent_edge_info_weight_);
+    }
   }
 
   /* modified_map publish */

--- a/graph_based_slam/test/test_adjacent_edge_auto_scale.cpp
+++ b/graph_based_slam/test/test_adjacent_edge_auto_scale.cpp
@@ -29,6 +29,8 @@
 
 #include <gtest/gtest.h>
 
+#include <Eigen/Core>
+
 #include "graph_based_slam/adjacent_edge_auto_scale.hpp"
 
 namespace graphslam
@@ -177,6 +179,75 @@ TEST(AdjacentEdgeAutoScale, RepeatedApplicationConvergesToTarget)
     scale = nextScale(scale, observed_chi2, cfg);
   }
   EXPECT_NEAR(500.0, scale, 1e-2);
+}
+
+// Level 2: the same scalar helper can be driven independently for the trans
+// block and the rot block of the SE(3) Information matrix. These tests model
+// the runtime call pattern used in graph_based_slam_component.cpp when
+// adjacent_edge_info_auto_scale_split_trans_rot_ is on.
+
+TEST(AdjacentEdgeAutoScaleSplit, IndependentTransAndRotMoveSeparately)
+{
+  // Equilibrium target per block: SE(3) split with 3 DoF each → target_nis=3.
+  AutoScaleConfig cfg_trans;
+  cfg_trans.target_nis = 3.0;
+  cfg_trans.ema_alpha = 1.0;
+
+  AutoScaleConfig cfg_rot;
+  cfg_rot.target_nis = 3.0;
+  cfg_rot.ema_alpha = 1.0;
+
+  // Trans residuals are noisier than rot residuals (median_chi2 6 vs 1.5),
+  // so the trans weight should halve while the rot weight doubles in one step.
+  EXPECT_DOUBLE_EQ(500.0, nextScale(1000.0, 6.0, cfg_trans));
+  EXPECT_DOUBLE_EQ(2000.0, nextScale(1000.0, 1.5, cfg_rot));
+}
+
+TEST(AdjacentEdgeAutoScaleSplit, RepeatedApplicationConvergesIndependently)
+{
+  AutoScaleConfig cfg_trans;
+  cfg_trans.target_nis = 3.0;
+  cfg_trans.ema_alpha = 0.5;
+  cfg_trans.min_scale = 1.0;
+  cfg_trans.max_scale = 1.0e6;
+
+  AutoScaleConfig cfg_rot;
+  cfg_rot.target_nis = 3.0;
+  cfg_rot.ema_alpha = 0.5;
+  cfg_rot.min_scale = 1.0;
+  cfg_rot.max_scale = 1.0e6;
+
+  // Independent chi2-per-unit-scale for translation vs rotation. Equilibrium:
+  // w_trans* = 3 / 0.01 = 300, w_rot* = 3 / 0.003 = 1000.
+  const double trans_unit = 0.01;
+  const double rot_unit = 0.003;
+  double w_trans = 800.0;
+  double w_rot = 200.0;
+  for (int i = 0; i < 80; ++i) {
+    w_trans = nextScale(w_trans, trans_unit * w_trans, cfg_trans);
+    w_rot = nextScale(w_rot, rot_unit * w_rot, cfg_rot);
+  }
+  EXPECT_NEAR(300.0, w_trans, 1e-2);
+  EXPECT_NEAR(1000.0, w_rot, 1e-2);
+}
+
+TEST(AdjacentEdgeAutoScaleSplit, ChiSquaredDecompositionMatchesBlockShape)
+{
+  // For a diagonal block-diag Information matrix
+  //   I = block_diag(w_t * I_3, w_r * I_3)
+  // the full chi^2 of e = [t; r] equals w_t ||t||^2 + w_r ||r||^2. Verify the
+  // accounting the component uses against the full e^T I e expression.
+  const Eigen::Matrix<double, 6, 1> err =
+    (Eigen::Matrix<double, 6, 1>() << 0.2, -0.1, 0.05, 0.01, 0.0, -0.03).finished();
+  const double w_t = 250.0;
+  const double w_r = 800.0;
+  Eigen::Matrix<double, 6, 6> info = Eigen::Matrix<double, 6, 6>::Zero();
+  info.topLeftCorner<3, 3>().diagonal().setConstant(w_t);
+  info.bottomRightCorner<3, 3>().diagonal().setConstant(w_r);
+  const double full = err.transpose() * info * err;
+  const double trans_part = w_t * err.head<3>().squaredNorm();
+  const double rot_part = w_r * err.tail<3>().squaredNorm();
+  EXPECT_NEAR(full, trans_part + rot_part, 1e-12);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- Opt-in Level 2 mode for the adjacent-edge NIS auto-scaler that builds the SE(3) edge Information as `block_diag(w_trans * I_3, w_rot * I_3)` instead of `s * I_6`, and rescales `w_trans` and `w_rot` independently against per-block targets (default 3 DoF each).
- Level 1 path is preserved verbatim — when the new `adjacent_edge_info_auto_scale_split_trans_rot` flag is off (default), the existing weight / target are used and nothing changes for any current dataset or preset.

## Why
v0.3 plan §GPT-pro recommendation #4: the current NIS auto-scaler treats the 6 DoF SE(3) edge as one block, which means a dataset that is much noisier in rotation than translation (or vice versa) ends up either over-trusting the noisy block or under-trusting the clean one. Splitting trans / rot lets the auto-scaler balance each block to its own degree of freedom budget, which should especially help short-trajectory MID-360 / Newer College runs where the LIO front-end is much tighter in rotation than translation (RKO-LIO is gyro-strong, IMU pre-integrated).

## Test plan
- `colcon test --packages-select graph_based_slam` — 327 tests, 0 fail (25 skipped).
- New gtests in `test_adjacent_edge_auto_scale.cpp`:
  - `IndependentTransAndRotMoveSeparately` — one-step independence
  - `RepeatedApplicationConvergesIndependently` — two distinct equilibria
  - `ChiSquaredDecompositionMatchesBlockShape` — verifies `e^T I e == w_trans ||t||^2 + w_rot ||r||^2` so the runtime decomposition is the exact chi^2 contribution of each block.
- Live integration: ran a quick MID-360 baseline (split flag off) — banner / behaviour identical to develop.

## Notes
This PR only adds the mechanism. A follow-up will measure split mode on NTU VIRAL / MID-360 / Newer College and propose dataset-specific defaults.