### PR TITLE
feat: dogfood wrapper measurement plumbing — frames, quiescence, /modified_path capture, optional APE

### DIFF
--- a/scripts/run_rko_lio_graph_autoware_dogfood.sh
+++ b/scripts/run_rko_lio_graph_autoware_dogfood.sh
@@ -19,11 +19,26 @@ Options:
   --imu-topic <topic>            IMU topic
   --lidarslam-param <file>       graph_based_slam parameter YAML
   --rko-param <file>             RKO-LIO parameter YAML
+  --base-frame <frame>           Robot base frame passed to RKO-LIO
+  --lidar-frame <frame>          LiDAR frame override
+  --imu-frame <frame>            IMU frame override
   --output-dir <dir>             Directory for SLAM outputs and logs
   --run-name <name>              RKO-LIO run_name
   --save-timeout-secs <sec>      Timeout waiting for saved map files (default: 60)
   --startup-timeout-secs <sec>   Timeout waiting for SLAM node startup (default: 30)
+  --offline-quiet-log-secs <sec> Treat an unchanged launch log after first odom/cloud
+                                 as offline completion after N seconds (default: 0, disabled)
   --wait-for-offline-completion  Wait for the full offline bag run to finish before saving
+  --graph-drain-secs <sec>       After offline completion, wait additional N seconds
+                                 with no launch-log changes before calling /map_save.
+                                 Use this for long bags where graph_based_slam still
+                                 has buffered submaps to process (default: 0, disabled).
+  --capture-corrected-path BOOL  Subscribe to /modified_path during the run and write
+                                 traj_corrected.tum next to the map outputs (default: true).
+  --corrected-path-topic TOPIC   nav_msgs/Path topic to capture (default: /modified_path).
+  --reference-tum <file>         Reference TUM. When provided, ape_from_tum.py runs after
+                                 /map_save and traj_corrected_ape.txt is written under the
+                                 output directory.
   --viewer-run-dir <dir>         Reuse an existing built Autoware map-loader run directory
   --viewer-rebuild               Rebuild the minimal Autoware runtime workspace before viewing
   --auto-exit-secs <sec>         Auto-close RViz after N seconds
@@ -43,6 +58,9 @@ EOF
 DEFAULT_BAG="${REPO_ROOT}/demo_data/ntu_viral/tnp_01_points_restamped_vn100_rosbag2"
 DEFAULT_LIDAR_TOPIC="/os1_cloud_node1/points"
 DEFAULT_IMU_TOPIC="/imu/imu"
+DEFAULT_BASE_FRAME="base_link"
+DEFAULT_LIDAR_FRAME=""
+DEFAULT_IMU_FRAME=""
 DEFAULT_LIDARSLAM_PARAM="${REPO_ROOT}/lidarslam/param/lidarslam.yaml"
 DEFAULT_RKO_PARAM="${REPO_ROOT}/lidarslam/param/rko_lio_ntu_viral.yaml"
 DEFAULT_AUTOWARE_CORE="/tmp/autoware_core"
@@ -51,12 +69,17 @@ DEFAULT_WORK_DIR="/tmp/autoware_map_runtime_ws"
 BAG_PATH="$DEFAULT_BAG"
 LIDAR_TOPIC="$DEFAULT_LIDAR_TOPIC"
 IMU_TOPIC="$DEFAULT_IMU_TOPIC"
+BASE_FRAME="$DEFAULT_BASE_FRAME"
+LIDAR_FRAME="$DEFAULT_LIDAR_FRAME"
+IMU_FRAME="$DEFAULT_IMU_FRAME"
 LIDARSLAM_PARAM="$DEFAULT_LIDARSLAM_PARAM"
 RKO_PARAM="$DEFAULT_RKO_PARAM"
 OUTPUT_DIR=""
 RUN_NAME=""
 SAVE_TIMEOUT_SECS=60
 STARTUP_TIMEOUT_SECS=30
+OFFLINE_QUIET_LOG_SECS=0
+GRAPH_DRAIN_SECS=0
 VIEWER_RUN_DIR=""
 VIEWER_REBUILD=false
 AUTO_EXIT_SECS=""
@@ -65,6 +88,9 @@ WORK_DIR="$DEFAULT_WORK_DIR"
 KEEP_LAUNCH=false
 WAIT_FOR_OFFLINE_COMPLETION=false
 SKIP_VIEWER=false
+CAPTURE_CORRECTED_PATH=true
+CORRECTED_PATH_TOPIC="/modified_path"
+REFERENCE_TUM=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -81,6 +107,21 @@ while [[ $# -gt 0 ]]; do
     --imu-topic)
       [[ $# -ge 2 ]] || usage
       IMU_TOPIC="$2"
+      shift 2
+      ;;
+    --base-frame)
+      [[ $# -ge 2 ]] || usage
+      BASE_FRAME="$2"
+      shift 2
+      ;;
+    --lidar-frame)
+      [[ $# -ge 2 ]] || usage
+      LIDAR_FRAME="$2"
+      shift 2
+      ;;
+    --imu-frame)
+      [[ $# -ge 2 ]] || usage
+      IMU_FRAME="$2"
       shift 2
       ;;
     --lidarslam-param)
@@ -111,6 +152,16 @@ while [[ $# -gt 0 ]]; do
     --startup-timeout-secs)
       [[ $# -ge 2 ]] || usage
       STARTUP_TIMEOUT_SECS="$2"
+      shift 2
+      ;;
+    --offline-quiet-log-secs)
+      [[ $# -ge 2 ]] || usage
+      OFFLINE_QUIET_LOG_SECS="$2"
+      shift 2
+      ;;
+    --graph-drain-secs)
+      [[ $# -ge 2 ]] || usage
+      GRAPH_DRAIN_SECS="$2"
       shift 2
       ;;
     --viewer-run-dir)
@@ -148,6 +199,25 @@ while [[ $# -gt 0 ]]; do
     --skip-viewer)
       SKIP_VIEWER=true
       shift
+      ;;
+    --capture-corrected-path)
+      [[ $# -ge 2 ]] || usage
+      case "${2,,}" in
+        true|1|yes) CAPTURE_CORRECTED_PATH=true ;;
+        false|0|no) CAPTURE_CORRECTED_PATH=false ;;
+        *) echo "--capture-corrected-path expects true/false" >&2; usage ;;
+      esac
+      shift 2
+      ;;
+    --corrected-path-topic)
+      [[ $# -ge 2 ]] || usage
+      CORRECTED_PATH_TOPIC="$2"
+      shift 2
+      ;;
+    --reference-tum)
+      [[ $# -ge 2 ]] || usage
+      REFERENCE_TUM=$(realpath -m "$2")
+      shift 2
       ;;
     --help|-h)
       usage
@@ -211,9 +281,17 @@ mkdir -p "$ROS_LOG_DIR"
 LAUNCH_LOG="${OUTPUT_DIR}/slam.launch.log"
 MAP_SAVE_LOG="${OUTPUT_DIR}/map_save.log"
 RKO_ROS_PARAM_FILE="${OUTPUT_DIR}/rko_params.ros.yaml"
+CORRECTED_TUM="${OUTPUT_DIR}/traj_corrected.tum"
+CORRECTED_LOG="${OUTPUT_DIR}/path_corrected_logger.log"
+CORRECTED_APE_REPORT="${OUTPUT_DIR}/traj_corrected_ape.txt"
+PATH_TO_TUM_SCRIPT="${REPO_ROOT}/scripts/path_to_tum.py"
+APE_FROM_TUM_SCRIPT="${REPO_ROOT}/scripts/ape_from_tum.py"
 LAUNCH_PID=""
 LAUNCH_PGID=""
+CORRECTED_LOGGER_PID=""
 KEEP_RUNNING=0
+
+[[ -n "$REFERENCE_TUM" && ! -f "$REFERENCE_TUM" ]] && { echo "--reference-tum file not found: $REFERENCE_TUM" >&2; exit 1; }
 
 python3 - "$RKO_PARAM" "$RKO_ROS_PARAM_FILE" <<'PY'
 import shutil
@@ -239,6 +317,10 @@ PY
 cleanup() {
   if [[ "$KEEP_RUNNING" -eq 1 ]]; then
     return
+  fi
+  if [[ -n "$CORRECTED_LOGGER_PID" ]]; then
+    kill "$CORRECTED_LOGGER_PID" >/dev/null 2>&1 || true
+    wait "$CORRECTED_LOGGER_PID" 2>/dev/null || true
   fi
   if [[ -n "$LAUNCH_PGID" ]]; then
     kill -- "-${LAUNCH_PGID}" >/dev/null 2>&1 || true
@@ -303,16 +385,56 @@ map_output_snapshot() {
   }
 }
 
+wait_for_graph_drain() {
+  local drain_secs="$1"
+  if (( drain_secs <= 0 )); then
+    return 0
+  fi
+  echo "Waiting for graph_based_slam to drain: ${drain_secs}s without new launch-log activity ..."
+  local last_log_size
+  last_log_size=$(stat -c %s "$LAUNCH_LOG" 2>/dev/null || echo 0)
+  local last_change_secs=$SECONDS
+  local timeout_deadline=$((SECONDS + drain_secs * 4))
+  while (( SECONDS < timeout_deadline )); do
+    local current_log_size
+    current_log_size=$(stat -c %s "$LAUNCH_LOG" 2>/dev/null || echo 0)
+    if [[ "$current_log_size" != "$last_log_size" ]]; then
+      last_log_size="$current_log_size"
+      last_change_secs=$SECONDS
+    elif (( SECONDS - last_change_secs >= drain_secs )); then
+      echo "graph_based_slam log quiet for ${drain_secs}s; proceeding to /map_save."
+      return 0
+    fi
+    if [[ -n "$LAUNCH_PID" ]] && ! kill -0 "$LAUNCH_PID" 2>/dev/null; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Graph drain wait timed out after $((drain_secs * 4))s; proceeding anyway." >&2
+  return 0
+}
+
 wait_for_offline_completion() {
   local timeout_secs="$1"
   local quiet_secs="$2"
   local deadline=$((SECONDS + timeout_secs))
   local last_snapshot=""
   local last_change_secs=$SECONDS
+  local last_log_size=-1
+  local last_log_change_secs=$SECONDS
 
   while (( SECONDS < deadline )); do
     if grep -Fq "RKO LIO Offline Node took" "$LAUNCH_LOG" 2>/dev/null; then
       return 0
+    fi
+
+    if [[ -f "$LAUNCH_LOG" ]]; then
+      local current_log_size
+      current_log_size=$(stat -c %s "$LAUNCH_LOG" 2>/dev/null || echo 0)
+      if [[ "$current_log_size" != "$last_log_size" ]]; then
+        last_log_size="$current_log_size"
+        last_log_change_secs=$SECONDS
+      fi
     fi
 
     if snapshot=$(map_output_snapshot 2>/dev/null); then
@@ -322,6 +444,14 @@ wait_for_offline_completion() {
       elif (( SECONDS - last_change_secs >= quiet_secs )); then
         return 0
       fi
+    fi
+
+    if (( OFFLINE_QUIET_LOG_SECS > 0 )) &&
+      grep -Fq "First cloud received" "$LAUNCH_LOG" 2>/dev/null &&
+      grep -Fq "First odom received" "$LAUNCH_LOG" 2>/dev/null &&
+      (( SECONDS - last_log_change_secs >= OFFLINE_QUIET_LOG_SECS )); then
+      echo "No launch log changes for ${OFFLINE_QUIET_LOG_SECS}s after first odom/cloud; treating offline processing as quiescent."
+      return 0
     fi
 
     if [[ -n "$LAUNCH_PID" ]] && ! kill -0 "$LAUNCH_PID" 2>/dev/null; then
@@ -336,6 +466,9 @@ echo "Running end-to-end dogfood pipeline"
 echo "  bag:            $BAG_PATH"
 echo "  lidar_topic:    $LIDAR_TOPIC"
 echo "  imu_topic:      $IMU_TOPIC"
+echo "  base_frame:     $BASE_FRAME"
+echo "  lidar_frame:    $LIDAR_FRAME"
+echo "  imu_frame:      $IMU_FRAME"
 echo "  lidarslam_yaml: $LIDARSLAM_PARAM"
 echo "  rko_yaml:       $RKO_PARAM"
 echo "  output_dir:     $OUTPUT_DIR"
@@ -349,6 +482,9 @@ if command -v setsid >/dev/null 2>&1; then
     "bag_path:=${BAG_PATH}" \
     "lidar_topic:=${LIDAR_TOPIC}" \
     "imu_topic:=${IMU_TOPIC}" \
+    "base_frame:=${BASE_FRAME}" \
+    "lidar_frame:=${LIDAR_FRAME}" \
+    "imu_frame:=${IMU_FRAME}" \
     "save_dir:=${OUTPUT_DIR}" \
     "results_dir:=${OUTPUT_DIR}" \
     "run_name:=${RUN_NAME}" \
@@ -364,6 +500,9 @@ else
     "bag_path:=${BAG_PATH}" \
     "lidar_topic:=${LIDAR_TOPIC}" \
     "imu_topic:=${IMU_TOPIC}" \
+    "base_frame:=${BASE_FRAME}" \
+    "lidar_frame:=${LIDAR_FRAME}" \
+    "imu_frame:=${IMU_FRAME}" \
     "save_dir:=${OUTPUT_DIR}" \
     "results_dir:=${OUTPUT_DIR}" \
     "run_name:=${RUN_NAME}" \
@@ -389,6 +528,20 @@ fi
 
 echo "SLAM launch is up"
 
+if [[ "$CAPTURE_CORRECTED_PATH" == "true" ]]; then
+  if [[ ! -f "$PATH_TO_TUM_SCRIPT" ]]; then
+    echo "Warning: $PATH_TO_TUM_SCRIPT not found; skipping /modified_path capture." >&2
+  else
+    echo "Capturing $CORRECTED_PATH_TOPIC -> $CORRECTED_TUM"
+    python3 "$PATH_TO_TUM_SCRIPT" \
+      --topic "$CORRECTED_PATH_TOPIC" \
+      --output "$CORRECTED_TUM" \
+      --use-sim-time false \
+      >"$CORRECTED_LOG" 2>&1 &
+    CORRECTED_LOGGER_PID="$!"
+  fi
+fi
+
 if [[ "$WAIT_FOR_OFFLINE_COMPLETION" == "true" ]]; then
   echo "Waiting for offline bag playback to finish ..."
   if ! wait_for_offline_completion 900 15; then
@@ -405,6 +558,7 @@ else
   fi
 fi
 
+wait_for_graph_drain "$GRAPH_DRAIN_SECS"
 sleep 3
 echo "Calling /map_save ..."
 if ! call_map_save_with_retry; then
@@ -425,6 +579,49 @@ if ! wait_for_map_outputs "$SAVE_TIMEOUT_SECS"; then
 fi
 
 echo "Map outputs saved under $OUTPUT_DIR"
+
+if [[ -n "$CORRECTED_LOGGER_PID" ]]; then
+  # Give graph_based_slam a moment to publish its final /modified_path.
+  sleep 3
+  kill -INT "$CORRECTED_LOGGER_PID" >/dev/null 2>&1 || true
+  # SIGKILL fallback: older path_to_tum.py versions had a custom signal
+  # handler that masked rclpy's default and wedged rcl_wait in C, so the
+  # wait below would hang indefinitely. The current path_to_tum.py is
+  # fixed (it lets rclpy install its own handler), but keep this guard in
+  # case an old copy is on PATH or the script is reused elsewhere.
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    kill -0 "$CORRECTED_LOGGER_PID" 2>/dev/null || break
+    sleep 1
+  done
+  if kill -0 "$CORRECTED_LOGGER_PID" 2>/dev/null; then
+    echo "Warning: path_to_tum did not exit on SIGINT, sending SIGKILL." >&2
+    kill -KILL "$CORRECTED_LOGGER_PID" >/dev/null 2>&1 || true
+  fi
+  wait "$CORRECTED_LOGGER_PID" 2>/dev/null || true
+  CORRECTED_LOGGER_PID=""
+  if [[ -f "$CORRECTED_TUM" ]]; then
+    echo "Corrected trajectory written: $CORRECTED_TUM ($(wc -l < "$CORRECTED_TUM") poses)"
+  else
+    echo "Warning: $CORRECTED_TUM was not produced (no /modified_path messages?)." >&2
+  fi
+fi
+
+if [[ -n "$REFERENCE_TUM" && -f "$CORRECTED_TUM" ]]; then
+  if [[ -f "$APE_FROM_TUM_SCRIPT" ]]; then
+    echo "Computing APE vs $REFERENCE_TUM ..."
+    if python3 "$APE_FROM_TUM_SCRIPT" \
+        --ref "$REFERENCE_TUM" \
+        --est "$CORRECTED_TUM" \
+        --out "$CORRECTED_APE_REPORT"; then
+      echo "APE report: $CORRECTED_APE_REPORT"
+      grep -E '^(rmse|mean|median|max|pairs):' "$CORRECTED_APE_REPORT" || true
+    else
+      echo "Warning: ape_from_tum.py failed (insufficient pairs?)." >&2
+    fi
+  else
+    echo "Warning: $APE_FROM_TUM_SCRIPT not found; skipping APE." >&2
+  fi
+fi
 
 if [[ "$KEEP_LAUNCH" == "false" ]]; then
   if [[ -n "$LAUNCH_PGID" ]]; then


### PR DESCRIPTION
## Summary
- Add frame override flags (`--base-frame`, `--lidar-frame`, `--imu-frame`) so the wrapper can run on robots whose frames don't match the launch defaults.
- Add quiescence-based offline completion (`--offline-quiet-log-secs`) and a graph-drain wait (`--graph-drain-secs`) for long bags where `/map_save` would otherwise fire before graph_based_slam has finished consuming buffered submaps.
- Add `/modified_path` → `traj_corrected.tum` capture during the run (`--capture-corrected-path`, `--corrected-path-topic`) and optional APE-vs-reference computation (`--reference-tum FILE` → `traj_corrected_ape.txt`).
- Reap the path_to_tum subprocess from `cleanup()` on early exit. The structured kill block uses SIGINT first and falls back to SIGKILL after 10s as a guard.

## Why
The wrapper previously only produced map outputs — there was no corrected-trajectory artifact and no absolute ATE comparable to the bench wrapper. Producing those in the same run is what the loop-alignment analyzer + dashboard integration consume, so getting them in one shot avoids manual `path_to_tum` + `ape_from_tum.py` reruns after each dogfood.

## Test plan
- [x] Smoke-run on driving_slam_mid360 with `--capture-corrected-path --reference-tum glim_mid360_reference.tum`: wrapper completes end-to-end and emits both `traj_corrected.tum` (599 poses) and `traj_corrected_ape.txt` (6.31m RMSE).
- [x] Verify the SIGKILL fallback fires when path_to_tum doesn't exit on SIGINT (the original bug, since fixed in #165 — kept as a guard).
- [ ] CI green on humble + jazzy.