### PR TITLE
feat: descriptor-only loop_max_delta override for long-baseline NDT corrections

### DIFF
--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -190,6 +190,12 @@ private:
     int loop_edge_dedup_index_window_ {8};
     double loop_max_translation_delta_ {15.0};
     double loop_max_rotation_delta_deg_ {45.0};
+    // Per-source overrides for descriptor-based candidates (TRIANGLE,
+    // SCAN_CONTEXT, BEV, SOLID). When positive, replace the generic caps
+    // above for those sources only — DISTANCE keeps the strict default.
+    // -1.0 = disabled / fall back to the generic cap.
+    double loop_max_translation_delta_descriptor_ {-1.0};
+    double loop_max_rotation_delta_deg_descriptor_ {-1.0};
 
     // pose graph optimization parameter
     int num_adjacent_pose_cnstraints_;

--- a/graph_based_slam/param/graphbasedslam.yaml
+++ b/graph_based_slam/param/graphbasedslam.yaml
@@ -13,6 +13,14 @@ graph_based_slam:
       loop_edge_dedup_index_window: 8
       loop_max_translation_delta: 15.0
       loop_max_rotation_delta_deg: 45.0
+      # Per-source caps for descriptor-based candidates (TRIANGLE,
+      # SCAN_CONTEXT, BEV, SOLID). -1 = disabled, fall back to the
+      # generic caps above. Set to a larger value when the descriptor
+      # has been validated as precise on the target dataset and large
+      # NDT corrections are expected (e.g. long-baseline loops on a
+      # drifting trajectory).
+      loop_max_translation_delta_descriptor: -1.0
+      loop_max_rotation_delta_deg_descriptor: -1.0
       use_gnss: false
       gnss_topic: "/gnss/fix"
       gnss_info_weight: 1.0

--- a/graph_based_slam/param/graphbasedslam_indoor.yaml
+++ b/graph_based_slam/param/graphbasedslam_indoor.yaml
@@ -13,6 +13,15 @@ graph_based_slam:
       loop_edge_dedup_index_window: 8
       loop_max_translation_delta: 15.0
       loop_max_rotation_delta_deg: 45.0
+      # Descriptor-only override (opt-in). Indoor structured scenes can
+      # accumulate >15 m drift over long traversals; when triangle / scan
+      # context propose a revisit with confident inliers, NDT often
+      # converges to the drift correction (53.7 m observed in Newer
+      # College math_hard, fitness 11.9). Default left at -1 (disabled)
+      # since cross-dataset evidence for a safe relaxation is not in yet;
+      # bump per dataset after verifying the descriptor's precision.
+      loop_max_translation_delta_descriptor: -1.0
+      loop_max_rotation_delta_deg_descriptor: -1.0
       use_gnss: false
       gnss_topic: "/gnss/fix"
       gnss_info_weight: 1.0
@@ -48,9 +57,11 @@ graph_based_slam:
       #
       # NDT gate との関係: Newer College では NDT fitness は通る (11.9 < 15)
       # ものの loop_max_translation_delta=15m を翻訳補正が超えて reject される
-      # ケースがある。これは triangle SE(3) の翻訳が 3-point SVD で振れる別問題
-      # で、loop_max_translation_delta を緩めると trajectory に有害な loop が
-      # 入る恐れがあるためここでは default 値を維持する。
+      # ケースがある。generic な loop_max_translation_delta を緩めると DISTANCE
+      # 候補にも影響して有害な loop が入る恐れがあるため、descriptor 専用の
+      # override (loop_max_translation_delta_descriptor) を opt-in で用意し、
+      # こちらは -1 (無効) のままにしておく。長距離 drift を伴うシーンで
+      # triangle/scan-context 候補だけ救済したい場合は明示的に値を入れる。
       use_triangle_descriptor: false
       triangle_descriptor_keypoint_mode: "edge_3d"
       triangle_descriptor_grid_size_m: 60.0

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -91,6 +91,10 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("loop_max_translation_delta", loop_max_translation_delta_);
   declare_parameter("loop_max_rotation_delta_deg", 45.0);
   get_parameter("loop_max_rotation_delta_deg", loop_max_rotation_delta_deg_);
+  declare_parameter("loop_max_translation_delta_descriptor", -1.0);
+  get_parameter("loop_max_translation_delta_descriptor", loop_max_translation_delta_descriptor_);
+  declare_parameter("loop_max_rotation_delta_deg_descriptor", -1.0);
+  get_parameter("loop_max_rotation_delta_deg_descriptor", loop_max_rotation_delta_deg_descriptor_);
   declare_parameter("num_adjacent_pose_cnstraints", 5);
   get_parameter("num_adjacent_pose_cnstraints", num_adjacent_pose_cnstraints_);
   declare_parameter("use_save_map_in_loop", true);
@@ -464,6 +468,30 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       loop_max_rotation_delta_deg_);
     loop_max_rotation_delta_deg_ = 45.0;
   }
+  // Descriptor overrides: -1.0 = disabled (fall back to generic cap).
+  // Any other non-positive value is treated as invalid and clamped to -1.0
+  // so that operators see clear feedback instead of silently disabling the
+  // generic cap for descriptor sources.
+  if (loop_max_translation_delta_descriptor_ <= 0.0 &&
+    loop_max_translation_delta_descriptor_ != -1.0)
+  {
+    RCLCPP_WARN(
+      get_logger(),
+      "loop_max_translation_delta_descriptor must be > 0 (override) or -1 "
+      "(disabled); resetting %.3f to -1",
+      loop_max_translation_delta_descriptor_);
+    loop_max_translation_delta_descriptor_ = -1.0;
+  }
+  if (loop_max_rotation_delta_deg_descriptor_ <= 0.0 &&
+    loop_max_rotation_delta_deg_descriptor_ != -1.0)
+  {
+    RCLCPP_WARN(
+      get_logger(),
+      "loop_max_rotation_delta_deg_descriptor must be > 0 (override) or -1 "
+      "(disabled); resetting %.3f to -1",
+      loop_max_rotation_delta_deg_descriptor_);
+    loop_max_rotation_delta_deg_descriptor_ = -1.0;
+  }
   if (num_adjacent_pose_cnstraints_ < 1) {
     RCLCPP_WARN(
       get_logger(),
@@ -797,6 +825,10 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   std::cout << "loop_edge_dedup_index_window:" << loop_edge_dedup_index_window_ << std::endl;
   std::cout << "loop_max_translation_delta[m]:" << loop_max_translation_delta_ << std::endl;
   std::cout << "loop_max_rotation_delta[deg]:" << loop_max_rotation_delta_deg_ << std::endl;
+  std::cout << "loop_max_translation_delta_descriptor[m]:" <<
+    loop_max_translation_delta_descriptor_ << std::endl;
+  std::cout << "loop_max_rotation_delta_deg_descriptor[deg]:" <<
+    loop_max_rotation_delta_deg_descriptor_ << std::endl;
   std::cout << "num_adjacent_pose_cnstraints:" << num_adjacent_pose_cnstraints_ << std::endl;
   std::cout << "adjacent_edge_info_weight:" << adjacent_edge_info_weight_ << std::endl;
   std::cout << "adjacent_edge_info_auto_scale:" << std::boolalpha
@@ -2360,7 +2392,19 @@ void GraphBasedSlamComponent::searchLoop()
       }
       continue;
     }
-    if (translation_delta_m > loop_max_translation_delta_) {
+    // Descriptor-sourced candidates (TRIANGLE / SCAN_CONTEXT / BEV / SOLID)
+    // already passed a place-recognition gate, so they can accept a larger
+    // NDT correction when the operator opts in. DISTANCE candidates (close
+    // in stored pose) keep the strict generic cap.
+    const bool is_descriptor_source =
+      candidate.source != LoopCandidate::Source::DISTANCE;
+    const double effective_translation_cap =
+      (is_descriptor_source && loop_max_translation_delta_descriptor_ > 0.0) ?
+      loop_max_translation_delta_descriptor_ : loop_max_translation_delta_;
+    const double effective_rotation_cap_deg =
+      (is_descriptor_source && loop_max_rotation_delta_deg_descriptor_ > 0.0) ?
+      loop_max_rotation_delta_deg_descriptor_ : loop_max_rotation_delta_deg_;
+    if (translation_delta_m > effective_translation_cap) {
       if (debug_flag_) {
         RCLCPP_INFO(
           get_logger(),
@@ -2368,11 +2412,11 @@ void GraphBasedSlamComponent::searchLoop()
           candidate.index,
           latest_idx,
           translation_delta_m,
-          loop_max_translation_delta_);
+          effective_translation_cap);
       }
       continue;
     }
-    if (rotation_delta_deg > loop_max_rotation_delta_deg_) {
+    if (rotation_delta_deg > effective_rotation_cap_deg) {
       if (debug_flag_) {
         RCLCPP_INFO(
           get_logger(),
@@ -2380,7 +2424,7 @@ void GraphBasedSlamComponent::searchLoop()
           candidate.index,
           latest_idx,
           rotation_delta_deg,
-          loop_max_rotation_delta_deg_);
+          effective_rotation_cap_deg);
       }
       continue;
     }

--- a/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
+++ b/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
@@ -219,3 +219,33 @@ def test_indoor_preset_voxel_tighter_than_mid360():
         < mid360['triangle_descriptor_edge_voxel_size_m'], (
         'Indoor preset must use a tighter voxel than the MID-360 outdoor preset'
     )
+
+
+@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
+def test_loop_max_delta_descriptor_override_present_and_safe(path):
+    """
+    Descriptor-only loop_max_delta override must be present and safe by default.
+
+    Defaults to -1 (disabled) so opting in is explicit per dataset.
+    DISTANCE candidates keep the strict generic cap; descriptor sources can
+    accept a larger NDT correction when the operator sets a positive value.
+    The default-disabled stance keeps backward compatibility — every yaml
+    that shipped before the override was added used a single cap.
+    """
+    params = _load_graph_params(path)
+    assert 'loop_max_translation_delta_descriptor' in params, (
+        f'{path.name}: missing loop_max_translation_delta_descriptor — the '
+        'override is the documented escape hatch for long-baseline triangle '
+        'loops; ship it (even at -1) so users know it exists'
+    )
+    assert 'loop_max_rotation_delta_deg_descriptor' in params
+    t_override = params['loop_max_translation_delta_descriptor']
+    r_override = params['loop_max_rotation_delta_deg_descriptor']
+    assert t_override == -1.0 or t_override > 0.0, (
+        f'{path.name}: loop_max_translation_delta_descriptor must be -1 '
+        f'(disabled) or > 0; got {t_override}'
+    )
+    assert r_override == -1.0 or r_override > 0.0, (
+        f'{path.name}: loop_max_rotation_delta_deg_descriptor must be -1 '
+        f'(disabled) or > 0; got {r_override}'
+    )

--- a/lidarslam/param/lidarslam_mid360_rko_graph.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph.yaml
@@ -18,6 +18,13 @@ graph_based_slam:
     loop_edge_dedup_index_window: 20
     loop_max_translation_delta: 15.0
     loop_max_rotation_delta_deg: 45.0
+    # Descriptor-only override (opt-in). MID-360 narrow-FOV outdoor
+    # rarely produces large NDT corrections from triangle candidates
+    # today (3-pt RANSAC SE(3) tends to be ~identity when wrong, or
+    # close-correct when right). Default disabled; flip per-bag if a
+    # long-baseline revisit is rejected purely by the cap.
+    loop_max_translation_delta_descriptor: -1.0
+    loop_max_rotation_delta_deg_descriptor: -1.0
     adjacent_edge_info_weight: 1000.0
     loop_edge_info_weight: 200.0
     loop_edge_robust_kernel_delta: 1.0


### PR DESCRIPTION
## Summary

- Add **descriptor-source-only** override for `loop_max_translation_delta` / `loop_max_rotation_delta_deg`. DISTANCE candidates keep the strict generic cap; TRIANGLE / SCAN_CONTEXT / BEV / SOLID can now accept a larger NDT correction when the operator opts in.
- Default `-1.0` (disabled) — every existing preset / yaml stays bit-for-bit identical in behaviour.
- Ship the knob in the 3 triangle-tracked yamls (generic / indoor / MID-360) so the option is discoverable.
- Add yaml regression assert: override key must be present and either `-1` (disabled) or `> 0`.

## Why

Newer College math_hard ablation (2026-05-19, see `project_triangle_descriptor_stack` memory) confirmed triangle emits with legit yaw (inliers=5 at yaw 3.6°) and NDT fitness 11.9 < 15, but the world-frame correction reaches **~53 m** due to accumulated trajectory drift — past the generic 15 m cap. Bumping the generic cap would also relax DISTANCE candidates, which can introduce harmful loops in structured indoor scenes. The per-source override is the right shape.

## Test plan

- [x] `scripts/run_default_ci_checks.sh` → 531 tests, 0 failures
- [x] New yaml regression: override key present + safe (`-1` or `> 0`) in generic / indoor / MID-360 yamls
- [x] Existing 20+ yaml regression tests untouched
- [ ] Cross-dataset ablation with `loop_max_translation_delta_descriptor: 60.0` follow-up (not in this PR — mechanism only)