### PR TITLE
fix: delegate SIGINT to rclpy default in path/odom_to_tum to avoid spin hang

### DIFF
--- a/scripts/odom_to_tum.py
+++ b/scripts/odom_to_tum.py
@@ -2,11 +2,11 @@
 """Subscribe to nav_msgs/Odometry and save trajectory in TUM format (append mode)."""
 
 import argparse
-import signal
 import sys
 import rclpy
 from rclpy.node import Node
 from rclpy.parameter import Parameter
+from rclpy.executors import ExternalShutdownException
 from nav_msgs.msg import Odometry
 
 
@@ -17,7 +17,6 @@ class OdomToTum(Node):
             self.set_parameters([Parameter('use_sim_time', Parameter.Type.BOOL, True)])
         self.output = output
         self.count = 0
-        # Open file in append mode, write as we go
         self.f = open(output, 'w')
         self.sub = self.create_subscription(Odometry, topic, self.cb, 10)
         self.get_logger().info(f'Subscribed to {topic}, writing to {output}')
@@ -32,9 +31,10 @@ class OdomToTum(Node):
             self.f.flush()
 
     def close(self):
-        self.f.flush()
-        self.f.close()
-        self.get_logger().info(f'Saved {self.count} poses to {self.output}')
+        if not self.f.closed:
+            self.f.flush()
+            self.f.close()
+            self.get_logger().info(f'Saved {self.count} poses to {self.output}')
 
 
 def main():
@@ -44,26 +44,22 @@ def main():
     ap.add_argument('--use-sim-time', default='true')
     args = ap.parse_args()
 
-    rclpy.init()
+    # Let rclpy install its own SIGINT/SIGTERM handlers — custom signal.signal()
+    # handlers do not interrupt rclpy.spin() because rcl_wait blocks in C and
+    # never yields to Python signal processing.
+    rclpy.init(args=sys.argv)
     node = OdomToTum(args.topic, args.output,
                      args.use_sim_time.lower() in ('true', '1', 'yes'))
-
-    def signal_handler(sig, frame):
-        node.close()
-        node.destroy_node()
-        rclpy.shutdown()
-        sys.exit(0)
-
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
-
     try:
         rclpy.spin(node)
-    except Exception:
+    except KeyboardInterrupt:
         pass
-    node.close()
-    node.destroy_node()
-    rclpy.shutdown()
+    except ExternalShutdownException:
+        pass
+    finally:
+        node.close()
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/scripts/path_to_tum.py
+++ b/scripts/path_to_tum.py
@@ -2,11 +2,11 @@
 """Subscribe to nav_msgs/Path and save the latest path as TUM format."""
 
 import argparse
-import signal
 import sys
 import rclpy
 from rclpy.node import Node
 from rclpy.parameter import Parameter
+from rclpy.executors import ExternalShutdownException
 from nav_msgs.msg import Path
 
 
@@ -21,7 +21,6 @@ class PathToTum(Node):
 
     def cb(self, msg):
         self.get_logger().info(f'Received path with {len(msg.poses)} poses')
-        # Write immediately on each path received (overwrites previous)
         with open(self.output, 'w') as f:
             for ps in msg.poses:
                 t = ps.header.stamp.sec + ps.header.stamp.nanosec * 1e-9
@@ -37,24 +36,23 @@ def main():
     ap.add_argument('--use-sim-time', default='true')
     args = ap.parse_args()
 
-    rclpy.init()
+    # Let rclpy install its own SIGINT/SIGTERM handlers (signal_handler_options
+    # defaults to ALL). Custom signal.signal() handlers do not interrupt
+    # rclpy.spin() because rcl_wait blocks in C and never yields to Python
+    # signal processing — we discovered this when the dogfood wrapper hung
+    # forever on `kill -INT`.
+    rclpy.init(args=sys.argv)
     node = PathToTum(args.topic, args.output,
                      args.use_sim_time.lower() in ('true', '1', 'yes'))
-
-    def signal_handler(sig, frame):
-        node.destroy_node()
-        rclpy.shutdown()
-        sys.exit(0)
-
-    signal.signal(signal.SIGINT, signal_handler)
-    signal.signal(signal.SIGTERM, signal_handler)
-
     try:
         rclpy.spin(node)
-    except Exception:
+    except KeyboardInterrupt:
         pass
-    node.destroy_node()
-    rclpy.shutdown()
+    except ExternalShutdownException:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Remove custom `signal.signal()` handlers in `scripts/path_to_tum.py` and `scripts/odom_to_tum.py`; rely on rclpy's default SIGINT/SIGTERM handlers installed by `rclpy.init(args=sys.argv)`.
- Catch `KeyboardInterrupt` / `ExternalShutdownException` and clean up via `finally` + `rclpy.try_shutdown()`.

## Why
Custom Python signal handlers do not run while `rclpy.spin()` is blocked in `rcl_wait` (C extension). Wrappers that spawned these helpers, then sent `kill -INT`, hung indefinitely on `wait \$PID` — observed in the dogfood pipeline where a `path_to_tum.py` subscriber stayed alive 40+ minutes after `Map outputs saved` and required manual SIGKILL to unblock the wrapper.

## Test plan
- [x] Smoke test `path_to_tum.py --topic /__nonexistent__ --output ...` + `kill -INT` → process exits in <2s
- [x] Smoke test `odom_to_tum.py` with the same pattern → process exits in <2s
- [ ] Re-run a dogfood bench end-to-end and confirm the wrapper now completes the `wait` step without manual intervention