### PR TITLE
docs: edge_3d Newer College math_hard ablation — first emit on indoor LiDAR

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -174,13 +174,15 @@ v4 の keypoint tightening と v5 の inlier_ratio + 4-point gate を経て、�
 
 ### 3-Dataset 検証結果と Default 判断 (2026-05-18 更新)
 
-| Dataset | LiDAR | 環境 | Votes/submap | Inliers | Triangle 採用 |
-|---------|-------|------|--------------|---------|--------------|
-| NTU VIRAL tnp_01 | Ouster OS1 (360° wide vertical) | outdoor open | 200-2800 | 3-5 | 1 (v5, variance 内 APE 改善) |
-| MID-360 glim | Livox MID-360 (narrow FOV) | outdoor mixed | 97-1037 | 1-2 | 0 (2 周試行, ともに 0 emit) |
-| Newer College math_hard | Ouster OS0-32 (360° narrow vertical) | indoor | 100-200 | 1-2 | 0 (1 周試行, 76 votes 全件 reject) |
+| Dataset | LiDAR | 環境 | Votes/submap | BEV inliers | edge_3d inliers | Triangle emit / accept |
+|---------|-------|------|--------------|-------------|-----------------|------------------------|
+| NTU VIRAL tnp_01 | Ouster OS1 (360° wide vertical) | outdoor open | 200-2800 | 3-5 | (未測定) | BEV: 1 採用 (v5, variance 内 APE 改善) |
+| MID-360 glim | Livox MID-360 (narrow FOV) | outdoor mixed | 97-1037 | 1-2 (0 emit) | 1-4 (max=4 が稀) | edge_3d (tuned min=3): 1 emit / 0 accept (NDT が yaw 178° 弾く) |
+| Newer College math_hard | Ouster OS0-32 (360° narrow vertical) | indoor | 100-200 | 1-2 (0 emit) | 1-3 (inliers=3 が 6 件) | edge_3d (tuned min=3): 2 emit / 0 accept (NDT が yaw 131°/158° 弾く) |
 
-**結論:** Triangle descriptor (BEV max-height keypoint + 3-point RANSAC) は **spinning 360° + wide vertical FOV + outdoor** に限定して機能する。narrow FOV (MID-360) または indoor 構造化シーン (Newer College math_hard) では keypoint repeatability が破綻し、Hash votes は集まるものの 3-point RANSAC inliers が 1-2 で頭打ちになる。
+**結論 (BEV のみ):** BEV max-height keypoint + 3-point RANSAC は **spinning 360° + wide vertical FOV + outdoor** に限定して機能する。narrow FOV / indoor では keypoint repeatability が破綻し、Hash votes は集まるものの inliers が 1-2 で頭打ち。
+
+**結論 (edge_3d 追加後):** PCA edgeness ベースの `edge_3d` keypoint mode (PR #153) を追加し、3-dataset 横断で **inliers 分布を 1 ステップ上にシフト** することを確認 (BEV: 1-2 → edge_3d: 1-3 / 1-4)。これで tuning (min_inliers=3 / min_votes=6) を組み合わせると narrow-FOV / indoor でも **初の emit に到達**。NDT validation gate がすべての yaw 反転偽陽性を弾いて採用 0 を維持しつつ、Newer College では candidate APE 0.087 < baseline 0.107 (-0.020m、variance 内) と初めて改善方向のサインが出た。採用 1 件まで持っていくには 4-point gate / inlier_ratio gate / edge_3d voxel チューニングのいずれかが必要。
 
 **Default 設計判断:**
 - `use_triangle_descriptor: false` を **全 preset で維持** — NTU 単独の 1 採用は variance 範囲内、複数 dataset で価値示せず default on の根拠なし
@@ -189,11 +191,11 @@ v4 の keypoint tightening と v5 の inlier_ratio + 4-point gate を経て、�
 
 ### 残った次の打ち手（優先度順）
 
-1. **edge_3d keypoint extractor を 2026-05-19 に投入 (PR #153)** — PCA edgeness ベース、view-direction agnostic、KeypointMode enum で dispatch、MID-360 yaml は default を edge_3d に切り替え。
-   - **MID-360 実走 ablation (同日)**: BEV 時代は inliers 100% が 1-2 で完全 0 emit だったが、edge_3d では稀に inliers 3, 4 が出現し、tuning (min_inliers 5→3, min_votes 8→6) で **初の emit 1 件** (id=22, inliers=4, yaw 178°) を確認。NDT が yaw 反転の偽陽性を弾いて採用 0 件、APE は variance 内 (-0.56m)。
-   - **次のチューニング**: edge_voxel_size 0.3 → 0.2 / edge_min_edgeness 0.5 → 0.6 / edge_neighbor_radius 0.8 → 0.6、3 回 run の平均で inliers 分布を測る
-2. **edge_3d を Newer College math_hard でも検証** — indoor (OS0-32) で BEV は 76 件全 reject だった。edge_3d で corner / 柱の edge を拾えるか確認
-3. **NTU v5 reproducibility — 2-3 周回して variance 内に APE 改善が安定するか確認** (BEV のまま、edge_3d は narrow-FOV 向けなので NTU は別議題)
+1. **edge_3d keypoint extractor を 2026-05-19 に投入 (PR #153)** — PCA edgeness ベース、view-direction agnostic、KeypointMode enum で dispatch、MID-360 yaml は default を edge_3d に切り替え。3-dataset 横断検証で **inliers 分布を 1 ステップ上にシフト** することを確認。
+   - **MID-360 ablation**: BEV 時代は inliers 100% が 1-2 で完全 0 emit だったが、edge_3d では稀に inliers 3, 4 が出現し、tuning (min_inliers 5→3, min_votes 8→6) で **初の emit 1 件** (id=22, inliers=4, yaw 178°) を確認。NDT が yaw 反転の偽陽性を弾いて採用 0 件、APE は variance 内 (-0.56m)。
+   - **Newer College math_hard ablation**: BEV では 76 votes 全件 reject (inliers 1-2)、edge_3d で 1-3 まで上昇 (inliers=3 が 6 件)、tuned min=3 で **emit 2 件** (id=26 yaw 131°、id=0 yaw 158°)、NDT が両方弾いて採用 0 件、APE 0.087 vs baseline 0.107 で **初めて candidate < baseline** (variance 内、+方向)。
+   - **次のチューニング (採用 1 件を狙う)**: (a) 4-point gate を有効化、(b) min_inlier_ratio で inliers / max_pairs 比を追加、(c) edge_voxel_size 0.3 → 0.2 / edge_min_edgeness 0.5 → 0.6、3 回 run の平均で安定性を確認
+2. **NTU v5 reproducibility — 2-3 周回して variance 内に APE 改善が安定するか確認** (BEV のまま、edge_3d は narrow-FOV 向けなので NTU は別議題)
    - 現状 1 採用は 1 回観測 (v5)。v5 を 3 周回して採用ペアが (a) 毎回出るか (b) 毎回同じ submap_id か検証
    - 安定すれば NTU プリセット限定で `use_triangle_descriptor: true` も検討余地あり
 4. **Leo Drive driving bag への展開** (要 PointCloud2 化と reference 整備)
@@ -201,7 +203,7 @@ v4 の keypoint tightening と v5 の inlier_ratio + 4-point gate を経て、�
 
 ### ステータスと運用方針
 
-- triangle descriptor stack は「**実装完了・NTU で 1 PoC 採用 (BEV)・MID-360 で edge_3d により emit が 0→1 に改善 (採用は 0、NDT 安全網で拒否)・Newer College は未検証**」段階。v0.4 リリースでは引き続き default off (`use_triangle_descriptor: false`) で opt-in 機能として提供。
+- triangle descriptor stack は「**実装完了・NTU で 1 PoC 採用 (BEV)・MID-360 と Newer College で edge_3d により emit が 0→1/2 に改善、採用は NDT 安全網で 0 維持・3-dataset 横断で edge_3d redesign の有効性を確認**」段階。v0.4 リリースでは引き続き default off (`use_triangle_descriptor: false`) で opt-in 機能として提供。
 - v0.4 release notes には「STD/BTC 風 place recognition の opt-in 実装あり、NTU VIRAL tnp_01 で 1 採用ループ確認 (BEV、variance 範囲)、MID-360 / Newer College は edge_3d keypoint mode で対応 — narrow-FOV / indoor では emit に至るも geometric consensus がまだ脆く、production gate は通っていない研究機能」と書く。
 - 4-point gate と `use_triangle_descriptor` の default 判断は 3-dataset 検証によりクローズ済。edge_3d 追加で keypoint 抽出の根本見直しは部分的に進捗。次は edge_3d パラメータチューニングと Newer College 検証。
 


### PR DESCRIPTION
## Summary

PR #153 (edge_3d) を Newer College math_hard (indoor OS0-32) で実走し、3-dataset 横断検証 (NTU / MID-360 / Newer College) を完成させた。

## Newer College math_hard 結果 (2026-05-19)

| 設定 | inliers 分布 | emit | accept | APE (m) |
|------|------|------|--------|---------|
| BEV (旧) | 1-2 (n=53), 3+=0 | 0 | 0 | 0.139 |
| edge_3d default (min=4) | 1=37, 2=36, **3=6**, 4+=0 | 0 | 0 | 0.117 |
| edge_3d tuned (min=3) | 1=20, 2=33, **3=2 emit** | **2** | 0 (NDT reject) | **0.087 vs base 0.107 (-0.020m)** |

emit details: id=26 votes=277 inliers=3 yaw_deg=131°、id=0 votes=256 inliers=3 yaw_deg=158°

## 3-dataset 横断結論

\`edge_3d\` は narrow-FOV / indoor 両方で **inliers 分布を 1 ステップ上にシフト**:

- MID-360 (narrow FOV): BEV 1-2 → edge_3d 1-4、tuned min=3 で 1 emit (yaw 178°)
- Newer College (indoor): BEV 1-2 → edge_3d 1-3、tuned min=3 で 2 emit (yaw 131° / 158°)

両 dataset とも NDT validation gate が yaw 反転偽陽性をすべて弾いて採用 0 を維持、precision が崩れていない。Newer College では初めて candidate APE < baseline (variance 内だが方向性は明確)。

## 次の打ち手 (採用 1 件を狙う)

1. 4-point gate を有効化 (現在 min_4th_point_agreements=0)
2. min_inlier_ratio (inliers / max_pairs) を追加 gate に
3. edge_voxel_size 0.3 → 0.2 / edge_min_edgeness 0.5 → 0.6 を 3 回 run 平均で評価

## Test plan

- [x] plan.md §1.2 のみ更新、コード変更なし
- [x] memory (project_triangle_descriptor_stack) にも同期済