### PR TITLE
docs: rewrite README for user-friendliness (badges + 5-min try + grouped features)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,204 +1,189 @@
-lidarslam_ros2
-====
+# lidarslam_ros2
 
-ROS 2 LiDAR SLAM focused on non-GPL pointcloud-map authoring, benchmarking, and compatibility with Autoware pointcloud-map workflows.
+[![CI](https://github.com/rsasaki0109/lidarslam_ros2/actions/workflows/main.yml/badge.svg?branch=develop)](https://github.com/rsasaki0109/lidarslam_ros2/actions/workflows/main.yml)
+[![License: BSD-2-Clause](https://img.shields.io/badge/License-BSD--2--Clause-blue.svg)](https://opensource.org/licenses/BSD-2-Clause)
+[![ROS 2: Humble | Jazzy](https://img.shields.io/badge/ROS%202-Humble%20%7C%20Jazzy-22314E?logo=ros&logoColor=white)](#support-matrix)
 
-> Status: `develop` tracks the current `v2 alpha` line.
-> For the latest tagged public beta, see [v0.2.2 Release Notes](docs/releases/v0.2.2.md).
-## Recommended Public Workflow
+**ROS 2 LiDAR SLAM that produces Autoware-compatible pointcloud maps without a GPL frontend.**
 
-The recommended public path in this repository is:
+Drop in a rosbag2, get back a `pointcloud_map/` directory Autoware can load, with optional lanelet2, GNSS georeferencing, and a working AWSIM → Autoware autonomous-driving demo on the map you just built.
 
-- frontend: `RKO-LIO`
-- backend: `graph_based_slam`
-- output: Autoware-compatible `pointcloud_map/` and `map_projector_info.yaml`
+![Autoware-compatible proof](lidarslam/images/autoware_map_loader_proof.png)
+> Live `/map/pointcloud_map` rendered by Autoware map loaders. `map_verify: PASS`, `LocalCartesian` from GNSS.
 
-This is the path exercised in the public quickstart, benchmark flow, and release/readiness gate.
+---
 
-## Scope
-
-This repository is for people who want:
-
-- ROS 2 LiDAR SLAM with loop closure
-- pointcloud maps that Autoware can load
-- lanelet2 maps auto-generated from SLAM trajectories
-- end-to-end autonomous driving on self-made maps (AWSIM + Autoware)
-- a non-GPL default workflow
-
-Out of scope for the public path:
-
-- Autoware planning/localization bringup beyond the provided demo scripts
-- GPL-only frontend or backend components in the default workflow
-
-## Why This Repo
-
-- non-GPL default path: `graph_based_slam`, `scanmatcher`, `RKO-LIO`, `DLIO`, and optional `FAST_GICP`
-- pointcloud-map authoring is treated as a first-class workflow, not just a side-effect of odometry
-- Autoware pointcloud-map flow is exercised end-to-end
-- **AWSIM → lidarslam → Autoware autonomous driving** pipeline with one-command demo
-- **lanelet2 auto-generation** from SLAM trajectories (multi-segment with shared boundary nodes), structurally validated before Autoware loads it
-- release-track benchmarks: `NTU VIRAL` (outdoor GT) and KITTI Odometry 00/05/07 (LO baseline non-regression)
-- research-track benchmarks (`report_only_until: v0.4`): `MID-360` solid-state LiDAR vs GLIM, Leo Drive open-data Velodyne cross-validation
-- per-dataset pass / target thresholds in `scripts/release_profiles.yaml`; `bash scripts/run_release_readiness_checks.sh --fail-on-profiles` gates release without forcing one global APE threshold
-- optional GNSS georeferencing writes `map_projector_info.yaml`; GNSS edges can use covariance-based weighting
-- GPL-free Scan Context place recognition is available in `graph_based_slam`
-- opt-in NIS-driven auto-scale for the adjacent-edge information weight so the backend self-tunes between strong and weak LIO datasets
-- optional MIT-licensed 3D-BBS loop-candidate verification can be built from the vendored `Thirdparty/3d_bbs` source and remains disabled at runtime by default
-- report helpers cover benchmarks, GNSS, cleanup, dynamic filtering, place recognition, and submission bundles
-
-## Install
-
-Clone with submodules and install dependencies:
+## ⚡ Try It in 5 Minutes
 
 ```bash
+# 1. Clone with submodules
 cd ~/ros2_ws/src
 git clone --recursive https://github.com/rsasaki0109/lidarslam_ros2.git
-cd ..
-rosdep install --from-paths src --ignore-src -r -y
-```
+cd .. && rosdep install --from-paths src --ignore-src -r -y
 
-If you already cloned without submodules:
-
-```bash
-git -C src/lidarslam_ros2 submodule update --init --recursive
-```
-
-Build the workspace:
-
-```bash
+# 2. Build
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
-```
+source install/setup.bash
 
-## Quickstart
-
-```bash
-# local checks
-bash scripts/run_default_ci_checks.sh
-
-# fixed public quickstart
+# 3. Run the public quickstart (NTU VIRAL tnp_01, ~580 s outdoor bag)
+cd src/lidarslam_ros2
 bash scripts/download_ntu_viral_tnp01.sh
 bash scripts/run_autoware_quickstart.sh
+```
 
-# arbitrary rosbag2
+Expected output: `output/.../pointcloud_map/` (Autoware-compatible) plus a TUM trajectory. To verify:
+
+```bash
+python3 scripts/verify_autoware_map.py output/.../pointcloud_map
+# expect: map_verify: PASS
+```
+
+Got your own rosbag2?
+
+```bash
 bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2
 ```
 
-## AWSIM Autonomous Driving Pipeline
+---
 
-AWSIM simulator data can flow through lidarslam into `pointcloud_map`, generated lanelet2, and Autoware driving demos. Start with:
+## 🎯 What You Can Do With This
+
+### 🗺️ Pointcloud-Map Authoring (Autoware-compatible)
+- `RKO-LIO` frontend + `graph_based_slam` backend, both non-GPL
+- Outputs Autoware `pointcloud_map/` + `map_projector_info.yaml`
+- Optional **GNSS georeferencing** writes `LocalCartesian` for direct Autoware loading
+- Save-time **dynamic-object filter** (~50 % size reduction on Leo Drive `bag6` with verification still `PASS`)
+
+![Dynamic-object filter summary](lidarslam/images/dynamic_object_filter_bag6_summary.svg)
+
+### 🚗 AWSIM → Autoware Autonomous Driving Pipeline
+One-command demo that goes from AWSIM simulator → lidarslam map → Autoware autonomous driving on the map you just built. Includes **lanelet2 auto-generation** from SLAM trajectories (multi-segment with shared boundary nodes, structurally validated before Autoware loads it).
 
 ```bash
 bash scripts/test_awsim_setup.sh
 bash scripts/run_awsim_selfmade_map_demo.sh
 ```
 
-For map packaging, lanelet2 generation, and terminal-by-terminal bringup, see [AWSIM Autonomous Driving Tutorial](docs/awsim-autonomous-driving-tutorial.md).
+See [AWSIM Autonomous Driving Tutorial](docs/awsim-autonomous-driving-tutorial.md) for terminal-by-terminal bringup.
 
-## Point-Cloud Map Example
-Autoware-compatible browser proof built from a live `/map/pointcloud_map`: the rendered map comes from Autoware map loaders, map verify is `PASS`, and GNSS runs emit `LocalCartesian`.
-![Autoware-compatible proof](lidarslam/images/autoware_map_loader_proof.png)
-Save-time dynamic-object filtering on Leo Drive `bag6` cuts saved points by about `50%` while keeping verification `PASS`.
-![Dynamic-object filter summary](lidarslam/images/dynamic_object_filter_bag6_summary.svg)
+### 🔁 Loop Closure & Place Recognition (BSD-2 only)
+- Built-in **Scan Context** (re-implemented locally, GPL-free)
+- **BEV** / **SOLiD** / **Triangle (STD/BTC-style)** descriptors, all opt-in
+- Optional MIT-licensed **3D-BBS** loop verification (vendored, runtime-disabled by default)
 
-## Docs
-- [AWSIM Autonomous Driving Tutorial](docs/awsim-autonomous-driving-tutorial.md)
-- [Autoware-Compatible Map Authoring](docs/autoware-map-authoring.md) / [Autoware Quickstart](docs/autoware-quickstart.md) / [Autoware Foxglove](docs/autoware-foxglove.md)
-- [Operator Workflows](docs/workflows.md)
-- [Benchmarking And Release Gate](docs/benchmarking.md)
-- [Comparison](docs/comparison.md)
-- [v0.2.2 Release Notes](docs/releases/v0.2.2.md)
-- [Contributing](CONTRIBUTING.md)
-- [Changelog](CHANGELOG.md)
-- [Releasing](RELEASING.md)
-
-Preview the doc site locally with `python3 -m mkdocs serve`.
-
-## Current Snapshot
-
-Release track:
-- `NTU VIRAL tnp_01` outdoor GT (current default 0.952 m, best 0.870 m; gate `WARN`, `report_only_until: v0.4`)
-- KITTI Odometry 00 / 05 / 07 LO baseline (non-regression report; `bash scripts/run_kitti_00_05_07_report.sh`)
-- Autoware-compatible pointcloud_map + lanelet2 + AWSIM → Autoware E2E demo
-
-Research track (`report_only_until: v0.4`, does not block release):
-- `MID-360` vs GLIM cross-validation (current default 3.641 m, best 3.590 m; solid-state LiDAR research dataset)
-- Leo Drive applanix/velodyne open-data cross-validation
-
-More detail lives in [docs/comparison.md](docs/comparison.md), [docs/benchmarking.md](docs/benchmarking.md), `scripts/release_profiles.yaml`, `output/benchmark_summary.md`, and `output/latest_report.html`.
-
-## Main Entrypoints
-
-Required input topics for the main public path:
-
-| Launch path | Required topics | Optional topics |
-| --- | --- | --- |
-| `ros2 launch lidarslam rko_lio_slam.launch.py` | LiDAR `sensor_msgs/PointCloud2` on `lidar_topic`, IMU `sensor_msgs/Imu` on `imu_topic` | `sensor_msgs/NavSatFix` on `gnss_topic` (default: `/gnss/fix`) when `use_gnss:=true` |
-| `ros2 launch lidarslam lidarslam.launch.py` | Point cloud `sensor_msgs/PointCloud2` on `input_cloud`, TF from `robot_frame_id` to the LiDAR frame | IMU on `imu_topic` when `scanmatcher use_imu:=true`, odom TF when `scanmatcher use_odom:=true`, GNSS on `gnss_topic` (default: `/gnss/fix`) when backend `use_gnss:=true` |
-| `ros2 launch graph_based_slam graphbasedslam.launch.py` | `lidarslam_msgs/MapArray` on `map_array` | IMU on `/imu` when `use_imu_preintegration:=true`, GNSS on `gnss_topic` (default: `/gnss/fix`) when `use_gnss:=true` |
-
-There is no wheel-speed / vehicle-speed input in the current public path yet.
-The backend GNSS subscription topic is configurable with `gnss_topic` (default: `/gnss/fix`). Inspect covariance with `scripts/inspect_navsatfix_covariance.py`; Applanix conversion details live in [docs/workflows.md](docs/workflows.md).
-
-Run the public Autoware quickstart:
-
-```bash
-bash scripts/run_autoware_quickstart.sh
-```
-
-Run `RKO-LIO + graph_based_slam` directly:
-
-```bash
-ros2 launch lidarslam rko_lio_slam.launch.py \
-  bag_path:=/path/to/rosbag2 \
-  lidar_topic:=/os_cloud_node/points \
-  imu_topic:=/os_cloud_node/imu
-```
-
-Save the current map:
-
-```bash
-ros2 service call /map_save std_srvs/srv/Empty
-```
-
-To filter likely dynamic objects only in the saved map output, enable `use_dynamic_object_filter: true` and tune `dynamic_object_filter_voxel_size`, `dynamic_object_filter_min_observations`, `dynamic_object_filter_temporal_window`, and `dynamic_object_filter_max_range_from_sensor_m` before calling `/map_save`.
-
-Run the standard benchmark path:
-
-```bash
-bash scripts/download_ntu_viral_tnp01.sh
-bash scripts/run_rko_lio_graph_benchmark.sh
-```
-
-For KITTI Odometry / Velodyne-only evaluation, Leo Drive classic-path suites, dynamic-filter benchmarks, and `MID-360` place-recognition comparisons, use the entrypoints documented in [docs/benchmarking.md](docs/benchmarking.md). The KITTI Odometry 00/05/07 LO baseline aggregator lives at `scripts/run_kitti_00_05_07_report.sh` (uses frozen params and writes `kitti_dev_report.md` with `t_rel` / `r_rel` per sequence).
-
-Run the local readiness gate. The default uses the per-dataset profiles in
-`scripts/release_profiles.yaml`, so `WARN` is emitted for research-track
-datasets (`MID-360`, `NTU VIRAL`, Leo Drive) and only release-track profiles
-without `report_only_until` (Newer College) can block release:
+### 📊 Reproducible Benchmarks
+Per-dataset pass / target thresholds in `scripts/release_profiles.yaml` — no single global APE knob.
 
 ```bash
 bash scripts/run_release_readiness_checks.sh --fail-on-profiles
 ```
 
-The legacy single-threshold mode is still supported for compatibility:
+Release track: NTU VIRAL `tnp_01`, KITTI Odometry 00/05/07 LO baseline, Autoware E2E.
+Research track (`report_only_until: v0.4`): MID-360 vs GLIM, Leo Drive Velodyne.
+
+### 🧰 Operator Tooling
+NIS-driven auto-scale for adjacent-edge weights, report helpers for benchmarks / GNSS / cleanup / dynamic filtering / place recognition / submission bundles. See [`docs/workflows.md`](docs/workflows.md).
+
+---
+
+## 🚀 Main Entrypoints
+
+Required input topics for the main public path:
+
+| Launch path | Required topics | Optional topics |
+| --- | --- | --- |
+| `ros2 launch lidarslam rko_lio_slam.launch.py` | LiDAR `PointCloud2` on `lidar_topic`, IMU on `imu_topic` | `NavSatFix` on `gnss_topic` when `use_gnss:=true` |
+| `ros2 launch lidarslam lidarslam.launch.py` | `PointCloud2` on `input_cloud`, TF from `robot_frame_id` to LiDAR frame | IMU / odom TF (when enabled), GNSS (when enabled) |
+| `ros2 launch graph_based_slam graphbasedslam.launch.py` | `lidarslam_msgs/MapArray` on `map_array` | IMU on `/imu` (preintegration), GNSS (when enabled) |
 
 ```bash
-bash scripts/run_release_readiness_checks.sh --ape-threshold 0.10
+# Run RKO-LIO + graph_based_slam directly
+ros2 launch lidarslam rko_lio_slam.launch.py \
+  bag_path:=/path/to/rosbag2 \
+  lidar_topic:=/os_cloud_node/points \
+  imu_topic:=/os_cloud_node/imu
+
+# Save the current map
+ros2 service call /map_save std_srvs/srv/Empty
 ```
 
-## License Policy
+Wheel/vehicle-speed input is **not** in the current public path. Backend GNSS topic is configurable (`gnss_topic`, default `/gnss/fix`); inspect covariance with `scripts/inspect_navsatfix_covariance.py`.
 
-The default public workflow excludes GPL-only frontend/backend components. `graph_based_slam` is BSD-2-Clause; `RKO-LIO`, `DLIO`, and optional vendored `3D-BBS` are MIT; `FAST_GICP` is BSD-3-Clause; built-in `Scan Context` is implemented locally. `Thirdparty/lio-sam` and `Thirdparty/3d_bbs` are excluded from direct `colcon` package discovery via `COLCON_IGNORE`.
+---
 
-## Support Matrix
+## 📚 Docs
+
+| | |
+| --- | --- |
+| Get started | [AWSIM Driving Tutorial](docs/awsim-autonomous-driving-tutorial.md) · [Autoware Quickstart](docs/autoware-quickstart.md) · [Autoware Foxglove](docs/autoware-foxglove.md) |
+| Author maps | [Autoware-Compatible Map Authoring](docs/autoware-map-authoring.md) · [Operator Workflows](docs/workflows.md) |
+| Benchmark | [Benchmarking & Release Gate](docs/benchmarking.md) · [Comparison](docs/comparison.md) |
+| Release | [v0.2.2 Release Notes](docs/releases/v0.2.2.md) · [Changelog](CHANGELOG.md) · [Releasing](RELEASING.md) |
+| Contribute | [Contributing](CONTRIBUTING.md) |
+
+Preview the doc site locally: `python3 -m mkdocs serve`.
+
+---
+
+## 📈 Current Snapshot
+
+**Release track**
+- NTU VIRAL `tnp_01` outdoor GT — current default `0.952 m`, best `0.870 m` (gate `WARN`, `report_only_until: v0.4`)
+- KITTI Odometry 00 / 05 / 07 LO baseline — non-regression report (`bash scripts/run_kitti_00_05_07_report.sh`)
+- Autoware-compatible `pointcloud_map` + lanelet2 + AWSIM → Autoware E2E demo
+
+**Research track** (`report_only_until: v0.4`, does not block release)
+- MID-360 vs GLIM — current default `3.641 m`, best `3.590 m` (solid-state research dataset)
+- Leo Drive applanix/velodyne open-data cross-validation
+
+Detail: [`docs/comparison.md`](docs/comparison.md), [`docs/benchmarking.md`](docs/benchmarking.md), `scripts/release_profiles.yaml`, `output/benchmark_summary.md`, `output/latest_report.html`.
+
+---
+
+<details>
+<summary><b>Scope, license, support matrix</b> (click to expand)</summary>
+
+### Scope
+
+In scope:
+- ROS 2 LiDAR SLAM with loop closure
+- Autoware-loadable pointcloud maps
+- Lanelet2 maps auto-generated from SLAM trajectories
+- End-to-end autonomous driving on self-made maps (AWSIM + Autoware)
+- A non-GPL default workflow
+
+Out of scope (for the public path):
+- Autoware planning / localization bringup beyond the provided demo scripts
+- GPL-only frontend or backend components
+
+### License Policy
+
+The default public workflow excludes GPL-only frontend/backend components. `graph_based_slam` is BSD-2-Clause; `RKO-LIO`, `DLIO`, and optional vendored `3D-BBS` are MIT; `FAST_GICP` is BSD-3-Clause; built-in Scan Context is implemented locally. `Thirdparty/lio-sam` and `Thirdparty/3d_bbs` are excluded from `colcon` discovery via `COLCON_IGNORE`.
+
+### Support Matrix
 
 | ROS 2 distro | Ubuntu | Scope |
 | --- | --- | --- |
-| Humble | 22.04 | default workflow build and package tests in CI |
-| Jazzy | 24.04 | default workflow build and package tests in CI; Autoware pointcloud-map dogfood exercised locally |
+| Humble | 22.04 | default workflow build + package tests in CI |
+| Jazzy | 24.04 | default workflow build + package tests in CI; Autoware dogfood exercised locally |
 
-## Quality Gates
+### Quality Gates
 
-The main checks for the public path are `bash scripts/run_default_ci_checks.sh`, `python3 scripts/verify_autoware_map.py <pointcloud_map_dir>`, `bash scripts/run_autoware_quickstart.sh`, `bash scripts/run_rko_lio_graph_autoware_dogfood.sh --auto-exit-secs 20`, and `bash scripts/run_release_readiness_checks.sh --ape-threshold 0.10`.
+The main checks for the public path:
 
-For the command-level details, parameter-file pointers, and Autoware map output notes, see [docs/workflows.md](docs/workflows.md).
+```bash
+bash scripts/run_default_ci_checks.sh
+python3 scripts/verify_autoware_map.py <pointcloud_map_dir>
+bash scripts/run_autoware_quickstart.sh
+bash scripts/run_rko_lio_graph_autoware_dogfood.sh --auto-exit-secs 20
+bash scripts/run_release_readiness_checks.sh --ape-threshold 0.10   # legacy single-threshold
+bash scripts/run_release_readiness_checks.sh --fail-on-profiles      # per-dataset profiles
+```
+
+Command-level details, parameter pointers, and Autoware map output notes are in [`docs/workflows.md`](docs/workflows.md).
+
+</details>
+
+---
+
+> `develop` tracks the current `v2 alpha` line. For the latest tagged public beta, see [v0.2.2 Release Notes](docs/releases/v0.2.2.md).


### PR DESCRIPTION
## Summary

The README opened with jargon-dense status / scope blurbs and buried the showcase image at line 97. New visitors had to scroll past two metadata blocks before seeing what the repo actually does or a single command to try.

This rewrite:

- Leads with **CI / license / ROS-distro badges** + a 1-sentence pitch
- Promotes the **Autoware-compatible map proof image** to the hero slot
- Adds a **'5 Minutes'** section: clone → build → quickstart → verify with the expected \`map_verify: PASS\` line, plus a bring-your-own-bag variant
- Groups capabilities into themed sections with emojis: 🗺️ Mapping, 🚗 Autonomous Driving, 🔁 Loop Closure, 📊 Benchmarks, 🧰 Operator Tooling
- Replaces the 'Docs' bullet list with a category table
- Moves Scope / License Policy / Support Matrix / Quality Gates into a single collapsible \`<details>\` at the bottom — still discoverable, not in the way

## Compatibility

- Preserves every string asserted by \`test_docs_entrypoints.py\` (repo URL, install commands, doc links, image paths, 'Required input topics for the main public path', '/gnss/fix', mkdocs serve, etc.)
- 189 lines (under the 220-line cap)

## Test plan

- [x] \`pytest -k docs_entrypoints\` → 0 failures
- [x] \`scripts/run_default_ci_checks.sh\` → 539 tests, 0 failures