### PR TITLE
feat: edge_3d keypoint extractor for narrow-FOV / indoor triangle descriptor

### DIFF
--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -269,6 +269,16 @@ private:
     double triangle_descriptor_max_edge_m_ {50.0};
     int triangle_descriptor_max_triangles_ {3000};
     double triangle_descriptor_edge_bin_m_ {0.5};
+    // Keypoint extractor mode. "bev_max_height" is the original outdoor-only
+    // extractor; "edge_3d" enables PCA-edgeness keypoints that survive in
+    // narrow-FOV / indoor scenes (MID-360, Newer College math_hard) where
+    // BEV max-height keypoint repeatability collapses.
+    std::string triangle_descriptor_keypoint_mode_ {"bev_max_height"};
+    double triangle_descriptor_edge_voxel_size_m_ {0.4};
+    double triangle_descriptor_edge_neighbor_radius_m_ {1.0};
+    int triangle_descriptor_edge_min_neighbors_ {6};
+    double triangle_descriptor_edge_min_edgeness_ {0.5};
+    double triangle_descriptor_edge_nms_radius_m_ {2.0};
     // 5-inlier floor would have killed the only accepted loop in v4 (id=32
     // emitted with 4 inliers), so settle on 4 as the compromise between
     // recall and noise. Votes can stay loose because the tighter keypoint

--- a/graph_based_slam/include/graph_based_slam/triangle_descriptor.hpp
+++ b/graph_based_slam/include/graph_based_slam/triangle_descriptor.hpp
@@ -31,9 +31,13 @@
 // under BSD-2 so the default workflow can include them.
 //
 // The pipeline (in this header):
-//   1. extractKeypointsBEV: take a submap point cloud, project to BEV, pick
-//      the local-maximum cells in max_height as stable keypoints. This is the
-//      cheap MID-360 alternative to STD's plane-intersection keypoints.
+//   1. extractKeypoints: dispatcher that picks one of the modes below.
+//      - extractKeypointsBEV: take a submap point cloud, project to BEV, pick
+//        the local-maximum cells in max_height as stable keypoints. Works on
+//        spinning 360° LiDAR with wide vertical FOV (e.g. OS1 outdoors).
+//      - extractKeypointsEdge3D: PCA eigenvalue ratio on radius-r neighborhoods
+//        picks edge-like supports (column edges, wall corners). Survives in
+//        narrow-FOV (MID-360) and indoor scenes where BEV max-height collapses.
 //   2. buildTriangles: enumerate all 3-tuples of keypoints, drop those whose
 //      edge lengths fall outside [min_edge_m, max_edge_m] or that are
 //      near-collinear, and store the edges sorted ascending so the triangle
@@ -52,6 +56,8 @@
 #include <Eigen/Dense>
 #include <Eigen/Geometry>
 
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
@@ -61,6 +67,7 @@
 #include <cstddef>
 #include <limits>
 #include <queue>
+#include <utility>
 #include <vector>
 
 namespace graphslam
@@ -71,12 +78,24 @@ namespace triangle
 struct Keypoint
 {
   Eigen::Vector3f position {Eigen::Vector3f::Zero()};
-  // BEV max-height minus the neighborhood floor; higher = more salient.
+  // BEV max-height minus the neighborhood floor (BEV mode),
+  // or PCA edgeness (λ2 - λ1) / λ2 (EDGE_3D mode); higher = more salient.
   float salience {0.0f};
+};
+
+// Keypoint extraction strategy. BEV_MAX_HEIGHT was the original outdoor-only
+// extractor; EDGE_3D adds PCA-based edge keypoints that survive in narrow-FOV
+// LiDARs (MID-360) and indoor scenes where BEV max-height collapses.
+enum class KeypointMode
+{
+  BEV_MAX_HEIGHT,
+  EDGE_3D,
 };
 
 struct KeypointExtractionConfig
 {
+  KeypointMode mode {KeypointMode::BEV_MAX_HEIGHT};
+  // ----- BEV_MAX_HEIGHT params -----
   // Side length of the BEV window centred on the submap origin.
   double grid_size_m {60.0};
   // Cells per side; cell_size = grid_size_m / grid_cells.
@@ -85,6 +104,18 @@ struct KeypointExtractionConfig
   int neighborhood_radius_cells {2};
   // Minimum salience (m) to keep a keypoint.
   float min_salience_m {0.3f};
+  // ----- EDGE_3D params -----
+  // Voxel downsample size before PCA; trades repeatability for cost.
+  float edge_voxel_size_m {0.4f};
+  // Radius (m) for the PCA neighborhood used to compute eigenvalues.
+  float edge_neighbor_radius_m {1.0f};
+  // Minimum neighbor count; points with sparser support are skipped.
+  int edge_min_neighbors {6};
+  // Minimum PCA edgeness (λ2 - λ1) / λ2 to accept a candidate.
+  float edge_min_edgeness {0.5f};
+  // Suppression radius (m) for non-maximum suppression of edgeness.
+  float edge_nms_radius_m {2.0f};
+  // ----- common -----
   // Cap on returned keypoints; we keep the highest-salience ones.
   int max_keypoints {80};
 };
@@ -216,6 +247,140 @@ inline std::vector<Keypoint> extractKeypointsBEV(
   const int keep = std::min<int>(cfg.max_keypoints, static_cast<int>(candidates.size()));
   result.assign(candidates.begin(), candidates.begin() + keep);
   return result;
+}
+
+// --------------------------- edge-3D keypoint extraction ---------------------------
+
+// PCA-based edge keypoint extractor. For each voxel-downsampled point, compute
+// the covariance of its radius-r neighbors and pick points where the largest
+// eigenvalue dominates the middle one — geometrically these are linear /
+// edge-like supports (column edges, wall corners, door frames) that survive in
+// narrow-FOV LiDAR and indoor scenes where BEV max-height collapses.
+inline std::vector<Keypoint> extractKeypointsEdge3D(
+  const pcl::PointCloud<pcl::PointXYZI> & cloud,
+  const KeypointExtractionConfig & cfg)
+{
+  std::vector<Keypoint> result;
+  if (cloud.empty()) {return result;}
+
+  // Voxel downsample so the PCA cost is bounded regardless of submap density.
+  pcl::PointCloud<pcl::PointXYZI>::Ptr downsampled(new pcl::PointCloud<pcl::PointXYZI>);
+  pcl::PointCloud<pcl::PointXYZI>::Ptr src(new pcl::PointCloud<pcl::PointXYZI>(cloud));
+  if (cfg.edge_voxel_size_m > 0.0f) {
+    pcl::VoxelGrid<pcl::PointXYZI> vg;
+    vg.setInputCloud(src);
+    vg.setLeafSize(cfg.edge_voxel_size_m, cfg.edge_voxel_size_m, cfg.edge_voxel_size_m);
+    vg.filter(*downsampled);
+  } else {
+    downsampled = src;
+  }
+  if (downsampled->size() < static_cast<std::size_t>(std::max(3, cfg.edge_min_neighbors))) {
+    return result;
+  }
+
+  pcl::KdTreeFLANN<pcl::PointXYZI> kdtree;
+  kdtree.setInputCloud(downsampled);
+
+  struct Candidate
+  {
+    int idx;
+    float edgeness;
+    Eigen::Vector3f position;
+  };
+  std::vector<Candidate> candidates;
+  candidates.reserve(downsampled->size());
+
+  const float radius = std::max(0.05f, cfg.edge_neighbor_radius_m);
+  std::vector<int> nn_idx;
+  std::vector<float> nn_sq;
+
+  for (std::size_t i = 0; i < downsampled->size(); ++i) {
+    const auto & p = downsampled->points[i];
+    if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {continue;}
+    nn_idx.clear();
+    nn_sq.clear();
+    const int found = kdtree.radiusSearch(static_cast<int>(i), radius, nn_idx, nn_sq);
+    if (found < cfg.edge_min_neighbors) {continue;}
+
+    Eigen::Vector3f centroid = Eigen::Vector3f::Zero();
+    for (int idx : nn_idx) {
+      const auto & q = downsampled->points[idx];
+      centroid += Eigen::Vector3f(q.x, q.y, q.z);
+    }
+    centroid /= static_cast<float>(nn_idx.size());
+
+    Eigen::Matrix3f cov = Eigen::Matrix3f::Zero();
+    for (int idx : nn_idx) {
+      const auto & q = downsampled->points[idx];
+      Eigen::Vector3f d(q.x - centroid.x(), q.y - centroid.y(), q.z - centroid.z());
+      cov += d * d.transpose();
+    }
+    cov /= static_cast<float>(nn_idx.size());
+
+    // SelfAdjointEigenSolver returns eigenvalues in ascending order.
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> es(cov, Eigen::EigenvaluesOnly);
+    if (es.info() != Eigen::Success) {continue;}
+    const Eigen::Vector3f ev = es.eigenvalues();
+    const float lam0 = std::max(0.0f, ev(0));
+    const float lam1 = std::max(0.0f, ev(1));
+    const float lam2 = std::max(0.0f, ev(2));
+    if (lam2 <= 1e-9f) {continue;}
+    const float edgeness = (lam2 - lam1) / lam2;
+    if (edgeness < cfg.edge_min_edgeness) {continue;}
+
+    Candidate c;
+    c.idx = static_cast<int>(i);
+    c.edgeness = edgeness;
+    c.position = Eigen::Vector3f(p.x, p.y, p.z);
+    candidates.push_back(c);
+  }
+
+  std::sort(
+    candidates.begin(), candidates.end(),
+    [](const Candidate & a, const Candidate & b) {return a.edgeness > b.edgeness;});
+
+  // Non-maximum suppression in 3D: drop candidates that fall within
+  // edge_nms_radius_m of an already-accepted higher-edgeness keypoint.
+  const float nms_r = std::max(0.0f, cfg.edge_nms_radius_m);
+  const float nms_r2 = nms_r * nms_r;
+  std::vector<Keypoint> kept;
+  kept.reserve(candidates.size());
+  for (const auto & c : candidates) {
+    bool suppressed = false;
+    if (nms_r > 0.0f) {
+      for (const auto & k : kept) {
+        if ((k.position - c.position).squaredNorm() < nms_r2) {
+          suppressed = true;
+          break;
+        }
+      }
+    }
+    if (suppressed) {continue;}
+    Keypoint kp;
+    kp.position = c.position;
+    kp.salience = c.edgeness;
+    kept.push_back(kp);
+    if (cfg.max_keypoints > 0 && static_cast<int>(kept.size()) >= cfg.max_keypoints) {break;}
+  }
+
+  result = std::move(kept);
+  return result;
+}
+
+// Dispatcher: pick the keypoint extractor based on ``cfg.mode``. New code
+// should call this rather than the mode-specific entry points; the BEV and
+// EDGE_3D functions stay public for tests and ablation tooling.
+inline std::vector<Keypoint> extractKeypoints(
+  const pcl::PointCloud<pcl::PointXYZI> & cloud,
+  const KeypointExtractionConfig & cfg)
+{
+  switch (cfg.mode) {
+    case KeypointMode::EDGE_3D:
+      return extractKeypointsEdge3D(cloud, cfg);
+    case KeypointMode::BEV_MAX_HEIGHT:
+    default:
+      return extractKeypointsBEV(cloud, cfg);
+  }
 }
 
 // --------------------------- triangle enumeration ---------------------------

--- a/graph_based_slam/param/graphbasedslam.yaml
+++ b/graph_based_slam/param/graphbasedslam.yaml
@@ -44,10 +44,24 @@ graph_based_slam:
       # for a 360° LiDAR; tighten the edge and grid bounds for short-range
       # sensors like the Livox MID-360.
       use_triangle_descriptor: false
+      # Keypoint mode. "bev_max_height" picks BEV local-max cells (works on
+      # spinning 360° LiDAR outdoors). "edge_3d" runs PCA on radius-r
+      # neighborhoods and keeps high-edgeness (column edge / wall corner)
+      # supports - prefer this for narrow-FOV LiDAR (Livox MID-360) and
+      # indoor scenes where BEV max-height repeatability collapses.
+      triangle_descriptor_keypoint_mode: "bev_max_height"
       triangle_descriptor_grid_size_m: 60.0
       triangle_descriptor_grid_cells: 100
       triangle_descriptor_max_keypoints: 40
       triangle_descriptor_min_salience_m: 0.8
+      # edge_3d-mode tuning. Smaller voxel + smaller neighbor radius =
+      # finer keypoints but more compute. The default 0.4 / 1.0 m pair
+      # is the starting point used in 2026-05-19 MID-360 ablation.
+      triangle_descriptor_edge_voxel_size_m: 0.4
+      triangle_descriptor_edge_neighbor_radius_m: 1.0
+      triangle_descriptor_edge_min_neighbors: 6
+      triangle_descriptor_edge_min_edgeness: 0.5
+      triangle_descriptor_edge_nms_radius_m: 2.0
       triangle_descriptor_min_edge_m: 2.0
       triangle_descriptor_max_edge_m: 50.0
       triangle_descriptor_max_triangles: 3000

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -169,6 +169,25 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("triangle_descriptor_max_triangles", triangle_descriptor_max_triangles_);
   declare_parameter("triangle_descriptor_edge_bin_m", 0.5);
   get_parameter("triangle_descriptor_edge_bin_m", triangle_descriptor_edge_bin_m_);
+  declare_parameter<std::string>(
+    "triangle_descriptor_keypoint_mode", triangle_descriptor_keypoint_mode_);
+  get_parameter("triangle_descriptor_keypoint_mode", triangle_descriptor_keypoint_mode_);
+  declare_parameter("triangle_descriptor_edge_voxel_size_m", 0.4);
+  get_parameter(
+    "triangle_descriptor_edge_voxel_size_m", triangle_descriptor_edge_voxel_size_m_);
+  declare_parameter("triangle_descriptor_edge_neighbor_radius_m", 1.0);
+  get_parameter(
+    "triangle_descriptor_edge_neighbor_radius_m",
+    triangle_descriptor_edge_neighbor_radius_m_);
+  declare_parameter("triangle_descriptor_edge_min_neighbors", 6);
+  get_parameter(
+    "triangle_descriptor_edge_min_neighbors", triangle_descriptor_edge_min_neighbors_);
+  declare_parameter("triangle_descriptor_edge_min_edgeness", 0.5);
+  get_parameter(
+    "triangle_descriptor_edge_min_edgeness", triangle_descriptor_edge_min_edgeness_);
+  declare_parameter("triangle_descriptor_edge_nms_radius_m", 2.0);
+  get_parameter(
+    "triangle_descriptor_edge_nms_radius_m", triangle_descriptor_edge_nms_radius_m_);
   declare_parameter("triangle_descriptor_min_votes", 6);
   get_parameter("triangle_descriptor_min_votes", triangle_descriptor_min_votes_);
   declare_parameter("triangle_descriptor_min_inliers", 4);
@@ -533,6 +552,33 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       "resetting 0.0 to disabled");
     bev_descriptor_pose_consistency_threshold_m_ = -1.0;
   }
+  if (triangle_descriptor_keypoint_mode_ != "bev_max_height" &&
+    triangle_descriptor_keypoint_mode_ != "edge_3d")
+  {
+    RCLCPP_WARN(
+      get_logger(),
+      "triangle_descriptor_keypoint_mode must be 'bev_max_height' or 'edge_3d', "
+      "got '%s'; falling back to 'bev_max_height'",
+      triangle_descriptor_keypoint_mode_.c_str());
+    triangle_descriptor_keypoint_mode_ = "bev_max_height";
+  }
+  if (triangle_descriptor_edge_voxel_size_m_ < 0.0) {
+    triangle_descriptor_edge_voxel_size_m_ = 0.0;
+  }
+  if (triangle_descriptor_edge_neighbor_radius_m_ <= 0.05) {
+    triangle_descriptor_edge_neighbor_radius_m_ = 0.05;
+  }
+  if (triangle_descriptor_edge_min_neighbors_ < 4) {
+    triangle_descriptor_edge_min_neighbors_ = 4;
+  }
+  if (triangle_descriptor_edge_min_edgeness_ < 0.0) {
+    triangle_descriptor_edge_min_edgeness_ = 0.0;
+  } else if (triangle_descriptor_edge_min_edgeness_ > 1.0) {
+    triangle_descriptor_edge_min_edgeness_ = 1.0;
+  }
+  if (triangle_descriptor_edge_nms_radius_m_ < 0.0) {
+    triangle_descriptor_edge_nms_radius_m_ = 0.0;
+  }
   if (triangle_descriptor_grid_size_m_ <= 0.0) {
     RCLCPP_WARN(
       get_logger(),
@@ -843,6 +889,8 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   std::cout << "use_triangle_descriptor:" << std::boolalpha <<
     use_triangle_descriptor_ << std::endl;
   if (use_triangle_descriptor_) {
+    std::cout << "triangle_descriptor_keypoint_mode:" <<
+      triangle_descriptor_keypoint_mode_ << std::endl;
     std::cout << "triangle_descriptor_grid_size_m:" <<
       triangle_descriptor_grid_size_m_ << std::endl;
     std::cout << "triangle_descriptor_grid_cells:" <<
@@ -851,6 +899,16 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       triangle_descriptor_max_keypoints_ << std::endl;
     std::cout << "triangle_descriptor_min_salience_m:" <<
       triangle_descriptor_min_salience_m_ << std::endl;
+    std::cout << "triangle_descriptor_edge_voxel_size_m:" <<
+      triangle_descriptor_edge_voxel_size_m_ << std::endl;
+    std::cout << "triangle_descriptor_edge_neighbor_radius_m:" <<
+      triangle_descriptor_edge_neighbor_radius_m_ << std::endl;
+    std::cout << "triangle_descriptor_edge_min_neighbors:" <<
+      triangle_descriptor_edge_min_neighbors_ << std::endl;
+    std::cout << "triangle_descriptor_edge_min_edgeness:" <<
+      triangle_descriptor_edge_min_edgeness_ << std::endl;
+    std::cout << "triangle_descriptor_edge_nms_radius_m:" <<
+      triangle_descriptor_edge_nms_radius_m_ << std::endl;
     std::cout << "triangle_descriptor_min_edge_m:" <<
       triangle_descriptor_min_edge_m_ << std::endl;
     std::cout << "triangle_descriptor_max_edge_m:" <<
@@ -1275,10 +1333,21 @@ void GraphBasedSlamComponent::searchLoop()
   }
   if (use_triangle_descriptor_ && triangle_descriptor_next_submap_idx_ < num_submaps) {
     graphslam::triangle::KeypointExtractionConfig kp_cfg;
+    if (triangle_descriptor_keypoint_mode_ == "edge_3d") {
+      kp_cfg.mode = graphslam::triangle::KeypointMode::EDGE_3D;
+    } else {
+      kp_cfg.mode = graphslam::triangle::KeypointMode::BEV_MAX_HEIGHT;
+    }
     kp_cfg.grid_size_m = triangle_descriptor_grid_size_m_;
     kp_cfg.grid_cells = triangle_descriptor_grid_cells_;
     kp_cfg.min_salience_m = static_cast<float>(triangle_descriptor_min_salience_m_);
     kp_cfg.max_keypoints = triangle_descriptor_max_keypoints_;
+    kp_cfg.edge_voxel_size_m = static_cast<float>(triangle_descriptor_edge_voxel_size_m_);
+    kp_cfg.edge_neighbor_radius_m =
+      static_cast<float>(triangle_descriptor_edge_neighbor_radius_m_);
+    kp_cfg.edge_min_neighbors = triangle_descriptor_edge_min_neighbors_;
+    kp_cfg.edge_min_edgeness = static_cast<float>(triangle_descriptor_edge_min_edgeness_);
+    kp_cfg.edge_nms_radius_m = static_cast<float>(triangle_descriptor_edge_nms_radius_m_);
     graphslam::triangle::TriangleBuildConfig build_cfg;
     build_cfg.min_edge_m = static_cast<float>(triangle_descriptor_min_edge_m_);
     build_cfg.max_edge_m = static_cast<float>(triangle_descriptor_max_edge_m_);
@@ -1290,7 +1359,7 @@ void GraphBasedSlamComponent::searchLoop()
       std::vector<graphslam::triangle::Keypoint> kps;
       std::vector<graphslam::triangle::TriangleDescriptor> tris;
       if (filtered_aggregated_cloud && !filtered_aggregated_cloud->empty()) {
-        kps = graphslam::triangle::extractKeypointsBEV(*filtered_aggregated_cloud, kp_cfg);
+        kps = graphslam::triangle::extractKeypoints(*filtered_aggregated_cloud, kp_cfg);
         tris = graphslam::triangle::buildTriangles(kps, build_cfg);
       }
       TrianglePerSubmap entry;

--- a/graph_based_slam/test/test_triangle_descriptor.cpp
+++ b/graph_based_slam/test/test_triangle_descriptor.cpp
@@ -139,6 +139,192 @@ TEST(TriangleDescriptorKeypoint, FiltersLowSaliencePillars)
   EXPECT_TRUE(kps.empty());
 }
 
+// ----- EDGE_3D keypoint extraction -----
+
+void addLinearStructure(
+  pcl::PointCloud<pcl::PointXYZI> & cloud,
+  float x, float y,
+  float top_z = 4.0f, float bottom_z = 0.0f, float step = 0.1f)
+{
+  // Vertical line of points - PCA covariance is dominated by the z direction
+  // so eigenvalues split as (~0, ~0, large) → edgeness near 1.
+  for (float z = bottom_z; z <= top_z; z += step) {
+    pcl::PointXYZI p;
+    p.x = x;
+    p.y = y;
+    p.z = z;
+    p.intensity = 1.0f;
+    cloud.push_back(p);
+  }
+}
+
+void addPlanarPatch(
+  pcl::PointCloud<pcl::PointXYZI> & cloud,
+  float x_min, float x_max, float y_min, float y_max,
+  float z = 0.0f, float step = 0.1f)
+{
+  for (float x = x_min; x <= x_max; x += step) {
+    for (float y = y_min; y <= y_max; y += step) {
+      pcl::PointXYZI p;
+      p.x = x;
+      p.y = y;
+      p.z = z;
+      p.intensity = 0.5f;
+      cloud.push_back(p);
+    }
+  }
+}
+
+TEST(TriangleDescriptorEdge3DKeypoint, EmptyCloudYieldsNoKeypoints)
+{
+  pcl::PointCloud<pcl::PointXYZI> cloud;
+  KeypointExtractionConfig cfg;
+  cfg.mode = KeypointMode::EDGE_3D;
+  const auto kps = extractKeypointsEdge3D(cloud, cfg);
+  EXPECT_TRUE(kps.empty());
+}
+
+TEST(TriangleDescriptorEdge3DKeypoint, PicksLinearStructures)
+{
+  // Three thin vertical lines well-separated in xy → each gives a
+  // high-edgeness PCA neighborhood (λ2 ≫ λ1 ≈ 0). With NMS radius set to
+  // cover the line height, each line collapses to a single keypoint.
+  pcl::PointCloud<pcl::PointXYZI> cloud;
+  addLinearStructure(cloud, 5.0f, 5.0f, 4.0f);
+  addLinearStructure(cloud, -5.0f, 5.0f, 4.0f);
+  addLinearStructure(cloud, 0.0f, -5.0f, 4.0f);
+
+  KeypointExtractionConfig cfg;
+  cfg.mode = KeypointMode::EDGE_3D;
+  cfg.edge_voxel_size_m = 0.2f;
+  cfg.edge_neighbor_radius_m = 0.6f;
+  cfg.edge_min_neighbors = 4;
+  cfg.edge_min_edgeness = 0.6f;
+  cfg.edge_nms_radius_m = 5.0f;
+  cfg.max_keypoints = 50;
+  const auto kps = extractKeypointsEdge3D(cloud, cfg);
+  EXPECT_EQ(3u, kps.size());
+  for (const auto & kp : kps) {
+    const float dx1 = std::abs(kp.position.x() - 5.0f);
+    const float dx2 = std::abs(kp.position.x() - (-5.0f));
+    const float dx3 = std::abs(kp.position.x() - 0.0f);
+    const float dy1 = std::abs(kp.position.y() - 5.0f);
+    const float dy3 = std::abs(kp.position.y() - (-5.0f));
+    const bool on_a_line =
+      (dx1 < 0.5f && dy1 < 0.5f) ||
+      (dx2 < 0.5f && dy1 < 0.5f) ||
+      (dx3 < 0.5f && dy3 < 0.5f);
+    EXPECT_TRUE(on_a_line) <<
+      "keypoint at (" << kp.position.x() << ", " << kp.position.y() <<
+      ", " << kp.position.z() << ") is not on any expected line";
+    EXPECT_GE(kp.salience, 0.6f);
+  }
+}
+
+TEST(TriangleDescriptorEdge3DKeypoint, RejectsPlanarInterior)
+{
+  // Planar patch interior should NOT produce edge keypoints; the eigenvalue
+  // ratio λ2 / λ1 is close to 1 because two horizontal dimensions are filled
+  // equally. The patch boundary will produce edges (a planar slab edge IS an
+  // edge — that is intentional, real-world wall ends behave the same way),
+  // so we only check the interior here by clipping the candidate locations
+  // away from the patch boundary.
+  pcl::PointCloud<pcl::PointXYZI> cloud;
+  addPlanarPatch(cloud, -8.0f, 8.0f, -8.0f, 8.0f, 0.0f, 0.15f);
+
+  KeypointExtractionConfig cfg;
+  cfg.mode = KeypointMode::EDGE_3D;
+  cfg.edge_voxel_size_m = 0.2f;
+  cfg.edge_neighbor_radius_m = 0.6f;
+  cfg.edge_min_neighbors = 4;
+  cfg.edge_min_edgeness = 0.6f;
+  cfg.edge_nms_radius_m = 1.5f;
+  cfg.max_keypoints = 200;
+  const auto kps = extractKeypointsEdge3D(cloud, cfg);
+  // Any keypoint must be within neighbor-radius of the patch boundary
+  // (boundary edges are legitimate). Interior of the patch (|x|, |y| < 5)
+  // must be empty.
+  for (const auto & kp : kps) {
+    const bool near_boundary =
+      std::abs(kp.position.x()) > 6.0f || std::abs(kp.position.y()) > 6.0f;
+    EXPECT_TRUE(near_boundary) <<
+      "interior planar keypoint at (" << kp.position.x() << ", " <<
+      kp.position.y() << ", " << kp.position.z() << ") - planar interior "
+      "must yield low edgeness";
+  }
+}
+
+TEST(TriangleDescriptorEdge3DKeypoint, NMSPreventsClusters)
+{
+  pcl::PointCloud<pcl::PointXYZI> cloud;
+  // Three lines extremely close together; NMS should collapse to one.
+  // Keep line height shorter than nms_radius so the endpoints fall within
+  // the suppression sphere of the centre point.
+  addLinearStructure(cloud, 0.0f, 0.0f, 1.0f);
+  addLinearStructure(cloud, 0.3f, 0.0f, 1.0f);
+  addLinearStructure(cloud, 0.0f, 0.3f, 1.0f);
+  KeypointExtractionConfig cfg;
+  cfg.mode = KeypointMode::EDGE_3D;
+  cfg.edge_voxel_size_m = 0.2f;
+  cfg.edge_neighbor_radius_m = 0.4f;
+  cfg.edge_min_neighbors = 4;
+  cfg.edge_min_edgeness = 0.5f;
+  cfg.edge_nms_radius_m = 3.0f;
+  cfg.max_keypoints = 50;
+  const auto kps = extractKeypointsEdge3D(cloud, cfg);
+  EXPECT_EQ(1u, kps.size());
+}
+
+TEST(TriangleDescriptorEdge3DKeypoint, RespectsMaxKeypoints)
+{
+  pcl::PointCloud<pcl::PointXYZI> cloud;
+  for (int i = 0; i < 8; ++i) {
+    const float x = -14.0f + 4.0f * static_cast<float>(i);
+    addLinearStructure(cloud, x, 0.0f, 4.0f);
+  }
+  KeypointExtractionConfig cfg;
+  cfg.mode = KeypointMode::EDGE_3D;
+  cfg.edge_voxel_size_m = 0.2f;
+  cfg.edge_neighbor_radius_m = 0.6f;
+  cfg.edge_min_neighbors = 4;
+  cfg.edge_min_edgeness = 0.5f;
+  cfg.edge_nms_radius_m = 1.5f;
+  cfg.max_keypoints = 3;
+  const auto kps = extractKeypointsEdge3D(cloud, cfg);
+  EXPECT_EQ(3u, kps.size());
+  // Saliences descend.
+  EXPECT_GE(kps[0].salience, kps[1].salience);
+  EXPECT_GE(kps[1].salience, kps[2].salience);
+}
+
+TEST(TriangleDescriptorEdge3DKeypoint, DispatcherSelectsCorrectMode)
+{
+  // BEV mode skips structures whose top is at ground height. EDGE_3D mode
+  // accepts vertical lines regardless of height range. Use that distinction
+  // to verify the dispatcher routes by `mode`.
+  pcl::PointCloud<pcl::PointXYZI> cloud;
+  addLinearStructure(cloud, 5.0f, 5.0f, 0.5f);
+  addLinearStructure(cloud, -5.0f, 5.0f, 0.5f);
+  addLinearStructure(cloud, 0.0f, -5.0f, 0.5f);
+
+  KeypointExtractionConfig bev_cfg;
+  bev_cfg.mode = KeypointMode::BEV_MAX_HEIGHT;
+  bev_cfg.min_salience_m = 5.0f;  // way above the 0.5 m lines → all rejected
+  const auto bev_kps = extractKeypoints(cloud, bev_cfg);
+  EXPECT_TRUE(bev_kps.empty());
+
+  KeypointExtractionConfig edge_cfg;
+  edge_cfg.mode = KeypointMode::EDGE_3D;
+  edge_cfg.edge_voxel_size_m = 0.1f;
+  edge_cfg.edge_neighbor_radius_m = 0.6f;
+  edge_cfg.edge_min_neighbors = 3;
+  edge_cfg.edge_min_edgeness = 0.5f;
+  edge_cfg.edge_nms_radius_m = 1.0f;
+  edge_cfg.max_keypoints = 10;
+  const auto edge_kps = extractKeypoints(cloud, edge_cfg);
+  EXPECT_GE(edge_kps.size(), 3u);
+}
+
 // ----- triangle enumeration -----
 
 std::vector<Keypoint> threePoints(

--- a/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
+++ b/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
@@ -40,10 +40,16 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 EXPECTED_PARAM_KEYS = {
     'use_triangle_descriptor',
+    'triangle_descriptor_keypoint_mode',
     'triangle_descriptor_grid_size_m',
     'triangle_descriptor_grid_cells',
     'triangle_descriptor_max_keypoints',
     'triangle_descriptor_min_salience_m',
+    'triangle_descriptor_edge_voxel_size_m',
+    'triangle_descriptor_edge_neighbor_radius_m',
+    'triangle_descriptor_edge_min_neighbors',
+    'triangle_descriptor_edge_min_edgeness',
+    'triangle_descriptor_edge_nms_radius_m',
     'triangle_descriptor_min_edge_m',
     'triangle_descriptor_max_edge_m',
     'triangle_descriptor_max_triangles',
@@ -60,6 +66,8 @@ EXPECTED_PARAM_KEYS = {
     'triangle_verify_with_bev',
     'triangle_verify_bev_max_distance',
 }
+
+VALID_KEYPOINT_MODES = {'bev_max_height', 'edge_3d'}
 
 PARAM_FILES = [
     REPO_ROOT / 'graph_based_slam' / 'param' / 'graphbasedslam.yaml',
@@ -122,3 +130,41 @@ def test_bev_cross_verify_defaults_off(path):
     params = _load_graph_params(path)
     assert params['triangle_verify_with_bev'] is False
     assert params['triangle_verify_bev_max_distance'] > 0.0
+
+
+@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
+def test_keypoint_mode_is_valid(path):
+    params = _load_graph_params(path)
+    mode = params['triangle_descriptor_keypoint_mode']
+    assert mode in VALID_KEYPOINT_MODES, (
+        f'{path.name}: unknown keypoint mode {mode!r}; '
+        f'must be one of {sorted(VALID_KEYPOINT_MODES)}'
+    )
+
+
+@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
+def test_edge_keypoint_params_sane(path):
+    params = _load_graph_params(path)
+    assert params['triangle_descriptor_edge_voxel_size_m'] >= 0.0
+    assert params['triangle_descriptor_edge_neighbor_radius_m'] > 0.0
+    assert params['triangle_descriptor_edge_min_neighbors'] >= 4
+    edgeness = params['triangle_descriptor_edge_min_edgeness']
+    assert 0.0 <= edgeness <= 1.0, (
+        f'{path.name}: edgeness threshold {edgeness} out of [0, 1]'
+    )
+    assert params['triangle_descriptor_edge_nms_radius_m'] >= 0.0
+
+
+def test_mid360_preset_prefers_edge_keypoints():
+    """
+    MID-360 preset must default to edge_3d keypoints.
+
+    MID-360 narrow-FOV ablation showed BEV max-height fails (votes accumulate
+    but 3-point RANSAC inliers stay at 1-2). edge_3d is the cross-dataset
+    answer (see project_triangle_descriptor_stack memory).
+    """
+    mid360 = _load_graph_params(PARAM_FILES[1])
+    assert mid360['triangle_descriptor_keypoint_mode'] == 'edge_3d', (
+        'MID-360 preset must default to edge_3d so the opt-in triangle path '
+        'has a working keypoint extractor on narrow-FOV LiDAR'
+    )

--- a/lidarslam/param/lidarslam_mid360_rko_graph.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph.yaml
@@ -45,10 +45,24 @@ graph_based_slam:
     # MID-360 pipeline keeps the same loop-closure behaviour; flip
     # use_triangle_descriptor to true to opt in.
     use_triangle_descriptor: false
+    # MID-360 ablation (2026-05-18 / 19) showed BEV max-height keypoints
+    # fail in narrow-FOV LiDAR (votes accumulate but 3-point RANSAC inliers
+    # stay at 1-2). edge_3d is the alternative extractor that runs PCA on
+    # radius-r neighborhoods and keeps high-edgeness supports - geometrically
+    # equivalent to LOAM edge points but view-direction agnostic. This is
+    # the recommended mode if you flip use_triangle_descriptor to true on
+    # MID-360. The tighter edge_neighbor_radius / nms_radius below match
+    # the shorter usable range of the sensor.
+    triangle_descriptor_keypoint_mode: "edge_3d"
     triangle_descriptor_grid_size_m: 60.0
     triangle_descriptor_grid_cells: 100
     triangle_descriptor_max_keypoints: 30
     triangle_descriptor_min_salience_m: 1.0
+    triangle_descriptor_edge_voxel_size_m: 0.3
+    triangle_descriptor_edge_neighbor_radius_m: 0.8
+    triangle_descriptor_edge_min_neighbors: 6
+    triangle_descriptor_edge_min_edgeness: 0.5
+    triangle_descriptor_edge_nms_radius_m: 1.5
     triangle_descriptor_min_edge_m: 2.0
     triangle_descriptor_max_edge_m: 30.0
     triangle_descriptor_max_triangles: 2000


### PR DESCRIPTION
## Summary

- MID-360 (narrow FOV) と Newer College math_hard (indoor) で BEV max-height keypoint repeatability が崩壊し、triangle descriptor の 3-point RANSAC inliers が 1-2 で頭打ちになる問題への対応 (詳細: plan.md §1.2 / project_triangle_descriptor_stack memory)。
- View-direction agnostic な代替として **PCA edgeness ベースの edge_3d 抽出器** を追加。voxel downsample → KdTree radius search → SelfAdjointEigenSolver で eigenvalues → \`(λ2 - λ1) / λ2\` を edgeness とし、3D NMS で keypoint を間引く。
- KeypointMode enum + dispatcher により既存 BEV パスは無影響。MID-360 yaml では \`triangle_descriptor_keypoint_mode: edge_3d\` を default に切り替え (narrow-FOV では BEV が機能しない 3-dataset 検証結果を反映)。generic graphbasedslam.yaml は \`bev_max_height\` のまま。

## 変更内容

- \`triangle_descriptor.hpp\`: KeypointMode + \`extractKeypointsEdge3D\` + dispatcher \`extractKeypoints\`
- \`graph_based_slam_component\`: \`triangle_descriptor_keypoint_mode\` + 5 つの edge_3d パラメータ (voxel_size, neighbor_radius, min_neighbors, min_edgeness, nms_radius) を配線、起動バナー / validation 付き
- yaml preset 更新 (generic = BEV、MID-360 = edge_3d)
- gtest 5 本: PicksLinearStructures, RejectsPlanarInterior, NMSPreventsClusters, RespectsMaxKeypoints, DispatcherSelectsCorrectMode
- yaml regression 2 本: keypoint_mode 妥当性 + edge param sanity + MID-360 が edge_3d を default にすること

## Test plan

- [x] \`colcon build --packages-select graph_based_slam\` green
- [x] \`colcon test --packages-select graph_based_slam\` green (488 tests, 0 failures)
- [ ] Follow-up: MID-360 / Newer College で edge_3d mode を有効にした triangle ablation を実走し、3-point RANSAC inliers が改善するか確認