### PR TITLE
feat: MID-360 production-readiness gate (operator gating script)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -224,6 +224,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_mid360_robot_production_readiness
+    test/test_mid360_robot_production_readiness.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_navsatfix_covariance_inspector
     test/test_navsatfix_covariance_inspector.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_mid360_robot_production_readiness.py
+++ b/graph_based_slam/test/test_mid360_robot_production_readiness.py
@@ -43,9 +43,9 @@ PRODUCTION_SCRIPT = SCRIPT_DIR / 'check_mid360_robot_production_readiness.py'
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from mid360_robot_production_readiness import (  # noqa: E402
+    Mid360ProductionReadinessGate,
     PRODUCTION_READINESS_JSON,
     PRODUCTION_READINESS_MARKDOWN,
-    Mid360ProductionReadinessGate,
     ProductionReadinessInputs,
     ProductionReadinessThresholds,
     render_production_readiness_markdown,

--- a/graph_based_slam/test/test_mid360_robot_production_readiness.py
+++ b/graph_based_slam/test/test_mid360_robot_production_readiness.py
@@ -1,0 +1,225 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for MID-360 robot production-readiness gate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = REPO_ROOT / 'scripts'
+PRODUCTION_SCRIPT = SCRIPT_DIR / 'check_mid360_robot_production_readiness.py'
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from mid360_robot_production_readiness import (  # noqa: E402
+    PRODUCTION_READINESS_JSON,
+    PRODUCTION_READINESS_MARKDOWN,
+    Mid360ProductionReadinessGate,
+    ProductionReadinessInputs,
+    ProductionReadinessThresholds,
+    render_production_readiness_markdown,
+    write_production_readiness_report,
+)
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding='utf-8')
+    return path
+
+
+def _production_artifacts(tmp_path: Path, *, bag_path: str | None = None) -> dict[str, Path]:
+    artifact_dir = tmp_path / 'robot_artifacts'
+    bag = bag_path or '/data/robot_bags/field_route_01'
+    paths = {
+        'host': artifact_dir / 'jetson_mid360_host_readiness.json',
+        'recording': artifact_dir / 'mid360_robot_recording_check.json',
+        'readiness': artifact_dir / 'mid360_robot_readiness.json',
+        'map': artifact_dir / 'autoware_map_diagnosis.json',
+        'adoption': tmp_path / 'public_gate' / 'mid360_robot_public_rko_adoption_gate.json',
+    }
+    _write_json(paths['host'], {
+        'status': 'PASS',
+        'checks': [{'id': 'jetson_model', 'status': 'ok', 'message': 'Jetson'}],
+    })
+    _write_json(paths['recording'], {
+        'status': 'PASS',
+        'bag_path': bag,
+        'readiness_status': 'PASS',
+        'checks': [{'id': 'readiness_status', 'status': 'ok', 'message': 'passed'}],
+    })
+    _write_json(paths['readiness'], {
+        'status': 'PASS',
+        'bag_path': bag,
+        'ready_for_mid360_launch': True,
+        'checks': [{'id': 'pointcloud2', 'status': 'ok', 'message': 'ok'}],
+        'bag_diagnostics': {
+            'topics': {
+                'pointcloud': {
+                    'metadata_message_count': 6000,
+                    'metadata_rate_hz': 10.0,
+                    'sampled_message_count': 20,
+                    'stable_frame_id': True,
+                    'matches_expected_frame': True,
+                },
+                'imu': {
+                    'metadata_message_count': 120000,
+                    'metadata_rate_hz': 200.0,
+                    'sampled_message_count': 20,
+                    'stable_frame_id': True,
+                    'matches_expected_frame': True,
+                },
+            }
+        },
+    })
+    _write_json(paths['map'], {
+        'status': 'success',
+        'verify': {'result': 'PASS'},
+    })
+    _write_json(paths['adoption'], {
+        'status': 'PASS',
+        'decision': {
+            'matched_case': 'voxel_0p50_min_1p00_dd_on',
+            'recommended_case': 'voxel_0p50_min_1p00_dd_on',
+            'gate_pass_cases': 4,
+        },
+    })
+    return paths
+
+
+def _inputs(paths: dict[str, Path], output_dir: Path) -> ProductionReadinessInputs:
+    return ProductionReadinessInputs(
+        host_readiness=paths['host'],
+        recording_check=paths['recording'],
+        readiness=paths['readiness'],
+        map_diagnosis=paths['map'],
+        adoption_gate=paths['adoption'],
+        output_dir=output_dir,
+    )
+
+
+def test_production_readiness_passes_with_robot_artifacts(tmp_path: Path):
+    paths = _production_artifacts(tmp_path)
+
+    report = Mid360ProductionReadinessGate(
+        _inputs(paths, tmp_path / 'out'),
+        thresholds=ProductionReadinessThresholds(min_bag_duration_sec=600.0),
+    ).build_report()
+
+    assert report['status'] == 'PASS'
+    assert report['production_ready'] is True
+    assert report['evidence']['estimated_bag_duration_sec'] == 600.0
+    assert report['evidence']['adoption_matched_case'] == 'voxel_0p50_min_1p00_dd_on'
+    assert all(check['status'] == 'PASS' for check in report['checks'])
+
+
+def test_production_readiness_fails_for_public_bag_evidence(tmp_path: Path):
+    paths = _production_artifacts(
+        tmp_path,
+        bag_path=str(REPO_ROOT / 'datasets' / 'mid360_public' / 'bag'),
+    )
+
+    report = Mid360ProductionReadinessGate(
+        _inputs(paths, tmp_path / 'out'),
+        thresholds=ProductionReadinessThresholds(min_bag_duration_sec=600.0),
+    ).build_report()
+
+    assert report['status'] == 'FAIL'
+    assert report['production_ready'] is False
+    assert any(check['id'] == 'real_robot_bag' and check['status'] == 'FAIL'
+               for check in report['checks'])
+    assert any('actual robot field bag' in action for action in report['next_actions'])
+
+
+def test_production_readiness_fails_when_map_is_not_verified(tmp_path: Path):
+    paths = _production_artifacts(tmp_path)
+    _write_json(paths['map'], {'status': 'map_saved', 'verify': {'result': 'unknown'}})
+
+    report = Mid360ProductionReadinessGate(
+        _inputs(paths, tmp_path / 'out'),
+        thresholds=ProductionReadinessThresholds(min_bag_duration_sec=600.0),
+    ).build_report()
+
+    assert report['status'] == 'FAIL'
+    assert any(check['id'] == 'map_run_verified' and check['status'] == 'FAIL'
+               for check in report['checks'])
+
+
+def test_production_readiness_writes_json_and_markdown(tmp_path: Path):
+    paths = _production_artifacts(tmp_path)
+    output_dir = tmp_path / 'out'
+    report = Mid360ProductionReadinessGate(_inputs(paths, output_dir)).build_report()
+
+    written = write_production_readiness_report(report, output_dir)
+    markdown = render_production_readiness_markdown(report)
+
+    assert written['json'] == output_dir / PRODUCTION_READINESS_JSON
+    assert written['markdown'] == output_dir / PRODUCTION_READINESS_MARKDOWN
+    assert 'production_ready' in markdown
+    assert json.loads(written['json'].read_text(encoding='utf-8'))['status'] == 'PASS'
+
+
+def test_production_readiness_cli_outputs_json(tmp_path: Path):
+    paths = _production_artifacts(tmp_path)
+    output_dir = tmp_path / 'out'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PRODUCTION_SCRIPT),
+            '--host-readiness',
+            str(paths['host']),
+            '--recording-check',
+            str(paths['recording']),
+            '--readiness',
+            str(paths['readiness']),
+            '--map-diagnosis',
+            str(paths['map']),
+            '--adoption-gate',
+            str(paths['adoption']),
+            '--output-dir',
+            str(output_dir),
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    report = json.loads(result.stdout)
+
+    assert report['status'] == 'PASS'
+    assert report['production_ready'] is True
+    assert (output_dir / PRODUCTION_READINESS_JSON).is_file()
+    assert (output_dir / PRODUCTION_READINESS_MARKDOWN).is_file()

--- a/scripts/check_mid360_robot_production_readiness.py
+++ b/scripts/check_mid360_robot_production_readiness.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Check production readiness for a Jetson MID-360 robot mapping deployment."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from mid360_robot_production_readiness import (
+    PRODUCTION_READINESS_JSON,
+    PRODUCTION_READINESS_MARKDOWN,
+    Mid360ProductionReadinessGate,
+    ProductionReadinessInputs,
+    ProductionReadinessThresholds,
+    render_production_readiness_markdown,
+    write_production_readiness_report,
+)
+from mid360_robot_tools import payload_to_json
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_ARTIFACT_DIR = REPO_ROOT / 'output' / 'mid360_robot_test'
+DEFAULT_PUBLIC_ADOPTION_GATE = (
+    REPO_ROOT
+    / 'output'
+    / 'mid360_public'
+    / 'rko_sweep'
+    / 'mid360_robot_public_rko_adoption_gate.json'
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description='Gate production readiness for Jetson MID-360 robot mapping.'
+    )
+    parser.add_argument(
+        '--artifact-dir',
+        default=str(DEFAULT_ARTIFACT_DIR),
+        help='Directory containing host/readiness/recording/map artifacts.',
+    )
+    parser.add_argument('--host-readiness', default='', help='jetson_mid360_host_readiness.json')
+    parser.add_argument('--recording-check', default='', help='mid360_robot_recording_check.json')
+    parser.add_argument('--readiness', default='', help='mid360_robot_readiness.json')
+    parser.add_argument('--map-diagnosis', default='', help='autoware_map_diagnosis.json')
+    parser.add_argument(
+        '--adoption-gate',
+        default=str(DEFAULT_PUBLIC_ADOPTION_GATE),
+        help='mid360_robot_public_rko_adoption_gate.json from public real-data evidence.',
+    )
+    parser.add_argument(
+        '--output-dir',
+        default='',
+        help='Directory for production-readiness JSON/Markdown. Defaults to --artifact-dir.',
+    )
+    parser.add_argument('--min-bag-duration-sec', type=float, default=600.0)
+    parser.add_argument('--min-pointcloud-hz', type=float, default=5.0)
+    parser.add_argument('--min-imu-hz', type=float, default=50.0)
+    parser.add_argument('--allow-warnings', action='store_true')
+    parser.add_argument('--allow-public-bag', action='store_true')
+    parser.add_argument('--json', action='store_true', help='Print JSON instead of Markdown.')
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point."""
+    args = parse_args()
+    artifact_dir = Path(args.artifact_dir).expanduser().resolve()
+    output_dir = Path(args.output_dir).expanduser().resolve() if args.output_dir else artifact_dir
+    inputs = ProductionReadinessInputs(
+        host_readiness=_path_arg(
+            args.host_readiness, artifact_dir / 'jetson_mid360_host_readiness.json',
+        ),
+        recording_check=_path_arg(
+            args.recording_check, artifact_dir / 'mid360_robot_recording_check.json',
+        ),
+        readiness=_path_arg(args.readiness, artifact_dir / 'mid360_robot_readiness.json'),
+        map_diagnosis=_path_arg(args.map_diagnosis, artifact_dir / 'autoware_map_diagnosis.json'),
+        adoption_gate=Path(args.adoption_gate).expanduser().resolve(),
+        output_dir=output_dir,
+    )
+    thresholds = ProductionReadinessThresholds(
+        min_bag_duration_sec=max(0.0, float(args.min_bag_duration_sec)),
+        min_pointcloud_hz=max(0.0, float(args.min_pointcloud_hz)),
+        min_imu_hz=max(0.0, float(args.min_imu_hz)),
+        allow_warnings=bool(args.allow_warnings),
+        allow_public_bag=bool(args.allow_public_bag),
+    )
+    try:
+        report = Mid360ProductionReadinessGate(inputs, thresholds).build_report()
+        paths = write_production_readiness_report(report, output_dir)
+    except Exception as exc:
+        print(f'failed to check MID-360 production readiness: {exc}', file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(payload_to_json(report))
+    else:
+        print(render_production_readiness_markdown(report))
+        print(f'{PRODUCTION_READINESS_JSON}: {paths["json"]}')
+        print(f'{PRODUCTION_READINESS_MARKDOWN}: {paths["markdown"]}')
+    return 0 if report['status'] == 'PASS' else 1
+
+
+def _path_arg(value: str, default: Path) -> Path:
+    return Path(value).expanduser().resolve() if value else default.expanduser().resolve()
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print('Interrupted', file=sys.stderr)
+        raise SystemExit(130)

--- a/scripts/mid360_robot_production_readiness.py
+++ b/scripts/mid360_robot_production_readiness.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Production-readiness gate for Jetson MID-360 robot mapping."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from mid360_robot_tools import payload_to_json
+
+
+PRODUCTION_READINESS_JSON = 'mid360_robot_production_readiness.json'
+PRODUCTION_READINESS_MARKDOWN = 'mid360_robot_production_readiness.md'
+
+
+@dataclass(frozen=True)
+class ProductionReadinessThresholds:
+    """Thresholds required before calling a robot deployment production ready."""
+
+    min_bag_duration_sec: float = 600.0
+    min_pointcloud_hz: float = 5.0
+    min_imu_hz: float = 50.0
+    allow_warnings: bool = False
+    allow_public_bag: bool = False
+
+
+@dataclass(frozen=True)
+class ProductionReadinessInputs:
+    """Artifact paths used by the production readiness gate."""
+
+    host_readiness: Path
+    recording_check: Path
+    readiness: Path
+    map_diagnosis: Path
+    adoption_gate: Path
+    output_dir: Path
+
+
+class Mid360ProductionReadinessGate:
+    """Build a production-readiness decision from robot and public-gate artifacts."""
+
+    def __init__(
+        self,
+        inputs: ProductionReadinessInputs,
+        thresholds: ProductionReadinessThresholds | None = None,
+    ) -> None:
+        self._inputs = inputs
+        self._thresholds = thresholds or ProductionReadinessThresholds()
+
+    def build_report(self) -> dict[str, Any]:
+        """Build a production-readiness report."""
+        artifacts = {
+            'host_readiness': _load_json(self._inputs.host_readiness),
+            'recording_check': _load_json(self._inputs.recording_check),
+            'readiness': _load_json(self._inputs.readiness),
+            'map_diagnosis': _load_json(self._inputs.map_diagnosis),
+            'adoption_gate': _load_json(self._inputs.adoption_gate),
+        }
+        paths = {
+            'host_readiness': str(self._inputs.host_readiness.expanduser().resolve()),
+            'recording_check': str(self._inputs.recording_check.expanduser().resolve()),
+            'readiness': str(self._inputs.readiness.expanduser().resolve()),
+            'map_diagnosis': str(self._inputs.map_diagnosis.expanduser().resolve()),
+            'adoption_gate': str(self._inputs.adoption_gate.expanduser().resolve()),
+        }
+        evidence = _evidence_summary(artifacts)
+        checks = _build_checks(artifacts, paths, evidence, self._thresholds)
+        status = _overall_status(checks)
+        return {
+            'created_at': datetime.now(timezone.utc).isoformat(),
+            'status': status,
+            'production_ready': status == 'PASS',
+            'output_dir': str(self._inputs.output_dir.expanduser().resolve()),
+            'thresholds': asdict(self._thresholds),
+            'artifact_paths': paths,
+            'evidence': evidence,
+            'checks': checks,
+            'counts': _count_checks(checks),
+            'next_actions': _next_actions(checks, paths),
+        }
+
+
+def write_production_readiness_report(report: dict[str, Any], output_dir: Path) -> dict[str, Path]:
+    """Write JSON and Markdown production-readiness reports."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / PRODUCTION_READINESS_JSON
+    markdown_path = output_dir / PRODUCTION_READINESS_MARKDOWN
+    json_path.write_text(payload_to_json(report) + '\n', encoding='utf-8')
+    markdown_path.write_text(render_production_readiness_markdown(report) + '\n', encoding='utf-8')
+    return {'json': json_path, 'markdown': markdown_path}
+
+
+def render_production_readiness_markdown(report: dict[str, Any]) -> str:
+    """Render a concise production-readiness report."""
+    evidence = report.get('evidence') or {}
+    thresholds = report.get('thresholds') or {}
+    lines = [
+        '# MID-360 Robot Production Readiness',
+        '',
+        f"- status: `{report.get('status', '')}`",
+        f"- production_ready: `{report.get('production_ready')}`",
+        f"- created_at: `{report.get('created_at', '')}`",
+        f"- output_dir: `{report.get('output_dir', '')}`",
+        f"- min_bag_duration_sec: `{thresholds.get('min_bag_duration_sec')}`",
+        '',
+        '## Evidence',
+        '',
+        f"- bag_path: `{evidence.get('bag_path', '')}`",
+        '- estimated_bag_duration_sec: '
+        f"`{_fmt_float(evidence.get('estimated_bag_duration_sec'))}`",
+        f"- pointcloud_hz: `{_fmt_float(evidence.get('pointcloud_hz'))}`",
+        f"- imu_hz: `{_fmt_float(evidence.get('imu_hz'))}`",
+        f"- map_status: `{evidence.get('map_status', '')}`",
+        f"- map_verify_result: `{evidence.get('map_verify_result', '')}`",
+        f"- adoption_matched_case: `{evidence.get('adoption_matched_case', '')}`",
+        '',
+        '## Checks',
+        '',
+    ]
+    for check in report.get('checks') or []:
+        lines.append(
+            f"- `{check.get('status', '')}` `{check.get('id', '')}`: "
+            f"{check.get('message', '')}"
+        )
+
+    actions = report.get('next_actions') or []
+    lines.extend(['', '## Next Actions', ''])
+    if actions:
+        for action in actions:
+            lines.append(f'- {action}')
+    else:
+        lines.append('- none')
+    return '\n'.join(lines)
+
+
+def _build_checks(
+    artifacts: dict[str, dict[str, Any]],
+    paths: dict[str, str],
+    evidence: dict[str, Any],
+    thresholds: ProductionReadinessThresholds,
+) -> list[dict[str, str]]:
+    checks: list[dict[str, str]] = []
+    artifact_keys = (
+        'host_readiness', 'recording_check', 'readiness', 'map_diagnosis', 'adoption_gate',
+    )
+    for key in artifact_keys:
+        checks.append(_check(
+            f'{key}_present',
+            bool(artifacts.get(key)),
+            f'{key}: {paths.get(key, "")}',
+        ))
+
+    checks.extend([
+        _status_check(
+            'host_readiness_pass',
+            artifacts.get('host_readiness') or {},
+            thresholds.allow_warnings,
+        ),
+        _status_check(
+            'recording_check_pass',
+            artifacts.get('recording_check') or {},
+            thresholds.allow_warnings,
+        ),
+        _status_check(
+            'readiness_pass',
+            artifacts.get('readiness') or {},
+            thresholds.allow_warnings,
+        ),
+        _check(
+            'ready_for_mid360_launch',
+            bool((artifacts.get('readiness') or {}).get('ready_for_mid360_launch')),
+            'ready_for_mid360_launch='
+            f"{(artifacts.get('readiness') or {}).get('ready_for_mid360_launch')}",
+        ),
+        _check(
+            'public_rko_adoption_gate_pass',
+            (artifacts.get('adoption_gate') or {}).get('status') == 'PASS',
+            f"adoption_gate_status={(artifacts.get('adoption_gate') or {}).get('status', '')}",
+        ),
+        _check(
+            'map_run_verified',
+            evidence.get('map_status') == 'success'
+            and evidence.get('map_verify_result') == 'PASS',
+            (
+                f"map_status={evidence.get('map_status', '')} "
+                f"verify={evidence.get('map_verify_result', '')}"
+            ),
+        ),
+        _check(
+            'real_robot_bag',
+            bool(evidence.get('bag_path'))
+            and (
+                thresholds.allow_public_bag
+                or not _looks_like_public_or_sample_bag(evidence.get('bag_path', ''))
+            ),
+            f"bag_path={evidence.get('bag_path', '')}",
+        ),
+        _check(
+            'bag_duration',
+            _maybe_float(evidence.get('estimated_bag_duration_sec')) is not None
+            and float(evidence.get('estimated_bag_duration_sec') or 0.0)
+            >= thresholds.min_bag_duration_sec,
+            (
+                f"estimated={_fmt_float(evidence.get('estimated_bag_duration_sec'))} "
+                f"min={thresholds.min_bag_duration_sec}"
+            ),
+        ),
+        _check(
+            'pointcloud_rate',
+            _maybe_float(evidence.get('pointcloud_hz')) is not None
+            and float(evidence.get('pointcloud_hz') or 0.0) >= thresholds.min_pointcloud_hz,
+            (
+                f"pointcloud_hz={_fmt_float(evidence.get('pointcloud_hz'))} "
+                f"min={thresholds.min_pointcloud_hz}"
+            ),
+        ),
+        _check(
+            'imu_rate',
+            _maybe_float(evidence.get('imu_hz')) is not None
+            and float(evidence.get('imu_hz') or 0.0) >= thresholds.min_imu_hz,
+            f"imu_hz={_fmt_float(evidence.get('imu_hz'))} min={thresholds.min_imu_hz}",
+        ),
+        _check(
+            'stable_expected_frames',
+            bool(evidence.get('pointcloud_frame_ok')) and bool(evidence.get('imu_frame_ok')),
+            (
+                f"pointcloud_frame_ok={evidence.get('pointcloud_frame_ok')} "
+                f"imu_frame_ok={evidence.get('imu_frame_ok')}"
+            ),
+        ),
+    ])
+    return checks
+
+
+def _status_check(
+    check_id: str,
+    payload: dict[str, Any],
+    allow_warnings: bool,
+) -> dict[str, str]:
+    status = str(payload.get('status') or '').upper()
+    ok = status == 'PASS' or (allow_warnings and status == 'WARN')
+    return _check(check_id, ok, f'status={status or "MISSING"}')
+
+
+def _evidence_summary(artifacts: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    readiness = artifacts.get('readiness') or {}
+    recording = artifacts.get('recording_check') or {}
+    map_diagnosis = artifacts.get('map_diagnosis') or {}
+    adoption = artifacts.get('adoption_gate') or {}
+    diagnostics = readiness.get('bag_diagnostics') or {}
+    topics = diagnostics.get('topics') or {}
+    pointcloud = topics.get('pointcloud') or {}
+    imu = topics.get('imu') or {}
+    bag_path = readiness.get('bag_path') or recording.get('bag_path') or ''
+    return {
+        'bag_path': bag_path,
+        'estimated_bag_duration_sec': _estimate_bag_duration_sec(pointcloud, imu),
+        'pointcloud_hz': _maybe_float(pointcloud.get('metadata_rate_hz')),
+        'imu_hz': _maybe_float(imu.get('metadata_rate_hz')),
+        'pointcloud_messages': int(pointcloud.get('metadata_message_count') or 0),
+        'imu_messages': int(imu.get('metadata_message_count') or 0),
+        'pointcloud_frame_ok': _topic_frame_ok(pointcloud),
+        'imu_frame_ok': _topic_frame_ok(imu),
+        'map_status': map_diagnosis.get('status', ''),
+        'map_verify_result': (map_diagnosis.get('verify') or {}).get('result', ''),
+        'adoption_matched_case': (
+            (adoption.get('decision') or {}).get('matched_case')
+            or ((adoption.get('matched_case') or {}).get('case_id'))
+            or ''
+        ),
+        'adoption_recommended_case': (
+            (adoption.get('decision') or {}).get('recommended_case')
+            or ((adoption.get('recommended_case') or {}).get('case_id'))
+            or ''
+        ),
+    }
+
+
+def _topic_frame_ok(topic: dict[str, Any]) -> bool:
+    if topic.get('stable_frame_id') is False:
+        return False
+    if topic.get('matches_expected_frame') is False:
+        return False
+    if topic.get('sampled_message_count') == 0:
+        return False
+    return True
+
+
+def _estimate_bag_duration_sec(pointcloud: dict[str, Any], imu: dict[str, Any]) -> float | None:
+    estimates = []
+    for topic in (pointcloud, imu):
+        count = _maybe_float(topic.get('metadata_message_count'))
+        rate = _maybe_float(topic.get('metadata_rate_hz'))
+        if count is not None and rate is not None and rate > 0.0:
+            estimates.append(count / rate)
+    if not estimates:
+        return None
+    return max(estimates)
+
+
+def _looks_like_public_or_sample_bag(path: str) -> bool:
+    text = path.replace('\\', '/').lower()
+    blocked_tokens = (
+        '/datasets/mid360_public/',
+        '/datasets/mid360_public_segments/',
+        'mid360_sample',
+        'sample_session',
+        'synthetic',
+    )
+    return any(token in text for token in blocked_tokens)
+
+
+def _check(check_id: str, passed: bool, message: str) -> dict[str, str]:
+    return {
+        'id': check_id,
+        'status': 'PASS' if passed else 'FAIL',
+        'message': message,
+    }
+
+
+def _overall_status(checks: list[dict[str, str]]) -> str:
+    if any(check['status'] == 'FAIL' for check in checks):
+        return 'FAIL'
+    if any(check['status'] == 'WARN' for check in checks):
+        return 'WARN'
+    return 'PASS'
+
+
+def _count_checks(checks: list[dict[str, str]]) -> dict[str, int]:
+    return {
+        'pass': sum(1 for check in checks if check['status'] == 'PASS'),
+        'warn': sum(1 for check in checks if check['status'] == 'WARN'),
+        'fail': sum(1 for check in checks if check['status'] == 'FAIL'),
+    }
+
+
+def _next_actions(checks: list[dict[str, str]], paths: dict[str, str]) -> list[str]:
+    failed = {check['id'] for check in checks if check['status'] == 'FAIL'}
+    actions = []
+    if 'host_readiness_present' in failed or 'host_readiness_pass' in failed:
+        actions.append(
+            'Run check_jetson_mid360_host_readiness.py on the Jetson '
+            'with the production bag directory.'
+        )
+    if 'recording_check_present' in failed or 'recording_check_pass' in failed:
+        actions.append(
+            'Run check_mid360_robot_recording.sh on a real robot recording '
+            'with the final robot profile.'
+        )
+    if (
+        'readiness_present' in failed
+        or 'readiness_pass' in failed
+        or 'ready_for_mid360_launch' in failed
+    ):
+        actions.append(
+            'Run check_mid360_robot_readiness.py with the exact production '
+            'robot profile and bag.'
+        )
+    if 'map_diagnosis_present' in failed or 'map_run_verified' in failed:
+        actions.append(
+            'Run the production bag through mapping, call /map_save, then run '
+            'diagnose_autoware_map_run.py --write.'
+        )
+    if 'adoption_gate_present' in failed or 'public_rko_adoption_gate_pass' in failed:
+        actions.append(
+            'Run run_mid360_robot_public_rko_adoption_gate.py from the latest '
+            'public MID-360 sweep evidence.'
+        )
+    if 'real_robot_bag' in failed:
+        actions.append(
+            'Use an actual robot field bag, not public dataset or synthetic sample evidence.'
+        )
+    if 'bag_duration' in failed:
+        actions.append(
+            'Record a longer stationary/walking production candidate bag and rerun readiness.'
+        )
+    if 'stable_expected_frames' in failed:
+        actions.append('Fix frame IDs and static TF/profile measurements before mapping.')
+    return actions[:8]
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    path = path.expanduser()
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _maybe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def _fmt_float(value: Any) -> str:
+    number = _maybe_float(value)
+    return '' if number is None else f'{number:.3f}'


### PR DESCRIPTION
## Summary

Adds `scripts/mid360_robot_production_readiness.py` — an operator-facing gate that decides whether a Jetson + MID-360 robot deployment is *production-ready*, by aggregating signals from the artifacts produced by earlier checks in the pipeline.

Depends only on `mid360_robot_tools` (foundation, PR #168), so it slots cleanly above PR #171 (record-tools) on the inside-out stack.

### What's in
- **`Mid360ProductionReadinessGate`** — builds a report with checks for:
  - presence + PASS status of each input artifact (host_readiness, recording_check, readiness, map_diagnosis, public RKO adoption_gate)
  - `ready_for_mid360_launch` flag from readiness
  - **real robot bag** (rejects public dataset / synthetic sample bags unless `--allow-public-bag` is set — see `_looks_like_public_or_sample_bag`)
  - bag duration ≥ threshold (default 600s)
  - point cloud + IMU rates ≥ threshold
  - stable expected frame IDs on both topics
  - Autoware map verify result == PASS
- **`ProductionReadinessThresholds`** — tunable: min bag duration / pointcloud / IMU Hz, `allow_warnings`, `allow_public_bag`.
- **`write_production_readiness_report` / `render_production_readiness_markdown`** — operator-facing JSON + Markdown.
- **`_next_actions`** — surfaces remediation commands per failed check (e.g. \"Run check_jetson_mid360_host_readiness.py …\").
- **`scripts/check_mid360_robot_production_readiness.py`** — argparse CLI wrapper, exits non-zero on FAIL.

### Why this PR
This is the gating layer that the downstream session orchestrator + dashboard (still local) call to decide whether the candidate session is shippable. Landing it next, between record-tools (PR #171) and the public-RKO stack, keeps each PR narrow.

## Test plan

- [x] `python3 -m pytest graph_based_slam/test/test_mid360_robot_production_readiness.py -v` → 5 passed (PASS path, public-bag FAIL, map-not-verified FAIL, write_report, CLI subprocess)
- [x] `python3 -m flake8 --select=E,W,F --ignore=W503 --max-line-length=99 scripts/mid360_robot_production_readiness.py scripts/check_mid360_robot_production_readiness.py graph_based_slam/test/test_mid360_robot_production_readiness.py` → clean
- [ ] Humble + Jazzy matrix CI (colcon build + colcon test) — let CI confirm