### PR TITLE
feat: surface inlier_ratio + eval_n for triangle precision-floor tuning

### DIFF
--- a/graph_based_slam/include/graph_based_slam/triangle_descriptor_database.hpp
+++ b/graph_based_slam/include/graph_based_slam/triangle_descriptor_database.hpp
@@ -274,6 +274,15 @@ struct LoopCandidate
   int submap_id {-1};
   int votes {0};
   int inliers {0};
+  // Triangle pairs actually evaluated by RANSAC (= min(verify_cfg.max_pairs,
+  // total bucket hits)). Useful for the operator to compute / verify the
+  // inlier ratio that gated this emit; populated even when the candidate
+  // is rejected so post-mortem tuning can see the ratio that came up
+  // short.
+  int eval_n {0};
+  // ``inliers / eval_n`` when eval_n > 0, else 0. Precomputed so operators
+  // can log the ratio without re-computing it from int fields.
+  float inlier_ratio {0.0f};
   Eigen::Matrix4f transform {Eigen::Matrix4f::Identity()};
   bool accepted {false};
 };
@@ -415,12 +424,14 @@ inline LoopCandidate findLoopCandidate(
   }
 
   result.inliers = best_inliers;
+  result.eval_n = eval_n;
+  result.inlier_ratio = (eval_n > 0) ?
+    static_cast<float>(best_inliers) / static_cast<float>(eval_n) : 0.0f;
   result.transform = best_T;
   bool count_ok = best_inliers >= verify_cfg.min_inliers;
   bool ratio_ok = true;
   if (verify_cfg.min_inlier_ratio > 0.0f && eval_n > 0) {
-    const float ratio = static_cast<float>(best_inliers) / static_cast<float>(eval_n);
-    ratio_ok = ratio >= verify_cfg.min_inlier_ratio;
+    ratio_ok = result.inlier_ratio >= verify_cfg.min_inlier_ratio;
   }
   bool fourth_ok = true;
   if (count_ok && ratio_ok && verify_cfg.min_4th_point_agreements > 0) {

--- a/graph_based_slam/param/graphbasedslam.yaml
+++ b/graph_based_slam/param/graphbasedslam.yaml
@@ -68,9 +68,15 @@ graph_based_slam:
       triangle_descriptor_edge_bin_m: 0.5
       triangle_descriptor_min_votes: 6
       triangle_descriptor_min_inliers: 4
-      # 0.0 disables the relative-density floor. Set to e.g. 0.15 in combination
-      # with triangle_descriptor_max_pairs: 20 if you want to insist on >=15%
-      # of evaluated triangle pairs agreeing on SE(3).
+      # Precision floor recipe: combine triangle_descriptor_min_inliers
+      # (absolute) AND triangle_descriptor_min_inlier_ratio (relative).
+      # Both must pass for an emit -> stricter when max_pairs is high.
+      # 0.0 disables the relative gate. Useful values:
+      #   max_pairs=64, min_inlier_ratio=0.10  -> at least 7 inliers
+      #   max_pairs=32, min_inlier_ratio=0.15  -> at least 5 inliers
+      # The component logs "inliers=N eval_n=M inlier_ratio=R" on every
+      # emit AND on every rejection (when debug_flag is on) so tuning is
+      # observable without re-running.
       triangle_descriptor_min_inlier_ratio: 0.0
       triangle_descriptor_max_pairs: 64
       # 4-point consensus: project non-triangle query keypoints by the

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -2111,6 +2111,10 @@ void GraphBasedSlamComponent::searchLoop()
             std::cout << "Triangle loop candidate: id=" << chosen_submap_id
                       << " votes=" << chosen_votes
                       << " inliers=" << cand.inliers
+                      << " eval_n=" << cand.eval_n
+                      << " inlier_ratio="
+                      << std::fixed << std::setprecision(3) << cand.inlier_ratio
+                      << std::defaultfloat
                       << " yaw_deg=" << tri_yaw_rad * 180.0 / M_PI;
             if (triangle_verify_with_bev_) {
               std::cout << " bev_xv_dist=" << bev_cross_verify_distance;
@@ -2129,11 +2133,17 @@ void GraphBasedSlamComponent::searchLoop()
               chosen_submap_id, travel_distance, distance_loop_closure_);
           }
         } else if (debug_flag_) {
+          // Surface the ratio gate too: an inlier count that beats the
+          // absolute min can still fail when min_inlier_ratio is set and
+          // eval_n is high. Knowing the ratio is the only way operators
+          // can tune precision_floor without re-running.
           RCLCPP_INFO(
             get_logger(),
-            "Triangle votes for %d (%d votes) rejected: inliers %d below %d",
-            chosen_submap_id, chosen_votes, cand.inliers,
-            triangle_descriptor_min_inliers_);
+            "Triangle votes for %d (%d votes) rejected: inliers %d/%d "
+            "(ratio %.3f) below min_inliers=%d min_inlier_ratio=%.3f",
+            chosen_submap_id, chosen_votes, cand.inliers, cand.eval_n,
+            cand.inlier_ratio, triangle_descriptor_min_inliers_,
+            triangle_descriptor_min_inlier_ratio_);
         }
       } else if (debug_flag_ && !votes.empty()) {
         RCLCPP_INFO(

--- a/graph_based_slam/test/test_triangle_descriptor_database.cpp
+++ b/graph_based_slam/test/test_triangle_descriptor_database.cpp
@@ -320,11 +320,47 @@ TEST(TriangleLoopCandidate, RecoversIdentity)
   ASSERT_TRUE(candidate.accepted);
   EXPECT_EQ(candidate.submap_id, 11);
   EXPECT_GT(candidate.inliers, verify_cfg.min_inliers);
+  EXPECT_GT(candidate.eval_n, 0) << "eval_n must reflect the RANSAC pool size";
+  EXPECT_GE(candidate.inlier_ratio, 0.0f);
+  EXPECT_LE(candidate.inlier_ratio, 1.0f);
+  EXPECT_NEAR(
+    candidate.inlier_ratio,
+    static_cast<float>(candidate.inliers) / static_cast<float>(candidate.eval_n),
+    1e-6f) <<
+    "inlier_ratio must equal inliers / eval_n so the operator can verify "
+    "the precision floor against either field independently";
   const Eigen::Matrix4f T = candidate.transform;
   const Eigen::Matrix3f R = T.block<3, 3>(0, 0);
   const Eigen::Vector3f t = T.block<3, 1>(0, 3);
   EXPECT_LT((R - Eigen::Matrix3f::Identity()).norm(), 1e-3f);
   EXPECT_LT(t.norm(), 1e-3f);
+}
+
+TEST(TriangleLoopCandidate, PopulatesRatioFieldsOnRejection)
+{
+  // Even when min_inliers can't be met, the candidate must report
+  // (inliers, eval_n, inlier_ratio) so operators can post-mortem the
+  // precision floor without re-running.
+  const auto kps_a = makeAsymmetricKeypointSet();
+  const auto tris_a = buildTriangles(kps_a, TriangleBuildConfig{});
+
+  // Build the database from a completely unrelated keypoint set so that
+  // hash matches happen but RANSAC inliers stay low.
+  auto kps_b = makeKeypointGrid(5, 5, 4.0f);
+  const auto tris_b = buildTriangles(kps_b, TriangleBuildConfig{});
+
+  TriangleDatabase db;
+  HashConfig cfg;
+  db.addSubmap(99, kps_b, tris_b, cfg);
+
+  VoteConfig vote_cfg;
+  VerificationConfig verify_cfg;
+  verify_cfg.min_inliers = 1000;  // unreachable -> guaranteed rejection
+  const auto candidate = findLoopCandidate(db, kps_a, tris_a, cfg, vote_cfg, verify_cfg);
+  EXPECT_FALSE(candidate.accepted);
+  EXPECT_GE(candidate.eval_n, 0);
+  EXPECT_GE(candidate.inlier_ratio, 0.0f);
+  EXPECT_LE(candidate.inlier_ratio, 1.0f);
 }
 
 TEST(TriangleLoopCandidate, RecoversYawAndTranslation)


### PR DESCRIPTION
## Summary

- Populate `LoopCandidate::eval_n` and `LoopCandidate::inlier_ratio` so the precision-floor recipe (`min_inliers` AND `min_inlier_ratio`) is observable.
- Emit log now prints `inliers=N eval_n=M inlier_ratio=R` on every triangle loop candidate.
- Debug-flag rejection log prints the same fields alongside the limits that failed.
- Document the precision-floor recipe in `graphbasedslam.yaml` with example pairings.

## Why

`min_inlier_ratio` already exists as a verification gate, but until now it was unobservable: only the absolute inlier count was logged. Operators had to guess what `eval_n` was (= `min(max_pairs, total pair hits)`) to verify whether the relative-density floor passed or failed. Without that, choosing a non-zero `min_inlier_ratio` is blind tuning.

No behaviour change — gate logic is unchanged, just observable.

## Test plan

- [x] gtest `RecoversIdentity` asserts `eval_n > 0`, `inlier_ratio = inliers / eval_n`, ratio in `[0, 1]`
- [x] new gtest `PopulatesRatioFieldsOnRejection`: fields populated even when rejected
- [x] existing 11 LoopCandidate gtests still pass
- [x] `scripts/run_default_ci_checks.sh` → 529 tests, 0 failures
- [ ] Cross-dataset ablation choosing a default `min_inlier_ratio` per preset — follow-up (this PR ships the observability that ablation needs)