### PR TITLE
feat: STD/BTC-style quad-hash extension for triangle descriptor (4th-point context)

### DIFF
--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -269,6 +269,12 @@ private:
     double triangle_descriptor_max_edge_m_ {50.0};
     int triangle_descriptor_max_triangles_ {3000};
     double triangle_descriptor_edge_bin_m_ {0.5};
+    // Quad-hash 4th-point feature bin (m). 0 = disabled (legacy 3-edge hash).
+    // When > 0, the bucket key also includes the quantized distance from the
+    // triangle centroid to the nearest non-vertex keypoint, which makes the
+    // hash 4-dim and rejects wrong-but-agreeing triangle pairs in repeated
+    // geometry (corridor / parking-row / parallel column rows).
+    double triangle_descriptor_quad_feature_bin_m_ {0.0};
     // Keypoint extractor mode. "bev_max_height" is the original outdoor-only
     // extractor; "edge_3d" enables PCA-edgeness keypoints that survive in
     // narrow-FOV / indoor scenes (MID-360, Newer College math_hard) where

--- a/graph_based_slam/include/graph_based_slam/triangle_descriptor_database.hpp
+++ b/graph_based_slam/include/graph_based_slam/triangle_descriptor_database.hpp
@@ -73,18 +73,31 @@ struct HashConfig
   // Hard upper bound on the quantized bin index (clipped at this value).
   // Default keeps the packed key small (uint64) for triangles up to ~80 m.
   int max_bin {255};
+  // Quad-key extension (STD/BTC-style 4-point context). When > 0, the
+  // hash key gains a 4th rotation-invariant dim: the quantized distance
+  // from the triangle centroid to the nearest non-vertex keypoint in the
+  // same submap. Two triangles must then agree on all 4 bins to collide,
+  // which suppresses the wrong-but-agreeing matches that the 3-edge hash
+  // alone admits in repeated geometry (corridor, parking lot rows). The
+  // 4th-point lookup needs the keypoint list available at hash time; the
+  // legacy 3-edge entry point is preserved as a backward-compat overload
+  // and is what every test and yaml hits today. 0 = disabled (3-edge).
+  float quad_feature_bin_m {0.0f};
 };
 
-// (le, me, ge) integer bin tuple, le <= me <= ge.
+// (le, me, ge) integer bin tuple, le <= me <= ge. ``quad`` is the optional
+// 4th-point dim (zero when quad hashing is disabled — matches the legacy
+// 3-edge packed key bit-for-bit).
 struct TriangleHash
 {
   uint16_t le {0};
   uint16_t me {0};
   uint16_t ge {0};
+  uint16_t quad {0};
 
   bool operator==(const TriangleHash & other) const
   {
-    return le == other.le && me == other.me && ge == other.ge;
+    return le == other.le && me == other.me && ge == other.ge && quad == other.quad;
   }
 };
 
@@ -103,9 +116,47 @@ inline TriangleHash quantizeEdges(const TriangleDescriptor & t, const HashConfig
   return h;
 }
 
+// Quad-aware quantize. When cfg.quad_feature_bin_m <= 0 or keypoints is
+// empty, behaves identically to quantizeEdges so the legacy hash key
+// stays bit-for-bit identical.
+inline TriangleHash quantizeKey(
+  const TriangleDescriptor & t,
+  const std::vector<Keypoint> & keypoints,
+  const HashConfig & cfg)
+{
+  TriangleHash h = quantizeEdges(t, cfg);
+  if (cfg.quad_feature_bin_m <= 0.0f || keypoints.empty()) {
+    return h;
+  }
+  Eigen::Vector3f centroid = Eigen::Vector3f::Zero();
+  for (int k = 0; k < 3; ++k) {
+    const int idx = t.keypoint_ids[k];
+    if (idx < 0 || idx >= static_cast<int>(keypoints.size())) {
+      return h;
+    }
+    centroid += keypoints[idx].position;
+  }
+  centroid /= 3.0f;
+  float best = std::numeric_limits<float>::infinity();
+  for (int i = 0; i < static_cast<int>(keypoints.size()); ++i) {
+    if (i == t.keypoint_ids[0] || i == t.keypoint_ids[1] || i == t.keypoint_ids[2]) {
+      continue;
+    }
+    const float d = (keypoints[i].position - centroid).norm();
+    if (d < best) {best = d;}
+  }
+  if (std::isfinite(best)) {
+    const float qbin = std::max(1e-3f, cfg.quad_feature_bin_m);
+    const int qidx = static_cast<int>(std::floor(best / qbin));
+    h.quad = static_cast<uint16_t>(std::max(0, std::min(cfg.max_bin, qidx)));
+  }
+  return h;
+}
+
 inline uint64_t packHash(const TriangleHash & h)
 {
-  return (static_cast<uint64_t>(h.le) << 32) |
+  return (static_cast<uint64_t>(h.quad) << 48) |
+         (static_cast<uint64_t>(h.le) << 32) |
          (static_cast<uint64_t>(h.me) << 16) |
          static_cast<uint64_t>(h.ge);
 }
@@ -145,7 +196,10 @@ public:
         e.vertices[k] = keypoints[idx].position;
       }
       if (!ok) {continue;}
-      const uint64_t key = packHash(quantizeEdges(t, cfg));
+      // Use the quad-aware key: when cfg.quad_feature_bin_m <= 0 this is
+      // bit-for-bit identical to the legacy 3-edge key, so every call site
+      // that hasn't enabled quad hashing is unchanged.
+      const uint64_t key = packHash(quantizeKey(t, keypoints, cfg));
       buckets_[key].push_back(e);
       ++triangle_count_;
     }
@@ -200,15 +254,21 @@ struct VoteConfig
   int exclude_submap_id {-1};
 };
 
+// Quad-aware overload: pass the query keypoint list so the hash lookup
+// agrees with the database when cfg.quad_feature_bin_m > 0. The legacy
+// 4-arg overload below forwards an empty vector, which keeps the hash
+// equivalent to the original 3-edge key (matching the database that
+// addSubmap built under the same cfg).
 inline std::vector<SubmapVote> accumulateVotes(
   const TriangleDatabase & db,
+  const std::vector<Keypoint> & query_keypoints,
   const std::vector<TriangleDescriptor> & query_triangles,
   const HashConfig & cfg,
   const VoteConfig & vote_cfg)
 {
   std::unordered_map<int, int> counts;
   for (const auto & t : query_triangles) {
-    const auto & bucket = db.lookup(quantizeEdges(t, cfg));
+    const auto & bucket = db.lookup(quantizeKey(t, query_keypoints, cfg));
     if (bucket.empty()) {continue;}
     // Per-query cap: dedupe by submap id and cap the contribution count.
     std::unordered_map<int, int> per_query;
@@ -231,6 +291,19 @@ inline std::vector<SubmapVote> accumulateVotes(
     result.begin(), result.end(),
     [](const SubmapVote & a, const SubmapVote & b) {return a.votes > b.votes;});
   return result;
+}
+
+// Backward-compatible overload: no keypoints -> quad bin always 0 ->
+// hash matches the legacy 3-edge key. Existing tests and call sites
+// that haven't been updated to pass query_keypoints land here.
+inline std::vector<SubmapVote> accumulateVotes(
+  const TriangleDatabase & db,
+  const std::vector<TriangleDescriptor> & query_triangles,
+  const HashConfig & cfg,
+  const VoteConfig & vote_cfg)
+{
+  static const std::vector<Keypoint> empty;
+  return accumulateVotes(db, empty, query_triangles, cfg, vote_cfg);
 }
 
 struct VerificationConfig
@@ -330,7 +403,7 @@ inline LoopCandidate findLoopCandidate(
   const VerificationConfig & verify_cfg)
 {
   LoopCandidate result;
-  const auto votes = accumulateVotes(db, query_triangles, cfg, vote_cfg);
+  const auto votes = accumulateVotes(db, query_keypoints, query_triangles, cfg, vote_cfg);
   if (votes.empty()) {return result;}
 
   result.submap_id = votes.front().submap_id;
@@ -348,7 +421,7 @@ inline LoopCandidate findLoopCandidate(
   std::vector<Pair> pairs;
   pairs.reserve(query_triangles.size());
   for (const auto & qt : query_triangles) {
-    const auto & bucket = db.lookup(quantizeEdges(qt, cfg));
+    const auto & bucket = db.lookup(quantizeKey(qt, query_keypoints, cfg));
     for (const auto & e : bucket) {
       if (e.submap_id != result.submap_id) {continue;}
       pairs.push_back({&qt, &e, qt.edges[2]});

--- a/graph_based_slam/param/graphbasedslam.yaml
+++ b/graph_based_slam/param/graphbasedslam.yaml
@@ -66,6 +66,13 @@ graph_based_slam:
       triangle_descriptor_max_edge_m: 50.0
       triangle_descriptor_max_triangles: 3000
       triangle_descriptor_edge_bin_m: 0.5
+      # Quad-hash extension: when > 0, the bucket key gains a 4th dim:
+      # quantized distance from the triangle centroid to the nearest
+      # non-vertex keypoint (rotation-invariant local context). Defaults
+      # to 0 so the legacy 3-edge hash is preserved bit-for-bit; flip per
+      # dataset when repeated geometry produces too many wrong-but-agreeing
+      # triangle pairs.
+      triangle_descriptor_quad_feature_bin_m: 0.0
       triangle_descriptor_min_votes: 6
       triangle_descriptor_min_inliers: 4
       # 0.0 disables the relative-density floor. Set to e.g. 0.15 in combination

--- a/graph_based_slam/param/graphbasedslam_indoor.yaml
+++ b/graph_based_slam/param/graphbasedslam_indoor.yaml
@@ -71,6 +71,11 @@ graph_based_slam:
       triangle_descriptor_max_edge_m: 40.0
       triangle_descriptor_max_triangles: 3000
       triangle_descriptor_edge_bin_m: 0.5
+      # Quad-hash 4th-point context. 0 = disabled (legacy 3-edge hash).
+      # Indoor corridor / column-row scenes generate many wrong-but-agreeing
+      # triangle pairs through 3-edge similarity alone; flip this on (e.g.
+      # 0.5 m bin) after running an ablation on the target bag.
+      triangle_descriptor_quad_feature_bin_m: 0.0
       triangle_descriptor_min_votes: 6
       triangle_descriptor_min_inliers: 3
       triangle_descriptor_min_inlier_ratio: 0.0

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -169,6 +169,10 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("triangle_descriptor_max_triangles", triangle_descriptor_max_triangles_);
   declare_parameter("triangle_descriptor_edge_bin_m", 0.5);
   get_parameter("triangle_descriptor_edge_bin_m", triangle_descriptor_edge_bin_m_);
+  declare_parameter("triangle_descriptor_quad_feature_bin_m", 0.0);
+  get_parameter(
+    "triangle_descriptor_quad_feature_bin_m",
+    triangle_descriptor_quad_feature_bin_m_);
   declare_parameter<std::string>(
     "triangle_descriptor_keypoint_mode", triangle_descriptor_keypoint_mode_);
   get_parameter("triangle_descriptor_keypoint_mode", triangle_descriptor_keypoint_mode_);
@@ -620,6 +624,14 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   if (triangle_descriptor_edge_bin_m_ <= 0.0) {
     triangle_descriptor_edge_bin_m_ = 1.0;
   }
+  if (triangle_descriptor_quad_feature_bin_m_ < 0.0) {
+    RCLCPP_WARN(
+      get_logger(),
+      "triangle_descriptor_quad_feature_bin_m must be >= 0 (0 = disabled); "
+      "resetting %.3f to 0",
+      triangle_descriptor_quad_feature_bin_m_);
+    triangle_descriptor_quad_feature_bin_m_ = 0.0;
+  }
   if (triangle_descriptor_min_votes_ < 1) {
     triangle_descriptor_min_votes_ = 1;
   }
@@ -921,6 +933,8 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       triangle_descriptor_max_triangles_ << std::endl;
     std::cout << "triangle_descriptor_edge_bin_m:" <<
       triangle_descriptor_edge_bin_m_ << std::endl;
+    std::cout << "triangle_descriptor_quad_feature_bin_m:" <<
+      triangle_descriptor_quad_feature_bin_m_ << std::endl;
     std::cout << "triangle_descriptor_min_votes:" <<
       triangle_descriptor_min_votes_ << std::endl;
     std::cout << "triangle_descriptor_min_inliers:" <<
@@ -1360,6 +1374,8 @@ void GraphBasedSlamComponent::searchLoop()
     build_cfg.max_triangles = triangle_descriptor_max_triangles_;
     graphslam::triangle::HashConfig hash_cfg;
     hash_cfg.edge_bin_m = static_cast<float>(triangle_descriptor_edge_bin_m_);
+    hash_cfg.quad_feature_bin_m =
+      static_cast<float>(triangle_descriptor_quad_feature_bin_m_);
     for (int idx = triangle_descriptor_next_submap_idx_; idx < num_submaps; ++idx) {
       const auto filtered_aggregated_cloud = build_filtered_local_submap(idx);
       std::vector<graphslam::triangle::Keypoint> kps;
@@ -2019,6 +2035,8 @@ void GraphBasedSlamComponent::searchLoop()
     if (!query_tris.empty()) {
       graphslam::triangle::HashConfig hash_cfg;
       hash_cfg.edge_bin_m = static_cast<float>(triangle_descriptor_edge_bin_m_);
+      hash_cfg.quad_feature_bin_m =
+        static_cast<float>(triangle_descriptor_quad_feature_bin_m_);
       graphslam::triangle::VoteConfig vote_cfg;
       vote_cfg.exclude_submap_id = -1;
       graphslam::triangle::VerificationConfig verify_cfg;
@@ -2041,7 +2059,7 @@ void GraphBasedSlamComponent::searchLoop()
       // ourselves. We do this by running the vote step first and dropping any
       // candidate whose submap_id is too close to latest_idx.
       const auto votes = graphslam::triangle::accumulateVotes(
-        triangle_descriptor_db_, query_tris, hash_cfg, vote_cfg);
+        triangle_descriptor_db_, query_kps, query_tris, hash_cfg, vote_cfg);
       int chosen_submap_id = -1;
       int chosen_votes = 0;
       for (const auto & v : votes) {

--- a/graph_based_slam/test/test_triangle_descriptor_database.cpp
+++ b/graph_based_slam/test/test_triangle_descriptor_database.cpp
@@ -52,6 +52,7 @@ using graphslam::triangle::estimateRigidFromTriangle;
 using graphslam::triangle::findLoopCandidate;
 using graphslam::triangle::packHash;
 using graphslam::triangle::quantizeEdges;
+using graphslam::triangle::quantizeKey;
 
 namespace
 {
@@ -171,6 +172,126 @@ TEST(TriangleHash, ClipsAtMaxBin)
   EXPECT_EQ(h.le, 255);
   EXPECT_EQ(h.me, 255);
   EXPECT_EQ(h.ge, 255);
+}
+
+TEST(TriangleQuadHash, FallsBackTo3EdgeWhenDisabled)
+{
+  // With quad_feature_bin_m == 0, quantizeKey must return a hash that's
+  // bit-for-bit identical to quantizeEdges (legacy 3-edge behaviour).
+  const auto kps = makeKeypointGrid(4, 4, 3.0f);
+  TriangleDescriptor t = makeTriangle(kps, 0, 1, 5);
+  HashConfig cfg;
+  cfg.edge_bin_m = 1.0f;
+  cfg.quad_feature_bin_m = 0.0f;
+  const auto legacy = quantizeEdges(t, cfg);
+  const auto quad = quantizeKey(t, kps, cfg);
+  EXPECT_EQ(legacy.le, quad.le);
+  EXPECT_EQ(legacy.me, quad.me);
+  EXPECT_EQ(legacy.ge, quad.ge);
+  EXPECT_EQ(quad.quad, 0);
+  EXPECT_EQ(packHash(legacy), packHash(quad));
+}
+
+TEST(TriangleQuadHash, EmptyKeypointsActsLikeLegacy)
+{
+  // Even with the quad bin set, an empty keypoints vector means we can't
+  // compute the 4th-point context; the hash falls back to 3-edge.
+  TriangleDescriptor t;
+  t.edges = {{3.0f, 5.0f, 7.0f}};
+  t.keypoint_ids = {{0, 1, 2}};
+  HashConfig cfg;
+  cfg.edge_bin_m = 1.0f;
+  cfg.quad_feature_bin_m = 0.5f;
+  const std::vector<Keypoint> empty;
+  const auto h = quantizeKey(t, empty, cfg);
+  EXPECT_EQ(h.quad, 0);
+  EXPECT_EQ(packHash(h), packHash(quantizeEdges(t, cfg)));
+}
+
+TEST(TriangleQuadHash, EncodesNearestNonVertexDistance)
+{
+  // Two triangles with the same 3-edge geometry but different nearest
+  // non-vertex keypoints land in different buckets when quad hashing is on.
+  // Construct scenario explicitly so the nearest non-vertex is unambiguous.
+  std::vector<Keypoint> kps_a;
+  std::vector<Keypoint> kps_b;
+  auto push = [](std::vector<Keypoint> & dst, float x, float y) {
+      Keypoint k;
+      k.position = Eigen::Vector3f(x, y, 0.0f);
+      k.salience = 1.0f;
+      dst.push_back(k);
+    };
+  // Triangle vertices: A=(0,0), B=(6,0), C=(3,4) -> centroid (3, 4/3).
+  push(kps_a, 0.0f, 0.0f);
+  push(kps_a, 6.0f, 0.0f);
+  push(kps_a, 3.0f, 4.0f);
+  // 4th keypoint near centroid in set A: only 0.5 m offset.
+  push(kps_a, 3.0f, 1.333f + 0.5f);
+  // Same first 3 keypoints in set B.
+  push(kps_b, 0.0f, 0.0f);
+  push(kps_b, 6.0f, 0.0f);
+  push(kps_b, 3.0f, 4.0f);
+  // 4th keypoint in set B: 4 m away from centroid, well past 0.5 m bin.
+  push(kps_b, 3.0f, 1.333f + 4.0f);
+  TriangleDescriptor t = makeTriangle(kps_a, 0, 1, 2);
+
+  HashConfig cfg;
+  cfg.edge_bin_m = 1.0f;
+  cfg.quad_feature_bin_m = 0.5f;
+  const auto ha = quantizeKey(t, kps_a, cfg);
+  const auto hb = quantizeKey(t, kps_b, cfg);
+  EXPECT_EQ(ha.le, hb.le);
+  EXPECT_EQ(ha.me, hb.me);
+  EXPECT_EQ(ha.ge, hb.ge);
+  EXPECT_NE(ha.quad, hb.quad) <<
+    "Same triangle with very different 4th-point distances must land in "
+    "different quad bins (a=" << ha.quad << ", b=" << hb.quad << ")";
+  EXPECT_NE(packHash(ha), packHash(hb));
+}
+
+TEST(TriangleQuadHash, DatabaseQuadLookupRequiresMatchingContext)
+{
+  // End-to-end: build a database with quad hashing on, then verify that a
+  // query triangle with a different nearest-non-vertex distance produces
+  // zero votes (different quad bin -> different bucket).
+  HashConfig cfg;
+  cfg.edge_bin_m = 1.0f;
+  cfg.quad_feature_bin_m = 0.5f;
+  VoteConfig vote_cfg;
+
+  // Database: triangle (0,1,2) plus a 4th point close to centroid.
+  std::vector<Keypoint> kps_db;
+  auto push = [](std::vector<Keypoint> & dst, float x, float y) {
+      Keypoint k;
+      k.position = Eigen::Vector3f(x, y, 0.0f);
+      k.salience = 1.0f;
+      dst.push_back(k);
+    };
+  push(kps_db, 0.0f, 0.0f);
+  push(kps_db, 6.0f, 0.0f);
+  push(kps_db, 3.0f, 4.0f);
+  push(kps_db, 3.0f, 1.333f + 0.5f);
+  TriangleDescriptor t_db = makeTriangle(kps_db, 0, 1, 2);
+  TriangleDatabase db;
+  db.addSubmap(7, kps_db, {t_db}, cfg);
+
+  // Query: same triangle, but 4th point is far from centroid.
+  std::vector<Keypoint> kps_q = kps_db;
+  kps_q[3].position = Eigen::Vector3f(3.0f, 1.333f + 4.0f, 0.0f);
+  TriangleDescriptor t_q = makeTriangle(kps_q, 0, 1, 2);
+  const auto votes = accumulateVotes(db, kps_q, {t_q}, cfg, vote_cfg);
+  EXPECT_TRUE(votes.empty()) <<
+    "Query with mismatching 4th-point context must miss the bucket; "
+    "instead got " << votes.size() << " vote(s)";
+
+  // Sanity: when quad hashing is off, the same query DOES vote.
+  HashConfig cfg_legacy = cfg;
+  cfg_legacy.quad_feature_bin_m = 0.0f;
+  TriangleDatabase db_legacy;
+  db_legacy.addSubmap(7, kps_db, {t_db}, cfg_legacy);
+  const auto votes_legacy = accumulateVotes(db_legacy, kps_q, {t_q}, cfg_legacy, vote_cfg);
+  ASSERT_EQ(votes_legacy.size(), 1u);
+  EXPECT_EQ(votes_legacy.front().submap_id, 7);
 }
 
 TEST(TriangleDatabase, AddSubmapStoresAllValidTriangles)

--- a/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
+++ b/graph_based_slam/test/test_triangle_descriptor_yaml_defaults.py
@@ -54,6 +54,7 @@ EXPECTED_PARAM_KEYS = {
     'triangle_descriptor_max_edge_m',
     'triangle_descriptor_max_triangles',
     'triangle_descriptor_edge_bin_m',
+    'triangle_descriptor_quad_feature_bin_m',
     'triangle_descriptor_min_votes',
     'triangle_descriptor_min_inliers',
     'triangle_descriptor_inlier_translation_m',
@@ -115,6 +116,23 @@ def test_triangle_descriptor_edge_bounds_sane(path):
     assert min_edge > 0.0, f'{path.name}: min_edge_m must be positive'
     assert max_edge > min_edge, (
         f'{path.name}: max_edge_m ({max_edge}) must exceed min_edge_m ({min_edge})'
+    )
+
+
+@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
+def test_triangle_descriptor_quad_hash_default_disabled(path):
+    """
+    Quad-hash extension must default to 0 so the legacy 3-edge hash holds.
+
+    The packed hash key is bit-for-bit identical when quad_feature_bin_m == 0,
+    so opting in is the only way to change bucket assignments. Negative is
+    rejected at runtime; here we just guard the yaml against accidental
+    negative defaults.
+    """
+    params = _load_graph_params(path)
+    bin_m = params['triangle_descriptor_quad_feature_bin_m']
+    assert bin_m >= 0.0, (
+        f'{path.name}: quad_feature_bin_m must be >= 0 (0 = disabled); got {bin_m}'
     )
 
 

--- a/lidarslam/param/lidarslam_mid360_rko_graph.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph.yaml
@@ -67,6 +67,10 @@ graph_based_slam:
     triangle_descriptor_max_edge_m: 30.0
     triangle_descriptor_max_triangles: 2000
     triangle_descriptor_edge_bin_m: 0.5
+    # Quad-hash 4th-point context. 0 = disabled (legacy 3-edge hash).
+    # MID-360 narrow FOV already has low keypoint density per submap; the
+    # 4th-point context may be unstable. Default off; tune per bag.
+    triangle_descriptor_quad_feature_bin_m: 0.0
     triangle_descriptor_min_votes: 8
     triangle_descriptor_min_inliers: 5
     # MID-360 narrower FOV / fewer keypoints means evaluated pair counts are


### PR DESCRIPTION
## Summary

- Add **opt-in 4th dim** to the triangle hash bucket key: quantized distance from triangle centroid to nearest non-vertex keypoint (rotation-invariant local context).
- Legacy 3-edge path preserved bit-for-bit (`quad_feature_bin_m == 0` defaults).
- 4-arg `accumulateVotes` overload retained as backward-compat; new 5-arg overload accepts query keypoints.
- New ROS param `triangle_descriptor_quad_feature_bin_m` (default `0.0` = disabled) wired through `graph_based_slam_component`.
- 3 triangle-tracked yamls ship the key at `0.0`, documented per preset.

## Why

The legacy 3-edge hash admits wrong-but-agreeing triangle pairs through edge-length similarity alone (corridor / parking row / parallel column geometry is the worst offender). Three points uniquely determine SE(3), so a wrong correspondence still produces a `transformAgrees` inlier and the post-hoc 4-point gate has to clean up after the fact. With the quad key the bucket already filters by local context, so RANSAC sees fewer false correspondences and the downstream refinement / 4-point gate work with cleaner inputs.

## Test plan

- [x] 4 new gtests: `FallsBackTo3EdgeWhenDisabled`, `EmptyKeypointsActsLikeLegacy`, `EncodesNearestNonVertexDistance`, `DatabaseQuadLookupRequiresMatchingContext`
- [x] yaml regression: `quad_feature_bin_m >= 0` in all 3 presets
- [x] `scripts/run_default_ci_checks.sh` → 535 tests, 0 failures
- [ ] Cross-dataset ablation (Newer College / MID-360 / NTU) with `quad_feature_bin_m: 0.5` — follow-up, not in this PR (mechanism only)