### PR TITLE
feat: MID-360 robot rosbag2 record-tools (planner + manifest writer)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -219,6 +219,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_mid360_robot_record_tools
+    test/test_mid360_robot_record_tools.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_navsatfix_covariance_inspector
     test/test_navsatfix_covariance_inspector.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_mid360_robot_record_tools.py
+++ b/graph_based_slam/test/test_mid360_robot_record_tools.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Unit tests for MID-360 robot recording helpers."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+import sys
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / 'scripts'
+
+
+def _load_record_module():
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    return importlib.import_module('mid360_robot_record_tools')
+
+
+def _load_robot_module():
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    return importlib.import_module('mid360_robot_tools')
+
+
+def _profile(tmp_path: Path):
+    robot_module = _load_robot_module()
+    profile_path = tmp_path / 'profile.yaml'
+    profile_path.write_text(
+        yaml.safe_dump({
+            'robot_name': 'record_robot',
+            'base_frame': 'base_link',
+            'lidar_frame': 'livox_frame',
+            'imu_frame': 'livox_frame',
+            'expected_pointcloud_topic': '/livox/lidar',
+            'expected_imu_topic': '/livox/imu',
+        }),
+        encoding='utf-8',
+    )
+    return robot_module.RobotProfileLoader().load(profile_path)
+
+
+def test_record_planner_builds_rosbag_command(tmp_path: Path):
+    module = _load_record_module()
+    profile = _profile(tmp_path)
+
+    plan = module.Mid360RobotRecordPlanner().build_plan(
+        profile,
+        module.RecordOptions(
+            bag_root=tmp_path / 'bags',
+            run_id='field test 01',
+            duration_sec='30',
+            extra_topics=('/diagnostics', '/tf'),
+            storage_id='sqlite3',
+            max_cache_size='104857600',
+        ),
+    )
+
+    assert plan.run_id == 'field_test_01'
+    assert plan.bag_path == tmp_path / 'bags' / 'field_test_01'
+    assert plan.topics == ('/livox/lidar', '/livox/imu', '/tf', '/tf_static', '/diagnostics')
+    assert plan.command[:6] == (
+        'timeout',
+        '30',
+        'ros2',
+        'bag',
+        'record',
+        '-o',
+    )
+    assert '--storage' in plan.command
+    assert '--max-cache-size' in plan.command
+    assert '/livox/lidar' in plan.command
+    assert '/livox/imu' in plan.command
+
+
+def test_record_manifest_writer_persists_plan_and_profile_snapshot(tmp_path: Path):
+    module = _load_record_module()
+    profile = _profile(tmp_path)
+    plan = module.Mid360RobotRecordPlanner().build_plan(
+        profile,
+        module.RecordOptions(bag_root=tmp_path / 'bags', run_id='record_run'),
+    )
+
+    paths = module.Mid360RecordManifestWriter().write(profile, plan)
+
+    assert paths['json'].is_file()
+    assert paths['markdown'].is_file()
+    assert paths['profile'].is_file()
+    assert '/livox/lidar' in paths['json'].read_text(encoding='utf-8')
+    assert 'ros2 bag record' in paths['markdown'].read_text(encoding='utf-8')
+    assert 'record_robot' in paths['profile'].read_text(encoding='utf-8')
+
+
+def test_record_planner_requires_profile_topics(tmp_path: Path):
+    module = _load_record_module()
+    robot_module = _load_robot_module()
+    profile = robot_module.RobotProfile(
+        robot_name='missing_topics',
+        frames=robot_module.RobotFrames(),
+    )
+
+    try:
+        module.Mid360RobotRecordPlanner().build_plan(
+            profile,
+            module.RecordOptions(bag_root=tmp_path / 'bags'),
+        )
+    except ValueError as exc:
+        assert 'expected_pointcloud_topic' in str(exc)
+    else:
+        raise AssertionError('expected missing profile topic to fail')

--- a/scripts/mid360_robot_record_tools.py
+++ b/scripts/mid360_robot_record_tools.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""MID-360 robot rosbag2 recording planner."""
+
+from __future__ import annotations
+
+import json
+import re
+import shlex
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from mid360_robot_tools import RobotProfile, payload_to_json
+
+
+@dataclass(frozen=True)
+class RecordOptions:
+    """Operator options for one MID-360 robot recording."""
+
+    bag_root: Path
+    run_id: str = ''
+    include_tf: bool = True
+    include_tf_static: bool = True
+    extra_topics: tuple[str, ...] = ()
+    storage_id: str = ''
+    max_cache_size: str = ''
+    compression_mode: str = ''
+    compression_format: str = ''
+    duration_sec: str = ''
+
+
+@dataclass(frozen=True)
+class RecordPlan:
+    """One executable rosbag2 recording plan."""
+
+    run_id: str
+    bag_root: Path
+    bag_path: Path
+    manifest_json_path: Path
+    manifest_markdown_path: Path
+    profile_snapshot_path: Path
+    topics: tuple[str, ...]
+    command: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'run_id': self.run_id,
+            'bag_root': str(self.bag_root),
+            'bag_path': str(self.bag_path),
+            'manifest_json_path': str(self.manifest_json_path),
+            'manifest_markdown_path': str(self.manifest_markdown_path),
+            'profile_snapshot_path': str(self.profile_snapshot_path),
+            'topics': list(self.topics),
+            'command': list(self.command),
+            'command_shell': shlex.join(self.command),
+        }
+
+
+class Mid360RobotRecordPlanner:
+    """Build ros2 bag record commands from a robot profile."""
+
+    def build_plan(self, profile: RobotProfile, options: RecordOptions) -> RecordPlan:
+        if not profile.expected_pointcloud_topic:
+            raise ValueError('robot profile expected_pointcloud_topic is required for recording')
+        if not profile.expected_imu_topic:
+            raise ValueError('robot profile expected_imu_topic is required for recording')
+
+        run_id = self._run_id(profile.robot_name, options.run_id)
+        bag_root = options.bag_root
+        bag_path = bag_root / run_id
+        manifest_json_path = bag_root / f'{run_id}_record_plan.json'
+        manifest_markdown_path = bag_root / f'{run_id}_record_plan.md'
+        profile_snapshot_path = bag_root / f'{run_id}_profile.yaml'
+        topics = self._topics(profile, options)
+        command = self._command(bag_path, topics, options)
+        return RecordPlan(
+            run_id=run_id,
+            bag_root=bag_root,
+            bag_path=bag_path,
+            manifest_json_path=manifest_json_path,
+            manifest_markdown_path=manifest_markdown_path,
+            profile_snapshot_path=profile_snapshot_path,
+            topics=tuple(topics),
+            command=tuple(command),
+        )
+
+    @staticmethod
+    def _run_id(robot_name: str, requested: str) -> str:
+        if requested:
+            candidate = requested
+        else:
+            timestamp = datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')
+            candidate = f'mid360_{robot_name}_{timestamp}'
+        sanitized = re.sub(r'[^A-Za-z0-9_.-]+', '_', candidate).strip('._-')
+        if not sanitized:
+            raise ValueError('run_id must contain at least one safe filename character')
+        return sanitized
+
+    @staticmethod
+    def _topics(profile: RobotProfile, options: RecordOptions) -> list[str]:
+        topics = [
+            profile.expected_pointcloud_topic,
+            profile.expected_imu_topic,
+        ]
+        if options.include_tf:
+            topics.append('/tf')
+        if options.include_tf_static:
+            topics.append('/tf_static')
+        topics.extend(options.extra_topics)
+        return list(dict.fromkeys(topic for topic in topics if topic))
+
+    @staticmethod
+    def _command(bag_path: Path, topics: list[str], options: RecordOptions) -> list[str]:
+        command = ['ros2', 'bag', 'record', '-o', str(bag_path)]
+        if options.storage_id:
+            command.extend(['--storage', options.storage_id])
+        if options.max_cache_size:
+            command.extend(['--max-cache-size', options.max_cache_size])
+        if options.compression_mode:
+            command.extend(['--compression-mode', options.compression_mode])
+        if options.compression_format:
+            command.extend(['--compression-format', options.compression_format])
+        command.extend(topics)
+        if options.duration_sec:
+            command = ['timeout', options.duration_sec] + command
+        return command
+
+
+class Mid360RecordManifestWriter:
+    """Write recording plan artifacts before rosbag2 recording starts."""
+
+    def build_manifest(self, profile: RobotProfile, plan: RecordPlan) -> dict[str, Any]:
+        return {
+            'created_at': datetime.now(timezone.utc).isoformat(),
+            'run_id': plan.run_id,
+            'bag_root': str(plan.bag_root),
+            'bag_path': str(plan.bag_path),
+            'topics': list(plan.topics),
+            'command': list(plan.command),
+            'command_shell': shlex.join(plan.command),
+            'robot_profile': profile.to_dict(),
+            'profile_snapshot_path': str(plan.profile_snapshot_path),
+            'post_recording_next_steps': [
+                'Run ros2 bag info on the recorded bag.',
+                'Run check_mid360_robot_readiness.py with the same robot profile.',
+                'Keep the profile snapshot with the bag artifacts.',
+            ],
+        }
+
+    def write(self, profile: RobotProfile, plan: RecordPlan) -> dict[str, Path]:
+        plan.bag_root.mkdir(parents=True, exist_ok=True)
+        manifest = self.build_manifest(profile, plan)
+        plan.manifest_json_path.write_text(payload_to_json(manifest) + '\n', encoding='utf-8')
+        plan.manifest_markdown_path.write_text(
+            self.render_markdown(manifest) + '\n',
+            encoding='utf-8',
+        )
+        self._write_profile_snapshot(profile, plan.profile_snapshot_path)
+        return {
+            'json': plan.manifest_json_path,
+            'markdown': plan.manifest_markdown_path,
+            'profile': plan.profile_snapshot_path,
+        }
+
+    @staticmethod
+    def render_markdown(manifest: dict[str, Any]) -> str:
+        lines = [
+            '# MID-360 Robot Recording Plan',
+            '',
+            f"- created_at: `{manifest['created_at']}`",
+            f"- run_id: `{manifest['run_id']}`",
+            f"- bag_root: `{manifest['bag_root']}`",
+            f"- bag_path: `{manifest['bag_path']}`",
+            f"- profile_snapshot_path: `{manifest['profile_snapshot_path']}`",
+            '',
+            '## Topics',
+            '',
+        ]
+        for topic in manifest['topics']:
+            lines.append(f"- `{topic}`")
+        lines.extend([
+            '',
+            '## Command',
+            '',
+            '```bash',
+            manifest['command_shell'],
+            '```',
+            '',
+            '## Robot Profile',
+            '',
+        ])
+        profile = manifest.get('robot_profile') or {}
+        lines.extend([
+            f"- robot_name: `{profile.get('robot_name')}`",
+            f"- expected_pointcloud_topic: `{profile.get('expected_pointcloud_topic')}`",
+            f"- expected_imu_topic: `{profile.get('expected_imu_topic')}`",
+            '',
+            '## Next Steps',
+            '',
+        ])
+        for item in manifest.get('post_recording_next_steps', []):
+            lines.append(f"- {item}")
+        return '\n'.join(lines)
+
+    @staticmethod
+    def _write_profile_snapshot(profile: RobotProfile, path: Path) -> None:
+        source_path = Path(profile.source_path) if profile.source_path else None
+        if source_path and source_path.is_file():
+            path.write_text(source_path.read_text(encoding='utf-8'), encoding='utf-8')
+            return
+        path.write_text(yaml.safe_dump(profile.to_dict(), sort_keys=False), encoding='utf-8')
+
+
+def record_plan_to_json(profile: RobotProfile, plan: RecordPlan) -> str:
+    """Serialize a record plan with the profile snapshot payload."""
+    payload = Mid360RecordManifestWriter().build_manifest(profile, plan)
+    return json.dumps(payload, indent=2, sort_keys=True)


### PR DESCRIPTION
## Summary

Adds `scripts/mid360_robot_record_tools.py` — the recording leg of the MID-360 robot operator pipeline. Depends only on `mid360_robot_tools` (foundation, PR #168) + PyYAML, so it lands as a self-contained slice of the inside-out stack.

### What's in
- **`Mid360RobotRecordPlanner`** — builds `ros2 bag record` commands from a `RobotProfile`:
  - enforces `expected_pointcloud_topic` + `expected_imu_topic` are configured
  - sanitizes operator-supplied `run_id`, auto-generates UTC-stamped IDs otherwise
  - threads through optional `timeout`, `--storage`, `--max-cache-size`, `--compression-mode/-format`
  - includes `/tf` + `/tf_static` by default, supports extra topics
- **`Mid360RecordManifestWriter`** — persists a reproducible record plan:
  - `<run_id>_record_plan.json` + `.md` next to the bag
  - `<run_id>_profile.yaml` snapshot (verbatim from source file or serialized from `RobotProfile`)
  - manifest carries `post_recording_next_steps` hints for downstream tooling
- **`record_plan_to_json`** — helper for embedding the manifest payload in higher-level orchestrators

### Why this PR
Downstream `mid360_robot_production_candidate_session` + `mid360_robot_production_candidate_bundle_import` (still local, will follow) both import this module. Landing the foundation first keeps the next PRs narrow.

## Test plan

- [x] `python3 -m pytest graph_based_slam/test/test_mid360_robot_record_tools.py -v` → 3 passed
- [x] `python3 -m flake8 --select=E,W,F --ignore=W503 --max-line-length=99 scripts/mid360_robot_record_tools.py graph_based_slam/test/test_mid360_robot_record_tools.py` → clean
- [ ] Humble + Jazzy matrix CI (colcon build + colcon test) — let CI confirm