### PR TITLE
feat: MID-360 public RKO quality report + RKO config adoption checks

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -229,6 +229,16 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_mid360_robot_rko_config_adoption
+    test/test_mid360_robot_rko_config_adoption.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
+    test_mid360_robot_public_rko_quality_report
+    test/test_mid360_robot_public_rko_quality_report.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_navsatfix_covariance_inspector
     test/test_navsatfix_covariance_inspector.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_mid360_robot_public_rko_quality_report.py
+++ b/graph_based_slam/test/test_mid360_robot_public_rko_quality_report.py
@@ -1,0 +1,232 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for public MID-360 RKO-LIO quality reports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import struct
+import subprocess
+import sys
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = REPO_ROOT / 'scripts'
+QUALITY_SCRIPT = SCRIPT_DIR / 'generate_mid360_robot_public_rko_quality_report.py'
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from mid360_robot_public_rko_quality_report import (  # noqa: E402
+    RKO_QUALITY_HTML,
+    RKO_QUALITY_JSON,
+    RKO_QUALITY_MARKDOWN,
+    RkoQualityGateThresholds,
+    RkoQualityReportBuilder,
+    render_rko_quality_markdown,
+    write_rko_quality_report,
+)
+
+
+def _write_binary_xyz_pcd(path: Path, points: list[tuple[float, float, float]]) -> None:
+    header = '\n'.join([
+        '# .PCD v0.7 - Point Cloud Data file format',
+        'VERSION 0.7',
+        'FIELDS x y z',
+        'SIZE 4 4 4',
+        'TYPE F F F',
+        'COUNT 1 1 1',
+        f'WIDTH {len(points)}',
+        'HEIGHT 1',
+        'VIEWPOINT 0 0 0 1 0 0 0',
+        f'POINTS {len(points)}',
+        'DATA binary',
+        '',
+    ])
+    payload = b''.join(struct.pack('<fff', *point) for point in points)
+    path.write_bytes(header.encode('ascii') + payload)
+
+
+def _write_case_output(root: Path, case_id: str, *, points: int, poses: int) -> Path:
+    case_dir = root / case_id
+    map_dir = case_dir / 'pointcloud_map'
+    traj_dir = case_dir / f'{case_id}_0'
+    map_dir.mkdir(parents=True)
+    traj_dir.mkdir(parents=True)
+    (case_dir / 'map_projector_info.yaml').write_text('projector_type: Local\n', encoding='utf-8')
+    (map_dir / 'pointcloud_map_metadata.yaml').write_text(
+        yaml.safe_dump({
+            'x_resolution': 20,
+            'y_resolution': 20,
+            '0_0.pcd': [0, 0],
+        }, sort_keys=False),
+        encoding='utf-8',
+    )
+    _write_binary_xyz_pcd(
+        map_dir / '0_0.pcd',
+        [(float(index), 1.0, 0.0) for index in range(points)],
+    )
+    traj_lines = [
+        f'{float(index):.1f} {float(index):.3f} 0.0 0.0 0.0 0.0 0.0 1.0'
+        for index in range(poses)
+    ]
+    (traj_dir / f'{case_id}_tum_0.txt').write_text('\n'.join(traj_lines) + '\n', encoding='utf-8')
+    return case_dir
+
+
+def _write_sweep(tmp_path: Path) -> Path:
+    sweep_dir = tmp_path / 'sweep'
+    best_dir = _write_case_output(sweep_dir, 'voxel_0p50_min_1p00_dd_on', points=4, poses=5)
+    weak_dir = _write_case_output(sweep_dir, 'voxel_0p30_min_1p00_dd_on', points=2, poses=3)
+    manifest = {
+        'status': 'PASS',
+        'bag_path': str(tmp_path / 'bag'),
+        'output_dir': str(sweep_dir),
+        'diagnostics': [
+            {
+                'case_id': 'voxel_0p50_min_1p00_dd_on',
+                'label': 'voxel_0p50_min_1p00_dd_on',
+                'status': 'MAP_VERIFIED',
+                'parameters': {'voxel_size': 0.5, 'min_range': 1.0},
+                'output_dir': str(best_dir),
+                'run_result': {'returncode': 0, 'timed_out': False, 'duration_sec': 13.5},
+                'runtime': {
+                    'offline_completed': True,
+                    'keypoints_too_few_count': 0,
+                    'lidar_delta_error_count': 0,
+                },
+                'outputs': {'map_saved': True},
+                'verification': {'result': 'PASS'},
+            },
+            {
+                'case_id': 'voxel_0p30_min_1p00_dd_on',
+                'label': 'voxel_0p30_min_1p00_dd_on',
+                'status': 'MAP_SAVED',
+                'parameters': {'voxel_size': 0.3, 'min_range': 1.0},
+                'output_dir': str(weak_dir),
+                'run_result': {'returncode': 0, 'timed_out': False, 'duration_sec': 19.5},
+                'runtime': {
+                    'offline_completed': True,
+                    'keypoints_too_few_count': 1,
+                    'lidar_delta_error_count': 0,
+                },
+                'outputs': {'map_saved': True},
+                'verification': {'result': 'SKIP'},
+            },
+        ],
+    }
+    path = sweep_dir / 'mid360_robot_public_rko_sweep.json'
+    path.write_text(json.dumps(manifest), encoding='utf-8')
+    return path
+
+
+def test_quality_report_summarizes_map_and_trajectory(tmp_path: Path):
+    sweep_path = _write_sweep(tmp_path)
+
+    report = RkoQualityReportBuilder(
+        sweep_path,
+        thresholds=RkoQualityGateThresholds(
+            min_trajectory_poses=5,
+            min_path_length_m=3.0,
+            max_step_m=2.0,
+            min_map_points=4,
+            min_map_tiles=1,
+            max_runtime_sec=20.0,
+        ),
+    ).build_report()
+
+    assert report['status'] == 'PASS'
+    assert report['counts']['cases'] == 2
+    assert report['counts']['map_verified'] == 1
+    assert report['counts']['gate_pass'] == 1
+    assert report['counts']['total_map_points'] == 6
+    assert report['best_case']['case_id'] == 'voxel_0p50_min_1p00_dd_on'
+    assert report['best_case']['gate_status'] == 'PASS'
+    assert report['cases'][0]['rank'] == 1
+    assert report['cases'][0]['quality_gate']['status'] == 'PASS'
+    assert report['cases'][0]['trajectory']['poses'] == 5
+    assert report['cases'][0]['trajectory']['path_length_m'] == 4.0
+    assert report['cases'][0]['map_quality']['tile_count'] == 1
+    assert report['cases'][0]['map_quality']['point_density_per_m2'] == 0.01
+
+
+def test_quality_report_writes_json_markdown_and_html(tmp_path: Path):
+    sweep_path = _write_sweep(tmp_path)
+    report = RkoQualityReportBuilder(sweep_path).build_report()
+    output_dir = tmp_path / 'report'
+
+    paths = write_rko_quality_report(report, output_dir)
+    markdown = render_rko_quality_markdown(report)
+    html = paths['html'].read_text(encoding='utf-8')
+
+    assert paths['json'] == output_dir / RKO_QUALITY_JSON
+    assert paths['markdown'] == output_dir / RKO_QUALITY_MARKDOWN
+    assert paths['html'] == output_dir / RKO_QUALITY_HTML
+    assert 'Quality Report' in markdown
+    assert 'Gate' in markdown
+    assert 'Map Points' in html
+    assert json.loads(paths['json'].read_text(encoding='utf-8'))['counts']['cases'] == 2
+
+
+def test_quality_report_cli_outputs_json(tmp_path: Path):
+    sweep_path = _write_sweep(tmp_path)
+    output_dir = tmp_path / 'quality'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(QUALITY_SCRIPT),
+            '--sweep',
+            str(sweep_path),
+            '--output-dir',
+            str(output_dir),
+            '--min-trajectory-poses',
+            '5',
+            '--min-path-length-m',
+            '3',
+            '--min-map-points',
+            '4',
+            '--min-map-tiles',
+            '1',
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    report = json.loads(result.stdout)
+
+    assert report['best_case']['case_id'] == 'voxel_0p50_min_1p00_dd_on'
+    assert report['counts']['gate_pass'] == 1
+    assert (output_dir / RKO_QUALITY_JSON).is_file()
+    assert (output_dir / RKO_QUALITY_MARKDOWN).is_file()
+    assert (output_dir / RKO_QUALITY_HTML).is_file()

--- a/graph_based_slam/test/test_mid360_robot_public_rko_quality_report.py
+++ b/graph_based_slam/test/test_mid360_robot_public_rko_quality_report.py
@@ -46,12 +46,12 @@ QUALITY_SCRIPT = SCRIPT_DIR / 'generate_mid360_robot_public_rko_quality_report.p
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from mid360_robot_public_rko_quality_report import (  # noqa: E402
+    render_rko_quality_markdown,
     RKO_QUALITY_HTML,
     RKO_QUALITY_JSON,
     RKO_QUALITY_MARKDOWN,
     RkoQualityGateThresholds,
     RkoQualityReportBuilder,
-    render_rko_quality_markdown,
     write_rko_quality_report,
 )
 

--- a/graph_based_slam/test/test_mid360_robot_public_rko_quality_report.py
+++ b/graph_based_slam/test/test_mid360_robot_public_rko_quality_report.py
@@ -31,6 +31,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 from pathlib import Path
 import struct
@@ -43,17 +44,12 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_DIR = REPO_ROOT / 'scripts'
 QUALITY_SCRIPT = SCRIPT_DIR / 'generate_mid360_robot_public_rko_quality_report.py'
-sys.path.insert(0, str(SCRIPT_DIR))
 
-from mid360_robot_public_rko_quality_report import (  # noqa: E402
-    render_rko_quality_markdown,
-    RKO_QUALITY_HTML,
-    RKO_QUALITY_JSON,
-    RKO_QUALITY_MARKDOWN,
-    RkoQualityGateThresholds,
-    RkoQualityReportBuilder,
-    write_rko_quality_report,
-)
+
+def _quality_module():
+    if str(SCRIPT_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_DIR))
+    return importlib.import_module('mid360_robot_public_rko_quality_report')
 
 
 def _write_binary_xyz_pcd(path: Path, points: list[tuple[float, float, float]]) -> None:
@@ -149,11 +145,12 @@ def _write_sweep(tmp_path: Path) -> Path:
 
 
 def test_quality_report_summarizes_map_and_trajectory(tmp_path: Path):
+    module = _quality_module()
     sweep_path = _write_sweep(tmp_path)
 
-    report = RkoQualityReportBuilder(
+    report = module.RkoQualityReportBuilder(
         sweep_path,
-        thresholds=RkoQualityGateThresholds(
+        thresholds=module.RkoQualityGateThresholds(
             min_trajectory_poses=5,
             min_path_length_m=3.0,
             max_step_m=2.0,
@@ -179,17 +176,18 @@ def test_quality_report_summarizes_map_and_trajectory(tmp_path: Path):
 
 
 def test_quality_report_writes_json_markdown_and_html(tmp_path: Path):
+    module = _quality_module()
     sweep_path = _write_sweep(tmp_path)
-    report = RkoQualityReportBuilder(sweep_path).build_report()
+    report = module.RkoQualityReportBuilder(sweep_path).build_report()
     output_dir = tmp_path / 'report'
 
-    paths = write_rko_quality_report(report, output_dir)
-    markdown = render_rko_quality_markdown(report)
+    paths = module.write_rko_quality_report(report, output_dir)
+    markdown = module.render_rko_quality_markdown(report)
     html = paths['html'].read_text(encoding='utf-8')
 
-    assert paths['json'] == output_dir / RKO_QUALITY_JSON
-    assert paths['markdown'] == output_dir / RKO_QUALITY_MARKDOWN
-    assert paths['html'] == output_dir / RKO_QUALITY_HTML
+    assert paths['json'] == output_dir / module.RKO_QUALITY_JSON
+    assert paths['markdown'] == output_dir / module.RKO_QUALITY_MARKDOWN
+    assert paths['html'] == output_dir / module.RKO_QUALITY_HTML
     assert 'Quality Report' in markdown
     assert 'Gate' in markdown
     assert 'Map Points' in html
@@ -197,6 +195,7 @@ def test_quality_report_writes_json_markdown_and_html(tmp_path: Path):
 
 
 def test_quality_report_cli_outputs_json(tmp_path: Path):
+    module = _quality_module()
     sweep_path = _write_sweep(tmp_path)
     output_dir = tmp_path / 'quality'
 
@@ -227,6 +226,6 @@ def test_quality_report_cli_outputs_json(tmp_path: Path):
 
     assert report['best_case']['case_id'] == 'voxel_0p50_min_1p00_dd_on'
     assert report['counts']['gate_pass'] == 1
-    assert (output_dir / RKO_QUALITY_JSON).is_file()
-    assert (output_dir / RKO_QUALITY_MARKDOWN).is_file()
-    assert (output_dir / RKO_QUALITY_HTML).is_file()
+    assert (output_dir / module.RKO_QUALITY_JSON).is_file()
+    assert (output_dir / module.RKO_QUALITY_MARKDOWN).is_file()
+    assert (output_dir / module.RKO_QUALITY_HTML).is_file()

--- a/graph_based_slam/test/test_mid360_robot_rko_config_adoption.py
+++ b/graph_based_slam/test/test_mid360_robot_rko_config_adoption.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for MID-360 RKO-LIO config adoption checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = REPO_ROOT / 'scripts'
+ADOPTION_SCRIPT = SCRIPT_DIR / 'check_mid360_robot_rko_config_adoption.py'
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from mid360_robot_rko_config_adoption import (  # noqa: E402
+    RKO_CONFIG_ADOPTION_JSON,
+    RKO_CONFIG_ADOPTION_MARKDOWN,
+    RkoConfigAdoptionChecker,
+    render_rko_config_adoption_markdown,
+    write_rko_config_adoption_report,
+)
+
+
+BEST_PARAMETERS = {
+    'voxel_size': 0.5,
+    'min_range': 1.0,
+    'max_range': 100.0,
+    'deskew': False,
+    'double_downsample': True,
+    'initialization_phase': False,
+}
+
+
+def _write_quality_report(tmp_path: Path) -> Path:
+    quality = {
+        'status': 'PASS',
+        'cases': [
+            {
+                'case_id': 'voxel_0p50_min_1p00_dd_on',
+                'rank': 1,
+                'status': 'MAP_VERIFIED',
+                'quality_score': 95,
+                'parameters': BEST_PARAMETERS,
+                'quality_gate': {'status': 'PASS'},
+                'output_dir': str(tmp_path / 'sweep' / 'voxel_0p50_min_1p00_dd_on'),
+            },
+            {
+                'case_id': 'voxel_0p30_min_1p00_dd_on',
+                'rank': 2,
+                'status': 'MAP_VERIFIED',
+                'quality_score': 92,
+                'parameters': {**BEST_PARAMETERS, 'voxel_size': 0.3},
+                'quality_gate': {'status': 'PASS'},
+                'output_dir': str(tmp_path / 'sweep' / 'voxel_0p30_min_1p00_dd_on'),
+            },
+        ],
+    }
+    path = tmp_path / 'mid360_robot_public_rko_quality_report.json'
+    path.write_text(json.dumps(quality), encoding='utf-8')
+    return path
+
+
+def _write_config(tmp_path: Path, parameters: dict) -> Path:
+    path = tmp_path / 'rko_config.yaml'
+    path.write_text(yaml.safe_dump(parameters, sort_keys=False), encoding='utf-8')
+    return path
+
+
+def test_adoption_checker_passes_for_best_gate_config(tmp_path: Path):
+    quality_path = _write_quality_report(tmp_path)
+    config_path = _write_config(tmp_path, BEST_PARAMETERS)
+
+    report = RkoConfigAdoptionChecker(
+        quality_report_path=quality_path,
+        config_path=config_path,
+        require_best=True,
+    ).build_report()
+
+    assert report['status'] == 'PASS'
+    assert report['matched_case']['case_id'] == 'voxel_0p50_min_1p00_dd_on'
+    assert report['recommended_case']['case_id'] == 'voxel_0p50_min_1p00_dd_on'
+    assert report['parameter_diff_to_recommended'] == []
+    assert all(check['status'] == 'PASS' for check in report['checks'])
+
+
+def test_adoption_checker_fails_when_config_is_not_best(tmp_path: Path):
+    quality_path = _write_quality_report(tmp_path)
+    config_path = _write_config(tmp_path, {**BEST_PARAMETERS, 'voxel_size': 0.3})
+
+    report = RkoConfigAdoptionChecker(
+        quality_report_path=quality_path,
+        config_path=config_path,
+        require_best=True,
+    ).build_report()
+
+    assert report['status'] == 'FAIL'
+    assert report['matched_case']['case_id'] == 'voxel_0p30_min_1p00_dd_on'
+    assert any(check['id'] == 'matched_case_is_best' and check['status'] == 'FAIL'
+               for check in report['checks'])
+    assert report['parameter_diff_to_recommended'][0]['key'] == 'voxel_size'
+
+
+def test_adoption_report_writes_json_and_markdown(tmp_path: Path):
+    quality_path = _write_quality_report(tmp_path)
+    config_path = _write_config(tmp_path, BEST_PARAMETERS)
+    report = RkoConfigAdoptionChecker(quality_path, config_path, require_best=True).build_report()
+    output_dir = tmp_path / 'out'
+
+    paths = write_rko_config_adoption_report(report, output_dir)
+    markdown = render_rko_config_adoption_markdown(report)
+
+    assert paths['json'] == output_dir / RKO_CONFIG_ADOPTION_JSON
+    assert paths['markdown'] == output_dir / RKO_CONFIG_ADOPTION_MARKDOWN
+    assert 'matched_case' in markdown
+    assert json.loads(paths['json'].read_text(encoding='utf-8'))['status'] == 'PASS'
+
+
+def test_adoption_cli_returns_nonzero_for_non_best_config(tmp_path: Path):
+    quality_path = _write_quality_report(tmp_path)
+    config_path = _write_config(tmp_path, {**BEST_PARAMETERS, 'voxel_size': 0.3})
+    output_dir = tmp_path / 'adoption'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ADOPTION_SCRIPT),
+            '--quality-report',
+            str(quality_path),
+            '--config',
+            str(config_path),
+            '--output-dir',
+            str(output_dir),
+            '--require-best',
+            '--json',
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    report = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert report['status'] == 'FAIL'
+    assert (output_dir / RKO_CONFIG_ADOPTION_JSON).is_file()
+    assert (output_dir / RKO_CONFIG_ADOPTION_MARKDOWN).is_file()

--- a/graph_based_slam/test/test_mid360_robot_rko_config_adoption.py
+++ b/graph_based_slam/test/test_mid360_robot_rko_config_adoption.py
@@ -45,10 +45,10 @@ ADOPTION_SCRIPT = SCRIPT_DIR / 'check_mid360_robot_rko_config_adoption.py'
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from mid360_robot_rko_config_adoption import (  # noqa: E402
+    render_rko_config_adoption_markdown,
     RKO_CONFIG_ADOPTION_JSON,
     RKO_CONFIG_ADOPTION_MARKDOWN,
     RkoConfigAdoptionChecker,
-    render_rko_config_adoption_markdown,
     write_rko_config_adoption_report,
 )
 

--- a/graph_based_slam/test/test_mid360_robot_rko_config_adoption.py
+++ b/graph_based_slam/test/test_mid360_robot_rko_config_adoption.py
@@ -31,6 +31,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 from pathlib import Path
 import subprocess
@@ -42,15 +43,12 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_DIR = REPO_ROOT / 'scripts'
 ADOPTION_SCRIPT = SCRIPT_DIR / 'check_mid360_robot_rko_config_adoption.py'
-sys.path.insert(0, str(SCRIPT_DIR))
 
-from mid360_robot_rko_config_adoption import (  # noqa: E402
-    render_rko_config_adoption_markdown,
-    RKO_CONFIG_ADOPTION_JSON,
-    RKO_CONFIG_ADOPTION_MARKDOWN,
-    RkoConfigAdoptionChecker,
-    write_rko_config_adoption_report,
-)
+
+def _adoption_module():
+    if str(SCRIPT_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_DIR))
+    return importlib.import_module('mid360_robot_rko_config_adoption')
 
 
 BEST_PARAMETERS = {
@@ -99,10 +97,11 @@ def _write_config(tmp_path: Path, parameters: dict) -> Path:
 
 
 def test_adoption_checker_passes_for_best_gate_config(tmp_path: Path):
+    module = _adoption_module()
     quality_path = _write_quality_report(tmp_path)
     config_path = _write_config(tmp_path, BEST_PARAMETERS)
 
-    report = RkoConfigAdoptionChecker(
+    report = module.RkoConfigAdoptionChecker(
         quality_report_path=quality_path,
         config_path=config_path,
         require_best=True,
@@ -116,10 +115,11 @@ def test_adoption_checker_passes_for_best_gate_config(tmp_path: Path):
 
 
 def test_adoption_checker_fails_when_config_is_not_best(tmp_path: Path):
+    module = _adoption_module()
     quality_path = _write_quality_report(tmp_path)
     config_path = _write_config(tmp_path, {**BEST_PARAMETERS, 'voxel_size': 0.3})
 
-    report = RkoConfigAdoptionChecker(
+    report = module.RkoConfigAdoptionChecker(
         quality_report_path=quality_path,
         config_path=config_path,
         require_best=True,
@@ -133,21 +133,25 @@ def test_adoption_checker_fails_when_config_is_not_best(tmp_path: Path):
 
 
 def test_adoption_report_writes_json_and_markdown(tmp_path: Path):
+    module = _adoption_module()
     quality_path = _write_quality_report(tmp_path)
     config_path = _write_config(tmp_path, BEST_PARAMETERS)
-    report = RkoConfigAdoptionChecker(quality_path, config_path, require_best=True).build_report()
+    report = module.RkoConfigAdoptionChecker(
+        quality_path, config_path, require_best=True,
+    ).build_report()
     output_dir = tmp_path / 'out'
 
-    paths = write_rko_config_adoption_report(report, output_dir)
-    markdown = render_rko_config_adoption_markdown(report)
+    paths = module.write_rko_config_adoption_report(report, output_dir)
+    markdown = module.render_rko_config_adoption_markdown(report)
 
-    assert paths['json'] == output_dir / RKO_CONFIG_ADOPTION_JSON
-    assert paths['markdown'] == output_dir / RKO_CONFIG_ADOPTION_MARKDOWN
+    assert paths['json'] == output_dir / module.RKO_CONFIG_ADOPTION_JSON
+    assert paths['markdown'] == output_dir / module.RKO_CONFIG_ADOPTION_MARKDOWN
     assert 'matched_case' in markdown
     assert json.loads(paths['json'].read_text(encoding='utf-8'))['status'] == 'PASS'
 
 
 def test_adoption_cli_returns_nonzero_for_non_best_config(tmp_path: Path):
+    module = _adoption_module()
     quality_path = _write_quality_report(tmp_path)
     config_path = _write_config(tmp_path, {**BEST_PARAMETERS, 'voxel_size': 0.3})
     output_dir = tmp_path / 'adoption'
@@ -173,5 +177,5 @@ def test_adoption_cli_returns_nonzero_for_non_best_config(tmp_path: Path):
 
     assert result.returncode == 1
     assert report['status'] == 'FAIL'
-    assert (output_dir / RKO_CONFIG_ADOPTION_JSON).is_file()
-    assert (output_dir / RKO_CONFIG_ADOPTION_MARKDOWN).is_file()
+    assert (output_dir / module.RKO_CONFIG_ADOPTION_JSON).is_file()
+    assert (output_dir / module.RKO_CONFIG_ADOPTION_MARKDOWN).is_file()

--- a/scripts/check_mid360_robot_rko_config_adoption.py
+++ b/scripts/check_mid360_robot_rko_config_adoption.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Check that a tracked MID-360 RKO-LIO config is backed by real-data QA."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from mid360_robot_rko_config_adoption import (
+    RKO_CONFIG_ADOPTION_JSON,
+    RKO_CONFIG_ADOPTION_MARKDOWN,
+    RkoConfigAdoptionChecker,
+    render_rko_config_adoption_markdown,
+    write_rko_config_adoption_report,
+)
+from mid360_robot_tools import payload_to_json
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_QUALITY_REPORT = (
+    REPO_ROOT
+    / 'output'
+    / 'mid360_public'
+    / 'rko_sweep'
+    / 'mid360_robot_public_rko_quality_report.json'
+)
+DEFAULT_CONFIG = (
+    REPO_ROOT
+    / 'configs'
+    / 'mid360_robot'
+    / 'rko_lio_mid360_low_voxel_no_deskew.yaml'
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description='Validate a tracked RKO-LIO MID-360 config against public real-data QA.'
+    )
+    parser.add_argument(
+        '--quality-report',
+        default=str(DEFAULT_QUALITY_REPORT),
+        help='Path to mid360_robot_public_rko_quality_report.json.',
+    )
+    parser.add_argument(
+        '--config',
+        default=str(DEFAULT_CONFIG),
+        help='Tracked RKO-LIO YAML to validate.',
+    )
+    parser.add_argument(
+        '--output-dir',
+        default='',
+        help='Directory for adoption report outputs. Defaults to the quality report directory.',
+    )
+    parser.add_argument(
+        '--require-best',
+        action='store_true',
+        help='Require the config to match the top-ranked gate-pass case.',
+    )
+    parser.add_argument(
+        '--tolerance',
+        type=float,
+        default=1e-6,
+        help='Float comparison tolerance for config parameters.',
+    )
+    parser.add_argument('--json', action='store_true', help='Print JSON instead of Markdown.')
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point."""
+    args = parse_args()
+    quality_report_path = Path(args.quality_report).expanduser().resolve()
+    output_dir = (
+        Path(args.output_dir).expanduser().resolve()
+        if args.output_dir
+        else quality_report_path.parent
+    )
+    try:
+        report = RkoConfigAdoptionChecker(
+            quality_report_path=quality_report_path,
+            config_path=Path(args.config),
+            require_best=args.require_best,
+            tolerance=max(0.0, float(args.tolerance)),
+        ).build_report()
+        paths = write_rko_config_adoption_report(report, output_dir)
+    except Exception as exc:
+        print(f'failed to check MID-360 RKO-LIO config adoption: {exc}', file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(payload_to_json(report))
+    else:
+        print(render_rko_config_adoption_markdown(report))
+        print(f'{RKO_CONFIG_ADOPTION_JSON}: {paths["json"]}')
+        print(f'{RKO_CONFIG_ADOPTION_MARKDOWN}: {paths["markdown"]}')
+    return 0 if report['status'] == 'PASS' else 1
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print('Interrupted', file=sys.stderr)
+        raise SystemExit(130)

--- a/scripts/generate_mid360_robot_public_rko_quality_report.py
+++ b/scripts/generate_mid360_robot_public_rko_quality_report.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Generate a quality dashboard from a public MID-360 RKO-LIO sweep manifest."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from mid360_robot_public_rko_quality_report import (
+    RKO_QUALITY_HTML,
+    RKO_QUALITY_JSON,
+    RKO_QUALITY_MARKDOWN,
+    RkoQualityGateThresholds,
+    RkoQualityReportBuilder,
+    render_rko_quality_markdown,
+    write_rko_quality_report,
+)
+from mid360_robot_tools import payload_to_json
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SWEEP = (
+    REPO_ROOT
+    / 'output'
+    / 'mid360_public'
+    / 'rko_sweep'
+    / 'mid360_robot_public_rko_sweep.json'
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description='Build a map and trajectory quality report for a MID-360 public RKO sweep.'
+    )
+    parser.add_argument(
+        '--sweep',
+        default=str(DEFAULT_SWEEP),
+        help='Path to mid360_robot_public_rko_sweep.json.',
+    )
+    parser.add_argument(
+        '--output-dir',
+        default='',
+        help='Directory for quality report outputs. Defaults to the sweep manifest directory.',
+    )
+    parser.add_argument(
+        '--min-trajectory-poses',
+        type=int,
+        default=200,
+        help='Minimum valid TUM trajectory poses for the quality gate.',
+    )
+    parser.add_argument(
+        '--min-path-length-m',
+        type=float,
+        default=10.0,
+        help='Minimum trajectory path length for the quality gate.',
+    )
+    parser.add_argument(
+        '--max-step-m',
+        type=float,
+        default=5.0,
+        help='Maximum adjacent trajectory step for the quality gate.',
+    )
+    parser.add_argument(
+        '--min-map-points',
+        type=int,
+        default=100000,
+        help='Minimum total point count across referenced pointcloud_map tiles.',
+    )
+    parser.add_argument(
+        '--min-map-tiles',
+        type=int,
+        default=10,
+        help='Minimum referenced pointcloud_map tile count for the quality gate.',
+    )
+    parser.add_argument(
+        '--max-runtime-sec',
+        type=float,
+        default=120.0,
+        help='Maximum wrapper runtime for the quality gate.',
+    )
+    parser.add_argument('--json', action='store_true', help='Print JSON instead of Markdown.')
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point."""
+    args = parse_args()
+    sweep_path = Path(args.sweep).expanduser().resolve()
+    output_dir = (
+        Path(args.output_dir).expanduser().resolve()
+        if args.output_dir else sweep_path.parent
+    )
+    try:
+        thresholds = RkoQualityGateThresholds(
+            min_trajectory_poses=max(0, int(args.min_trajectory_poses)),
+            min_path_length_m=max(0.0, float(args.min_path_length_m)),
+            max_step_m=max(0.0, float(args.max_step_m)),
+            min_map_points=max(0, int(args.min_map_points)),
+            min_map_tiles=max(0, int(args.min_map_tiles)),
+            max_runtime_sec=max(0.0, float(args.max_runtime_sec)),
+        )
+        report = RkoQualityReportBuilder(
+            sweep_path=sweep_path,
+            thresholds=thresholds,
+        ).build_report()
+        paths = write_rko_quality_report(report, output_dir)
+    except Exception as exc:
+        print(f'failed to generate public MID-360 RKO quality report: {exc}', file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(payload_to_json(report))
+    else:
+        print(render_rko_quality_markdown(report))
+        print(f'{RKO_QUALITY_JSON}: {paths["json"]}')
+        print(f'{RKO_QUALITY_MARKDOWN}: {paths["markdown"]}')
+        print(f'{RKO_QUALITY_HTML}: {paths["html"]}')
+    return 1 if report['status'] in ('EMPTY',) else 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print('Interrupted', file=sys.stderr)
+        raise SystemExit(130)

--- a/scripts/mid360_robot_public_rko_quality_report.py
+++ b/scripts/mid360_robot_public_rko_quality_report.py
@@ -1,0 +1,872 @@
+#!/usr/bin/env python3
+"""Quality reports for public MID-360 RKO-LIO sweep outputs."""
+
+from __future__ import annotations
+
+import html
+import json
+import math
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from mid360_robot_tools import payload_to_json
+
+
+RKO_QUALITY_JSON = 'mid360_robot_public_rko_quality_report.json'
+RKO_QUALITY_MARKDOWN = 'mid360_robot_public_rko_quality_report.md'
+RKO_QUALITY_HTML = 'mid360_robot_public_rko_quality_report.html'
+
+
+@dataclass(frozen=True)
+class RkoQualityGateThresholds:
+    """Minimum acceptance thresholds for a real-data MID-360 RKO-LIO case."""
+
+    min_trajectory_poses: int = 200
+    min_path_length_m: float = 10.0
+    max_step_m: float = 5.0
+    min_map_points: int = 100000
+    min_map_tiles: int = 10
+    max_runtime_sec: float = 120.0
+
+
+class RkoQualityReportBuilder:
+    """Build a case-by-case quality report from a public RKO sweep manifest."""
+
+    def __init__(
+        self,
+        sweep_path: Path,
+        thresholds: RkoQualityGateThresholds | None = None,
+    ) -> None:
+        self._sweep_path = sweep_path.expanduser().resolve()
+        self._thresholds = thresholds or RkoQualityGateThresholds()
+
+    def build_report(self) -> dict[str, Any]:
+        """Build the quality report payload."""
+        manifest = _load_json(self._sweep_path)
+        cases = [_build_case_quality(row) for row in manifest.get('diagnostics') or []]
+        for row in cases:
+            row['quality_gate'] = _quality_gate(row, self._thresholds)
+        ranked = _rank_cases(cases)
+        rank_by_case = {
+            str(row.get('case_id') or ''): index + 1 for index, row in enumerate(ranked)
+        }
+        for row in cases:
+            row['rank'] = rank_by_case.get(str(row.get('case_id') or ''), 0)
+        best = ranked[0] if ranked else {}
+        return {
+            'created_at': datetime.now(timezone.utc).isoformat(),
+            'status': _overall_status(cases),
+            'sweep_path': str(self._sweep_path),
+            'sweep_status': manifest.get('status', ''),
+            'bag_path': manifest.get('bag_path', ''),
+            'output_dir': manifest.get('output_dir', ''),
+            'gate_thresholds': asdict(self._thresholds),
+            'counts': _counts(cases),
+            'best_case': _best_case_summary(best),
+            'cases': sorted(cases, key=lambda item: int(item.get('rank') or 9999)),
+        }
+
+
+def write_rko_quality_report(report: dict[str, Any], output_dir: Path) -> dict[str, Path]:
+    """Write JSON, Markdown, and HTML quality reports."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / RKO_QUALITY_JSON
+    markdown_path = output_dir / RKO_QUALITY_MARKDOWN
+    html_path = output_dir / RKO_QUALITY_HTML
+    json_path.write_text(payload_to_json(report) + '\n', encoding='utf-8')
+    markdown_path.write_text(render_rko_quality_markdown(report) + '\n', encoding='utf-8')
+    html_path.write_text(render_rko_quality_html(report), encoding='utf-8')
+    return {'json': json_path, 'markdown': markdown_path, 'html': html_path}
+
+
+def render_rko_quality_markdown(report: dict[str, Any]) -> str:
+    """Render the quality report as Markdown."""
+    counts = report.get('counts') or {}
+    best = report.get('best_case') or {}
+    lines = [
+        '# MID-360 Public RKO-LIO Quality Report',
+        '',
+        f"- status: `{report.get('status', '')}`",
+        f"- created_at: `{report.get('created_at', '')}`",
+        f"- sweep_path: `{report.get('sweep_path', '')}`",
+        f"- bag_path: `{report.get('bag_path', '')}`",
+        f"- cases: `{counts.get('cases', 0)}`",
+        f"- map_verified: `{counts.get('map_verified', 0)}`",
+        f"- gate_pass: `{counts.get('gate_pass', 0)}`",
+        f"- total_map_points: `{counts.get('total_map_points', 0)}`",
+        f"- best_case: `{best.get('case_id', '')}`",
+        '',
+        '## Case Quality',
+        '',
+    ]
+    cases = report.get('cases') or []
+    if not cases:
+        lines.append('- none')
+        return '\n'.join(lines)
+
+    lines.extend([
+        (
+            '| Rank | Case | Status | Verify | Voxel | Min Range | Runtime s | '
+            'Trajectory Poses | Path m | Max Step m | Map Points | Tiles | '
+            'Point Density | Gate | Score |'
+        ),
+        (
+            '| ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | '
+            '---: | ---: | ---: | --- | ---: |'
+        ),
+    ])
+    for row in cases:
+        params = row.get('parameters') or {}
+        runtime = row.get('runtime') or {}
+        trajectory = row.get('trajectory') or {}
+        map_quality = row.get('map_quality') or {}
+        verification = row.get('verification') or {}
+        gate = row.get('quality_gate') or {}
+        lines.append(
+            '| '
+            + ' | '.join([
+                str(row.get('rank', '')),
+                f"`{row.get('case_id', '')}`",
+                f"`{row.get('status', '')}`",
+                f"`{verification.get('result', '')}`",
+                _fmt_float(params.get('voxel_size')),
+                _fmt_float(params.get('min_range')),
+                _fmt_float(runtime.get('duration_sec')),
+                _fmt_int(trajectory.get('poses')),
+                _fmt_float(trajectory.get('path_length_m')),
+                _fmt_float(trajectory.get('max_step_m')),
+                _fmt_int(map_quality.get('point_count')),
+                _fmt_int(map_quality.get('tile_count')),
+                _fmt_float(map_quality.get('point_density_per_m2')),
+                f"`{gate.get('status', '')}`",
+                _fmt_int(row.get('quality_score')),
+            ])
+            + ' |'
+        )
+
+    lines.extend(['', '## Best Case', ''])
+    if best:
+        lines.extend([
+            f"- case: `{best.get('case_id', '')}`",
+            f"- status: `{best.get('status', '')}`",
+            f"- gate: `{best.get('gate_status', '')}`",
+            f"- score: `{best.get('quality_score', 0)}`",
+            f"- output_dir: `{best.get('output_dir', '')}`",
+        ])
+    else:
+        lines.append('- none')
+    return '\n'.join(lines)
+
+
+def render_rko_quality_html(report: dict[str, Any]) -> str:
+    """Render the quality report as self-contained HTML."""
+    rows = report.get('cases') or []
+    status = str(report.get('status') or 'UNKNOWN').upper()
+    return '\n'.join([
+        '<!doctype html>',
+        '<html lang="en">',
+        '<head>',
+        '<meta charset="utf-8">',
+        '<meta name="viewport" content="width=device-width, initial-scale=1">',
+        '<title>MID-360 Public RKO-LIO Quality Report</title>',
+        '<style>',
+        _css(),
+        '</style>',
+        '</head>',
+        '<body>',
+        '<main>',
+        '<section class="hero">',
+        '<div>',
+        '<p class="eyebrow">MID-360 Public RKO-LIO</p>',
+        '<h1>Quality Report</h1>',
+        f'<p class="subtle">{_h(report.get("sweep_path", ""))}</p>',
+        '</div>',
+        f'<div class="status {status.lower()}">{_h(status)}</div>',
+        '</section>',
+        _metric_cards(report),
+        _best_panel(report),
+        _case_table(rows),
+        '</main>',
+        '</body>',
+        '</html>',
+    ])
+
+
+def _build_case_quality(row: dict[str, Any]) -> dict[str, Any]:
+    output_dir = Path(str(row.get('output_dir') or '')).expanduser().resolve()
+    trajectory = _trajectory_quality(row, output_dir)
+    map_quality = _map_quality(output_dir / 'pointcloud_map')
+    runtime = row.get('run_result') or {}
+    case = {
+        'case_id': row.get('case_id', ''),
+        'label': row.get('label', ''),
+        'status': row.get('status', ''),
+        'parameters': row.get('parameters') or {},
+        'output_dir': str(output_dir),
+        'runtime': {
+            'duration_sec': _maybe_float(runtime.get('duration_sec')),
+            'returncode': runtime.get('returncode'),
+            'timed_out': bool(runtime.get('timed_out')),
+            'offline_completed': bool((row.get('runtime') or {}).get('offline_completed')),
+            'keypoint_drop_count': int(
+                (row.get('runtime') or {}).get('keypoints_too_few_count') or 0
+            ),
+            'lidar_delta_error_count': int(
+                (row.get('runtime') or {}).get('lidar_delta_error_count') or 0
+            ),
+            'buffer_throttle_count': int(
+                (row.get('runtime') or {}).get('buffer_throttle_count') or 0
+            ),
+        },
+        'outputs': row.get('outputs') or {},
+        'verification': row.get('verification') or {},
+        'trajectory': trajectory,
+        'map_quality': map_quality,
+    }
+    case['quality_score'] = _quality_score(case)
+    return case
+
+
+def _trajectory_quality(row: dict[str, Any], output_dir: Path) -> dict[str, Any]:
+    files = _trajectory_paths(row, output_dir)
+    summaries = [_trajectory_file_quality(path) for path in files]
+    valid = [item for item in summaries if int(item.get('poses') or 0) > 0]
+    bounds = _merge_bounds([item.get('bounds') or {} for item in valid])
+    return {
+        'file_count': len(files),
+        'poses': sum(int(item.get('poses') or 0) for item in summaries),
+        'invalid_lines': sum(int(item.get('invalid_lines') or 0) for item in summaries),
+        'duration_sec': sum(float(item.get('duration_sec') or 0.0) for item in valid),
+        'path_length_m': sum(float(item.get('path_length_m') or 0.0) for item in valid),
+        'max_step_m': max((float(item.get('max_step_m') or 0.0) for item in valid), default=0.0),
+        'bounds': bounds,
+        'files': summaries,
+    }
+
+
+def _trajectory_paths(row: dict[str, Any], output_dir: Path) -> list[Path]:
+    trajectory = (row.get('outputs') or {}).get('trajectory') or {}
+    paths: list[Path] = []
+    for item in trajectory.get('files') or []:
+        value = item.get('path') if isinstance(item, dict) else item
+        if value:
+            paths.append(Path(str(value)).expanduser().resolve())
+    if paths:
+        return sorted(path for path in paths if path.is_file())
+    if not output_dir.is_dir():
+        return []
+    patterns = ('*_tum_*.txt', 'traj_*.tum', '*.tum')
+    found: set[Path] = set()
+    for pattern in patterns:
+        found.update(path.resolve() for path in output_dir.rglob(pattern) if path.is_file())
+    return sorted(found)
+
+
+def _trajectory_file_quality(path: Path) -> dict[str, Any]:
+    poses: list[tuple[float, float, float, float]] = []
+    invalid = 0
+    for line in _read_text(path).splitlines():
+        text = line.strip()
+        if not text:
+            continue
+        parts = text.split()
+        if len(parts) < 4:
+            invalid += 1
+            continue
+        try:
+            poses.append((float(parts[0]), float(parts[1]), float(parts[2]), float(parts[3])))
+        except ValueError:
+            invalid += 1
+    path_length = 0.0
+    max_step = 0.0
+    for prev, cur in zip(poses, poses[1:]):
+        step = math.sqrt(
+            (cur[1] - prev[1]) ** 2
+            + (cur[2] - prev[2]) ** 2
+            + (cur[3] - prev[3]) ** 2
+        )
+        path_length += step
+        max_step = max(max_step, step)
+    timestamps = [item[0] for item in poses]
+    return {
+        'path': str(path),
+        'poses': len(poses),
+        'invalid_lines': invalid,
+        'duration_sec': max(timestamps) - min(timestamps) if len(timestamps) >= 2 else 0.0,
+        'path_length_m': path_length,
+        'max_step_m': max_step,
+        'bounds': _pose_bounds(poses),
+    }
+
+
+def _map_quality(pointcloud_map_dir: Path) -> dict[str, Any]:
+    metadata_path = pointcloud_map_dir / 'pointcloud_map_metadata.yaml'
+    metadata = _load_yaml(metadata_path)
+    x_res = _maybe_float(metadata.get('x_resolution'))
+    y_res = _maybe_float(metadata.get('y_resolution'))
+    tiles = _metadata_tiles(metadata)
+    pcd_files = sorted(path for path in pointcloud_map_dir.glob('*.pcd') if path.is_file())
+    referenced_names = {str(name) for name in tiles}
+    tile_stats = [_pcd_stats(pointcloud_map_dir / name) for name in sorted(referenced_names)]
+    existing_referenced = [item for item in tile_stats if item.get('exists')]
+    point_count = sum(int(item.get('points') or 0) for item in existing_referenced)
+    missing = [item.get('name') for item in tile_stats if not item.get('exists')]
+    orphans = [path.name for path in pcd_files if path.name not in referenced_names]
+    tile_bounds = _tile_bounds(tiles, x_res, y_res)
+    area = _bounds_area(tile_bounds)
+    return {
+        'map_dir': str(pointcloud_map_dir) if pointcloud_map_dir.is_dir() else '',
+        'metadata_path': str(metadata_path) if metadata_path.is_file() else '',
+        'x_resolution': x_res,
+        'y_resolution': y_res,
+        'tile_count': len(tiles),
+        'pcd_file_count': len(pcd_files),
+        'referenced_pcd_count': len(referenced_names),
+        'missing_referenced_pcd_count': len(missing),
+        'orphan_pcd_count': len(orphans),
+        'empty_tile_count': sum(
+            1 for item in existing_referenced if int(item.get('points') or 0) == 0
+        ),
+        'point_count': point_count,
+        'total_bytes': sum(int(item.get('size_bytes') or 0) for item in existing_referenced),
+        'min_points_per_tile': min(
+            (int(item.get('points') or 0) for item in existing_referenced), default=0,
+        ),
+        'max_points_per_tile': max(
+            (int(item.get('points') or 0) for item in existing_referenced), default=0,
+        ),
+        'mean_points_per_tile': (
+            point_count / len(existing_referenced) if existing_referenced else 0.0
+        ),
+        'tile_bounds': tile_bounds,
+        'tile_area_m2': area,
+        'point_density_per_m2': point_count / area if area > 0.0 else 0.0,
+        'missing_referenced_pcd': missing[:20],
+        'orphan_pcd': orphans[:20],
+    }
+
+
+def _metadata_tiles(metadata: dict[str, Any]) -> dict[str, tuple[float, float]]:
+    tiles: dict[str, tuple[float, float]] = {}
+    for key, value in metadata.items():
+        if key in ('x_resolution', 'y_resolution'):
+            continue
+        if not str(key).endswith('.pcd'):
+            continue
+        if not isinstance(value, (list, tuple)) or len(value) != 2:
+            continue
+        x = _maybe_float(value[0])
+        y = _maybe_float(value[1])
+        if x is None or y is None:
+            continue
+        tiles[str(key)] = (x, y)
+    return tiles
+
+
+def _pcd_stats(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {'name': path.name, 'exists': False, 'points': 0, 'size_bytes': 0, 'error': ''}
+    try:
+        from verify_autoware_map import parse_pcd_header
+
+        header = parse_pcd_header(str(path))
+        return {
+            'name': path.name,
+            'exists': True,
+            'points': int(header.get('points') or 0),
+            'size_bytes': path.stat().st_size,
+            'data': header.get('data', ''),
+            'error': '',
+        }
+    except Exception as exc:
+        return {
+            'name': path.name,
+            'exists': True,
+            'points': 0,
+            'size_bytes': path.stat().st_size if path.is_file() else 0,
+            'data': '',
+            'error': str(exc),
+        }
+
+
+def _quality_score(case: dict[str, Any]) -> int:
+    status = str(case.get('status') or '')
+    verification = case.get('verification') or {}
+    runtime = case.get('runtime') or {}
+    trajectory = case.get('trajectory') or {}
+    map_quality = case.get('map_quality') or {}
+    score = 0.0
+    if status == 'MAP_VERIFIED':
+        score += 30
+    elif status == 'MAP_SAVED':
+        score += 20
+    if verification.get('result') == 'PASS':
+        score += 20
+    if runtime.get('offline_completed'):
+        score += 10
+    if (
+        int(runtime.get('keypoint_drop_count') or 0) == 0
+        and int(runtime.get('lidar_delta_error_count') or 0) == 0
+    ):
+        score += 10
+    score += min(10.0, float(trajectory.get('path_length_m') or 0.0) / 10.0)
+    point_count = int(map_quality.get('point_count') or 0)
+    if point_count > 0:
+        score += min(10.0, math.log10(point_count + 1.0) * 2.0)
+    score += min(5.0, float(map_quality.get('point_density_per_m2') or 0.0))
+    duration = _maybe_float(runtime.get('duration_sec'))
+    if duration is not None:
+        score += max(0.0, min(5.0, (25.0 - duration) / 3.0))
+    score -= min(12, int(runtime.get('keypoint_drop_count') or 0) * 2)
+    score -= min(12, int(runtime.get('lidar_delta_error_count') or 0) * 2)
+    if runtime.get('timed_out'):
+        score -= 20
+    if int(map_quality.get('missing_referenced_pcd_count') or 0) > 0:
+        score -= 15
+    if int(map_quality.get('empty_tile_count') or 0) > 0:
+        score -= 5
+    return int(round(max(0.0, min(100.0, score))))
+
+
+def _quality_gate(
+    case: dict[str, Any],
+    thresholds: RkoQualityGateThresholds,
+) -> dict[str, Any]:
+    runtime = case.get('runtime') or {}
+    trajectory = case.get('trajectory') or {}
+    map_quality = case.get('map_quality') or {}
+    verification = case.get('verification') or {}
+    checks = [
+        _gate_check(
+            'map_verified',
+            str(case.get('status') or '') == 'MAP_VERIFIED'
+            and verification.get('result') == 'PASS',
+            f"status={case.get('status', '')} verify={verification.get('result', '')}",
+        ),
+        _gate_check(
+            'offline_completed',
+            bool(runtime.get('offline_completed')),
+            'RKO-LIO offline completion marker was observed.',
+        ),
+        _gate_check(
+            'no_runtime_timeout',
+            not bool(runtime.get('timed_out')),
+            f"timed_out={runtime.get('timed_out')}",
+        ),
+        _gate_check(
+            'no_keypoint_or_lidar_delta_errors',
+            int(runtime.get('keypoint_drop_count') or 0) == 0
+            and int(runtime.get('lidar_delta_error_count') or 0) == 0,
+            (
+                f"keypoint_drop_count={runtime.get('keypoint_drop_count', 0)} "
+                f"lidar_delta_error_count={runtime.get('lidar_delta_error_count', 0)}"
+            ),
+        ),
+        _gate_check(
+            'trajectory_poses',
+            int(trajectory.get('poses') or 0) >= thresholds.min_trajectory_poses,
+            f"poses={trajectory.get('poses', 0)} min={thresholds.min_trajectory_poses}",
+        ),
+        _gate_check(
+            'trajectory_path_length',
+            float(trajectory.get('path_length_m') or 0.0) >= thresholds.min_path_length_m,
+            (
+                f"path_length_m={_fmt_float(trajectory.get('path_length_m'))} "
+                f"min={thresholds.min_path_length_m}"
+            ),
+        ),
+        _gate_check(
+            'trajectory_max_step',
+            float(trajectory.get('max_step_m') or 0.0) <= thresholds.max_step_m,
+            f"max_step_m={_fmt_float(trajectory.get('max_step_m'))} max={thresholds.max_step_m}",
+        ),
+        _gate_check(
+            'map_points',
+            int(map_quality.get('point_count') or 0) >= thresholds.min_map_points,
+            f"point_count={map_quality.get('point_count', 0)} min={thresholds.min_map_points}",
+        ),
+        _gate_check(
+            'map_tiles',
+            int(map_quality.get('tile_count') or 0) >= thresholds.min_map_tiles,
+            f"tile_count={map_quality.get('tile_count', 0)} min={thresholds.min_map_tiles}",
+        ),
+        _gate_check(
+            'map_integrity',
+            int(map_quality.get('missing_referenced_pcd_count') or 0) == 0
+            and int(map_quality.get('orphan_pcd_count') or 0) == 0
+            and int(map_quality.get('empty_tile_count') or 0) == 0,
+            (
+                f"missing={map_quality.get('missing_referenced_pcd_count', 0)} "
+                f"orphan={map_quality.get('orphan_pcd_count', 0)} "
+                f"empty={map_quality.get('empty_tile_count', 0)}"
+            ),
+        ),
+        _gate_check(
+            'runtime_budget',
+            _runtime_within_budget(runtime.get('duration_sec'), thresholds.max_runtime_sec),
+            (
+                f"duration_sec={_fmt_float(runtime.get('duration_sec'))} "
+                f"max={thresholds.max_runtime_sec}"
+            ),
+        ),
+    ]
+    failures = [item for item in checks if item['status'] == 'FAIL']
+    return {
+        'status': 'PASS' if not failures else 'FAIL',
+        'fail_count': len(failures),
+        'checks': checks,
+    }
+
+
+def _gate_check(check_id: str, passed: bool, message: str) -> dict[str, str]:
+    return {
+        'id': check_id,
+        'status': 'PASS' if passed else 'FAIL',
+        'message': message,
+    }
+
+
+def _runtime_within_budget(value: Any, max_runtime_sec: float) -> bool:
+    duration = _maybe_float(value)
+    if duration is None:
+        return False
+    return duration <= max_runtime_sec
+
+
+def _rank_cases(cases: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def key(row: dict[str, Any]) -> tuple[int, int, int, float, float, str]:
+        trajectory = row.get('trajectory') or {}
+        runtime = row.get('runtime') or {}
+        gate = row.get('quality_gate') or {}
+        return (
+            0 if gate.get('status') == 'PASS' else 1,
+            -int(row.get('quality_score') or 0),
+            -int(trajectory.get('poses') or 0),
+            -float(trajectory.get('path_length_m') or 0.0),
+            float(runtime.get('duration_sec') or 999999.0),
+            str(row.get('case_id') or ''),
+        )
+
+    return sorted(cases, key=key)
+
+
+def _overall_status(cases: list[dict[str, Any]]) -> str:
+    if not cases:
+        return 'EMPTY'
+    if any((row.get('quality_gate') or {}).get('status') == 'PASS' for row in cases):
+        return 'PASS'
+    if any((row.get('map_quality') or {}).get('point_count') for row in cases):
+        return 'WARN'
+    return 'INCOMPLETE'
+
+
+def _counts(cases: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        'cases': len(cases),
+        'map_verified': sum(
+            1 for row in cases if str(row.get('status') or '') == 'MAP_VERIFIED'
+        ),
+        'gate_pass': sum(
+            1 for row in cases if (row.get('quality_gate') or {}).get('status') == 'PASS'
+        ),
+        'map_saved': sum(
+            1 for row in cases if (row.get('outputs') or {}).get('map_saved')
+        ),
+        'trajectories': sum(
+            1 for row in cases
+            if int((row.get('trajectory') or {}).get('poses') or 0) > 0
+        ),
+        'total_map_points': sum(
+            int((row.get('map_quality') or {}).get('point_count') or 0) for row in cases
+        ),
+        'total_tiles': sum(
+            int((row.get('map_quality') or {}).get('tile_count') or 0) for row in cases
+        ),
+    }
+
+
+def _best_case_summary(row: dict[str, Any]) -> dict[str, Any]:
+    if not row:
+        return {}
+    return {
+        'case_id': row.get('case_id', ''),
+        'status': row.get('status', ''),
+        'gate_status': (row.get('quality_gate') or {}).get('status', ''),
+        'quality_score': row.get('quality_score', 0),
+        'output_dir': row.get('output_dir', ''),
+    }
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = yaml.safe_load(path.read_text(encoding='utf-8')) or {}
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        return ''
+    return path.read_text(encoding='utf-8', errors='replace')
+
+
+def _pose_bounds(poses: list[tuple[float, float, float, float]]) -> dict[str, float]:
+    if not poses:
+        return {}
+    xs = [item[1] for item in poses]
+    ys = [item[2] for item in poses]
+    zs = [item[3] for item in poses]
+    return {
+        'min_x': min(xs),
+        'max_x': max(xs),
+        'min_y': min(ys),
+        'max_y': max(ys),
+        'min_z': min(zs),
+        'max_z': max(zs),
+    }
+
+
+def _merge_bounds(bounds_list: list[dict[str, Any]]) -> dict[str, float]:
+    valid = [item for item in bounds_list if item]
+    if not valid:
+        return {}
+    keys = ('min_x', 'min_y', 'min_z')
+    max_keys = ('max_x', 'max_y', 'max_z')
+    result: dict[str, float] = {}
+    for key in keys:
+        result[key] = min(float(item[key]) for item in valid if key in item)
+    for key in max_keys:
+        result[key] = max(float(item[key]) for item in valid if key in item)
+    return result
+
+
+def _tile_bounds(
+    tiles: dict[str, tuple[float, float]],
+    x_res: float | None,
+    y_res: float | None,
+) -> dict[str, float]:
+    if not tiles or x_res is None or y_res is None:
+        return {}
+    xs = [coord[0] for coord in tiles.values()]
+    ys = [coord[1] for coord in tiles.values()]
+    return {
+        'min_x': min(xs),
+        'max_x': max(xs) + x_res,
+        'min_y': min(ys),
+        'max_y': max(ys) + y_res,
+    }
+
+
+def _bounds_area(bounds: dict[str, Any]) -> float:
+    if not bounds:
+        return 0.0
+    width = float(bounds.get('max_x') or 0.0) - float(bounds.get('min_x') or 0.0)
+    height = float(bounds.get('max_y') or 0.0) - float(bounds.get('min_y') or 0.0)
+    return max(0.0, width) * max(0.0, height)
+
+
+def _maybe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except Exception:
+        return None
+
+
+def _fmt_float(value: Any) -> str:
+    number = _maybe_float(value)
+    return '' if number is None else f'{number:.2f}'
+
+
+def _fmt_int(value: Any) -> str:
+    if value is None:
+        return ''
+    try:
+        return str(int(value))
+    except Exception:
+        return ''
+
+
+def _metric_cards(report: dict[str, Any]) -> str:
+    counts = report.get('counts') or {}
+    cards = [
+        _metric_card('Cases', counts.get('cases', 0)),
+        _metric_card('Map Verified', counts.get('map_verified', 0)),
+        _metric_card('Gate Pass', counts.get('gate_pass', 0)),
+        _metric_card('Map Points', counts.get('total_map_points', 0)),
+    ]
+    return '<section class="metrics">' + ''.join(cards) + '</section>'
+
+
+def _metric_card(label: str, value: Any) -> str:
+    return f'<article class="metric"><h2>{_h(label)}</h2><p>{_h(value)}</p></article>'
+
+
+def _best_panel(report: dict[str, Any]) -> str:
+    best = report.get('best_case') or {}
+    if not best:
+        return '<section><p class="empty">No sweep cases found.</p></section>'
+    return (
+        '<section class="best">'
+        '<h2>Best Case</h2>'
+        f'<p><strong>{_h(best.get("case_id", ""))}</strong> '
+        f'<span class="pill {_h(str(best.get("status", "")).lower())}">'
+        f'{_h(best.get("status", ""))}</span></p>'
+        f'<p>Gate: <strong>{_h(best.get("gate_status", ""))}</strong> '
+        f'Score: <strong>{_h(best.get("quality_score", 0))}</strong></p>'
+        f'<p class="subtle">{_h(best.get("output_dir", ""))}</p>'
+        '</section>'
+    )
+
+
+def _case_table(rows: list[dict[str, Any]]) -> str:
+    if not rows:
+        return ''
+    body = []
+    for row in rows:
+        params = row.get('parameters') or {}
+        runtime = row.get('runtime') or {}
+        trajectory = row.get('trajectory') or {}
+        map_quality = row.get('map_quality') or {}
+        verification = row.get('verification') or {}
+        gate = row.get('quality_gate') or {}
+        status = str(row.get('status') or '').upper()
+        gate_status = str(gate.get('status') or '').upper()
+        body.append(
+            '<tr>'
+            f'<td>{_h(row.get("rank", ""))}</td>'
+            f'<td><code>{_h(row.get("case_id", ""))}</code></td>'
+            f'<td><span class="pill {status.lower()}">{_h(status)}</span></td>'
+            f'<td>{_h(verification.get("result", ""))}</td>'
+            f'<td>{_h(_fmt_float(params.get("voxel_size")))}</td>'
+            f'<td>{_h(_fmt_float(params.get("min_range")))}</td>'
+            f'<td>{_h(_fmt_float(runtime.get("duration_sec")))}</td>'
+            f'<td>{_h(_fmt_int(trajectory.get("poses")))}</td>'
+            f'<td>{_h(_fmt_float(trajectory.get("path_length_m")))}</td>'
+            f'<td>{_h(_fmt_int(map_quality.get("point_count")))}</td>'
+            f'<td>{_h(_fmt_int(map_quality.get("tile_count")))}</td>'
+            f'<td>{_h(_fmt_float(map_quality.get("point_density_per_m2")))}</td>'
+            f'<td><span class="pill gate-{gate_status.lower()}">{_h(gate_status)}</span></td>'
+            f'<td><strong>{_h(row.get("quality_score", 0))}</strong></td>'
+            '</tr>'
+        )
+    return (
+        '<section>'
+        '<h2>Case Quality</h2>'
+        '<table>'
+        '<thead><tr>'
+        '<th>Rank</th><th>Case</th><th>Status</th><th>Verify</th>'
+        '<th>Voxel</th><th>Min Range</th><th>Runtime s</th><th>Poses</th>'
+        '<th>Path m</th><th>Map Points</th><th>Tiles</th><th>Density</th>'
+        '<th>Gate</th><th>Score</th>'
+        '</tr></thead><tbody>'
+        + ''.join(body)
+        + '</tbody></table></section>'
+    )
+
+
+def _h(value: Any) -> str:
+    return html.escape('' if value is None else str(value))
+
+
+def _css() -> str:
+    return """
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f7f8fb;
+  color: #1f2937;
+}
+body { margin: 0; }
+main { max-width: 1220px; margin: 0 auto; padding: 28px; }
+.hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 28px 0 22px;
+  border-bottom: 1px solid #d7dee8;
+}
+.eyebrow {
+  margin: 0 0 8px;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  color: #506074;
+}
+h1, h2, p { margin-top: 0; }
+h1 { margin-bottom: 8px; font-size: 34px; line-height: 1.12; }
+h2 { margin: 28px 0 12px; font-size: 19px; }
+.subtle { color: #5b6778; overflow-wrap: anywhere; }
+.status, .pill {
+  border-radius: 6px;
+  font-weight: 800;
+  text-align: center;
+}
+.status { min-width: 104px; padding: 10px 14px; }
+.pill { display: inline-block; min-width: 76px; padding: 4px 8px; font-size: 12px; }
+.pass, .map_verified, .gate-pass { background: #dcfce7; color: #166534; }
+.warn, .map_saved { background: #fef3c7; color: #92400e; }
+.fail, .gate-fail { background: #fee2e2; color: #991b1b; }
+.incomplete, .empty, .no_run { background: #e5e7eb; color: #374151; }
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin: 20px 0;
+}
+.metric, .best {
+  background: #ffffff;
+  border: 1px solid #d7dee8;
+  border-radius: 8px;
+  padding: 16px;
+}
+.metric h2 { margin: 0 0 8px; font-size: 13px; color: #5b6778; }
+.metric p { margin: 0; font-size: 28px; font-weight: 800; }
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #ffffff;
+  border: 1px solid #d7dee8;
+}
+th, td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #e5eaf1;
+  text-align: left;
+  vertical-align: top;
+  font-size: 14px;
+}
+th { color: #506074; font-size: 12px; text-transform: uppercase; letter-spacing: 0; }
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+@media (max-width: 820px) {
+  main { padding: 18px; }
+  .hero { display: block; }
+  .status { display: inline-block; margin-top: 8px; }
+  .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  table { display: block; overflow-x: auto; white-space: nowrap; }
+}
+"""

--- a/scripts/mid360_robot_rko_config_adoption.py
+++ b/scripts/mid360_robot_rko_config_adoption.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Adoption checks for tracked MID-360 RKO-LIO configs."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from mid360_robot_tools import payload_to_json
+
+
+RKO_CONFIG_ADOPTION_JSON = 'mid360_robot_rko_config_adoption.json'
+RKO_CONFIG_ADOPTION_MARKDOWN = 'mid360_robot_rko_config_adoption.md'
+RKO_CONFIG_PARAMETER_KEYS = (
+    'voxel_size',
+    'min_range',
+    'max_range',
+    'deskew',
+    'double_downsample',
+    'initialization_phase',
+)
+
+
+class RkoConfigAdoptionChecker:
+    """Check whether a tracked config is backed by a quality-gated real-data case."""
+
+    def __init__(
+        self,
+        quality_report_path: Path,
+        config_path: Path,
+        *,
+        require_best: bool = False,
+        tolerance: float = 1e-6,
+    ) -> None:
+        self._quality_report_path = quality_report_path.expanduser().resolve()
+        self._config_path = config_path.expanduser().resolve()
+        self._require_best = bool(require_best)
+        self._tolerance = float(tolerance)
+
+    def build_report(self) -> dict[str, Any]:
+        """Build an adoption report."""
+        quality_report = _load_json(self._quality_report_path)
+        config = _load_yaml(self._config_path)
+        config_parameters = _extract_config_parameters(config)
+        cases = quality_report.get('cases') or []
+        matched_case = _find_matching_case(
+            config_parameters=config_parameters,
+            cases=cases,
+            tolerance=self._tolerance,
+        )
+        best_case = _best_gate_case(cases)
+        checks = _build_checks(
+            quality_report=quality_report,
+            config_parameters=config_parameters,
+            matched_case=matched_case,
+            best_case=best_case,
+            require_best=self._require_best,
+        )
+        return {
+            'created_at': datetime.now(timezone.utc).isoformat(),
+            'status': 'PASS' if all(item['status'] == 'PASS' for item in checks) else 'FAIL',
+            'quality_report_path': str(self._quality_report_path),
+            'config_path': str(self._config_path),
+            'require_best': self._require_best,
+            'parameter_keys': list(RKO_CONFIG_PARAMETER_KEYS),
+            'config_parameters': config_parameters,
+            'matched_case': _case_summary(matched_case),
+            'recommended_case': _case_summary(best_case),
+            'parameter_diff_to_recommended': _parameter_diff(
+                config_parameters,
+                (best_case.get('parameters') or {}) if best_case else {},
+                self._tolerance,
+            ),
+            'checks': checks,
+        }
+
+
+def write_rko_config_adoption_report(report: dict[str, Any], output_dir: Path) -> dict[str, Path]:
+    """Write JSON and Markdown adoption reports."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / RKO_CONFIG_ADOPTION_JSON
+    markdown_path = output_dir / RKO_CONFIG_ADOPTION_MARKDOWN
+    json_path.write_text(payload_to_json(report) + '\n', encoding='utf-8')
+    markdown_path.write_text(render_rko_config_adoption_markdown(report) + '\n', encoding='utf-8')
+    return {'json': json_path, 'markdown': markdown_path}
+
+
+def render_rko_config_adoption_markdown(report: dict[str, Any]) -> str:
+    """Render the adoption report as Markdown."""
+    matched = report.get('matched_case') or {}
+    recommended = report.get('recommended_case') or {}
+    lines = [
+        '# MID-360 RKO-LIO Config Adoption',
+        '',
+        f"- status: `{report.get('status', '')}`",
+        f"- created_at: `{report.get('created_at', '')}`",
+        f"- config_path: `{report.get('config_path', '')}`",
+        f"- quality_report_path: `{report.get('quality_report_path', '')}`",
+        f"- require_best: `{report.get('require_best')}`",
+        f"- matched_case: `{matched.get('case_id', '')}`",
+        f"- recommended_case: `{recommended.get('case_id', '')}`",
+        '',
+        '## Config Parameters',
+        '',
+    ]
+    for key, value in (report.get('config_parameters') or {}).items():
+        lines.append(f"- {key}: `{value}`")
+
+    lines.extend(['', '## Checks', ''])
+    for check in report.get('checks') or []:
+        lines.append(
+            f"- `{check.get('status', '')}` `{check.get('id', '')}`: "
+            f"{check.get('message', '')}"
+        )
+
+    diffs = report.get('parameter_diff_to_recommended') or []
+    lines.extend(['', '## Diff To Recommended', ''])
+    if diffs:
+        for item in diffs:
+            lines.append(
+                f"- `{item.get('key', '')}` config `{item.get('config')}` "
+                f"recommended `{item.get('recommended')}`"
+            )
+    else:
+        lines.append('- none')
+    return '\n'.join(lines)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = yaml.safe_load(path.read_text(encoding='utf-8')) or {}
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _extract_config_parameters(config: dict[str, Any]) -> dict[str, Any]:
+    return {key: config.get(key) for key in RKO_CONFIG_PARAMETER_KEYS}
+
+
+def _find_matching_case(
+    config_parameters: dict[str, Any],
+    cases: list[dict[str, Any]],
+    tolerance: float,
+) -> dict[str, Any]:
+    matches = [
+        row for row in cases
+        if _parameters_match(config_parameters, row.get('parameters') or {}, tolerance)
+    ]
+    if not matches:
+        return {}
+    return sorted(matches, key=lambda row: int(row.get('rank') or 9999))[0]
+
+
+def _best_gate_case(cases: list[dict[str, Any]]) -> dict[str, Any]:
+    gate_pass = [
+        row for row in cases
+        if (row.get('quality_gate') or {}).get('status') == 'PASS'
+    ]
+    candidates = gate_pass or cases
+    if not candidates:
+        return {}
+    return sorted(candidates, key=lambda row: int(row.get('rank') or 9999))[0]
+
+
+def _parameters_match(
+    config_parameters: dict[str, Any],
+    case_parameters: dict[str, Any],
+    tolerance: float,
+) -> bool:
+    return not _parameter_diff(config_parameters, case_parameters, tolerance)
+
+
+def _parameter_diff(
+    config_parameters: dict[str, Any],
+    case_parameters: dict[str, Any],
+    tolerance: float,
+) -> list[dict[str, Any]]:
+    diffs: list[dict[str, Any]] = []
+    for key in RKO_CONFIG_PARAMETER_KEYS:
+        config_value = config_parameters.get(key)
+        case_value = case_parameters.get(key)
+        if not _values_match(config_value, case_value, tolerance):
+            diffs.append({'key': key, 'config': config_value, 'recommended': case_value})
+    return diffs
+
+
+def _values_match(left: Any, right: Any, tolerance: float) -> bool:
+    if left is None or right is None:
+        return left is right
+    if isinstance(left, bool) or isinstance(right, bool):
+        return bool(left) == bool(right)
+    try:
+        return abs(float(left) - float(right)) <= tolerance
+    except Exception:
+        return left == right
+
+
+def _build_checks(
+    quality_report: dict[str, Any],
+    config_parameters: dict[str, Any],
+    matched_case: dict[str, Any],
+    best_case: dict[str, Any],
+    require_best: bool,
+) -> list[dict[str, str]]:
+    missing_parameters = [
+        key for key, value in config_parameters.items()
+        if value is None
+    ]
+    checks = [
+        _check(
+            'quality_report_pass',
+            quality_report.get('status') == 'PASS',
+            f"quality_report_status={quality_report.get('status', '')}",
+        ),
+        _check(
+            'config_parameters_present',
+            not missing_parameters,
+            (
+                'missing=' + ','.join(missing_parameters)
+                if missing_parameters
+                else 'all required parameters present'
+            ),
+        ),
+        _check(
+            'recommended_case_present',
+            bool(best_case),
+            f"recommended_case={best_case.get('case_id', '') if best_case else ''}",
+        ),
+        _check(
+            'config_matches_sweep_case',
+            bool(matched_case),
+            f"matched_case={matched_case.get('case_id', '') if matched_case else ''}",
+        ),
+        _check(
+            'matched_case_gate_pass',
+            (matched_case.get('quality_gate') or {}).get('status') == 'PASS',
+            (
+                f"matched_gate={_matched_gate_status(matched_case)}"
+            ),
+        ),
+    ]
+    if require_best:
+        checks.append(
+            _check(
+                'matched_case_is_best',
+                bool(matched_case)
+                and bool(best_case)
+                and matched_case.get('case_id') == best_case.get('case_id'),
+                (
+                    f"matched={matched_case.get('case_id', '') if matched_case else ''} "
+                    f"best={best_case.get('case_id', '') if best_case else ''}"
+                ),
+            )
+        )
+    return checks
+
+
+def _matched_gate_status(matched_case: dict[str, Any]) -> str:
+    if not matched_case:
+        return ''
+    return (matched_case.get('quality_gate') or {}).get('status', '')
+
+
+def _check(check_id: str, passed: bool, message: str) -> dict[str, str]:
+    return {
+        'id': check_id,
+        'status': 'PASS' if passed else 'FAIL',
+        'message': message,
+    }
+
+
+def _case_summary(row: dict[str, Any]) -> dict[str, Any]:
+    if not row:
+        return {}
+    return {
+        'case_id': row.get('case_id', ''),
+        'rank': row.get('rank', 0),
+        'status': row.get('status', ''),
+        'gate_status': (row.get('quality_gate') or {}).get('status', ''),
+        'quality_score': row.get('quality_score', 0),
+        'parameters': row.get('parameters') or {},
+        'output_dir': row.get('output_dir', ''),
+    }


### PR DESCRIPTION
## Summary

Two cohesive Layer-A scripts of the MID-360 robot pipeline (foundation-only deps, i.e. only `mid360_robot_tools` + PyYAML):

### 1. `scripts/mid360_robot_public_rko_quality_report.py`
- **`Mid360PublicRkoQualityReporter`** — aggregates a public MID-360 RKO-LIO sweep manifest:
  - per-case quality score (poses, path length, map points, tiles, density, runtime, integrity)
  - quality gate (configurable thresholds: trajectory poses / path length / max step, map points / tiles / area, runtime budget, missing-pcd integrity, runtime timeout, keypoint / lidar-delta error counts)
  - ranking + best-case selection
- **`generate_mid360_robot_public_rko_quality_report.py` CLI** — emits JSON + Markdown + HTML reports from a sweep manifest path.

### 2. `scripts/mid360_robot_rko_config_adoption.py`
- **`RkoConfigAdoptionChecker`** — cross-checks a tracked RKO-LIO config YAML against the sweep quality report; confirms config matches a gate-passing case, optionally requires the best-ranked case.
- **`check_mid360_robot_rko_config_adoption.py` CLI** — non-zero exit on FAIL for CI use.

### Why
Both feed the public-RKO sweep stack (next PRs in the inside-out chain). Bundled because they are tightly coupled: `RkoConfigAdoptionChecker` reads `Mid360PublicRkoQualityReporter` output. Splitting them would leave one half unusable in CI until the second lands.

## Test plan

- [x] `python3 -m pytest graph_based_slam/test/test_mid360_robot_rko_config_adoption.py graph_based_slam/test/test_mid360_robot_public_rko_quality_report.py -v` → 7 passed (adoption PASS/FAIL/writes/CLI + report aggregation/writes/CLI)
- [x] `python3 -m flake8 --select=E,W,F --ignore=W503 --max-line-length=99 scripts/mid360_robot_public_rko_quality_report.py scripts/mid360_robot_rko_config_adoption.py scripts/check_mid360_robot_rko_config_adoption.py scripts/generate_mid360_robot_public_rko_quality_report.py graph_based_slam/test/test_mid360_robot_rko_config_adoption.py graph_based_slam/test/test_mid360_robot_public_rko_quality_report.py` → clean
- [ ] Humble + Jazzy matrix CI (colcon build + colcon test) — let CI confirm

Notes: this PR may need a trivial CMakeLists rebase after PR #172 (production-readiness gate) merges, since both add entries in the same pytest registration block.