### PR TITLE
feat: graphbasedslam_indoor.yaml preset — tighter edge_3d + 4-point gate for indoor scenes

### DIFF
--- a/graph_based_slam/param/graphbasedslam_indoor.yaml
+++ b/graph_based_slam/param/graphbasedslam_indoor.yaml
@@ -1,0 +1,106 @@
+graph_based_slam:
+    ros__parameters:
+      registration_method: "GICP"
+      ndt_resolution: 1.5
+      voxel_leaf_size: 0.2
+      loop_detection_period: 3000
+      threshold_loop_closure_score: 1.5
+      scan_context_loop_closure_score_threshold: -1.0
+      distance_loop_closure: 30.0
+      range_of_searching_loop_closure: 20.0
+      search_submap_num: 3
+      max_loop_candidate_count: 3
+      loop_edge_dedup_index_window: 8
+      loop_max_translation_delta: 15.0
+      loop_max_rotation_delta_deg: 45.0
+      use_gnss: false
+      gnss_topic: "/gnss/fix"
+      gnss_info_weight: 1.0
+      gnss_use_covariance_weighting: true
+      gnss_covariance_min_variance_m2: 0.01
+      gnss_covariance_max_variance_m2: 25.0
+      gnss_rtk_fix_max_horizontal_stddev_m: 0.3
+      gnss_rtk_fix_weight_scale: 3.0
+      gnss_non_rtk_weight_scale: 1.0
+      use_scan_context: false
+      scan_context_threshold: 0.3
+      use_bev_descriptor: false
+      bev_descriptor_threshold: 0.20
+      bev_descriptor_grid_size_m: 80.0
+      bev_descriptor_grid_cells: 40
+      bev_descriptor_yaw_bins: 24
+      bev_descriptor_sequence_window: 0
+      bev_descriptor_sequence_threshold: -1.0
+      bev_descriptor_pose_consistency_threshold_m: -1.0
+      bev_descriptor_max_euclidean_distance_m: -1.0
+      bev_descriptor_rerank_weight_m: 100.0
+      use_solid_descriptor: false
+      solid_descriptor_min_similarity: 0.70
+      solid_descriptor_sequence_window: 0
+      solid_descriptor_sequence_min_similarity: -1.0
+      solid_descriptor_pose_consistency_threshold_m: -1.0
+      solid_descriptor_max_euclidean_distance_m: -1.0
+      # Indoor / narrow vertical FOV preset (Newer College math_hard と同種の
+      # OS0-32 scene)。tighter edge_3d voxel + 4-point gate を default に。
+      # 2026-05-19 ablation で APE -0.039m (過去最大の改善幅) と初の inliers=4
+      # emit に到達した設定。詳細は plan.md §1.2 と
+      # project_triangle_descriptor_stack memory。
+      #
+      # NDT gate との関係: Newer College では NDT fitness は通る (11.9 < 15)
+      # ものの loop_max_translation_delta=15m を翻訳補正が超えて reject される
+      # ケースがある。これは triangle SE(3) の翻訳が 3-point SVD で振れる別問題
+      # で、loop_max_translation_delta を緩めると trajectory に有害な loop が
+      # 入る恐れがあるためここでは default 値を維持する。
+      use_triangle_descriptor: false
+      triangle_descriptor_keypoint_mode: "edge_3d"
+      triangle_descriptor_grid_size_m: 60.0
+      triangle_descriptor_grid_cells: 100
+      triangle_descriptor_max_keypoints: 40
+      triangle_descriptor_min_salience_m: 0.8
+      # Tighter edge_3d: smaller voxel + smaller neighbor radius +
+      # higher edgeness threshold. Indoor 構造化シーンでは細い柱・壁角・
+      # door frame を細かく拾うほうが repeatability が上がるため。
+      triangle_descriptor_edge_voxel_size_m: 0.2
+      triangle_descriptor_edge_neighbor_radius_m: 0.6
+      triangle_descriptor_edge_min_neighbors: 6
+      triangle_descriptor_edge_min_edgeness: 0.6
+      triangle_descriptor_edge_nms_radius_m: 1.5
+      triangle_descriptor_min_edge_m: 2.0
+      # 40m: indoor 通路長を意識した上限。50m (outdoor 360°) と 30m (MID-360
+      # narrow) の中間。
+      triangle_descriptor_max_edge_m: 40.0
+      triangle_descriptor_max_triangles: 3000
+      triangle_descriptor_edge_bin_m: 0.5
+      triangle_descriptor_min_votes: 6
+      triangle_descriptor_min_inliers: 3
+      triangle_descriptor_min_inlier_ratio: 0.0
+      triangle_descriptor_max_pairs: 64
+      # 4-point gate ON. yaw 反転 / corridor degeneracy の偽陽性を弾く効果が
+      # Newer College ablation で確認できた (3 → 2 emit に絞り込み、yaw 13° の
+      # legit emit を保持)。
+      triangle_descriptor_min_4th_point_agreements: 2
+      triangle_descriptor_fourth_point_max_distance_m: 1.5
+      triangle_descriptor_inlier_translation_m: 2.0
+      triangle_descriptor_inlier_rotation_deg: 5.0
+      triangle_descriptor_exclude_recent: 4
+      triangle_verify_with_bev: false
+      triangle_verify_bev_max_distance: 0.30
+      prefer_scan_context_candidates: false
+      use_3d_bbs_for_scan_context: false
+      three_d_bbs_min_level_res: 1.0
+      three_d_bbs_max_level: 2
+      three_d_bbs_score_threshold_percentage: 0.25
+      three_d_bbs_timeout_msec: 250
+      three_d_bbs_num_threads: 1
+      three_d_bbs_voxel_leaf_size: 2.0
+      three_d_bbs_source_submap_num: 2
+      three_d_bbs_target_submap_radius: 1
+      three_d_bbs_translation_search_margin_m: 7.5
+      three_d_bbs_roll_pitch_search_deg: 5.0
+      three_d_bbs_yaw_search_deg: 90.0
+      use_dynamic_object_filter: false
+      dynamic_object_filter_voxel_size: 0.3
+      dynamic_object_filter_min_observations: 2
+      dynamic_object_filter_temporal_window: 5
+      dynamic_object_filter_max_range_from_sensor_m: 30.0
+      debug_flag: false

--- a/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
+++ b/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
@@ -71,8 +71,13 @@ VALID_KEYPOINT_MODES = {'bev_max_height', 'edge_3d'}
 
 PARAM_FILES = [
     REPO_ROOT / 'graph_based_slam' / 'param' / 'graphbasedslam.yaml',
+    REPO_ROOT / 'graph_based_slam' / 'param' / 'graphbasedslam_indoor.yaml',
     REPO_ROOT / 'lidarslam' / 'param' / 'lidarslam_mid360_rko_graph.yaml',
 ]
+
+INDOOR_PARAM_FILE = REPO_ROOT / 'graph_based_slam' / 'param' / 'graphbasedslam_indoor.yaml'
+MID360_PARAM_FILE = REPO_ROOT / 'lidarslam' / 'param' / 'lidarslam_mid360_rko_graph.yaml'
+GENERIC_PARAM_FILE = REPO_ROOT / 'graph_based_slam' / 'param' / 'graphbasedslam.yaml'
 
 
 def _load_graph_params(path: Path) -> dict:
@@ -114,13 +119,43 @@ def test_triangle_descriptor_edge_bounds_sane(path):
 
 def test_mid360_preset_tightens_for_short_range_sensor():
     """MID-360 has shorter range than spinning 360° LiDAR; preset must reflect."""
-    default = _load_graph_params(PARAM_FILES[0])
-    mid360 = _load_graph_params(PARAM_FILES[1])
+    default = _load_graph_params(GENERIC_PARAM_FILE)
+    mid360 = _load_graph_params(MID360_PARAM_FILE)
     assert mid360['triangle_descriptor_max_edge_m'] <= default['triangle_descriptor_max_edge_m'], (
         'MID-360 preset must not exceed the generic LiDAR max edge (shorter range sensor)'
     )
     assert mid360['triangle_descriptor_min_votes'] >= default['triangle_descriptor_min_votes'], (
         'MID-360 preset should be stricter on vote count to suppress FOV ambiguity'
+    )
+
+
+def test_indoor_preset_uses_tighter_edge3d():
+    """
+    Indoor preset must encode the tighter edge_3d + 4-point gate recipe.
+
+    Newer College math_hard ablation (2026-05-19) showed that tighter voxel /
+    smaller neighbor radius / higher edgeness produces the first inliers=4 emit
+    and APE -0.039m (past max). See plan.md §1.2 and
+    project_triangle_descriptor_stack memory.
+    """
+    indoor = _load_graph_params(INDOOR_PARAM_FILE)
+    assert indoor['triangle_descriptor_keypoint_mode'] == 'edge_3d', (
+        'Indoor preset must default to edge_3d; BEV max-height fails in indoor scenes'
+    )
+    assert indoor['triangle_descriptor_edge_voxel_size_m'] <= 0.25, (
+        'Indoor preset must use tighter voxel (<=0.25 m); 0.4 m default is too coarse'
+    )
+    assert indoor['triangle_descriptor_edge_neighbor_radius_m'] <= 0.7, (
+        'Indoor preset must use tighter neighbor radius (<=0.7 m)'
+    )
+    assert indoor['triangle_descriptor_edge_min_edgeness'] >= 0.55, (
+        'Indoor preset must use stricter edgeness floor (>=0.55) to suppress weak PCA cases'
+    )
+    assert indoor['triangle_descriptor_min_4th_point_agreements'] >= 2, (
+        'Indoor preset must enable 4-point gate (>=2) to filter yaw-flip false positives'
+    )
+    assert indoor['triangle_descriptor_min_inliers'] <= 3, (
+        'Indoor preset must keep min_inliers <= 3 so the edge_3d inlier shift can reach emit'
     )
 
 
@@ -163,8 +198,23 @@ def test_mid360_preset_prefers_edge_keypoints():
     but 3-point RANSAC inliers stay at 1-2). edge_3d is the cross-dataset
     answer (see project_triangle_descriptor_stack memory).
     """
-    mid360 = _load_graph_params(PARAM_FILES[1])
+    mid360 = _load_graph_params(MID360_PARAM_FILE)
     assert mid360['triangle_descriptor_keypoint_mode'] == 'edge_3d', (
         'MID-360 preset must default to edge_3d so the opt-in triangle path '
         'has a working keypoint extractor on narrow-FOV LiDAR'
+    )
+
+
+def test_indoor_preset_voxel_tighter_than_mid360():
+    """
+    Indoor preset must use a tighter edge_3d voxel than the MID-360 preset.
+
+    Newer College ablation (2026-05-19) showed indoor scenes benefit from a
+    tighter voxel than the MID-360 outdoor preset (0.2 m vs 0.3 m).
+    """
+    indoor = _load_graph_params(INDOOR_PARAM_FILE)
+    mid360 = _load_graph_params(MID360_PARAM_FILE)
+    assert indoor['triangle_descriptor_edge_voxel_size_m'] \
+        < mid360['triangle_descriptor_edge_voxel_size_m'], (
+        'Indoor preset must use a tighter voxel than the MID-360 outdoor preset'
     )


### PR DESCRIPTION
## Summary

2026-05-19 Newer College math_hard ablation で確認した **tighter edge_3d + 4-point gate** 設定を codify する indoor 向け preset を新設。MID-360 narrow-FOV outdoor の default では indoor の細い柱 / 壁角 / door frame を拾いきれないため、tighter voxel / smaller neighbor / higher edgeness を default 化した。

## Preset の差分 (vs generic graphbasedslam.yaml / MID-360)

| パラメータ | generic | MID-360 | **indoor (新設)** | 根拠 |
|----------|---------|---------|------------------|------|
| keypoint_mode | bev_max_height | edge_3d | **edge_3d** | indoor は edge_3d 必須 |
| edge_voxel_size_m | 0.4 | 0.3 | **0.2** | 細かい keypoint で repeatability ↑ |
| edge_neighbor_radius_m | 1.0 | 0.8 | **0.6** | tighter voxel に合わせる |
| edge_min_edgeness | 0.5 | 0.5 | **0.6** | weak PCA を強く suppress |
| edge_nms_radius_m | 2.0 | 1.5 | **1.5** | MID-360 同等 |
| max_edge_m | 50.0 | 30.0 | **40.0** | indoor 通路長 |
| min_inliers | 4 | 5 | **3** | edge_3d inlier shift で届くように |
| min_votes | 6 | 8 | **6** | generic 同等 |
| min_4th_point_agreements | 0 | 0 | **2** | 4-point gate ON で yaw-flip filter |
| fourth_point_max_distance_m | 2.0 | 1.5 | **1.5** | tighter |

## 経緯

PR #156 で Newer College tighter+4pt 設定が baseline 0.139 → candidate 0.101 (**APE -0.039m、過去最大の改善幅**) と初の **inliers=4 emit (yaw 13° legit)** に到達した。MID-360 では同設定が逆効果 (-1.52m regression) だったため env 別 preset として分離。

NDT validation が \`loop_max_translation_delta=15m\` を triangle SE(3) 翻訳補正が超えて reject される別問題が残るため、\`use_triangle_descriptor\` は default false の opt-in のまま。

## Test plan

- [x] yaml regression test 2 本追加 (パラメータ閾値 + MID-360 との順序関係)
- [x] colcon build + test: 496 tests / 0 failures
- [x] CMakeLists の \`DIRECTORY launch param\` で自動 install される

## 次の打ち手

1. \`loop_max_translation_delta\` Newer College 向け緩和の妥当性検討 (50m correction を accept すべきか別議論)
2. 3-run variance で APE -0.039m が confirmable か確認
3. lidarslam_newer_college_*.yaml (RKO-LIO 用 sensor topic / frame 固定) の整備