### PR TITLE
feat: MID-360 session dashboard + production-candidate bundle (loop_alignment integration)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -209,6 +209,16 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_mid360_robot_dashboard
+    test/test_mid360_robot_dashboard.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
+    test_mid360_robot_production_candidate_bundle
+    test/test_mid360_robot_production_candidate_bundle.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_navsatfix_covariance_inspector
     test/test_navsatfix_covariance_inspector.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_mid360_robot_dashboard.py
+++ b/graph_based_slam/test/test_mid360_robot_dashboard.py
@@ -1,0 +1,378 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the MID-360 robot session dashboard."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / 'scripts' / 'generate_mid360_robot_session_dashboard.py'
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding='utf-8')
+
+
+def _write_dashboard_fixture(output_dir: Path) -> None:
+    output_dir.mkdir()
+    _write_json(
+        output_dir / 'mid360_robot_field_session.json',
+        {
+            'status': 'PASS',
+            'run_id': 'stand_01',
+            'created_at': '2026-05-21T00:00:00+00:00',
+            'bag_path': '/bags/stand_01',
+            'output_dir': str(output_dir),
+            'steps': [
+                {
+                    'id': 'recording',
+                    'status': 'ok',
+                    'message': 'Recording completed.',
+                    'command': ['ros2', 'bag', 'record', '/livox/lidar'],
+                },
+                {
+                    'id': 'map',
+                    'status': 'planned',
+                    'message': 'Map dry-run planned.',
+                    'command': ['bash', 'scripts/run_mid360_robot_map.sh'],
+                },
+            ],
+        },
+    )
+    _write_json(
+        output_dir / 'mid360_robot_recording_check.json',
+        {
+            'status': 'PASS',
+            'checks': [
+                {'id': 'metadata_yaml', 'status': 'ok', 'message': 'metadata.yaml exists'},
+            ],
+        },
+    )
+    _write_json(
+        output_dir / 'mid360_robot_readiness.json',
+        {
+            'status': 'PASS',
+            'selected_topics': {'pointcloud': '/livox/lidar', 'imu': '/livox/imu'},
+            'frames': {
+                'base_frame': 'base_link',
+                'lidar_frame': 'livox_frame',
+                'imu_frame': 'livox_frame',
+            },
+            'bag_diagnostics': {
+                'topics': {
+                    'pointcloud': {'metadata_rate_hz': 10.0},
+                    'imu': {'metadata_rate_hz': 100.0},
+                }
+            },
+            'checks': [
+                {'id': 'pointcloud2', 'status': 'ok', 'message': 'PointCloud2 topic'},
+            ],
+        },
+    )
+    _write_json(
+        output_dir / 'mid360_robot_run_plan.json',
+        {
+            'status': 'PASS',
+            'dogfood_command_shell': 'bash scripts/run_rko_lio_graph_autoware_dogfood.sh',
+        },
+    )
+
+
+def test_dashboard_cli_generates_static_html(tmp_path: Path):
+    output_dir = tmp_path / 'session'
+    _write_dashboard_fixture(output_dir)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(output_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    html_path = output_dir / 'mid360_robot_session_dashboard.html'
+    html = html_path.read_text(encoding='utf-8')
+
+    assert 'MID-360 session dashboard:' in result.stdout
+    assert html_path.is_file()
+    assert 'MID-360 Robot Session' in html
+    assert 'Route Sketch' in html
+    assert 'Record Bag' in html
+    assert 'Post Check' in html
+    assert 'Map Dry-Run' in html
+    assert 'Map Run' in html
+    assert 'route-node ok' in html
+    assert 'route-node planned' in html
+    assert 'stand_01' in html
+    assert '/livox/lidar' in html
+    assert '10.00 Hz' in html
+    assert 'metadata_yaml' in html
+    assert 'bash scripts/run_rko_lio_graph_autoware_dogfood.sh' in html
+
+
+def test_dashboard_marks_missing_artifacts(tmp_path: Path):
+    output_dir = tmp_path / 'session'
+    output_dir.mkdir()
+    _write_json(
+        output_dir / 'mid360_robot_field_session.json',
+        {'status': 'PASS', 'run_id': 'missing_case', 'steps': []},
+    )
+
+    subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(output_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    html = (output_dir / 'mid360_robot_session_dashboard.html').read_text(encoding='utf-8')
+
+    assert 'MISSING' in html
+    assert 'route-node missing' in html
+    assert 'mid360_robot_readiness.json' in html
+    assert 'Create missing artifacts' in html
+
+
+def test_dashboard_prefers_production_candidate_session(tmp_path: Path):
+    output_dir = tmp_path / 'session'
+    output_dir.mkdir()
+    public_gate_dir = output_dir / 'public_rko_adoption_gate'
+    _write_json(
+        output_dir / 'mid360_robot_field_session.json',
+        {
+            'status': 'PASS',
+            'run_id': 'field_ignored',
+            'bag_path': '/bags/field_ignored',
+            'steps': [],
+        },
+    )
+    _write_json(
+        output_dir / 'mid360_robot_production_candidate_session.json',
+        {
+            'status': 'PASS',
+            'run_id': 'production_candidate_01',
+            'created_at': '2026-05-22T00:00:00+00:00',
+            'bag_path': '/bags/production_candidate_01',
+            'artifact_paths': {
+                'map_diagnosis_json': str(output_dir / 'autoware_map_diagnosis.json'),
+                'public_rko_adoption_gate_json': str(  # noqa: E501
+                    public_gate_dir / 'mid360_robot_public_rko_adoption_gate.json',
+                ),
+                'production_readiness_json': str(
+                    output_dir / 'mid360_robot_production_readiness.json',
+                ),
+            },
+            'steps': [
+                {
+                    'id': 'host_readiness',
+                    'status': 'ok',
+                    'message': 'Host readiness completed.',
+                    'command': ['python3', 'scripts/check_jetson_mid360_host_readiness.py'],
+                },
+                {
+                    'id': 'recording',
+                    'status': 'ok',
+                    'message': 'Recording completed.',
+                    'command': ['bash', 'scripts/record_mid360_robot_bag.sh'],
+                },
+                {
+                    'id': 'map',
+                    'status': 'ok',
+                    'message': 'Mapping completed.',
+                    'command': ['bash', 'scripts/run_mid360_robot_map.sh'],
+                },
+                {
+                    'id': 'public_rko_adoption_gate',
+                    'status': 'ok',
+                    'message': 'Public RKO adoption gate completed.',
+                    'command': ['python3', 'scripts/run_mid360_robot_public_rko_adoption_gate.py'],
+                },
+                {
+                    'id': 'production_readiness',
+                    'status': 'fail',
+                    'message': 'Production readiness failed.',
+                    'command': ['python3', 'scripts/check_mid360_robot_production_readiness.py'],
+                },
+            ],
+        },
+    )
+    _write_json(
+        output_dir / 'mid360_robot_recording_check.json',
+        {
+            'status': 'PASS',
+            'checks': [{'id': 'readiness_status', 'status': 'ok', 'message': 'passed'}],
+        },
+    )
+    _write_json(
+        output_dir / 'mid360_robot_readiness.json',
+        {
+            'status': 'PASS',
+            'selected_topics': {'pointcloud': '/livox/lidar', 'imu': '/livox/imu'},
+            'frames': {
+                'base_frame': 'base_link',
+                'lidar_frame': 'livox_frame',
+                'imu_frame': 'livox_frame',
+            },
+            'bag_diagnostics': {
+                'topics': {
+                    'pointcloud': {'metadata_rate_hz': 10.0},
+                    'imu': {'metadata_rate_hz': 100.0},
+                }
+            },
+            'checks': [{'id': 'pointcloud2', 'status': 'ok', 'message': 'PointCloud2 topic'}],
+        },
+    )
+    _write_json(output_dir / 'mid360_robot_run_plan.json', {'status': 'PASS'})
+    _write_json(
+        output_dir / 'autoware_map_diagnosis.json',
+        {'status': 'success', 'verify': {'result': 'PASS'}},
+    )
+    _write_json(
+        public_gate_dir / 'mid360_robot_public_rko_adoption_gate.json',
+        {
+            'status': 'PASS',
+            'checks': [{'id': 'matched_config', 'status': 'PASS', 'message': 'matched'}],
+        },
+    )
+    _write_json(
+        output_dir / 'mid360_robot_production_readiness.json',
+        {
+            'status': 'FAIL',
+            'checks': [{'id': 'bag_duration', 'status': 'FAIL', 'message': 'too short'}],
+            'next_actions': ['Record a longer production candidate bag.'],
+        },
+    )
+
+    subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(output_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    html = (output_dir / 'mid360_robot_session_dashboard.html').read_text(encoding='utf-8')
+
+    assert 'MID-360 Robot Production Candidate' in html
+    assert 'production_candidate_01' in html
+    assert 'field_ignored' not in html
+    assert 'Host Check' in html
+    assert 'Public Gate' in html
+    assert 'Prod Gate' in html
+    assert 'mid360_robot_public_rko_adoption_gate.json' in html
+    assert 'mid360_robot_production_readiness.json' in html
+    assert 'bag_duration' in html
+    assert 'Record a longer production candidate bag.' in html
+    assert 'route-node fail' in html
+
+
+def test_dashboard_renders_loop_alignment_section(tmp_path: Path):
+    output_dir = tmp_path / 'session'
+    _write_dashboard_fixture(output_dir)
+    _write_json(
+        output_dir / 'mid360_robot_loop_alignment.json',
+        {
+            'status': 'WARN',
+            'trajectory': {
+                'poses': 581,
+                'path_length_m': 1086.3,
+                'duration_sec': 277.4,
+            },
+            'cloud': {
+                'sampled_points': 104830,
+                'tile_count': 368,
+            },
+            'nearest_revisit': {'distance_m': 4.25},
+            'loop_candidates': [{'distance_m': 4.25}, {'distance_m': 4.30}, {'distance_m': 4.35}],
+            'local_cloud_checks': [
+                {'status': 'PASS', 'largest_component_ratio': 0.72},
+                {'status': 'FAIL', 'largest_component_ratio': 0.55},
+                {'status': 'PASS', 'largest_component_ratio': 0.81},
+            ],
+            'thresholds': {
+                'max_loop_distance_m': 5.0,
+                'min_largest_component_ratio': 0.6,
+            },
+            'checks': [
+                {
+                    'id': 'loop_alignment_local_cloud',
+                    'status': 'WARN',
+                    'message': 'mixed connectivity',
+                },
+            ],
+            'next_actions': ['Inspect the local loop cloud in CloudCompare.'],
+        },
+    )
+
+    subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(output_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    html = (output_dir / 'mid360_robot_session_dashboard.html').read_text(encoding='utf-8')
+
+    assert 'Loop Alignment' in html
+    assert 'Nearest revisit' in html
+    # nearest_revisit_m=4.25 rendered with threshold annotation
+    assert '4.25 m (≤ 5.0 m)' in html
+    # best ratio is max of [0.72, 0.55, 0.81] = 0.810, with threshold annotation
+    assert '0.810 (≥ 0.60)' in html
+    # local cloud check summary "2 PASS / 1 FAIL / 3 total"
+    assert '2 PASS / 1 FAIL / 3 total' in html
+    # loop_alignment check propagated into Checks table
+    assert 'loop_alignment_local_cloud' in html
+    # mixed connectivity message present
+    assert 'mixed connectivity' in html
+    # next_actions surfaced
+    assert 'Inspect the local loop cloud in CloudCompare.' in html
+
+
+def test_dashboard_omits_loop_alignment_when_absent(tmp_path: Path):
+    output_dir = tmp_path / 'session'
+    _write_dashboard_fixture(output_dir)
+
+    subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(output_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    html = (output_dir / 'mid360_robot_session_dashboard.html').read_text(encoding='utf-8')
+
+    # Section header is always present, but the placeholder fires when no artifact
+    assert 'Loop Alignment' in html
+    assert 'No loop alignment analyzer artifact found.' in html

--- a/graph_based_slam/test/test_mid360_robot_production_candidate_bundle.py
+++ b/graph_based_slam/test/test_mid360_robot_production_candidate_bundle.py
@@ -1,0 +1,279 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for MID-360 production-candidate artifact bundle export."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / 'scripts' / 'export_mid360_robot_production_candidate_bundle.py'
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding='utf-8')
+
+
+def _write_text(path: Path, text: str = 'ok\n') -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding='utf-8')
+
+
+def _write_candidate_artifacts(
+    root: Path,
+    bag_root: Path,
+    *,
+    omit_map_diagnosis: bool = False,
+) -> None:
+    run_id = 'production_candidate_01'
+    profile = bag_root / f'{run_id}_profile.yaml'
+    record_plan_json = bag_root / f'{run_id}_record_plan.json'
+    record_plan_md = bag_root / f'{run_id}_record_plan.md'
+    _write_text(profile, 'robot_name: production_robot\n')
+    _write_json(record_plan_json, {'run_id': run_id, 'bag_path': str(bag_root / run_id)})
+    _write_text(record_plan_md, '# Record Plan\n')
+
+    artifact_paths = {
+        'profile_snapshot': str(profile),
+        'record_plan_json': str(record_plan_json),
+        'record_plan_markdown': str(record_plan_md),
+        'host_readiness_json': str(root / 'jetson_mid360_host_readiness.json'),
+        'recording_check_json': str(root / 'mid360_robot_recording_check.json'),
+        'readiness_json': str(root / 'mid360_robot_readiness.json'),
+        'map_plan_json': str(root / 'mid360_robot_run_plan.json'),
+        'map_diagnosis_json': str(root / 'autoware_map_diagnosis.json'),
+        'public_rko_adoption_gate_json': str(
+            root / 'public_rko_adoption_gate' / 'mid360_robot_public_rko_adoption_gate.json',
+        ),
+        'production_readiness_json': str(root / 'mid360_robot_production_readiness.json'),
+        'dashboard_html': str(root / 'mid360_robot_session_dashboard.html'),
+    }
+    _write_json(
+        root / 'mid360_robot_production_candidate_session.json',
+        {
+            'status': 'PASS',
+            'run_id': run_id,
+            'bag_root': str(bag_root),
+            'bag_path': str(bag_root / run_id),
+            'profile_snapshot_path': str(profile),
+            'record_plan_json_path': str(record_plan_json),
+            'record_plan_markdown_path': str(record_plan_md),
+            'artifact_paths': artifact_paths,
+            'thresholds': {'min_bag_duration_sec': 600.0},
+        },
+    )
+    _write_text(root / 'mid360_robot_production_candidate_session.md', '# Candidate\n')
+    _write_json(root / 'jetson_mid360_host_readiness.json', {'status': 'PASS'})
+    _write_json(root / 'mid360_robot_recording_check.json', {'status': 'PASS'})
+    _write_json(root / 'mid360_robot_readiness.json', {'status': 'PASS'})
+    _write_json(root / 'mid360_robot_run_plan.json', {'status': 'PASS'})
+    if not omit_map_diagnosis:
+        _write_json(
+            root / 'autoware_map_diagnosis.json',
+            {'status': 'success', 'verify': {'result': 'PASS'}},
+        )
+    _write_json(
+        root / 'public_rko_adoption_gate' / 'mid360_robot_public_rko_adoption_gate.json',
+        {'status': 'PASS'},
+    )
+    _write_json(root / 'mid360_robot_production_readiness.json', {'status': 'PASS'})
+    _write_text(root / 'mid360_robot_session_dashboard.html', '<html>dashboard</html>\n')
+
+
+def test_export_bundle_writes_manifest_and_tarball(tmp_path: Path):
+    artifact_dir = tmp_path / 'out'
+    bag_root = tmp_path / 'bags'
+    _write_candidate_artifacts(artifact_dir, bag_root)
+    tarball = tmp_path / 'production_candidate_01.tar.gz'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            str(artifact_dir),
+            '--output',
+            str(tarball),
+            '--label',
+            'candidate_bundle',
+            '--verify',
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    manifest = json.loads(result.stdout)
+
+    assert manifest['status'] == 'PASS'
+    assert manifest['bundle_label'] == 'candidate_bundle'
+    assert manifest['tarball_verified'] is True
+    assert tarball.is_file()
+    bundle_json = (
+        tmp_path / 'production_candidate_01' / 'mid360_robot_production_candidate_bundle.json'
+    )
+    assert bundle_json.is_file()
+    assert 'artifacts/autoware_map_diagnosis.json' in manifest['required_files']
+    assert 'recording/production_candidate_01_profile.yaml' in manifest['required_files']
+    assert '--from-existing-artifacts' in manifest['recheck_command']
+
+    with tarfile.open(tarball, 'r:gz') as archive:
+        names = set(archive.getnames())
+    root = 'production_candidate_01'
+    assert f'{root}/mid360_robot_production_candidate_bundle.json' in names
+    assert f'{root}/artifacts/mid360_robot_production_candidate_session.json' in names
+    assert (
+        f'{root}/artifacts/public_rko_adoption_gate/'
+        'mid360_robot_public_rko_adoption_gate.json'
+    ) in names
+    assert f'{root}/recording/production_candidate_01_profile.yaml' in names
+
+
+def test_export_bundle_includes_optional_loop_alignment_when_present(tmp_path: Path):
+    artifact_dir = tmp_path / 'out'
+    bag_root = tmp_path / 'bags'
+    _write_candidate_artifacts(artifact_dir, bag_root)
+    _write_json(
+        artifact_dir / 'mid360_robot_loop_alignment.json',
+        {
+            'status': 'WARN',
+            'trajectory': {'poses': 500},
+            'nearest_revisit': {'distance_m': 4.0},
+            'loop_candidates': [],
+            'local_cloud_checks': [],
+            'checks': [],
+        },
+    )
+    _write_text(artifact_dir / 'mid360_robot_loop_alignment.md', '# Loop\n')
+
+    tarball = tmp_path / 'production_candidate_01.tar.gz'
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            str(artifact_dir),
+            '--output',
+            str(tarball),
+            '--verify',
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    manifest = json.loads(result.stdout)
+
+    # Loop alignment is optional but should be staged when present.
+    assert manifest['status'] == 'PASS'
+    assert manifest['tarball_verified'] is True
+    included_dests = {item['destination'] for item in manifest['included']}
+    assert 'artifacts/mid360_robot_loop_alignment.json' in included_dests
+    assert 'artifacts/mid360_robot_loop_alignment.md' in included_dests
+    # Optional artifacts must NOT appear in required_files so a missing analyzer
+    # cannot fail verify on its own.
+    assert 'artifacts/mid360_robot_loop_alignment.json' not in manifest['required_files']
+
+    with tarfile.open(tarball, 'r:gz') as archive:
+        names = set(archive.getnames())
+    root = 'production_candidate_01'
+    assert f'{root}/artifacts/mid360_robot_loop_alignment.json' in names
+    assert f'{root}/artifacts/mid360_robot_loop_alignment.md' in names
+
+
+def test_export_bundle_skips_loop_alignment_when_absent(tmp_path: Path):
+    artifact_dir = tmp_path / 'out'
+    bag_root = tmp_path / 'bags'
+    _write_candidate_artifacts(artifact_dir, bag_root)
+    tarball = tmp_path / 'production_candidate_01.tar.gz'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            str(artifact_dir),
+            '--output',
+            str(tarball),
+            '--verify',
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    manifest = json.loads(result.stdout)
+
+    # No loop_alignment present -> still PASS (optional artifact)
+    assert manifest['status'] == 'PASS'
+    assert manifest['tarball_verified'] is True
+    included_dests = {item['destination'] for item in manifest['included']}
+    assert 'artifacts/mid360_robot_loop_alignment.json' not in included_dests
+    # Not in missing_required either (because it's not required)
+    missing_dests = {item['destination'] for item in manifest['missing_required']}
+    assert 'artifacts/mid360_robot_loop_alignment.json' not in missing_dests
+
+
+def test_export_bundle_verify_fails_when_required_artifact_missing(tmp_path: Path):
+    artifact_dir = tmp_path / 'out'
+    bag_root = tmp_path / 'bags'
+    _write_candidate_artifacts(artifact_dir, bag_root, omit_map_diagnosis=True)
+    tarball = tmp_path / 'missing_map.tar.gz'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            str(artifact_dir),
+            '--output',
+            str(tarball),
+            '--verify',
+            '--json',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    manifest = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert manifest['status'] == 'FAIL'
+    assert any(
+        item['destination'] == 'artifacts/autoware_map_diagnosis.json'
+        for item in manifest['missing_required']
+    )
+    assert tarball.is_file()

--- a/scripts/export_mid360_robot_production_candidate_bundle.py
+++ b/scripts/export_mid360_robot_production_candidate_bundle.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Export a portable MID-360 production-candidate artifact bundle."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from mid360_robot_production_candidate_bundle import (
+    BUNDLE_MANIFEST_JSON,
+    BUNDLE_MANIFEST_MARKDOWN,
+    BundleOptions,
+    Mid360ProductionCandidateBundleExporter,
+    render_bundle_markdown,
+    verify_bundle_manifest,
+)
+from mid360_robot_tools import payload_to_json
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description='Export MID-360 production-candidate artifacts as a tar.gz bundle.'
+    )
+    parser.add_argument(
+        'artifact_dir',
+        help='Directory containing production-candidate session artifacts.',
+    )
+    parser.add_argument(
+        '--output',
+        default='',
+        help='Output .tar.gz path or staging directory. Defaults next to artifact_dir.',
+    )
+    parser.add_argument('--label', default='', help='Bundle label stored in the manifest.')
+    parser.add_argument('--verify', action='store_true', help='Fail if required bundle artifacts are missing.')
+    parser.add_argument('--force', action='store_true', help='Overwrite an existing bundle dir/tarball.')
+    parser.add_argument('--json', action='store_true', help='Print machine-readable bundle manifest JSON.')
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point."""
+    args = parse_args()
+    try:
+        manifest = Mid360ProductionCandidateBundleExporter().export(
+            BundleOptions(
+                artifact_dir=Path(args.artifact_dir),
+                output_path=Path(args.output) if args.output else None,
+                label=args.label,
+                force=args.force,
+            )
+        )
+    except Exception as exc:
+        print(f'failed to export MID-360 production-candidate bundle: {exc}', file=sys.stderr)
+        return 1
+
+    ok, errors = verify_bundle_manifest(manifest)
+    if args.json:
+        print(payload_to_json(manifest))
+    else:
+        print(render_bundle_markdown(manifest))
+        print(f'{BUNDLE_MANIFEST_JSON}: {Path(manifest["bundle_dir"]) / BUNDLE_MANIFEST_JSON}')
+        print(f'{BUNDLE_MANIFEST_MARKDOWN}: {Path(manifest["bundle_dir"]) / BUNDLE_MANIFEST_MARKDOWN}')
+        if manifest.get('tarball_path'):
+            print(f'Tarball: {manifest["tarball_path"]}')
+        if errors:
+            print('Bundle verification errors:', file=sys.stderr)
+            for error in errors:
+                print(f'- {error}', file=sys.stderr)
+
+    if args.verify and not ok:
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print('Interrupted', file=sys.stderr)
+        raise SystemExit(130)

--- a/scripts/generate_mid360_robot_session_dashboard.py
+++ b/scripts/generate_mid360_robot_session_dashboard.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Generate a static HTML dashboard for MID-360 robot session artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from mid360_robot_dashboard import DASHBOARD_HTML, write_dashboard
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Generate a MID-360 robot session HTML dashboard.'
+    )
+    parser.add_argument('output_dir', help='Directory containing MID-360 robot session JSON artifacts.')
+    parser.add_argument(
+        '--output',
+        help=f'HTML output path. Defaults to <output_dir>/{DASHBOARD_HTML}.',
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve() if args.output else None
+    path = write_dashboard(output_dir, output_path)
+    print(f'MID-360 session dashboard: {path}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/mid360_robot_dashboard.py
+++ b/scripts/mid360_robot_dashboard.py
@@ -1,0 +1,903 @@
+#!/usr/bin/env python3
+"""Static HTML dashboard for MID-360 robot session artifacts."""
+
+from __future__ import annotations
+
+import html
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DASHBOARD_HTML = 'mid360_robot_session_dashboard.html'
+
+ARTIFACTS = (
+    ('production_candidate_session', 'mid360_robot_production_candidate_session.json'),
+    ('field_session', 'mid360_robot_field_session.json'),
+    ('host_readiness', 'jetson_mid360_host_readiness.json'),
+    ('recording_check', 'mid360_robot_recording_check.json'),
+    ('readiness', 'mid360_robot_readiness.json'),
+    ('map_plan', 'mid360_robot_run_plan.json'),
+    ('diagnosis', 'autoware_map_diagnosis.json'),
+    ('public_rko_adoption_gate', 'public_rko_adoption_gate/mid360_robot_public_rko_adoption_gate.json'),
+    ('production_readiness', 'mid360_robot_production_readiness.json'),
+    ('loop_alignment', 'mid360_robot_loop_alignment.json'),
+)
+
+
+@dataclass(frozen=True)
+class DashboardArtifact:
+    """A loaded or missing session artifact."""
+
+    key: str
+    filename: str
+    path: Path
+    exists: bool
+    data: dict[str, Any]
+    error: str = ''
+
+
+def build_dashboard_payload(output_dir: Path) -> dict[str, Any]:
+    """Load known session artifacts from an output directory."""
+    artifacts = [_load_artifact(output_dir, key, filename) for key, filename in ARTIFACTS]
+    by_key = {artifact.key: artifact for artifact in artifacts}
+    session_artifact = _session_artifact(by_key)
+    artifacts = _load_dynamic_session_artifacts(output_dir, artifacts, session_artifact.data)
+    by_key = {artifact.key: artifact for artifact in artifacts}
+    session_artifact = _session_artifact(by_key)
+    session = session_artifact.data
+    readiness = by_key['readiness'].data
+    recording_check = by_key['recording_check'].data
+
+    return {
+        'output_dir': str(output_dir),
+        'overall_status': _overall_status(artifacts),
+        'session_kind': session_artifact.key,
+        'session_label': _session_label(session_artifact.key),
+        'run_id': session.get('run_id', ''),
+        'bag_path': session.get('bag_path') or readiness.get('bag_path') or recording_check.get('bag_path', ''),
+        'created_at': session.get('created_at') or readiness.get('created_at') or '',
+        'artifacts': artifacts,
+        'steps': session.get('steps', []),
+        'checks': _collect_checks(by_key),
+        'topics': readiness.get('selected_topics', {}),
+        'frames': readiness.get('frames', {}),
+        'rates': _topic_rates(readiness),
+        'commands': _commands(by_key),
+        'next_action': _next_action(artifacts, session_artifact),
+        'loop_alignment': _loop_alignment_summary(by_key['loop_alignment']),
+    }
+
+
+def write_dashboard(output_dir: Path, output_path: Path | None = None) -> Path:
+    """Render and write the dashboard HTML."""
+    output_dir = output_dir.resolve()
+    output_path = output_path or (output_dir / DASHBOARD_HTML)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = build_dashboard_payload(output_dir)
+    output_path.write_text(render_dashboard(payload), encoding='utf-8')
+    return output_path
+
+
+def render_dashboard(payload: dict[str, Any]) -> str:
+    """Render a self-contained dashboard."""
+    status = str(payload['overall_status'])
+    return '\n'.join([
+        '<!doctype html>',
+        '<html lang="en">',
+        '<head>',
+        '<meta charset="utf-8">',
+        '<meta name="viewport" content="width=device-width, initial-scale=1">',
+        '<title>MID-360 Robot Session Dashboard</title>',
+        '<style>',
+        _css(),
+        '</style>',
+        '</head>',
+        '<body>',
+        '<main>',
+        '<section class="summary">',
+        '<div>',
+        f'<p class="eyebrow">{_h(payload.get("session_label") or "MID-360 Robot Session")}</p>',
+        f'<h1>{_h(payload.get("run_id") or "Session")}</h1>',
+        f'<p class="path">{_h(payload.get("bag_path") or "bag path unavailable")}</p>',
+        '</div>',
+        f'<div class="status {status.lower()}">{_h(status)}</div>',
+        '</section>',
+        '<section class="grid metrics">',
+        _metric_card('Output', payload.get('output_dir', '')),
+        _metric_card('Created', payload.get('created_at', '')),
+        _metric_card('Next Action', payload.get('next_action', '')),
+        '</section>',
+        '<section>',
+        '<h2>Workflow</h2>',
+        _timeline(payload.get('steps', [])),
+        '</section>',
+        '<section>',
+        '<h2>Route Sketch</h2>',
+        _route_sketch(payload),
+        '</section>',
+        '<section class="grid two">',
+        '<div>',
+        '<h2>Artifacts</h2>',
+        _artifact_table(payload.get('artifacts', [])),
+        '</div>',
+        '<div>',
+        '<h2>Topics And Frames</h2>',
+        _topics_panel(payload),
+        '</div>',
+        '</section>',
+        '<section>',
+        '<h2>Loop Alignment</h2>',
+        _loop_alignment_panel(payload.get('loop_alignment', {})),
+        '</section>',
+        '<section>',
+        '<h2>Checks</h2>',
+        _checks_table(payload.get('checks', [])),
+        '</section>',
+        '<section>',
+        '<h2>Commands</h2>',
+        _commands_panel(payload.get('commands', [])),
+        '</section>',
+        '</main>',
+        '</body>',
+        '</html>',
+    ])
+
+
+def _load_artifact(output_dir: Path, key: str, filename: str) -> DashboardArtifact:
+    path = output_dir / filename
+    return _load_artifact_path(key, filename, path)
+
+
+def _load_artifact_path(key: str, filename: str, path: Path) -> DashboardArtifact:
+    if not path.is_file():
+        return DashboardArtifact(key, filename, path, False, {})
+    try:
+        data = json.loads(path.read_text(encoding='utf-8'))
+    except Exception as exc:
+        return DashboardArtifact(key, filename, path, True, {}, str(exc))
+    return DashboardArtifact(key, filename, path, True, data)
+
+
+def _session_artifact(by_key: dict[str, DashboardArtifact]) -> DashboardArtifact:
+    production_candidate = by_key.get('production_candidate_session')
+    if production_candidate and production_candidate.data:
+        return production_candidate
+    return by_key['field_session']
+
+
+def _session_label(session_key: str) -> str:
+    if session_key == 'production_candidate_session':
+        return 'MID-360 Robot Production Candidate'
+    return 'MID-360 Robot Field Session'
+
+
+def _load_dynamic_session_artifacts(
+    output_dir: Path,
+    artifacts: list[DashboardArtifact],
+    session: dict[str, Any],
+) -> list[DashboardArtifact]:
+    artifact_paths = session.get('artifact_paths') or {}
+    dynamic_paths = {
+        'diagnosis': artifact_paths.get('map_diagnosis_json'),
+        'public_rko_adoption_gate': artifact_paths.get('public_rko_adoption_gate_json'),
+        'production_readiness': artifact_paths.get('production_readiness_json'),
+    }
+    replacements = {}
+    for key, path_text in dynamic_paths.items():
+        if not path_text:
+            continue
+        path = Path(str(path_text)).expanduser()
+        if not path.is_absolute():
+            path = output_dir / path
+        replacements[key] = _load_artifact_path(key, path.name, path.resolve())
+    if not replacements:
+        return artifacts
+    return [replacements.get(artifact.key, artifact) for artifact in artifacts]
+
+
+def _overall_status(artifacts: list[DashboardArtifact]) -> str:
+    statuses = []
+    for artifact in artifacts:
+        if artifact.error:
+            statuses.append('FAIL')
+        if artifact.data.get('status'):
+            statuses.append(str(artifact.data['status']).upper())
+    if 'FAIL' in statuses:
+        return 'FAIL'
+    if 'WARN' in statuses:
+        return 'WARN'
+    if statuses:
+        return 'PASS'
+    return 'INCOMPLETE'
+
+
+def _collect_checks(by_key: dict[str, DashboardArtifact]) -> list[dict[str, str]]:
+    checks = []
+    for artifact_key in (
+        'host_readiness',
+        'recording_check',
+        'readiness',
+        'public_rko_adoption_gate',
+        'production_readiness',
+        'loop_alignment',
+    ):
+        artifact = by_key[artifact_key]
+        for check in artifact.data.get('checks', []):
+            checks.append({
+                'artifact': artifact.filename,
+                'id': str(check.get('id', '')),
+                'status': str(check.get('status', '')).upper(),
+                'message': str(check.get('message', '')),
+            })
+    return checks
+
+
+def _loop_alignment_summary(artifact: DashboardArtifact) -> dict[str, Any]:
+    if not artifact.exists or not artifact.data:
+        return {'present': False}
+    data = artifact.data
+    trajectory = data.get('trajectory') or {}
+    cloud = data.get('cloud') or {}
+    nearest = data.get('nearest_revisit') or {}
+    candidates = data.get('loop_candidates') or []
+    local_checks = data.get('local_cloud_checks') or []
+
+    ratios = [
+        c.get('largest_component_ratio')
+        for c in local_checks
+        if isinstance(c.get('largest_component_ratio'), (int, float))
+    ]
+    best_ratio = max(ratios) if ratios else None
+    failed_local = sum(1 for c in local_checks if str(c.get('status', '')).upper() == 'FAIL')
+    pass_local = sum(1 for c in local_checks if str(c.get('status', '')).upper() == 'PASS')
+
+    return {
+        'present': True,
+        'status': str(data.get('status', '')).upper(),
+        'poses': trajectory.get('poses'),
+        'path_length_m': trajectory.get('path_length_m'),
+        'duration_sec': trajectory.get('duration_sec'),
+        'sampled_points': cloud.get('sampled_points'),
+        'tile_count': cloud.get('tile_count'),
+        'nearest_revisit_m': nearest.get('distance_m'),
+        'loop_candidates': len(candidates),
+        'local_checks_total': len(local_checks),
+        'local_checks_pass': pass_local,
+        'local_checks_fail': failed_local,
+        'best_largest_component_ratio': best_ratio,
+        'thresholds': data.get('thresholds') or {},
+        'next_actions': data.get('next_actions') or [],
+    }
+
+
+def _topic_rates(readiness: dict[str, Any]) -> dict[str, Any]:
+    diagnostics = readiness.get('bag_diagnostics') or {}
+    topics = diagnostics.get('topics') or {}
+    return {
+        'pointcloud': (topics.get('pointcloud') or {}).get('metadata_rate_hz'),
+        'imu': (topics.get('imu') or {}).get('metadata_rate_hz'),
+    }
+
+
+def _commands(by_key: dict[str, DashboardArtifact]) -> list[dict[str, str]]:
+    commands = []
+    session = _session_artifact(by_key).data
+    for step in session.get('steps', []):
+        command = step.get('command') or []
+        if command:
+            commands.append({
+                'label': str(step.get('id', 'step')),
+                'command': ' '.join(str(item) for item in command),
+            })
+
+    map_plan = by_key['map_plan'].data
+    if map_plan.get('dogfood_command_shell'):
+        commands.append({
+            'label': 'map_dry_run',
+            'command': str(map_plan['dogfood_command_shell']),
+        })
+    return commands
+
+
+def _next_action(artifacts: list[DashboardArtifact], session_artifact: DashboardArtifact) -> str:
+    production_readiness = next(
+        (artifact for artifact in artifacts if artifact.key == 'production_readiness'),
+        None,
+    )
+    production_actions = (production_readiness.data.get('next_actions') if production_readiness else None) or []
+    production_status = str((production_readiness.data if production_readiness else {}).get('status') or '').upper()
+    if production_actions and production_status in ('FAIL', 'WARN'):
+        return '; '.join(str(action) for action in production_actions[:2])
+    session_actions = session_artifact.data.get('next_actions') or []
+    if session_actions:
+        return '; '.join(str(action) for action in session_actions[:2])
+    if production_actions:
+        return '; '.join(str(action) for action in production_actions[:2])
+    missing_required = [
+        artifact.filename
+        for artifact in artifacts
+        if artifact.key in _required_artifact_keys(session_artifact.key)
+        and not artifact.exists
+    ]
+    if missing_required:
+        return f'Create missing artifacts: {", ".join(missing_required)}'
+    status = _overall_status(artifacts)
+    if status == 'FAIL':
+        return 'Fix failing checks before the next production-candidate run.'
+    if status == 'WARN':
+        return 'Review warnings, then decide whether to rerun mapping or gate checks.'
+    if session_artifact.key == 'production_candidate_session':
+        return 'Ready for production-readiness review.'
+    return 'Ready for map run review.'
+
+
+def _required_artifact_keys(session_key: str) -> tuple[str, ...]:
+    if session_key == 'production_candidate_session':
+        return (
+            'production_candidate_session',
+            'recording_check',
+            'readiness',
+            'map_plan',
+            'diagnosis',
+            'production_readiness',
+        )
+    return ('field_session', 'recording_check', 'readiness', 'map_plan')
+
+
+def _metric_card(label: str, value: Any) -> str:
+    return f'<article class="card"><h3>{_h(label)}</h3><p>{_h(value or "n/a")}</p></article>'
+
+
+def _timeline(steps: list[dict[str, Any]]) -> str:
+    if not steps:
+        return '<p class="empty">No field-session steps found.</p>'
+    items = []
+    for step in steps:
+        status = str(step.get('status', 'unknown')).lower()
+        items.append(
+            '<li>'
+            f'<span class="dot {status}"></span>'
+            f'<strong>{_h(step.get("id", ""))}</strong>'
+            f'<em>{_h(step.get("status", ""))}</em>'
+            f'<p>{_h(step.get("message", ""))}</p>'
+            '</li>'
+        )
+    return '<ol class="timeline">' + ''.join(items) + '</ol>'
+
+
+def _route_sketch(payload: dict[str, Any]) -> str:
+    nodes = _route_nodes(payload)
+    width = max(840, 180 * len(nodes))
+    spacing = (width - 180) / max(1, len(nodes) - 1)
+    x_positions = [90 + round(index * spacing) for index in range(len(nodes))]
+    svg_parts = [
+        f'<svg class="route-sketch" viewBox="0 0 {width} 210" role="img" aria-label="MID-360 session route sketch">',
+        '<defs>',
+        '<marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">',
+        '<path d="M0,0 L0,6 L9,3 z" fill="#7d8da1"></path>',
+        '</marker>',
+        '</defs>',
+        f'<path class="route-ground" d="M56 154 C174 110, 278 184, 396 138 S{width - 204} 104, {width - 56} 144"></path>',
+    ]
+    for start, end in zip(x_positions, x_positions[1:]):
+        svg_parts.append(
+            f'<line class="route-link" x1="{start + 54}" y1="78" x2="{end - 54}" y2="78"></line>'
+        )
+    for node, x in zip(nodes, x_positions):
+        status = _status_class(node['status'])
+        svg_parts.extend([
+            f'<g class="route-node {status}">',
+            f'<circle cx="{x}" cy="78" r="42"></circle>',
+            f'<text class="route-index" x="{x}" y="72">{_h(node["index"])}</text>',
+            f'<text class="route-state" x="{x}" y="94">{_h(node["status"])}</text>',
+            f'<text class="route-label" x="{x}" y="142">{_h(node["label"])}</text>',
+            f'<text class="route-detail" x="{x}" y="164">{_h(node["detail"])}</text>',
+            '</g>',
+        ])
+    svg_parts.append('</svg>')
+    return '<div class="sketch-panel">' + ''.join(svg_parts) + '</div>'
+
+
+def _route_nodes(payload: dict[str, Any]) -> list[dict[str, str]]:
+    steps = {str(step.get('id', '')): step for step in payload.get('steps', [])}
+    artifacts = {artifact.key: artifact for artifact in payload.get('artifacts', [])}
+    recording_step = steps.get('recording') or steps.get('recording_plan') or {}
+    map_step = steps.get('map') or {}
+
+    if payload.get('session_kind') == 'production_candidate_session':
+        return [
+            {
+                'index': '1',
+                'label': 'Host Check',
+                'status': _step_or_artifact_status(steps.get('host_readiness'), artifacts.get('host_readiness')),
+                'detail': 'Jetson',
+            },
+            {
+                'index': '2',
+                'label': 'Record Bag',
+                'status': _display_status(str(recording_step.get('status') or 'missing')),
+                'detail': 'rosbag2',
+            },
+            {
+                'index': '3',
+                'label': 'Post Check',
+                'status': _step_or_artifact_status(steps.get('post_recording_check'), artifacts.get('recording_check')),
+                'detail': 'readiness',
+            },
+            {
+                'index': '4',
+                'label': 'Map Run',
+                'status': _step_or_artifact_status(map_step, artifacts.get('diagnosis')),
+                'detail': 'diagnosis',
+            },
+            {
+                'index': '5',
+                'label': 'Public Gate',
+                'status': _step_or_artifact_status(
+                    steps.get('public_rko_adoption_gate'),
+                    artifacts.get('public_rko_adoption_gate'),
+                ),
+                'detail': 'RKO evidence',
+            },
+            {
+                'index': '6',
+                'label': 'Prod Gate',
+                'status': _step_or_artifact_status(
+                    steps.get('production_readiness'),
+                    artifacts.get('production_readiness'),
+                ),
+                'detail': 'readiness',
+            },
+        ]
+
+    return [
+        {
+            'index': '1',
+            'label': 'Record Bag',
+            'status': _display_status(str(recording_step.get('status') or 'missing')),
+            'detail': 'rosbag2',
+        },
+        {
+            'index': '2',
+            'label': 'Post Check',
+            'status': _artifact_status(artifacts.get('recording_check')),
+            'detail': 'readiness',
+        },
+        {
+            'index': '3',
+            'label': 'Map Dry-Run',
+            'status': _artifact_status(artifacts.get('map_plan')),
+            'detail': 'command plan',
+        },
+        {
+            'index': '4',
+            'label': 'Map Run',
+            'status': _map_run_status(artifacts.get('diagnosis'), map_step),
+            'detail': 'diagnosis',
+        },
+    ]
+
+
+def _step_or_artifact_status(
+    step: dict[str, Any] | None,
+    artifact: DashboardArtifact | None,
+) -> str:
+    if artifact and artifact.exists:
+        return _artifact_status(artifact)
+    if step and step.get('status'):
+        return _display_status(str(step.get('status')))
+    return 'MISSING'
+
+
+def _artifact_status(artifact: DashboardArtifact | None) -> str:
+    if artifact is None or not artifact.exists:
+        return 'MISSING'
+    if artifact.error:
+        return 'FAIL'
+    return _display_status(str(artifact.data.get('status') or 'PASS'))
+
+
+def _map_run_status(artifact: DashboardArtifact | None, map_step: dict[str, Any]) -> str:
+    if artifact and artifact.exists:
+        return _artifact_status(artifact)
+    step_status = str(map_step.get('status') or '')
+    if step_status:
+        return _display_status(step_status)
+    return 'MISSING'
+
+
+def _display_status(status: str) -> str:
+    normalized = status.upper()
+    if normalized == 'OK':
+        return 'OK'
+    if normalized == 'PASS':
+        return 'OK'
+    if normalized == 'SUCCESS':
+        return 'OK'
+    if normalized in ('WARN', 'FAIL', 'PLANNED', 'SKIPPED', 'MISSING'):
+        return normalized
+    return normalized or 'MISSING'
+
+
+def _status_class(status: str) -> str:
+    return status.lower().replace('_', '-')
+
+
+def _artifact_table(artifacts: list[DashboardArtifact]) -> str:
+    rows = []
+    for artifact in artifacts:
+        status = 'ERROR' if artifact.error else ('FOUND' if artifact.exists else 'MISSING')
+        detail = artifact.error or str(artifact.path)
+        rows.append(
+            '<tr>'
+            f'<td>{_h(artifact.key)}</td>'
+            f'<td><span class="pill {status.lower()}">{status}</span></td>'
+            f'<td>{_h(detail)}</td>'
+            '</tr>'
+        )
+    return '<table><thead><tr><th>Artifact</th><th>Status</th><th>Path</th></tr></thead><tbody>' + ''.join(rows) + '</tbody></table>'
+
+
+def _topics_panel(payload: dict[str, Any]) -> str:
+    topics = payload.get('topics') or {}
+    frames = payload.get('frames') or {}
+    rates = payload.get('rates') or {}
+    return ''.join([
+        '<div class="panel-list">',
+        _kv('PointCloud', topics.get('pointcloud')),
+        _rate('PointCloud Rate', rates.get('pointcloud'), 10.0),
+        _kv('IMU', topics.get('imu')),
+        _rate('IMU Rate', rates.get('imu'), 100.0),
+        _kv('Base Frame', frames.get('base_frame')),
+        _kv('LiDAR Frame', frames.get('lidar_frame')),
+        _kv('IMU Frame', frames.get('imu_frame')),
+        '</div>',
+    ])
+
+
+def _kv(label: str, value: Any) -> str:
+    return f'<div class="kv"><span>{_h(label)}</span><strong>{_h(value or "n/a")}</strong></div>'
+
+
+def _rate(label: str, value: Any, target: float) -> str:
+    if isinstance(value, (int, float)):
+        width = min(100.0, max(2.0, (float(value) / target) * 100.0))
+        text = f'{float(value):.2f} Hz'
+    else:
+        width = 2.0
+        text = 'n/a'
+    return ''.join([
+        '<div class="rate">',
+        f'<div class="rate-label"><span>{_h(label)}</span><strong>{_h(text)}</strong></div>',
+        '<div class="bar"><span style="width:',
+        f'{width:.1f}%',
+        '"></span></div>',
+        '</div>',
+    ])
+
+
+def _checks_table(checks: list[dict[str, str]]) -> str:
+    if not checks:
+        return '<p class="empty">No checks found.</p>'
+    rows = []
+    for check in checks:
+        status = check['status'].lower()
+        rows.append(
+            '<tr>'
+            f'<td><span class="pill {status}">{_h(check["status"])}</span></td>'
+            f'<td>{_h(check["artifact"])}</td>'
+            f'<td>{_h(check["id"])}</td>'
+            f'<td>{_h(check["message"])}</td>'
+            '</tr>'
+        )
+    return '<table><thead><tr><th>Status</th><th>Artifact</th><th>Check</th><th>Message</th></tr></thead><tbody>' + ''.join(rows) + '</tbody></table>'
+
+
+def _loop_alignment_panel(summary: dict[str, Any]) -> str:
+    if not summary or not summary.get('present'):
+        return '<p class="empty">No loop alignment analyzer artifact found.</p>'
+
+    status = str(summary.get('status') or 'MISSING').upper()
+    thresholds = summary.get('thresholds') or {}
+
+    def _fmt_num(value: Any, suffix: str = '', digits: int = 2) -> str:
+        if isinstance(value, (int, float)):
+            return f'{float(value):.{digits}f}{suffix}'
+        return 'n/a'
+
+    def _fmt_int(value: Any) -> str:
+        if isinstance(value, (int, float)):
+            return f'{int(value)}'
+        return 'n/a'
+
+    nearest_threshold = thresholds.get('max_loop_distance_m')
+    ratio_threshold = thresholds.get('min_largest_component_ratio')
+    nearest_value = summary.get('nearest_revisit_m')
+    nearest_display = _fmt_num(nearest_value, ' m')
+    if isinstance(nearest_value, (int, float)) and isinstance(nearest_threshold, (int, float)):
+        nearest_display += f' (≤ {nearest_threshold:.1f} m)'
+    ratio_value = summary.get('best_largest_component_ratio')
+    ratio_display = _fmt_num(ratio_value, '', digits=3)
+    if isinstance(ratio_value, (int, float)) and isinstance(ratio_threshold, (int, float)):
+        ratio_display += f' (≥ {ratio_threshold:.2f})'
+
+    local_total = summary.get('local_checks_total') or 0
+    local_fail = summary.get('local_checks_fail') or 0
+    local_pass = summary.get('local_checks_pass') or 0
+    local_summary = f'{local_pass} PASS / {local_fail} FAIL / {local_total} total'
+
+    next_actions = summary.get('next_actions') or []
+
+    kvs = ''.join([
+        _kv('Status', status),
+        _kv('Trajectory poses', _fmt_int(summary.get('poses'))),
+        _kv('Path length', _fmt_num(summary.get('path_length_m'), ' m')),
+        _kv('Duration', _fmt_num(summary.get('duration_sec'), ' s', digits=1)),
+        _kv('Sampled cloud points', _fmt_int(summary.get('sampled_points'))),
+        _kv('Pointcloud tiles', _fmt_int(summary.get('tile_count'))),
+        _kv('Loop candidates', _fmt_int(summary.get('loop_candidates'))),
+        _kv('Nearest revisit', nearest_display),
+        _kv('Best largest_component_ratio', ratio_display),
+        _kv('Local cloud checks', local_summary),
+    ])
+    parts = [
+        f'<div class="loop-alignment-status status {status.lower()}">{_h(status)}</div>',
+        '<div class="panel-list">',
+        kvs,
+        '</div>',
+    ]
+    if next_actions:
+        parts.append('<h3>Next Actions</h3>')
+        parts.append('<ul class="next-actions">')
+        for action in next_actions[:4]:
+            parts.append(f'<li>{_h(action)}</li>')
+        parts.append('</ul>')
+    return ''.join(parts)
+
+
+def _commands_panel(commands: list[dict[str, str]]) -> str:
+    if not commands:
+        return '<p class="empty">No commands found.</p>'
+    blocks = []
+    for command in commands:
+        blocks.append(
+            '<article class="command">'
+            f'<h3>{_h(command["label"])}</h3>'
+            f'<pre><code>{_h(command["command"])}</code></pre>'
+            '</article>'
+        )
+    return ''.join(blocks)
+
+
+def _h(value: Any) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _css() -> str:
+    return """
+:root {
+  color-scheme: light;
+  --bg: #f6f7f9;
+  --panel: #ffffff;
+  --text: #17202a;
+  --muted: #667085;
+  --line: #d7dde5;
+  --ok: #16805b;
+  --warn: #b7791f;
+  --fail: #bd2f37;
+  --planned: #3366a8;
+  --accent: #245b73;
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+main {
+  width: min(1240px, calc(100vw - 32px));
+  margin: 24px auto 48px;
+}
+.summary {
+  min-height: 180px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 28px;
+  background: #102332;
+  color: #fff;
+  border-radius: 8px;
+}
+.eyebrow {
+  margin: 0 0 8px;
+  color: #9bc4d7;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+h1, h2, h3, p { margin-top: 0; }
+h1 { font-size: 34px; line-height: 1.1; margin-bottom: 10px; letter-spacing: 0; }
+h2 { margin: 28px 0 12px; font-size: 18px; letter-spacing: 0; }
+h3 { font-size: 13px; color: var(--muted); letter-spacing: 0; text-transform: uppercase; }
+.path { margin: 0; color: #c7d5dd; overflow-wrap: anywhere; }
+.status {
+  min-width: 118px;
+  text-align: center;
+  padding: 12px 16px;
+  border-radius: 8px;
+  font-weight: 800;
+  background: #6b7280;
+}
+.status.pass, .pill.ok, .pill.pass, .dot.ok { background: var(--ok); color: #fff; }
+.status.warn, .pill.warn, .dot.warn { background: var(--warn); color: #fff; }
+.status.fail, .pill.fail, .dot.fail, .pill.error { background: var(--fail); color: #fff; }
+.status.incomplete, .pill.missing, .dot.skipped { background: #5d6673; color: #fff; }
+.dot.planned { background: var(--planned); }
+.grid { display: grid; gap: 14px; }
+.metrics { grid-template-columns: repeat(3, minmax(0, 1fr)); margin-top: 14px; }
+.two { grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr); align-items: start; }
+.card, table, .panel-list, .command {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.card { padding: 16px; min-height: 92px; }
+.card p { margin: 0; overflow-wrap: anywhere; }
+table {
+  width: 100%;
+  border-collapse: collapse;
+  overflow: hidden;
+}
+th, td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+}
+th { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0; }
+td { overflow-wrap: anywhere; }
+tr:last-child td { border-bottom: 0; }
+.pill {
+  display: inline-block;
+  min-width: 68px;
+  padding: 3px 8px;
+  border-radius: 8px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 800;
+  background: #64748b;
+  color: #fff;
+}
+.pill.found { background: var(--accent); }
+.timeline {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  padding: 0;
+  margin: 0;
+}
+.timeline li {
+  position: relative;
+  min-height: 132px;
+  padding: 16px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+}
+.dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  margin-right: 8px;
+  vertical-align: middle;
+  background: #64748b;
+}
+.timeline strong { display: inline-block; margin-bottom: 8px; }
+.timeline em { display: block; color: var(--muted); font-style: normal; font-size: 12px; }
+.timeline p { margin: 8px 0 0; color: #344054; }
+.sketch-panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+  overflow-x: auto;
+}
+.route-sketch {
+  display: block;
+  min-width: 760px;
+  width: 100%;
+  height: auto;
+}
+.route-ground {
+  fill: none;
+  stroke: #c5ced9;
+  stroke-width: 5;
+  stroke-linecap: round;
+  stroke-dasharray: 10 12;
+}
+.route-link {
+  stroke: #7d8da1;
+  stroke-width: 3;
+  marker-end: url(#arrow);
+}
+.route-node circle {
+  fill: #64748b;
+  stroke: #ffffff;
+  stroke-width: 5;
+}
+.route-node.ok circle { fill: var(--ok); }
+.route-node.warn circle { fill: var(--warn); }
+.route-node.fail circle { fill: var(--fail); }
+.route-node.planned circle { fill: var(--planned); }
+.route-node.skipped circle,
+.route-node.missing circle { fill: #5d6673; }
+.route-index,
+.route-state {
+  fill: #ffffff;
+  text-anchor: middle;
+  font-weight: 800;
+}
+.route-index { font-size: 22px; }
+.route-state { font-size: 11px; }
+.route-label {
+  fill: var(--text);
+  text-anchor: middle;
+  font-weight: 800;
+  font-size: 14px;
+}
+.route-detail {
+  fill: var(--muted);
+  text-anchor: middle;
+  font-size: 12px;
+}
+.panel-list { padding: 14px; }
+.kv, .rate-label {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--line);
+}
+.kv:last-child { border-bottom: 0; }
+.kv span, .rate-label span { color: var(--muted); }
+.kv strong { overflow-wrap: anywhere; text-align: right; }
+.rate { padding: 8px 0 12px; border-bottom: 1px solid var(--line); }
+.bar {
+  height: 10px;
+  background: #e7ebf0;
+  border-radius: 8px;
+  overflow: hidden;
+}
+.bar span { display: block; height: 100%; background: #2f7d73; }
+.command { padding: 14px; margin-bottom: 12px; }
+.command h3 { margin-bottom: 8px; }
+pre {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  background: #111827;
+  color: #e5e7eb;
+  padding: 12px;
+  border-radius: 8px;
+}
+.empty {
+  padding: 14px;
+  border: 1px dashed var(--line);
+  border-radius: 8px;
+  color: var(--muted);
+  background: #fff;
+}
+@media (max-width: 760px) {
+  main { width: min(100vw - 20px, 720px); margin-top: 10px; }
+  .summary { display: block; min-height: 0; padding: 20px; }
+  .status { margin-top: 18px; width: 100%; }
+  .metrics, .two { grid-template-columns: 1fr; }
+  h1 { font-size: 26px; }
+}
+"""

--- a/scripts/mid360_robot_production_candidate_bundle.py
+++ b/scripts/mid360_robot_production_candidate_bundle.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Export MID-360 production-candidate artifacts as a portable bundle."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tarfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from mid360_robot_tools import payload_to_json
+
+
+BUNDLE_MANIFEST_JSON = 'mid360_robot_production_candidate_bundle.json'
+BUNDLE_MANIFEST_MARKDOWN = 'mid360_robot_production_candidate_bundle.md'
+DEFAULT_SESSION_JSON = 'mid360_robot_production_candidate_session.json'
+DEFAULT_SESSION_MARKDOWN = 'mid360_robot_production_candidate_session.md'
+DEFAULT_DASHBOARD_HTML = 'mid360_robot_session_dashboard.html'
+DEFAULT_PUBLIC_GATE_JSON = 'public_rko_adoption_gate/mid360_robot_public_rko_adoption_gate.json'
+
+
+@dataclass(frozen=True)
+class BundleOptions:
+    """Options for exporting a production-candidate bundle."""
+
+    artifact_dir: Path
+    output_path: Path | None = None
+    label: str = ''
+    force: bool = False
+
+
+@dataclass(frozen=True)
+class BundlePath:
+    """One file that may be included in a production-candidate bundle."""
+
+    key: str
+    source: Path
+    destination: Path
+    required: bool
+
+
+class Mid360ProductionCandidateBundleExporter:
+    """Stage and archive production-candidate artifacts."""
+
+    def export(self, options: BundleOptions) -> dict[str, Any]:
+        """Export a bundle and return its manifest."""
+        artifact_dir = options.artifact_dir.expanduser().resolve()
+        output_path = _resolve_output_path(artifact_dir, options.output_path)
+        bundle_dir, tarball_path = _bundle_targets(output_path)
+        _prepare_bundle_dir(bundle_dir, options.force)
+
+        session = _load_json(artifact_dir / DEFAULT_SESSION_JSON)
+        paths = _bundle_paths(artifact_dir, session)
+        included, missing = self._copy_paths(bundle_dir, paths)
+
+        manifest = self._build_manifest(
+            artifact_dir=artifact_dir,
+            bundle_dir=bundle_dir,
+            tarball_path=tarball_path,
+            label=options.label,
+            session=session,
+            included=included,
+            missing=missing,
+        )
+        self._write_manifest(bundle_dir, manifest)
+        manifest['files'] = _list_bundle_files(bundle_dir)
+        self._write_manifest(bundle_dir, manifest)
+
+        if tarball_path is not None:
+            _write_tarball(bundle_dir, tarball_path, options.force)
+            manifest['tarball_path'] = str(tarball_path)
+            manifest['tarball_verified'] = _verify_tarball(tarball_path, bundle_dir.name, manifest)
+            self._write_manifest(bundle_dir, manifest)
+
+        return manifest
+
+    @staticmethod
+    def _copy_paths(bundle_dir: Path, paths: list[BundlePath]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        included = []
+        missing = []
+        for item in paths:
+            source = item.source.expanduser().resolve()
+            entry = {
+                'key': item.key,
+                'source': str(source),
+                'destination': str(item.destination),
+                'required': item.required,
+            }
+            if not source.is_file():
+                if item.required:
+                    missing.append(entry)
+                continue
+            destination = bundle_dir / item.destination
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, destination)
+            entry['size_bytes'] = destination.stat().st_size
+            included.append(entry)
+        return included, missing
+
+    @staticmethod
+    def _build_manifest(
+        *,
+        artifact_dir: Path,
+        bundle_dir: Path,
+        tarball_path: Path | None,
+        label: str,
+        session: dict[str, Any],
+        included: list[dict[str, Any]],
+        missing: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        required_files = sorted(
+            item['destination'] for item in included if item.get('required')
+        )
+        status = 'FAIL' if missing else 'PASS'
+        run_id = str(session.get('run_id') or artifact_dir.name)
+        return {
+            'created_at': datetime.now(timezone.utc).isoformat(),
+            'status': status,
+            'bundle_label': label or f'{run_id}_production_candidate_bundle',
+            'run_id': run_id,
+            'source_artifact_dir': str(artifact_dir),
+            'bundle_dir': str(bundle_dir),
+            'tarball_path': str(tarball_path) if tarball_path is not None else '',
+            'tarball_verified': False,
+            'session_status': session.get('status', ''),
+            'production_readiness_json': 'artifacts/mid360_robot_production_readiness.json',
+            'recheck_command': [
+                'bash',
+                'scripts/run_mid360_robot_production_candidate_session.sh',
+                '--robot-profile',
+                f'<bundle_dir>/recording/{_profile_snapshot_name(session)}',
+                '--bag-root',
+                str(session.get('bag_root') or '<bag_root>'),
+                '--run-id',
+                run_id,
+                '--duration-sec',
+                str((session.get('thresholds') or {}).get('min_bag_duration_sec') or 600),
+                '--output-dir',
+                '<bundle_dir>/artifacts',
+                '--from-existing-artifacts',
+                '--run',
+            ],
+            'included': included,
+            'missing_required': missing,
+            'required_files': required_files,
+            'files': [],
+        }
+
+    @staticmethod
+    def _write_manifest(bundle_dir: Path, manifest: dict[str, Any]) -> None:
+        (bundle_dir / BUNDLE_MANIFEST_JSON).write_text(
+            payload_to_json(manifest) + '\n',
+            encoding='utf-8',
+        )
+        (bundle_dir / BUNDLE_MANIFEST_MARKDOWN).write_text(
+            render_bundle_markdown(manifest) + '\n',
+            encoding='utf-8',
+        )
+
+
+def render_bundle_markdown(manifest: dict[str, Any]) -> str:
+    """Render a production-candidate bundle manifest."""
+    lines = [
+        '# MID-360 Production Candidate Bundle',
+        '',
+        f"- status: `{manifest.get('status', '')}`",
+        f"- bundle_label: `{manifest.get('bundle_label', '')}`",
+        f"- run_id: `{manifest.get('run_id', '')}`",
+        f"- source_artifact_dir: `{manifest.get('source_artifact_dir', '')}`",
+        f"- bundle_dir: `{manifest.get('bundle_dir', '')}`",
+        f"- tarball_path: `{manifest.get('tarball_path', '')}`",
+        f"- tarball_verified: `{manifest.get('tarball_verified')}`",
+        '',
+        '## Recheck Command',
+        '',
+        '```bash',
+        ' '.join(str(item) for item in manifest.get('recheck_command') or []),
+        '```',
+        '',
+        '## Missing Required',
+        '',
+    ]
+    missing = manifest.get('missing_required') or []
+    if missing:
+        for item in missing:
+            lines.append(f"- `{item.get('destination', '')}` from `{item.get('source', '')}`")
+    else:
+        lines.append('- none')
+    lines.extend(['', '## Included', ''])
+    included = manifest.get('included') or []
+    if included:
+        for item in included:
+            marker = 'required' if item.get('required') else 'optional'
+            lines.append(f"- `{item.get('destination', '')}` ({marker})")
+    else:
+        lines.append('- none')
+    return '\n'.join(lines)
+
+
+def verify_bundle_manifest(manifest: dict[str, Any]) -> tuple[bool, list[str]]:
+    """Verify a bundle manifest has all required files and archive members."""
+    errors = []
+    if manifest.get('missing_required'):
+        errors.append('required artifact missing')
+    if manifest.get('status') != 'PASS':
+        errors.append(f"bundle status is {manifest.get('status')}")
+    tarball_path = str(manifest.get('tarball_path') or '')
+    if tarball_path and not manifest.get('tarball_verified'):
+        errors.append('tarball does not contain all required members')
+    return not errors, errors
+
+
+def _bundle_paths(artifact_dir: Path, session: dict[str, Any]) -> list[BundlePath]:
+    artifacts = session.get('artifact_paths') or {}
+    return [
+        _path('production_candidate_session_json', artifact_dir / DEFAULT_SESSION_JSON, 'artifacts/' + DEFAULT_SESSION_JSON, True),
+        _path('production_candidate_session_markdown', artifact_dir / DEFAULT_SESSION_MARKDOWN, 'artifacts/' + DEFAULT_SESSION_MARKDOWN, False),
+        _path('dashboard_html', _source(artifact_dir, artifacts, 'dashboard_html', artifact_dir / DEFAULT_DASHBOARD_HTML), 'artifacts/' + DEFAULT_DASHBOARD_HTML, False),
+        _path('host_readiness_json', _source(artifact_dir, artifacts, 'host_readiness_json', artifact_dir / 'jetson_mid360_host_readiness.json'), 'artifacts/jetson_mid360_host_readiness.json', True),
+        _path('host_readiness_markdown', artifact_dir / 'jetson_mid360_host_readiness.md', 'artifacts/jetson_mid360_host_readiness.md', False),
+        _path('recording_check_json', _source(artifact_dir, artifacts, 'recording_check_json', artifact_dir / 'mid360_robot_recording_check.json'), 'artifacts/mid360_robot_recording_check.json', True),
+        _path('recording_check_markdown', artifact_dir / 'mid360_robot_recording_check.md', 'artifacts/mid360_robot_recording_check.md', False),
+        _path('readiness_json', _source(artifact_dir, artifacts, 'readiness_json', artifact_dir / 'mid360_robot_readiness.json'), 'artifacts/mid360_robot_readiness.json', True),
+        _path('readiness_markdown', artifact_dir / 'mid360_robot_readiness.md', 'artifacts/mid360_robot_readiness.md', False),
+        _path('map_plan_json', _source(artifact_dir, artifacts, 'map_plan_json', artifact_dir / 'mid360_robot_run_plan.json'), 'artifacts/mid360_robot_run_plan.json', False),
+        _path('map_plan_markdown', artifact_dir / 'mid360_robot_run_plan.md', 'artifacts/mid360_robot_run_plan.md', False),
+        _path('map_diagnosis_json', _source(artifact_dir, artifacts, 'map_diagnosis_json', artifact_dir / 'autoware_map_diagnosis.json'), 'artifacts/autoware_map_diagnosis.json', True),
+        _path('map_diagnosis_markdown', artifact_dir / 'autoware_map_diagnosis.md', 'artifacts/autoware_map_diagnosis.md', False),
+        _path('public_rko_adoption_gate_json', _source(artifact_dir, artifacts, 'public_rko_adoption_gate_json', artifact_dir / DEFAULT_PUBLIC_GATE_JSON), 'artifacts/' + DEFAULT_PUBLIC_GATE_JSON, True),
+        _path('public_rko_adoption_gate_markdown', _source(artifact_dir, artifacts, 'public_rko_adoption_gate_markdown', artifact_dir / 'public_rko_adoption_gate/mid360_robot_public_rko_adoption_gate.md'), 'artifacts/public_rko_adoption_gate/mid360_robot_public_rko_adoption_gate.md', False),
+        _path('production_readiness_json', _source(artifact_dir, artifacts, 'production_readiness_json', artifact_dir / 'mid360_robot_production_readiness.json'), 'artifacts/mid360_robot_production_readiness.json', True),
+        _path('production_readiness_markdown', artifact_dir / 'mid360_robot_production_readiness.md', 'artifacts/mid360_robot_production_readiness.md', False),
+        _path('loop_alignment_json', _source(artifact_dir, artifacts, 'loop_alignment_json', artifact_dir / 'mid360_robot_loop_alignment.json'), 'artifacts/mid360_robot_loop_alignment.json', False),
+        _path('loop_alignment_markdown', _source(artifact_dir, artifacts, 'loop_alignment_markdown', artifact_dir / 'mid360_robot_loop_alignment.md'), 'artifacts/mid360_robot_loop_alignment.md', False),
+        _path('profile_snapshot', _session_source(session, 'profile_snapshot_path'), f'recording/{_profile_snapshot_name(session)}', True),
+        _path('record_plan_json', _session_source(session, 'record_plan_json_path'), f'recording/{_record_plan_name(session, ".json")}', True),
+        _path('record_plan_markdown', _session_source(session, 'record_plan_markdown_path'), f'recording/{_record_plan_name(session, ".md")}', False),
+    ]
+
+
+def _path(key: str, source: Path, destination: str, required: bool) -> BundlePath:
+    return BundlePath(key, source, Path(destination), required)
+
+
+def _source(artifact_dir: Path, artifacts: dict[str, Any], key: str, default: Path) -> Path:
+    value = artifacts.get(key)
+    if not value:
+        return default
+    path = Path(str(value)).expanduser()
+    return path if path.is_absolute() else artifact_dir / path
+
+
+def _session_source(session: dict[str, Any], key: str) -> Path:
+    value = session.get(key) or (session.get('artifact_paths') or {}).get(key.replace('_path', ''))
+    return Path(str(value)).expanduser() if value else Path('__missing__') / key
+
+
+def _profile_snapshot_name(session: dict[str, Any]) -> str:
+    return Path(str(session.get('profile_snapshot_path') or 'profile_snapshot.yaml')).name
+
+
+def _record_plan_name(session: dict[str, Any], suffix: str) -> str:
+    key = 'record_plan_json_path' if suffix == '.json' else 'record_plan_markdown_path'
+    fallback = 'record_plan' + suffix
+    return Path(str(session.get(key) or fallback)).name
+
+
+def _resolve_output_path(artifact_dir: Path, output_path: Path | None) -> Path:
+    if output_path is not None:
+        return output_path.expanduser().resolve()
+    return artifact_dir.parent / f'{artifact_dir.name}_production_candidate_bundle.tar.gz'
+
+
+def _bundle_targets(output_path: Path) -> tuple[Path, Path | None]:
+    suffixes = output_path.suffixes
+    if suffixes[-2:] == ['.tar', '.gz']:
+        return output_path.with_suffix('').with_suffix(''), output_path
+    if output_path.suffix == '.tgz':
+        return output_path.with_suffix(''), output_path
+    return output_path, None
+
+
+def _prepare_bundle_dir(bundle_dir: Path, force: bool) -> None:
+    if bundle_dir.exists():
+        if not force:
+            raise FileExistsError(f'bundle dir already exists: {bundle_dir}')
+        shutil.rmtree(bundle_dir)
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+
+
+def _write_tarball(bundle_dir: Path, tarball_path: Path, force: bool) -> None:
+    if tarball_path.exists():
+        if not force:
+            raise FileExistsError(f'tarball already exists: {tarball_path}')
+        tarball_path.unlink()
+    tarball_path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(tarball_path, 'w:gz') as archive:
+        archive.add(bundle_dir, arcname=bundle_dir.name)
+
+
+def _verify_tarball(tarball_path: Path, root_name: str, manifest: dict[str, Any]) -> bool:
+    required = {f'{root_name}/{path}' for path in manifest.get('required_files') or []}
+    required.add(f'{root_name}/{BUNDLE_MANIFEST_JSON}')
+    try:
+        with tarfile.open(tarball_path, 'r:gz') as archive:
+            names = set(archive.getnames())
+    except Exception:
+        return False
+    return required.issubset(names)
+
+
+def _list_bundle_files(bundle_dir: Path) -> list[str]:
+    return sorted(
+        str(path.relative_to(bundle_dir))
+        for path in bundle_dir.rglob('*')
+        if path.is_file()
+    )
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}


### PR DESCRIPTION
## Summary

Operator-facing surfaces for end-to-end MID-360 robot sessions. Closes the γ-integration thread tracked in plan.md.

### Dashboard
- `scripts/mid360_robot_dashboard.py` (903 行) — `write_dashboard` + section helpers, HTML one-pager that aggregates artifacts from a run output dir
- `scripts/generate_mid360_robot_session_dashboard.py` (34 行) — argparse CLI
- **Loop alignment section** (new this PR): surfaces \`largest_component_ratio\` and \`local_cloud_checks\` with threshold-coded chips; hidden when artifact absent
- 5 subprocess tests cover the rendered HTML

### Production-candidate bundle
- `scripts/mid360_robot_production_candidate_bundle.py` (330 行) — `export_bundle` packages artifacts into a tar.gz with a recheck command
- `scripts/export_mid360_robot_production_candidate_bundle.py` (82 行) — argparse CLI
- **Loop alignment integration** (new this PR): optionally bundles \`mid360_robot_loop_alignment.json\` and its markdown companion when present
- 4 subprocess tests over the export CLI

## Scope

Inside-out 戦略の **PR3 (最終)**。foundation (#168) + analyzer (#169) の上に乗る operator surface。Bundle import / production_candidate_session の連鎖は別 PR に切り出す予定。

## Test plan

- [x] `python3 -m pytest graph_based_slam/test/test_mid360_robot_dashboard.py graph_based_slam/test/test_mid360_robot_production_candidate_bundle.py -q` → 9 passed in 0.55s
- [x] flake8 (E/W/F, max-line-length=99, ignore=W503) → clean
- [x] copyright header matches existing test convention
- [ ] CI: Humble + Jazzy