### PR TITLE
feat: MID-360 production-candidate session orchestrator + bundle import

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -249,6 +249,16 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_mid360_robot_production_candidate_session
+    test/test_mid360_robot_production_candidate_session.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
+    test_mid360_robot_production_candidate_bundle_import
+    test/test_mid360_robot_production_candidate_bundle_import.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_navsatfix_covariance_inspector
     test/test_navsatfix_covariance_inspector.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_mid360_robot_production_candidate_bundle_import.py
+++ b/graph_based_slam/test/test_mid360_robot_production_candidate_bundle_import.py
@@ -2,6 +2,30 @@
 # All rights reserved.
 #
 # Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 """Tests for importing and rechecking MID-360 production-candidate bundles."""
 

--- a/graph_based_slam/test/test_mid360_robot_production_candidate_bundle_import.py
+++ b/graph_based_slam/test/test_mid360_robot_production_candidate_bundle_import.py
@@ -1,0 +1,295 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+
+"""Tests for importing and rechecking MID-360 production-candidate bundles."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXPORT_SCRIPT = REPO_ROOT / 'scripts' / 'export_mid360_robot_production_candidate_bundle.py'
+IMPORT_SCRIPT = REPO_ROOT / 'scripts' / 'import_mid360_robot_production_candidate_bundle.py'
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding='utf-8')
+
+
+def _write_text(path: Path, text: str = 'ok\n') -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding='utf-8')
+
+
+def _write_candidate_artifacts(
+    root: Path,
+    bag_root: Path,
+    *,
+    run_id: str = 'production_candidate_01',
+    pointcloud_messages: int = 6000,
+    imu_messages: int = 120000,
+) -> None:
+    profile = bag_root / f'{run_id}_profile.yaml'
+    record_plan_json = bag_root / f'{run_id}_record_plan.json'
+    record_plan_md = bag_root / f'{run_id}_record_plan.md'
+    _write_text(
+        profile,
+        yaml.safe_dump({
+            'robot_name': 'production_robot',
+            'base_frame': 'base_link',
+            'lidar_frame': 'livox_frame',
+            'imu_frame': 'livox_frame',
+            'expected_pointcloud_topic': '/livox/lidar',
+            'expected_imu_topic': '/livox/imu',
+        }),
+    )
+    _write_json(record_plan_json, {'run_id': run_id, 'bag_path': str(bag_root / run_id)})
+    _write_text(record_plan_md, '# Record Plan\n')
+
+    artifact_paths = {
+        'profile_snapshot': str(profile),
+        'record_plan_json': str(record_plan_json),
+        'record_plan_markdown': str(record_plan_md),
+        'host_readiness_json': str(root / 'jetson_mid360_host_readiness.json'),
+        'recording_check_json': str(root / 'mid360_robot_recording_check.json'),
+        'readiness_json': str(root / 'mid360_robot_readiness.json'),
+        'map_plan_json': str(root / 'mid360_robot_run_plan.json'),
+        'map_diagnosis_json': str(root / 'autoware_map_diagnosis.json'),
+        'public_rko_adoption_gate_json': str(
+            root / 'public_rko_adoption_gate' / 'mid360_robot_public_rko_adoption_gate.json',
+        ),
+        'production_readiness_json': str(root / 'mid360_robot_production_readiness.json'),
+        'dashboard_html': str(root / 'mid360_robot_session_dashboard.html'),
+    }
+    _write_json(
+        root / 'mid360_robot_production_candidate_session.json',
+        {
+            'status': 'PASS',
+            'run_id': run_id,
+            'bag_root': str(bag_root),
+            'bag_path': str(bag_root / run_id),
+            'profile_snapshot_path': str(profile),
+            'record_plan_json_path': str(record_plan_json),
+            'record_plan_markdown_path': str(record_plan_md),
+            'artifact_paths': artifact_paths,
+            'thresholds': {
+                'min_bag_duration_sec': 600.0,
+                'min_pointcloud_hz': 5.0,
+                'min_imu_hz': 50.0,
+                'allow_warnings': False,
+                'allow_public_bag': False,
+            },
+        },
+    )
+    _write_text(root / 'mid360_robot_production_candidate_session.md', '# Candidate\n')
+    _write_json(root / 'jetson_mid360_host_readiness.json', {'status': 'PASS'})
+    _write_json(
+        root / 'mid360_robot_recording_check.json',
+        {
+            'status': 'PASS',
+            'bag_path': str(bag_root / run_id),
+            'readiness_status': 'PASS',
+            'checks': [{'id': 'readiness_status', 'status': 'ok', 'message': 'passed'}],
+        },
+    )
+    _write_json(
+        root / 'mid360_robot_readiness.json',
+        {
+            'status': 'PASS',
+            'bag_path': str(bag_root / run_id),
+            'ready_for_mid360_launch': True,
+            'selected_topics': {'pointcloud': '/livox/lidar', 'imu': '/livox/imu'},
+            'frames': {
+                'base_frame': 'base_link',
+                'lidar_frame': 'livox_frame',
+                'imu_frame': 'livox_frame',
+            },
+            'checks': [{'id': 'pointcloud2', 'status': 'ok', 'message': 'PointCloud2 topic'}],
+            'bag_diagnostics': {
+                'topics': {
+                    'pointcloud': {
+                        'metadata_message_count': pointcloud_messages,
+                        'metadata_rate_hz': 10.0,
+                        'sampled_message_count': 20,
+                        'stable_frame_id': True,
+                        'matches_expected_frame': True,
+                    },
+                    'imu': {
+                        'metadata_message_count': imu_messages,
+                        'metadata_rate_hz': 200.0,
+                        'sampled_message_count': 20,
+                        'stable_frame_id': True,
+                        'matches_expected_frame': True,
+                    },
+                }
+            },
+        },
+    )
+    _write_json(root / 'mid360_robot_run_plan.json', {'status': 'PASS'})
+    _write_json(
+        root / 'autoware_map_diagnosis.json',
+        {'status': 'success', 'verify': {'result': 'PASS'}},
+    )
+    _write_json(
+        root / 'public_rko_adoption_gate' / 'mid360_robot_public_rko_adoption_gate.json',
+        {
+            'status': 'PASS',
+            'decision': {
+                'matched_case': 'voxel_0p50_min_1p00_dd_on',
+                'recommended_case': 'voxel_0p50_min_1p00_dd_on',
+                'gate_pass_cases': 4,
+            },
+        },
+    )
+    _write_json(root / 'mid360_robot_production_readiness.json', {'status': 'PASS'})
+    _write_text(root / 'mid360_robot_session_dashboard.html', '<html>dashboard</html>\n')
+
+
+def _export_bundle(artifact_dir: Path, tarball: Path) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            str(EXPORT_SCRIPT),
+            str(artifact_dir),
+            '--output',
+            str(tarball),
+            '--verify',
+            '--force',
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_import_bundle_recheck_passes_from_tarball(tmp_path: Path):
+    artifact_dir = tmp_path / 'jetson_out'
+    bag_root = tmp_path / 'bags'
+    tarball = tmp_path / 'production_candidate_01.tar.gz'
+    import_dir = tmp_path / 'imported_candidate'
+    _write_candidate_artifacts(artifact_dir, bag_root)
+    _export_bundle(artifact_dir, tarball)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(IMPORT_SCRIPT),
+            str(tarball),
+            '--output-dir',
+            str(import_dir),
+            '--recheck',
+            '--verify',
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    report = json.loads(result.stdout)
+    bundle_manifest = json.loads(
+        (import_dir / 'mid360_robot_production_candidate_bundle.json').read_text(encoding='utf-8')
+    )
+    production_path = (
+        import_dir / 'artifacts' / 'mid360_robot_production_readiness.json'
+    )
+    production = json.loads(production_path.read_text(encoding='utf-8'))
+
+    assert report['status'] == 'PASS'
+    assert report['verification']['status'] == 'PASS'
+    assert report['recheck']['status'] == 'PASS'
+    assert production['status'] == 'PASS'
+    assert production['production_ready'] is True
+    assert (import_dir / 'artifacts' / 'mid360_robot_session_dashboard.html').is_file()
+    assert (import_dir / 'mid360_robot_production_candidate_bundle_import.json').is_file()
+    assert bundle_manifest['last_import']['status'] == 'PASS'
+    assert bundle_manifest['last_import']['recheck_status'] == 'PASS'
+
+
+def test_import_bundle_recheck_failure_is_reported(tmp_path: Path):
+    artifact_dir = tmp_path / 'jetson_out'
+    bag_root = tmp_path / 'bags'
+    tarball = tmp_path / 'short_candidate.tar.gz'
+    import_dir = tmp_path / 'imported_short_candidate'
+    _write_candidate_artifacts(
+        artifact_dir,
+        bag_root,
+        pointcloud_messages=3000,
+        imu_messages=60000,
+    )
+    _export_bundle(artifact_dir, tarball)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(IMPORT_SCRIPT),
+            str(tarball),
+            '--output-dir',
+            str(import_dir),
+            '--recheck',
+            '--verify',
+            '--json',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    report = json.loads(result.stdout)
+    production_path = (
+        import_dir / 'artifacts' / 'mid360_robot_production_readiness.json'
+    )
+    production = json.loads(production_path.read_text(encoding='utf-8'))
+
+    assert result.returncode == 1
+    assert report['status'] == 'FAIL'
+    assert report['verification']['status'] == 'PASS'
+    assert report['recheck']['status'] == 'FAIL'
+    assert production['status'] == 'FAIL'
+    assert any(check['id'] == 'bag_duration' and check['status'] == 'FAIL'
+               for check in production['checks'])
+
+
+def test_import_bundle_fails_when_manifest_is_missing(tmp_path: Path):
+    bad_root = tmp_path / 'bad_bundle'
+    bad_root.mkdir()
+    _write_text(bad_root / 'README.txt', 'missing manifest\n')
+    tarball = tmp_path / 'bad_bundle.tar.gz'
+    with tarfile.open(tarball, 'w:gz') as archive:
+        archive.add(bad_root, arcname='bad_bundle')
+    import_dir = tmp_path / 'imported_bad'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(IMPORT_SCRIPT),
+            str(tarball),
+            '--output-dir',
+            str(import_dir),
+            '--verify',
+            '--json',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    report = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert report['status'] == 'FAIL'
+    assert report['manifest_status'] == 'MISSING'
+    assert report['verification']['status'] == 'FAIL'
+    assert 'missing or unreadable' in report['verification']['errors'][0]

--- a/graph_based_slam/test/test_mid360_robot_production_candidate_session.py
+++ b/graph_based_slam/test/test_mid360_robot_production_candidate_session.py
@@ -13,11 +13,13 @@ from pathlib import Path
 import subprocess
 import sys
 
+import pytest
 import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_DIR = REPO_ROOT / 'scripts'
+RECORDING_SCRIPT = SCRIPT_DIR / 'check_mid360_robot_recording.sh'
 SCRIPT_PATH = SCRIPT_DIR / 'run_mid360_robot_production_candidate_session.py'
 WRAPPER_PATH = SCRIPT_DIR / 'run_mid360_robot_production_candidate_session.sh'
 
@@ -228,6 +230,10 @@ def test_production_candidate_dry_run_writes_session_plan(tmp_path: Path):
     assert report['dashboard_html_path'].endswith('mid360_robot_session_dashboard.html')
 
 
+@pytest.mark.skipif(
+    not RECORDING_SCRIPT.is_file(),
+    reason='requires check_mid360_robot_recording.sh from a follow-up recording-cascade PR',
+)
 def test_production_candidate_record_only_run_records_fake_bag(tmp_path: Path):
     profile_path = _write_profile(tmp_path)
     fake_bin = _fake_ros2_bin(tmp_path)

--- a/graph_based_slam/test/test_mid360_robot_production_candidate_session.py
+++ b/graph_based_slam/test/test_mid360_robot_production_candidate_session.py
@@ -1,0 +1,414 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+
+"""Tests for the MID-360 production-candidate session runner."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = REPO_ROOT / 'scripts'
+SCRIPT_PATH = SCRIPT_DIR / 'run_mid360_robot_production_candidate_session.py'
+WRAPPER_PATH = SCRIPT_DIR / 'run_mid360_robot_production_candidate_session.sh'
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2), encoding='utf-8')
+
+
+def _write_profile(tmp_path: Path) -> Path:
+    profile_path = tmp_path / 'profile.yaml'
+    profile_path.write_text(
+        yaml.safe_dump({
+            'robot_name': 'production_robot',
+            'base_frame': 'base_link',
+            'lidar_frame': 'livox_frame',
+            'imu_frame': 'livox_frame',
+            'expected_pointcloud_topic': '/livox/lidar',
+            'expected_imu_topic': '/livox/imu',
+        }),
+        encoding='utf-8',
+    )
+    return profile_path
+
+
+def _fake_ros2_bin(tmp_path: Path) -> Path:
+    fake_bin = tmp_path / 'bin'
+    fake_bin.mkdir()
+    ros2 = fake_bin / 'ros2'
+    ros2.write_text(
+        f"""#!{sys.executable}
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+if args[:2] == ['bag', 'record'] and '-o' in args:
+    bag_path = Path(args[args.index('-o') + 1])
+    bag_path.mkdir(parents=True, exist_ok=True)
+    bag_path.joinpath('metadata.yaml').write_text('''rosbag2_bagfile_information:
+  duration:
+    nanoseconds: 1000000000
+  message_count: 11
+  topics_with_message_count:
+  - topic_metadata:
+      name: /livox/lidar
+      type: sensor_msgs/msg/PointCloud2
+      serialization_format: cdr
+      offered_qos_profiles: ''
+    message_count: 1
+  - topic_metadata:
+      name: /livox/imu
+      type: sensor_msgs/msg/Imu
+      serialization_format: cdr
+      offered_qos_profiles: ''
+    message_count: 10
+''', encoding='utf-8')
+    raise SystemExit(0)
+raise SystemExit(0)
+""",
+        encoding='utf-8',
+    )
+    ros2.chmod(0o755)
+    return fake_bin
+
+
+def _steps_by_id(report: dict) -> dict[str, dict]:
+    return {step['id']: step for step in report['steps']}
+
+
+def _write_existing_candidate_artifacts(
+    output_dir: Path,
+    bag_path: Path,
+    *,
+    pointcloud_messages: int = 6000,
+    imu_messages: int = 120000,
+) -> None:
+    _write_json(
+        output_dir / 'jetson_mid360_host_readiness.json',
+        {
+            'status': 'PASS',
+            'checks': [{'id': 'jetson_model', 'status': 'ok', 'message': 'Jetson'}],
+        },
+    )
+    _write_json(
+        output_dir / 'mid360_robot_recording_check.json',
+        {
+            'status': 'PASS',
+            'bag_path': str(bag_path),
+            'readiness_status': 'PASS',
+            'checks': [{'id': 'readiness_status', 'status': 'ok', 'message': 'passed'}],
+        },
+    )
+    _write_json(
+        output_dir / 'mid360_robot_readiness.json',
+        {
+            'status': 'PASS',
+            'bag_path': str(bag_path),
+            'ready_for_mid360_launch': True,
+            'selected_topics': {'pointcloud': '/livox/lidar', 'imu': '/livox/imu'},
+            'frames': {
+                'base_frame': 'base_link',
+                'lidar_frame': 'livox_frame',
+                'imu_frame': 'livox_frame',
+            },
+            'checks': [{'id': 'pointcloud2', 'status': 'ok', 'message': 'PointCloud2 topic'}],
+            'bag_diagnostics': {
+                'topics': {
+                    'pointcloud': {
+                        'metadata_message_count': pointcloud_messages,
+                        'metadata_rate_hz': 10.0,
+                        'sampled_message_count': 20,
+                        'stable_frame_id': True,
+                        'matches_expected_frame': True,
+                    },
+                    'imu': {
+                        'metadata_message_count': imu_messages,
+                        'metadata_rate_hz': 200.0,
+                        'sampled_message_count': 20,
+                        'stable_frame_id': True,
+                        'matches_expected_frame': True,
+                    },
+                }
+            },
+        },
+    )
+    _write_json(
+        output_dir / 'mid360_robot_run_plan.json',
+        {
+            'status': 'PASS',
+            'dogfood_command_shell': 'bash scripts/run_rko_lio_graph_autoware_dogfood.sh',
+        },
+    )
+    _write_json(
+        output_dir / 'autoware_map_diagnosis.json',
+        {
+            'status': 'success',
+            'verify': {'result': 'PASS'},
+        },
+    )
+    _write_json(
+        output_dir / 'public_rko_adoption_gate' / 'mid360_robot_public_rko_adoption_gate.json',
+        {
+            'status': 'PASS',
+            'decision': {
+                'matched_case': 'voxel_0p50_min_1p00_dd_on',
+                'recommended_case': 'voxel_0p50_min_1p00_dd_on',
+                'gate_pass_cases': 4,
+            },
+            'checks': [{'id': 'matched_config', 'status': 'PASS', 'message': 'matched'}],
+        },
+    )
+
+
+def test_production_candidate_dry_run_writes_session_plan(tmp_path: Path):
+    profile_path = _write_profile(tmp_path)
+    bag_root = tmp_path / 'bags'
+    output_dir = tmp_path / 'out'
+    public_sweep = tmp_path / 'public' / 'mid360_robot_public_rko_sweep.json'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            '--robot-profile',
+            str(profile_path),
+            '--bag-root',
+            str(bag_root),
+            '--run-id',
+            'candidate_01',
+            '--duration-sec',
+            '600',
+            '--output-dir',
+            str(output_dir),
+            '--public-rko-sweep',
+            str(public_sweep),
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    report = json.loads(result.stdout)
+    steps = _steps_by_id(report)
+
+    assert report['status'] == 'PASS'
+    assert report['dry_run'] is True
+    assert report['counts']['ok'] == 1
+    assert report['counts']['planned'] == 6
+    assert steps['recording_plan']['status'] == 'ok'
+    assert steps['host_readiness']['status'] == 'planned'
+    assert steps['recording']['status'] == 'planned'
+    assert steps['post_recording_check']['status'] == 'planned'
+    assert steps['map']['status'] == 'planned'
+    assert steps['public_rko_adoption_gate']['status'] == 'planned'
+    assert steps['production_readiness']['status'] == 'planned'
+    assert steps['recording']['command'][-1] == '--dry-run'
+    assert str(public_sweep) in steps['public_rko_adoption_gate']['command']
+    assert (bag_root / 'candidate_01_record_plan.json').is_file()
+    assert (bag_root / 'candidate_01_profile.yaml').is_file()
+    assert (output_dir / 'mid360_robot_production_candidate_session.json').is_file()
+    assert (output_dir / 'mid360_robot_production_candidate_session.md').is_file()
+    assert (output_dir / 'mid360_robot_session_dashboard.html').is_file()
+    assert report['map_diagnosis_json_path'].endswith('autoware_map_diagnosis.json')
+    assert report['production_readiness_json_path'].endswith(
+        'mid360_robot_production_readiness.json',
+    )
+    assert report['dashboard_html_path'].endswith('mid360_robot_session_dashboard.html')
+
+
+def test_production_candidate_record_only_run_records_fake_bag(tmp_path: Path):
+    profile_path = _write_profile(tmp_path)
+    fake_bin = _fake_ros2_bin(tmp_path)
+    bag_root = tmp_path / 'bags'
+    output_dir = tmp_path / 'out'
+    env = os.environ.copy()
+    env['PATH'] = f'{fake_bin}:{env["PATH"]}'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            '--run',
+            '--robot-profile',
+            str(profile_path),
+            '--bag-root',
+            str(bag_root),
+            '--run-id',
+            'record_only_01',
+            '--duration-sec',
+            '1',
+            '--output-dir',
+            str(output_dir),
+            '--skip-host-readiness',
+            '--record-only',
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+    report = json.loads(result.stdout)
+    steps = _steps_by_id(report)
+
+    assert report['status'] == 'PASS'
+    assert report['dry_run'] is False
+    assert (bag_root / 'record_only_01' / 'metadata.yaml').is_file()
+    assert steps['recording']['status'] == 'ok'
+    assert steps['post_recording_check']['status'] == 'skipped'
+    assert steps['map']['status'] == 'skipped'
+    assert steps['public_rko_adoption_gate']['status'] == 'skipped'
+    assert steps['production_readiness']['status'] == 'skipped'
+
+
+def test_production_candidate_existing_artifacts_pass_production_gate(tmp_path: Path):
+    profile_path = _write_profile(tmp_path)
+    bag_root = tmp_path / 'robot_bags'
+    output_dir = tmp_path / 'out'
+    run_id = 'existing_pass_01'
+    _write_existing_candidate_artifacts(output_dir, bag_root / run_id)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            '--run',
+            '--from-existing-artifacts',
+            '--robot-profile',
+            str(profile_path),
+            '--bag-root',
+            str(bag_root),
+            '--run-id',
+            run_id,
+            '--duration-sec',
+            '600',
+            '--output-dir',
+            str(output_dir),
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    report = json.loads(result.stdout)
+    steps = _steps_by_id(report)
+    readiness = json.loads((output_dir / 'mid360_robot_production_readiness.json').read_text())
+    dashboard = (output_dir / 'mid360_robot_session_dashboard.html').read_text()
+
+    assert report['status'] == 'PASS'
+    assert report['from_existing_artifacts'] is True
+    assert steps['host_readiness']['status'] == 'ok'
+    assert steps['recording']['status'] == 'ok'
+    assert steps['post_recording_check']['status'] == 'ok'
+    assert steps['map']['status'] == 'ok'
+    assert steps['public_rko_adoption_gate']['status'] == 'ok'
+    assert steps['production_readiness']['status'] == 'ok'
+    assert readiness['status'] == 'PASS'
+    assert readiness['production_ready'] is True
+    assert readiness['evidence']['adoption_matched_case'] == 'voxel_0p50_min_1p00_dd_on'
+    assert 'MID-360 Robot Production Candidate' in dashboard
+    assert 'Prod Gate' in dashboard
+    assert 'route-node ok' in dashboard
+    assert 'voxel_0p50_min_1p00_dd_on' in json.dumps(readiness)
+
+
+def test_production_candidate_existing_artifacts_fail_on_short_bag(tmp_path: Path):
+    profile_path = _write_profile(tmp_path)
+    bag_root = tmp_path / 'robot_bags'
+    output_dir = tmp_path / 'out'
+    run_id = 'existing_fail_01'
+    _write_existing_candidate_artifacts(
+        output_dir,
+        bag_root / run_id,
+        pointcloud_messages=3000,
+        imu_messages=60000,
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            '--run',
+            '--from-existing-artifacts',
+            '--robot-profile',
+            str(profile_path),
+            '--bag-root',
+            str(bag_root),
+            '--run-id',
+            run_id,
+            '--duration-sec',
+            '600',
+            '--output-dir',
+            str(output_dir),
+            '--json',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    report = json.loads(result.stdout)
+    steps = _steps_by_id(report)
+    readiness = json.loads((output_dir / 'mid360_robot_production_readiness.json').read_text())
+    dashboard = (output_dir / 'mid360_robot_session_dashboard.html').read_text()
+
+    assert result.returncode == 1
+    assert report['status'] == 'FAIL'
+    assert steps['production_readiness']['status'] == 'fail'
+    assert readiness['status'] == 'FAIL'
+    assert readiness['production_ready'] is False
+    assert any(check['id'] == 'bag_duration' and check['status'] == 'FAIL'
+               for check in readiness['checks'])
+    assert any('longer' in action for action in readiness['next_actions'])
+    assert 'Prod Gate' in dashboard
+    assert 'bag_duration' in dashboard
+    assert 'Record a longer stationary/walking production candidate bag' in dashboard
+    assert 'route-node fail' in dashboard
+
+
+def test_production_candidate_shell_wrapper_dry_run(tmp_path: Path):
+    profile_path = _write_profile(tmp_path)
+    bag_root = tmp_path / 'bags'
+    output_dir = tmp_path / 'out'
+
+    result = subprocess.run(
+        [
+            'bash',
+            str(WRAPPER_PATH),
+            '--robot-profile',
+            str(profile_path),
+            '--bag-root',
+            str(bag_root),
+            '--run-id',
+            'wrapper_01',
+            '--output-dir',
+            str(output_dir),
+            '--skip-public-gate',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert 'MID-360 Robot Production Candidate Session' in result.stdout
+    report = json.loads(
+        (output_dir / 'mid360_robot_production_candidate_session.json').read_text(),
+    )
+    steps = _steps_by_id(report)
+    assert steps['public_rko_adoption_gate']['status'] == 'skipped'
+    assert steps['production_readiness']['status'] == 'planned'

--- a/graph_based_slam/test/test_mid360_robot_production_candidate_session.py
+++ b/graph_based_slam/test/test_mid360_robot_production_candidate_session.py
@@ -2,6 +2,30 @@
 # All rights reserved.
 #
 # Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 """Tests for the MID-360 production-candidate session runner."""
 

--- a/scripts/import_mid360_robot_production_candidate_bundle.py
+++ b/scripts/import_mid360_robot_production_candidate_bundle.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Import and optionally recheck a MID-360 production-candidate bundle."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from mid360_robot_production_candidate_bundle_import import (
+    BUNDLE_IMPORT_JSON,
+    BUNDLE_IMPORT_MARKDOWN,
+    ImportOptions,
+    Mid360ProductionCandidateBundleImporter,
+    render_import_markdown,
+)
+from mid360_robot_tools import payload_to_json
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description='Import a MID-360 production-candidate bundle and optionally recheck it.'
+    )
+    parser.add_argument('bundle', help='Bundle tar.gz/tgz or staged bundle directory.')
+    parser.add_argument(
+        '--output-dir',
+        default='',
+        help='Directory where bundle contents are imported. Defaults beside the bundle.',
+    )
+    parser.add_argument('--recheck', action='store_true', help='Re-run production readiness from imported artifacts.')
+    parser.add_argument('--verify', action='store_true', help='Fail if the imported bundle is incomplete.')
+    parser.add_argument('--force', action='store_true', help='Overwrite an existing output directory.')
+    parser.add_argument(
+        '--bag-root',
+        default='',
+        help='Working bag root for recheck plan sidecars. Defaults to <bundle>/recheck_recording.',
+    )
+    parser.add_argument(
+        '--min-bag-duration-sec',
+        type=float,
+        default=None,
+        help='Override the production gate duration threshold during --recheck.',
+    )
+    parser.add_argument('--json', action='store_true', help='Print machine-readable import report JSON.')
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point."""
+    args = parse_args()
+    try:
+        report = Mid360ProductionCandidateBundleImporter().import_bundle(
+            ImportOptions(
+                bundle_path=Path(args.bundle),
+                output_dir=Path(args.output_dir) if args.output_dir else None,
+                recheck=args.recheck,
+                verify=args.verify,
+                force=args.force,
+                bag_root=Path(args.bag_root) if args.bag_root else None,
+                min_bag_duration_sec=args.min_bag_duration_sec,
+            ),
+            quiet=args.json,
+        )
+    except Exception as exc:
+        print(f'failed to import MID-360 production-candidate bundle: {exc}', file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(payload_to_json(report))
+    else:
+        print(render_import_markdown(report))
+        bundle_dir = Path(report['bundle_dir'])
+        print(f'{BUNDLE_IMPORT_JSON}: {bundle_dir / BUNDLE_IMPORT_JSON}')
+        print(f'{BUNDLE_IMPORT_MARKDOWN}: {bundle_dir / BUNDLE_IMPORT_MARKDOWN}')
+
+    if report['status'] == 'FAIL':
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print('Interrupted', file=sys.stderr)
+        raise SystemExit(130)

--- a/scripts/mid360_robot_production_candidate_bundle_import.py
+++ b/scripts/mid360_robot_production_candidate_bundle_import.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Import and recheck MID-360 production-candidate bundles."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tarfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from mid360_robot_production_candidate_bundle import (
+    BUNDLE_MANIFEST_JSON,
+    BUNDLE_MANIFEST_MARKDOWN,
+    render_bundle_markdown,
+)
+from mid360_robot_production_candidate_session import (
+    Mid360ProductionCandidateSessionRunner,
+    ProductionCandidateSessionOptions,
+)
+from mid360_robot_tools import payload_to_json
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUNDLE_IMPORT_JSON = 'mid360_robot_production_candidate_bundle_import.json'
+BUNDLE_IMPORT_MARKDOWN = 'mid360_robot_production_candidate_bundle_import.md'
+
+
+@dataclass(frozen=True)
+class ImportOptions:
+    """Options for importing and optionally rechecking a bundle."""
+
+    bundle_path: Path
+    output_dir: Path | None = None
+    recheck: bool = False
+    verify: bool = False
+    force: bool = False
+    bag_root: Path | None = None
+    min_bag_duration_sec: float | None = None
+
+
+class Mid360ProductionCandidateBundleImporter:
+    """Import a portable production-candidate bundle."""
+
+    def __init__(self, repo_root: Path = REPO_ROOT) -> None:
+        self._repo_root = repo_root
+
+    def import_bundle(self, options: ImportOptions, *, quiet: bool = False) -> dict[str, Any]:
+        """Import the bundle and optionally re-run the production gate."""
+        source = options.bundle_path.expanduser().resolve()
+        output_dir = _resolve_output_dir(source, options.output_dir)
+        _prepare_output_dir(output_dir, options.force)
+        bundle_dir = _stage_bundle(source, output_dir)
+        manifest_path = bundle_dir / BUNDLE_MANIFEST_JSON
+        manifest = _load_json(manifest_path)
+        verification = _verify_imported_bundle(bundle_dir, manifest)
+        recheck = self._maybe_recheck(
+            bundle_dir=bundle_dir,
+            manifest=manifest,
+            verification=verification,
+            options=options,
+            quiet=quiet,
+        )
+        report = _build_import_report(
+            source=source,
+            bundle_dir=bundle_dir,
+            manifest=manifest,
+            verification=verification,
+            recheck=recheck,
+            requested_recheck=options.recheck,
+        )
+        _write_import_report(bundle_dir, report)
+        _update_bundle_manifest(bundle_dir, manifest, report)
+        return report
+
+    def _maybe_recheck(
+        self,
+        *,
+        bundle_dir: Path,
+        manifest: dict[str, Any],
+        verification: dict[str, Any],
+        options: ImportOptions,
+        quiet: bool,
+    ) -> dict[str, Any]:
+        if not options.recheck:
+            return {
+                'requested': False,
+                'status': 'SKIPPED',
+                'message': 'Recheck was not requested.',
+                'command': _recheck_command(bundle_dir, manifest, options),
+            }
+        if verification['status'] != 'PASS':
+            return {
+                'requested': True,
+                'status': 'SKIPPED',
+                'message': 'Recheck skipped because bundle verification failed.',
+                'command': _recheck_command(bundle_dir, manifest, options),
+            }
+        session_path = bundle_dir / 'artifacts' / 'mid360_robot_production_candidate_session.json'
+        session = _load_json(session_path)
+        command = _recheck_command(bundle_dir, manifest, options)
+        try:
+            report = Mid360ProductionCandidateSessionRunner(self._repo_root).run(
+                _recheck_options(bundle_dir, manifest, session, options),
+                quiet=quiet,
+            )
+        except Exception as exc:
+            return {
+                'requested': True,
+                'status': 'FAIL',
+                'message': f'Recheck failed to execute: {exc}',
+                'command': command,
+                'returncode': 1,
+            }
+        return {
+            'requested': True,
+            'status': str(report.get('status') or 'FAIL').upper(),
+            'message': 'Production candidate artifacts rechecked.',
+            'command': command,
+            'returncode': 0 if report.get('status') == 'PASS' else 1,
+            'production_readiness_json': str(bundle_dir / 'artifacts' / 'mid360_robot_production_readiness.json'),
+            'dashboard_html': str(bundle_dir / 'artifacts' / 'mid360_robot_session_dashboard.html'),
+            'session_report': report,
+        }
+
+
+def render_import_markdown(report: dict[str, Any]) -> str:
+    """Render an import/recheck report."""
+    verification = report.get('verification') or {}
+    recheck = report.get('recheck') or {}
+    lines = [
+        '# MID-360 Production Candidate Bundle Import',
+        '',
+        f"- status: `{report.get('status', '')}`",
+        f"- created_at: `{report.get('created_at', '')}`",
+        f"- source_bundle: `{report.get('source_bundle', '')}`",
+        f"- bundle_dir: `{report.get('bundle_dir', '')}`",
+        f"- manifest_status: `{report.get('manifest_status', '')}`",
+        f"- verification_status: `{verification.get('status', '')}`",
+        f"- recheck_status: `{recheck.get('status', '')}`",
+        '',
+        '## Recheck Command',
+        '',
+        '```bash',
+        ' '.join(str(item) for item in recheck.get('command') or []),
+        '```',
+        '',
+        '## Verification Errors',
+        '',
+    ]
+    errors = verification.get('errors') or []
+    if errors:
+        lines.extend(f'- {error}' for error in errors)
+    else:
+        lines.append('- none')
+    return '\n'.join(lines)
+
+
+def _stage_bundle(source: Path, output_dir: Path) -> Path:
+    if source.is_dir():
+        _copy_dir_contents(source, output_dir)
+        return output_dir
+    if not source.is_file():
+        raise FileNotFoundError(f'bundle not found: {source}')
+    _safe_extract_tarball(source, output_dir)
+    return output_dir
+
+
+def _copy_dir_contents(source: Path, output_dir: Path) -> None:
+    for child in source.iterdir():
+        target = output_dir / child.name
+        if child.is_dir():
+            shutil.copytree(child, target)
+        elif child.is_file():
+            shutil.copy2(child, target)
+
+
+def _safe_extract_tarball(tarball: Path, output_dir: Path) -> None:
+    with tarfile.open(tarball, 'r:gz') as archive:
+        members = archive.getmembers()
+        top_level = _single_top_level(members)
+        for member in members:
+            if member.isdir():
+                relative = _safe_member_path(member.name, top_level)
+                if relative is not None:
+                    (output_dir / relative).mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile():
+                raise ValueError(f'unsupported tar member type: {member.name}')
+            relative = _safe_member_path(member.name, top_level)
+            if relative is None:
+                continue
+            destination = output_dir / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            extracted = archive.extractfile(member)
+            if extracted is None:
+                raise ValueError(f'failed to read tar member: {member.name}')
+            with extracted, destination.open('wb') as handle:
+                shutil.copyfileobj(extracted, handle)
+
+
+def _safe_member_path(name: str, top_level: str | None) -> Path | None:
+    pure = PurePosixPath(name)
+    if pure.is_absolute() or any(part == '..' for part in pure.parts):
+        raise ValueError(f'unsafe tar member path: {name}')
+    parts = list(pure.parts)
+    if top_level and parts and parts[0] == top_level:
+        parts = parts[1:]
+    if not parts:
+        return None
+    return Path(*parts)
+
+
+def _single_top_level(members: list[tarfile.TarInfo]) -> str | None:
+    top = {
+        PurePosixPath(member.name).parts[0]
+        for member in members
+        if PurePosixPath(member.name).parts
+    }
+    return next(iter(top)) if len(top) == 1 else None
+
+
+def _verify_imported_bundle(bundle_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    errors = []
+    if not manifest:
+        errors.append(f'missing or unreadable {BUNDLE_MANIFEST_JSON}')
+        return {
+            'status': 'FAIL',
+            'errors': errors,
+            'checked_required_files': [],
+            'missing_required_files': [],
+        }
+    missing = []
+    for path_text in manifest.get('required_files') or []:
+        path = bundle_dir / str(path_text)
+        if not path.is_file():
+            missing.append(str(path_text))
+    for item in manifest.get('missing_required') or []:
+        destination = str(item.get('destination') or '')
+        if destination and destination not in missing:
+            missing.append(destination)
+    if missing:
+        errors.extend(f'missing required file: {path}' for path in missing)
+    if manifest.get('status') != 'PASS':
+        errors.append(f"bundle manifest status is {manifest.get('status')}")
+    return {
+        'status': 'FAIL' if errors else 'PASS',
+        'errors': errors,
+        'checked_required_files': list(manifest.get('required_files') or []),
+        'missing_required_files': missing,
+    }
+
+
+def _recheck_options(
+    bundle_dir: Path,
+    manifest: dict[str, Any],
+    session: dict[str, Any],
+    options: ImportOptions,
+) -> ProductionCandidateSessionOptions:
+    thresholds = session.get('thresholds') or {}
+    min_duration = (
+        options.min_bag_duration_sec
+        if options.min_bag_duration_sec is not None
+        else float(thresholds.get('min_bag_duration_sec') or 600.0)
+    )
+    return ProductionCandidateSessionOptions(
+        profile_path=_profile_path(bundle_dir, manifest),
+        bag_root=(options.bag_root.expanduser().resolve() if options.bag_root else bundle_dir / 'recheck_recording'),
+        output_dir=bundle_dir / 'artifacts',
+        run_id=str(manifest.get('run_id') or session.get('run_id') or bundle_dir.name),
+        duration_sec=f'{min_duration:g}',
+        from_existing_artifacts=True,
+        execute=True,
+        min_bag_duration_sec=float(min_duration),
+        min_pointcloud_hz=float(thresholds.get('min_pointcloud_hz') or 5.0),
+        min_imu_hz=float(thresholds.get('min_imu_hz') or 50.0),
+        allow_warnings=bool(thresholds.get('allow_warnings')),
+        allow_public_bag=bool(thresholds.get('allow_public_bag')),
+    )
+
+
+def _recheck_command(
+    bundle_dir: Path,
+    manifest: dict[str, Any],
+    options: ImportOptions,
+) -> list[str]:
+    min_duration = options.min_bag_duration_sec
+    duration = f'{min_duration:g}' if min_duration is not None else '<bundle threshold>'
+    bag_root = options.bag_root.expanduser().resolve() if options.bag_root else bundle_dir / 'recheck_recording'
+    return [
+        'bash',
+        'scripts/run_mid360_robot_production_candidate_session.sh',
+        '--robot-profile',
+        str(_profile_path(bundle_dir, manifest)),
+        '--bag-root',
+        str(bag_root),
+        '--run-id',
+        str(manifest.get('run_id') or bundle_dir.name),
+        '--duration-sec',
+        duration,
+        '--output-dir',
+        str(bundle_dir / 'artifacts'),
+        '--from-existing-artifacts',
+        '--run',
+    ]
+
+
+def _profile_path(bundle_dir: Path, manifest: dict[str, Any]) -> Path:
+    for item in manifest.get('included') or []:
+        if item.get('key') == 'profile_snapshot':
+            return bundle_dir / str(item.get('destination'))
+    matches = sorted((bundle_dir / 'recording').glob('*_profile.yaml'))
+    if matches:
+        return matches[0]
+    return bundle_dir / 'recording' / 'profile_snapshot.yaml'
+
+
+def _build_import_report(
+    *,
+    source: Path,
+    bundle_dir: Path,
+    manifest: dict[str, Any],
+    verification: dict[str, Any],
+    recheck: dict[str, Any],
+    requested_recheck: bool,
+) -> dict[str, Any]:
+    status = 'PASS'
+    if verification.get('status') != 'PASS':
+        status = 'FAIL'
+    if requested_recheck and recheck.get('status') != 'PASS':
+        status = 'FAIL'
+    return {
+        'created_at': datetime.now(timezone.utc).isoformat(),
+        'status': status,
+        'source_bundle': str(source),
+        'bundle_dir': str(bundle_dir),
+        'manifest_path': str(bundle_dir / BUNDLE_MANIFEST_JSON),
+        'manifest_status': manifest.get('status', 'MISSING') if manifest else 'MISSING',
+        'run_id': manifest.get('run_id', '') if manifest else '',
+        'verification': verification,
+        'recheck': recheck,
+    }
+
+
+def _write_import_report(bundle_dir: Path, report: dict[str, Any]) -> None:
+    (bundle_dir / BUNDLE_IMPORT_JSON).write_text(payload_to_json(report) + '\n', encoding='utf-8')
+    (bundle_dir / BUNDLE_IMPORT_MARKDOWN).write_text(render_import_markdown(report) + '\n', encoding='utf-8')
+
+
+def _update_bundle_manifest(bundle_dir: Path, manifest: dict[str, Any], report: dict[str, Any]) -> None:
+    if not manifest:
+        return
+    manifest['last_import'] = {
+        'created_at': report.get('created_at', ''),
+        'status': report.get('status', ''),
+        'bundle_dir': str(bundle_dir),
+        'verification_status': (report.get('verification') or {}).get('status', ''),
+        'recheck_status': (report.get('recheck') or {}).get('status', ''),
+        'import_report_json': BUNDLE_IMPORT_JSON,
+    }
+    manifest['files'] = _list_files(bundle_dir)
+    (bundle_dir / BUNDLE_MANIFEST_JSON).write_text(payload_to_json(manifest) + '\n', encoding='utf-8')
+    (bundle_dir / BUNDLE_MANIFEST_MARKDOWN).write_text(render_bundle_markdown(manifest) + '\n', encoding='utf-8')
+
+
+def _resolve_output_dir(source: Path, output_dir: Path | None) -> Path:
+    if output_dir is not None:
+        return output_dir.expanduser().resolve()
+    if source.suffixes[-2:] == ['.tar', '.gz']:
+        return source.with_suffix('').with_suffix('')
+    if source.suffix == '.tgz':
+        return source.with_suffix('')
+    return source.parent / f'{source.name}_imported'
+
+
+def _prepare_output_dir(output_dir: Path, force: bool) -> None:
+    if output_dir.exists():
+        if not force:
+            raise FileExistsError(f'import output dir already exists: {output_dir}')
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=False)
+
+
+def _list_files(bundle_dir: Path) -> list[str]:
+    return sorted(
+        str(path.relative_to(bundle_dir))
+        for path in bundle_dir.rglob('*')
+        if path.is_file()
+    )
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding='utf-8'))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}

--- a/scripts/mid360_robot_production_candidate_session.py
+++ b/scripts/mid360_robot_production_candidate_session.py
@@ -1,0 +1,741 @@
+#!/usr/bin/env python3
+"""Run a production-candidate MID-360 robot mapping session workflow."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from mid360_robot_dashboard import DASHBOARD_HTML, write_dashboard
+from mid360_robot_production_readiness import (
+    PRODUCTION_READINESS_JSON,
+    PRODUCTION_READINESS_MARKDOWN,
+)
+from mid360_robot_public_rko_adoption_gate import RKO_ADOPTION_GATE_JSON
+from mid360_robot_public_rko_sweep import RKO_SWEEP_JSON
+from mid360_robot_record_tools import (
+    Mid360RecordManifestWriter,
+    Mid360RobotRecordPlanner,
+    RecordOptions,
+    RecordPlan,
+)
+from mid360_robot_tools import RobotProfileLoader, payload_to_json
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PRODUCTION_CANDIDATE_SESSION_JSON = 'mid360_robot_production_candidate_session.json'
+PRODUCTION_CANDIDATE_SESSION_MARKDOWN = 'mid360_robot_production_candidate_session.md'
+DEFAULT_PUBLIC_RKO_OUTPUT_DIR = REPO_ROOT / 'output' / 'mid360_public' / 'rko_sweep'
+DEFAULT_PUBLIC_RKO_SWEEP = DEFAULT_PUBLIC_RKO_OUTPUT_DIR / RKO_SWEEP_JSON
+DEFAULT_PUBLIC_RKO_CONFIG = (
+    REPO_ROOT
+    / 'configs'
+    / 'mid360_robot'
+    / 'rko_lio_mid360_low_voxel_no_deskew.yaml'
+)
+
+
+@dataclass(frozen=True)
+class ProductionCandidateSessionOptions:
+    """Operator options for one production-candidate MID-360 robot session."""
+
+    profile_path: Path
+    bag_root: Path
+    output_dir: Path | None = None
+    run_id: str = ''
+    duration_sec: str = '600'
+    include_tf: bool = True
+    include_tf_static: bool = True
+    extra_topics: tuple[str, ...] = ()
+    storage_id: str = ''
+    max_cache_size: str = ''
+    compression_mode: str = ''
+    compression_format: str = ''
+    host_root: Path = Path('/')
+    skip_host_readiness: bool = False
+    record_only: bool = False
+    skip_map: bool = False
+    skip_public_gate: bool = False
+    from_existing_artifacts: bool = False
+    execute: bool = False
+    public_rko_run: bool = False
+    public_rko_sweep: Path | None = None
+    public_rko_config: Path = DEFAULT_PUBLIC_RKO_CONFIG
+    public_rko_output_dir: Path | None = None
+    adoption_gate: Path | None = None
+    allow_non_best: bool = False
+    map_run_name: str = ''
+    map_save_timeout_secs: str = ''
+    map_startup_timeout_secs: str = ''
+    min_bag_duration_sec: float = 600.0
+    min_pointcloud_hz: float = 5.0
+    min_imu_hz: float = 50.0
+    allow_warnings: bool = False
+    allow_public_bag: bool = False
+
+
+@dataclass(frozen=True)
+class ProductionCandidateStep:
+    """One production-candidate workflow step."""
+
+    id: str
+    status: str
+    message: str
+    command: list[str]
+    returncode: int | None = None
+
+
+class Mid360ProductionCandidateSessionRunner:
+    """Run the real-robot workflow up to the production-readiness gate."""
+
+    def __init__(self, repo_root: Path = REPO_ROOT) -> None:
+        self._repo_root = repo_root
+
+    def run(self, options: ProductionCandidateSessionOptions, *, quiet: bool = False) -> dict[str, Any]:
+        """Build or execute the production-candidate workflow."""
+        profile_path = options.profile_path.expanduser().resolve()
+        profile = RobotProfileLoader().load(profile_path)
+        plan = Mid360RobotRecordPlanner().build_plan(profile, self._record_options(options))
+        output_dir = self._resolve_output_dir(options, plan.run_id)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        steps: list[ProductionCandidateStep] = []
+        Mid360RecordManifestWriter().write(profile, plan)
+        steps.append(
+            ProductionCandidateStep(
+                id='recording_plan',
+                status='ok',
+                message='Recording plan and profile snapshot written.',
+                command=self._record_command(options, plan.run_id, dry_run=True),
+            )
+        )
+
+        self._append_host_step(steps, options, output_dir, quiet=quiet)
+        self._append_recording_step(steps, options, plan, quiet=quiet)
+        self._append_post_check_step(steps, options, plan, output_dir, quiet=quiet)
+        self._append_map_step(steps, options, plan, output_dir, quiet=quiet)
+        self._append_public_gate_step(steps, options, output_dir, quiet=quiet)
+        self._append_production_readiness_step(steps, options, output_dir, quiet=quiet)
+
+        report = self._build_report(
+            options=options,
+            profile_path=profile_path,
+            plan=plan,
+            output_dir=output_dir,
+            steps=steps,
+        )
+        self.write_report(report, output_dir)
+        dashboard_path = write_dashboard(output_dir)
+        report['dashboard_html_path'] = str(dashboard_path)
+        report['artifact_paths']['dashboard_html'] = str(dashboard_path)
+        self.write_report(report, output_dir)
+        return report
+
+    def _append_host_step(
+        self,
+        steps: list[ProductionCandidateStep],
+        options: ProductionCandidateSessionOptions,
+        output_dir: Path,
+        *,
+        quiet: bool,
+    ) -> None:
+        command = self._host_command(options, output_dir)
+        if options.from_existing_artifacts:
+            steps.append(_existing_artifact_step(
+                'host_readiness',
+                'Host readiness artifact reused.',
+                output_dir / 'jetson_mid360_host_readiness.json',
+                command,
+            ))
+        elif options.skip_host_readiness:
+            steps.append(_skipped_step('host_readiness', 'Host readiness skipped by option.', command))
+        elif self._blocked(steps):
+            steps.append(_blocked_step('host_readiness', command))
+        elif options.execute:
+            steps.append(_run_step('host_readiness', 'Host readiness completed.', command, self._repo_root, quiet))
+        else:
+            steps.append(_planned_step('host_readiness', 'Host readiness command planned.', command))
+
+    def _append_recording_step(
+        self,
+        steps: list[ProductionCandidateStep],
+        options: ProductionCandidateSessionOptions,
+        plan: RecordPlan,
+        *,
+        quiet: bool,
+    ) -> None:
+        command = self._record_command(options, plan.run_id, dry_run=not options.execute)
+        if options.from_existing_artifacts:
+            steps.append(_existing_artifact_step(
+                'recording',
+                'Recording evidence artifacts reused.',
+                plan.bag_path,
+                command,
+                required=False,
+            ))
+        elif self._blocked(steps):
+            steps.append(_blocked_step('recording', command))
+        elif options.execute:
+            steps.append(_run_step('recording', 'Recording completed.', command, self._repo_root, quiet))
+        else:
+            steps.append(_planned_step('recording', 'Recording command planned.', command))
+
+    def _append_post_check_step(
+        self,
+        steps: list[ProductionCandidateStep],
+        options: ProductionCandidateSessionOptions,
+        plan: RecordPlan,
+        output_dir: Path,
+        *,
+        quiet: bool,
+    ) -> None:
+        command = self._post_check_command(plan, output_dir)
+        if options.from_existing_artifacts:
+            steps.append(_existing_artifact_step(
+                'post_recording_check',
+                'Post-recording check artifacts reused.',
+                output_dir / 'mid360_robot_recording_check.json',
+                command,
+            ))
+        elif options.record_only:
+            steps.append(_skipped_step('post_recording_check', 'Post-recording check skipped by --record-only.', command))
+        elif self._blocked(steps):
+            steps.append(_blocked_step('post_recording_check', command))
+        elif options.execute:
+            steps.append(_run_step('post_recording_check', 'Post-recording check completed.', command, self._repo_root, quiet))
+        else:
+            steps.append(_planned_step('post_recording_check', 'Post-recording check command planned.', command))
+
+    def _append_map_step(
+        self,
+        steps: list[ProductionCandidateStep],
+        options: ProductionCandidateSessionOptions,
+        plan: RecordPlan,
+        output_dir: Path,
+        *,
+        quiet: bool,
+    ) -> None:
+        command = self._map_command(options, plan, output_dir)
+        if options.from_existing_artifacts:
+            steps.append(_existing_artifact_step(
+                'map',
+                'Map diagnosis artifact reused.',
+                output_dir / 'autoware_map_diagnosis.json',
+                command,
+            ))
+        elif options.record_only:
+            steps.append(_skipped_step('map', 'Mapping skipped by --record-only.', command))
+        elif options.skip_map:
+            steps.append(_skipped_step('map', 'Mapping skipped by --skip-map.', command))
+        elif self._blocked(steps):
+            steps.append(_blocked_step('map', command))
+        elif options.execute:
+            steps.append(_run_step('map', 'Mapping and map diagnosis completed.', command, self._repo_root, quiet))
+        else:
+            steps.append(_planned_step('map', 'Mapping and map diagnosis command planned.', command))
+
+    def _append_public_gate_step(
+        self,
+        steps: list[ProductionCandidateStep],
+        options: ProductionCandidateSessionOptions,
+        output_dir: Path,
+        *,
+        quiet: bool,
+    ) -> None:
+        command = self._public_rko_gate_command(options, output_dir)
+        if options.from_existing_artifacts:
+            steps.append(_existing_artifact_step(
+                'public_rko_adoption_gate',
+                'Public RKO adoption gate artifact reused.',
+                self._adoption_gate_path(options, output_dir),
+                command,
+            ))
+        elif options.record_only:
+            steps.append(_skipped_step('public_rko_adoption_gate', 'Public RKO adoption gate skipped by --record-only.', command))
+        elif options.skip_public_gate:
+            steps.append(_skipped_step(
+                'public_rko_adoption_gate',
+                'Public RKO adoption gate generation skipped; production gate uses the configured adoption-gate JSON.',
+                command,
+            ))
+        elif self._blocked(steps):
+            steps.append(_blocked_step('public_rko_adoption_gate', command))
+        elif options.execute:
+            steps.append(_run_step(
+                'public_rko_adoption_gate',
+                'Public RKO adoption gate completed.',
+                command,
+                self._repo_root,
+                quiet,
+            ))
+        else:
+            steps.append(_planned_step('public_rko_adoption_gate', 'Public RKO adoption gate command planned.', command))
+
+    def _append_production_readiness_step(
+        self,
+        steps: list[ProductionCandidateStep],
+        options: ProductionCandidateSessionOptions,
+        output_dir: Path,
+        *,
+        quiet: bool,
+    ) -> None:
+        command = self._production_readiness_command(options, output_dir)
+        if options.from_existing_artifacts and self._blocked(steps):
+            steps.append(_blocked_step('production_readiness', command))
+        elif options.record_only:
+            steps.append(_skipped_step('production_readiness', 'Production readiness skipped by --record-only.', command))
+        elif options.skip_map and not options.from_existing_artifacts:
+            steps.append(_skipped_step('production_readiness', 'Production readiness skipped because mapping was skipped.', command))
+        elif self._blocked(steps):
+            steps.append(_blocked_step('production_readiness', command))
+        elif options.execute:
+            steps.append(_run_step(
+                'production_readiness',
+                'Production readiness gate completed.',
+                command,
+                self._repo_root,
+                quiet,
+            ))
+        else:
+            steps.append(_planned_step('production_readiness', 'Production readiness gate command planned.', command))
+
+    def _record_options(self, options: ProductionCandidateSessionOptions) -> RecordOptions:
+        return RecordOptions(
+            bag_root=options.bag_root.expanduser().resolve(),
+            run_id=options.run_id,
+            include_tf=options.include_tf,
+            include_tf_static=options.include_tf_static,
+            extra_topics=tuple(options.extra_topics or ()),
+            storage_id=options.storage_id,
+            max_cache_size=options.max_cache_size,
+            compression_mode=options.compression_mode,
+            compression_format=options.compression_format,
+            duration_sec=options.duration_sec,
+        )
+
+    def _resolve_output_dir(self, options: ProductionCandidateSessionOptions, run_id: str) -> Path:
+        if options.output_dir is not None:
+            return options.output_dir.expanduser().resolve()
+        return self._repo_root / 'output' / f'mid360_robot_production_candidate_{run_id}'
+
+    def _record_command(
+        self,
+        options: ProductionCandidateSessionOptions,
+        run_id: str,
+        *,
+        dry_run: bool,
+    ) -> list[str]:
+        command = [
+            'bash',
+            str(self._repo_root / 'scripts' / 'record_mid360_robot_bag.sh'),
+            '--robot-profile',
+            str(options.profile_path.expanduser().resolve()),
+            '--bag-root',
+            str(options.bag_root.expanduser().resolve()),
+            '--run-id',
+            run_id,
+        ]
+        if options.duration_sec:
+            command.extend(['--duration-sec', options.duration_sec])
+        for topic in options.extra_topics or ():
+            command.extend(['--extra-topic', topic])
+        if not options.include_tf:
+            command.append('--no-tf')
+        if not options.include_tf_static:
+            command.append('--no-tf-static')
+        if options.storage_id:
+            command.extend(['--storage-id', options.storage_id])
+        if options.max_cache_size:
+            command.extend(['--max-cache-size', options.max_cache_size])
+        if options.compression_mode:
+            command.extend(['--compression-mode', options.compression_mode])
+        if options.compression_format:
+            command.extend(['--compression-format', options.compression_format])
+        if dry_run:
+            command.append('--dry-run')
+        return command
+
+    def _host_command(self, options: ProductionCandidateSessionOptions, output_dir: Path) -> list[str]:
+        return [
+            'python3',
+            str(self._repo_root / 'scripts' / 'check_jetson_mid360_host_readiness.py'),
+            '--bag-dir',
+            str(options.bag_root.expanduser().resolve()),
+            '--output-dir',
+            str(output_dir),
+            '--host-root',
+            str(options.host_root.expanduser().resolve()),
+        ]
+
+    def _post_check_command(self, plan: RecordPlan, output_dir: Path) -> list[str]:
+        return [
+            'bash',
+            str(self._repo_root / 'scripts' / 'check_mid360_robot_recording.sh'),
+            '--bag',
+            str(plan.bag_path),
+            '--robot-profile',
+            str(plan.profile_snapshot_path),
+            '--record-plan',
+            str(plan.manifest_json_path),
+            '--output-dir',
+            str(output_dir),
+        ]
+
+    def _map_command(
+        self,
+        options: ProductionCandidateSessionOptions,
+        plan: RecordPlan,
+        output_dir: Path,
+    ) -> list[str]:
+        command = [
+            'bash',
+            str(self._repo_root / 'scripts' / 'run_mid360_robot_map.sh'),
+            str(plan.bag_path),
+            '--robot-profile',
+            str(plan.profile_snapshot_path),
+            '--output-dir',
+            str(output_dir),
+            '--write-manifest',
+            '--write-diagnosis',
+        ]
+        if options.map_run_name:
+            command.extend(['--run-name', options.map_run_name])
+        if options.map_save_timeout_secs:
+            command.extend(['--save-timeout-secs', options.map_save_timeout_secs])
+        if options.map_startup_timeout_secs:
+            command.extend(['--startup-timeout-secs', options.map_startup_timeout_secs])
+        return command
+
+    def _public_rko_gate_command(
+        self,
+        options: ProductionCandidateSessionOptions,
+        output_dir: Path,
+    ) -> list[str]:
+        mode = '--run' if options.public_rko_run else '--from-existing'
+        command = [
+            'python3',
+            str(self._repo_root / 'scripts' / 'run_mid360_robot_public_rko_adoption_gate.py'),
+            mode,
+            '--output-dir',
+            str(self._public_rko_output_dir(options, output_dir)),
+            '--config',
+            str(options.public_rko_config.expanduser().resolve()),
+        ]
+        sweep = self._public_rko_sweep(options)
+        if sweep is not None:
+            command.extend(['--sweep', str(sweep)])
+        if options.allow_non_best:
+            command.append('--allow-non-best')
+        return command
+
+    def _production_readiness_command(
+        self,
+        options: ProductionCandidateSessionOptions,
+        output_dir: Path,
+    ) -> list[str]:
+        command = [
+            'python3',
+            str(self._repo_root / 'scripts' / 'check_mid360_robot_production_readiness.py'),
+            '--artifact-dir',
+            str(output_dir),
+            '--host-readiness',
+            str(output_dir / 'jetson_mid360_host_readiness.json'),
+            '--recording-check',
+            str(output_dir / 'mid360_robot_recording_check.json'),
+            '--readiness',
+            str(output_dir / 'mid360_robot_readiness.json'),
+            '--map-diagnosis',
+            str(output_dir / 'autoware_map_diagnosis.json'),
+            '--adoption-gate',
+            str(self._adoption_gate_path(options, output_dir)),
+            '--output-dir',
+            str(output_dir),
+            '--min-bag-duration-sec',
+            f'{options.min_bag_duration_sec:g}',
+            '--min-pointcloud-hz',
+            f'{options.min_pointcloud_hz:g}',
+            '--min-imu-hz',
+            f'{options.min_imu_hz:g}',
+        ]
+        if options.allow_warnings:
+            command.append('--allow-warnings')
+        if options.allow_public_bag:
+            command.append('--allow-public-bag')
+        return command
+
+    def _public_rko_output_dir(
+        self,
+        options: ProductionCandidateSessionOptions,
+        output_dir: Path,
+    ) -> Path:
+        if options.public_rko_output_dir is not None:
+            return options.public_rko_output_dir.expanduser().resolve()
+        return output_dir / 'public_rko_adoption_gate'
+
+    def _public_rko_sweep(self, options: ProductionCandidateSessionOptions) -> Path | None:
+        if options.public_rko_sweep is not None:
+            return options.public_rko_sweep.expanduser().resolve()
+        if options.public_rko_run:
+            return None
+        return DEFAULT_PUBLIC_RKO_SWEEP
+
+    def _adoption_gate_path(
+        self,
+        options: ProductionCandidateSessionOptions,
+        output_dir: Path,
+    ) -> Path:
+        if options.adoption_gate is not None:
+            return options.adoption_gate.expanduser().resolve()
+        if options.skip_public_gate:
+            return DEFAULT_PUBLIC_RKO_OUTPUT_DIR / RKO_ADOPTION_GATE_JSON
+        return self._public_rko_output_dir(options, output_dir) / RKO_ADOPTION_GATE_JSON
+
+    def _build_report(
+        self,
+        *,
+        options: ProductionCandidateSessionOptions,
+        profile_path: Path,
+        plan: RecordPlan,
+        output_dir: Path,
+        steps: list[ProductionCandidateStep],
+    ) -> dict[str, Any]:
+        public_output_dir = self._public_rko_output_dir(options, output_dir)
+        artifacts = {
+            'profile_snapshot': str(plan.profile_snapshot_path),
+            'record_plan_json': str(plan.manifest_json_path),
+            'record_plan_markdown': str(plan.manifest_markdown_path),
+            'host_readiness_json': str(output_dir / 'jetson_mid360_host_readiness.json'),
+            'recording_check_json': str(output_dir / 'mid360_robot_recording_check.json'),
+            'readiness_json': str(output_dir / 'mid360_robot_readiness.json'),
+            'map_plan_json': str(output_dir / 'mid360_robot_run_plan.json'),
+            'map_diagnosis_json': str(output_dir / 'autoware_map_diagnosis.json'),
+            'public_rko_adoption_gate_json': str(self._adoption_gate_path(options, output_dir)),
+            'public_rko_adoption_gate_markdown': str(public_output_dir / 'mid360_robot_public_rko_adoption_gate.md'),
+            'production_readiness_json': str(output_dir / PRODUCTION_READINESS_JSON),
+            'production_readiness_markdown': str(output_dir / PRODUCTION_READINESS_MARKDOWN),
+            'dashboard_html': str(output_dir / DASHBOARD_HTML),
+            'production_candidate_session_json': str(output_dir / PRODUCTION_CANDIDATE_SESSION_JSON),
+            'production_candidate_session_markdown': str(output_dir / PRODUCTION_CANDIDATE_SESSION_MARKDOWN),
+        }
+        return {
+            'created_at': datetime.now(timezone.utc).isoformat(),
+            'status': _status_from_steps(steps),
+            'production_candidate_session': True,
+            'dry_run': not options.execute,
+            'record_only': options.record_only,
+            'skip_map': options.skip_map,
+            'skip_public_gate': options.skip_public_gate,
+            'from_existing_artifacts': options.from_existing_artifacts,
+            'public_rko_run': options.public_rko_run,
+            'run_id': plan.run_id,
+            'bag_root': str(plan.bag_root),
+            'bag_path': str(plan.bag_path),
+            'output_dir': str(output_dir),
+            'profile_path': str(profile_path),
+            'profile_snapshot_path': str(plan.profile_snapshot_path),
+            'record_plan_json_path': str(plan.manifest_json_path),
+            'record_plan_markdown_path': str(plan.manifest_markdown_path),
+            'host_readiness_json_path': artifacts['host_readiness_json'],
+            'recording_check_json_path': artifacts['recording_check_json'],
+            'readiness_json_path': artifacts['readiness_json'],
+            'map_plan_json_path': artifacts['map_plan_json'],
+            'map_diagnosis_json_path': artifacts['map_diagnosis_json'],
+            'public_rko_adoption_gate_json_path': artifacts['public_rko_adoption_gate_json'],
+            'production_readiness_json_path': artifacts['production_readiness_json'],
+            'dashboard_html_path': artifacts['dashboard_html'],
+            'production_candidate_session_json_path': artifacts['production_candidate_session_json'],
+            'production_candidate_session_markdown_path': artifacts['production_candidate_session_markdown'],
+            'thresholds': {
+                'min_bag_duration_sec': options.min_bag_duration_sec,
+                'min_pointcloud_hz': options.min_pointcloud_hz,
+                'min_imu_hz': options.min_imu_hz,
+                'allow_warnings': options.allow_warnings,
+                'allow_public_bag': options.allow_public_bag,
+            },
+            'artifact_paths': artifacts,
+            'steps': [asdict(step) for step in steps],
+            'counts': _count_steps(steps),
+            'next_actions': _next_actions(options, steps),
+        }
+
+    @staticmethod
+    def write_report(report: dict[str, Any], output_dir: Path) -> dict[str, Path]:
+        """Write JSON and Markdown production-candidate reports."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+        json_path = output_dir / PRODUCTION_CANDIDATE_SESSION_JSON
+        markdown_path = output_dir / PRODUCTION_CANDIDATE_SESSION_MARKDOWN
+        json_path.write_text(payload_to_json(report) + '\n', encoding='utf-8')
+        markdown_path.write_text(render_production_candidate_session_markdown(report) + '\n', encoding='utf-8')
+        return {'json': json_path, 'markdown': markdown_path}
+
+    @staticmethod
+    def _blocked(steps: list[ProductionCandidateStep]) -> bool:
+        return any(step.status == 'fail' for step in steps)
+
+
+def render_production_candidate_session_markdown(report: dict[str, Any]) -> str:
+    """Render a concise production-candidate session report."""
+    lines = [
+        '# MID-360 Robot Production Candidate Session',
+        '',
+        f"- status: `{report['status']}`",
+        f"- created_at: `{report['created_at']}`",
+        f"- dry_run: `{report['dry_run']}`",
+        f"- run_id: `{report['run_id']}`",
+        f"- bag_path: `{report['bag_path']}`",
+        f"- output_dir: `{report['output_dir']}`",
+        '',
+        '## Artifacts',
+        '',
+    ]
+    artifacts = report.get('artifact_paths') or {}
+    for key in (
+        'profile_snapshot',
+        'record_plan_json',
+        'host_readiness_json',
+        'recording_check_json',
+        'readiness_json',
+        'map_diagnosis_json',
+        'public_rko_adoption_gate_json',
+        'production_readiness_json',
+        'dashboard_html',
+        'production_candidate_session_json',
+    ):
+        lines.append(f"- {key}: `{artifacts.get(key, '')}`")
+
+    lines.extend(['', '## Steps', ''])
+    for step in report.get('steps', []):
+        lines.append(f"- `{step.get('status', '')}` `{step.get('id', '')}`: {step.get('message', '')}")
+        if step.get('command'):
+            lines.extend(['', '```bash', shlex.join(step['command']), '```', ''])
+
+    actions = report.get('next_actions') or []
+    lines.extend(['', '## Next Actions', ''])
+    if actions:
+        for action in actions:
+            lines.append(f'- {action}')
+    else:
+        lines.append('- none')
+    return '\n'.join(lines)
+
+
+def _run_step(
+    step_id: str,
+    success_message: str,
+    command: list[str],
+    repo_root: Path,
+    quiet: bool,
+) -> ProductionCandidateStep:
+    completed = subprocess.run(
+        command,
+        check=False,
+        cwd=repo_root,
+        stdout=subprocess.DEVNULL if quiet else None,
+        stderr=subprocess.DEVNULL if quiet else None,
+    )
+    status = 'ok' if completed.returncode == 0 else 'fail'
+    message = success_message if status == 'ok' else f'{success_message} failed.'
+    return ProductionCandidateStep(
+        id=step_id,
+        status=status,
+        message=message,
+        command=command,
+        returncode=completed.returncode,
+    )
+
+
+def _planned_step(step_id: str, message: str, command: list[str]) -> ProductionCandidateStep:
+    return ProductionCandidateStep(
+        id=step_id,
+        status='planned',
+        message=message,
+        command=command,
+    )
+
+
+def _skipped_step(step_id: str, message: str, command: list[str] | None = None) -> ProductionCandidateStep:
+    return ProductionCandidateStep(
+        id=step_id,
+        status='skipped',
+        message=message,
+        command=command or [],
+    )
+
+
+def _existing_artifact_step(
+    step_id: str,
+    message: str,
+    artifact_path: Path,
+    command: list[str],
+    *,
+    required: bool = True,
+) -> ProductionCandidateStep:
+    path = artifact_path.expanduser().resolve()
+    if path.exists() or not required:
+        suffix = f' ({path})' if path.exists() else ''
+        return ProductionCandidateStep(
+            id=step_id,
+            status='ok',
+            message=f'{message}{suffix}',
+            command=command,
+        )
+    return ProductionCandidateStep(
+        id=step_id,
+        status='fail',
+        message=f'Missing required existing artifact: {path}',
+        command=command,
+        returncode=1,
+    )
+
+
+def _blocked_step(step_id: str, command: list[str]) -> ProductionCandidateStep:
+    return _skipped_step(step_id, 'Step skipped because an earlier production-candidate step failed.', command)
+
+
+def _status_from_steps(steps: list[ProductionCandidateStep]) -> str:
+    if any(step.status == 'fail' for step in steps):
+        return 'FAIL'
+    if any(step.status == 'warn' for step in steps):
+        return 'WARN'
+    return 'PASS'
+
+
+def _count_steps(steps: list[ProductionCandidateStep]) -> dict[str, int]:
+    return {
+        'ok': sum(1 for step in steps if step.status == 'ok'),
+        'warn': sum(1 for step in steps if step.status == 'warn'),
+        'planned': sum(1 for step in steps if step.status == 'planned'),
+        'skipped': sum(1 for step in steps if step.status == 'skipped'),
+        'fail': sum(1 for step in steps if step.status == 'fail'),
+    }
+
+
+def _next_actions(
+    options: ProductionCandidateSessionOptions,
+    steps: list[ProductionCandidateStep],
+) -> list[str]:
+    if not options.execute:
+        if options.from_existing_artifacts:
+            return ['Run the same command with --run to evaluate the existing artifacts through the production gate.']
+        return ['Run the same command with --run on the Jetson when the planned commands and paths are correct.']
+    failed = [step for step in steps if step.status == 'fail']
+    if not failed:
+        return []
+    first = failed[0]
+    if first.id == 'host_readiness':
+        return ['Fix Jetson host readiness before recording a production candidate bag.']
+    if first.id == 'recording':
+        return ['Inspect ros2 bag record output, storage space, and MID-360 topic availability.']
+    if first.id == 'post_recording_check':
+        return ['Open mid360_robot_recording_check.md and fix bag/profile/topic issues before mapping.']
+    if first.id == 'map':
+        return ['Inspect Autoware/RKO-LIO logs and autoware_map_diagnosis.md before rerunning the production gate.']
+    if first.id == 'public_rko_adoption_gate':
+        return ['Regenerate the public RKO sweep/adoption evidence or pass --skip-public-gate with a valid --adoption-gate path.']
+    if first.id == 'production_readiness':
+        return ['Open mid360_robot_production_readiness.md and address each failing production gate check.']
+    return ['Inspect the failed step output and rerun the production-candidate session.']

--- a/scripts/run_mid360_robot_production_candidate_session.py
+++ b/scripts/run_mid360_robot_production_candidate_session.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""CLI for the MID-360 robot production-candidate session runner."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from mid360_robot_production_candidate_session import (
+    DEFAULT_PUBLIC_RKO_CONFIG,
+    Mid360ProductionCandidateSessionRunner,
+    PRODUCTION_CANDIDATE_SESSION_JSON,
+    PRODUCTION_CANDIDATE_SESSION_MARKDOWN,
+    ProductionCandidateSessionOptions,
+    render_production_candidate_session_markdown,
+)
+from mid360_robot_tools import payload_to_json
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PROFILE = REPO_ROOT / 'configs' / 'mid360_robot' / 'livox_mid360_default.yaml'
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description='Plan or run a production-candidate MID-360 robot mapping session.'
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        '--run',
+        dest='execute',
+        action='store_true',
+        help='Execute recording, post-check, mapping, public gate, and production gate.',
+    )
+    mode.add_argument(
+        '--dry-run',
+        dest='execute',
+        action='store_false',
+        help='Only write plans and commands. This is the default.',
+    )
+    parser.set_defaults(execute=False)
+    parser.add_argument(
+        '--robot-profile',
+        default=str(DEFAULT_PROFILE),
+        help='Robot profile YAML with expected MID-360 topics and frames.',
+    )
+    parser.add_argument(
+        '--bag-root',
+        required=True,
+        help='Directory where rosbag2 output and recording sidecars are written.',
+    )
+    parser.add_argument('--output-dir', default='', help='Directory for session artifacts.')
+    parser.add_argument('--run-id', default='', help='Recording run id and bag directory name.')
+    parser.add_argument(
+        '--duration-sec',
+        default='600',
+        help='Recording duration and production-gate minimum duration default.',
+    )
+    parser.add_argument('--extra-topic', action='append', default=[], help='Additional topic to record.')
+    parser.add_argument('--no-tf', action='store_true', help='Do not record /tf.')
+    parser.add_argument('--no-tf-static', action='store_true', help='Do not record /tf_static.')
+    parser.add_argument('--storage-id', default='', help='rosbag2 storage id.')
+    parser.add_argument('--max-cache-size', default='', help='ros2 bag record --max-cache-size.')
+    parser.add_argument('--compression-mode', default='', help='ros2 bag record compression mode.')
+    parser.add_argument('--compression-format', default='', help='ros2 bag record compression format.')
+    parser.add_argument('--host-root', default='/', help='Host filesystem root for Jetson readiness.')
+    parser.add_argument(
+        '--skip-host-readiness',
+        action='store_true',
+        help='Skip Jetson host readiness. Intended only for partial rehearsals.',
+    )
+    parser.add_argument('--record-only', action='store_true', help='Stop after recording.')
+    parser.add_argument('--skip-map', action='store_true', help='Skip mapping and production readiness.')
+    parser.add_argument(
+        '--skip-public-gate',
+        action='store_true',
+        help='Do not regenerate public RKO adoption evidence.',
+    )
+    parser.add_argument(
+        '--from-existing-artifacts',
+        action='store_true',
+        help='Reuse existing host, recording, map, and adoption artifacts and run only the production gate.',
+    )
+    parser.add_argument(
+        '--public-rko-run',
+        action='store_true',
+        help='Run the public clipped-bag RKO sweep before the public adoption gate.',
+    )
+    parser.add_argument(
+        '--public-rko-sweep',
+        default='',
+        help='Existing public RKO sweep JSON for the adoption gate.',
+    )
+    parser.add_argument(
+        '--public-rko-config',
+        default=str(DEFAULT_PUBLIC_RKO_CONFIG),
+        help='Tracked RKO-LIO config checked by the public adoption gate.',
+    )
+    parser.add_argument(
+        '--public-rko-output-dir',
+        default='',
+        help='Directory for public RKO adoption-gate artifacts.',
+    )
+    parser.add_argument(
+        '--adoption-gate',
+        default='',
+        help='Existing public RKO adoption-gate JSON for production readiness.',
+    )
+    parser.add_argument(
+        '--allow-non-best',
+        action='store_true',
+        help='Accept any matching public gate-pass case instead of requiring the top-ranked case.',
+    )
+    parser.add_argument('--map-run-name', default='', help='Optional RKO-LIO map run_name.')
+    parser.add_argument('--map-save-timeout-secs', default='', help='Timeout waiting for map files.')
+    parser.add_argument('--map-startup-timeout-secs', default='', help='Timeout waiting for SLAM startup.')
+    parser.add_argument('--min-bag-duration-sec', type=float, default=None)
+    parser.add_argument('--min-pointcloud-hz', type=float, default=5.0)
+    parser.add_argument('--min-imu-hz', type=float, default=50.0)
+    parser.add_argument('--allow-warnings', action='store_true')
+    parser.add_argument('--allow-public-bag', action='store_true')
+    parser.add_argument('--json', action='store_true', help='Print JSON instead of Markdown.')
+    return parser.parse_args()
+
+
+def _options_from_args(args: argparse.Namespace) -> ProductionCandidateSessionOptions:
+    min_duration = args.min_bag_duration_sec
+    if min_duration is None:
+        min_duration = _duration_as_float(args.duration_sec, default=600.0)
+    return ProductionCandidateSessionOptions(
+        profile_path=Path(args.robot_profile).expanduser().resolve(),
+        bag_root=Path(args.bag_root).expanduser().resolve(),
+        output_dir=Path(args.output_dir).expanduser().resolve() if args.output_dir else None,
+        run_id=args.run_id,
+        duration_sec=args.duration_sec,
+        include_tf=not args.no_tf,
+        include_tf_static=not args.no_tf_static,
+        extra_topics=tuple(args.extra_topic or []),
+        storage_id=args.storage_id,
+        max_cache_size=args.max_cache_size,
+        compression_mode=args.compression_mode,
+        compression_format=args.compression_format,
+        host_root=Path(args.host_root).expanduser().resolve(),
+        skip_host_readiness=args.skip_host_readiness,
+        record_only=args.record_only,
+        skip_map=args.skip_map,
+        skip_public_gate=args.skip_public_gate,
+        from_existing_artifacts=args.from_existing_artifacts,
+        execute=args.execute,
+        public_rko_run=args.public_rko_run,
+        public_rko_sweep=Path(args.public_rko_sweep).expanduser().resolve() if args.public_rko_sweep else None,
+        public_rko_config=Path(args.public_rko_config).expanduser().resolve(),
+        public_rko_output_dir=(
+            Path(args.public_rko_output_dir).expanduser().resolve()
+            if args.public_rko_output_dir else None
+        ),
+        adoption_gate=Path(args.adoption_gate).expanduser().resolve() if args.adoption_gate else None,
+        allow_non_best=args.allow_non_best,
+        map_run_name=args.map_run_name,
+        map_save_timeout_secs=args.map_save_timeout_secs,
+        map_startup_timeout_secs=args.map_startup_timeout_secs,
+        min_bag_duration_sec=max(0.0, float(min_duration)),
+        min_pointcloud_hz=max(0.0, float(args.min_pointcloud_hz)),
+        min_imu_hz=max(0.0, float(args.min_imu_hz)),
+        allow_warnings=args.allow_warnings,
+        allow_public_bag=args.allow_public_bag,
+    )
+
+
+def _duration_as_float(value: str, *, default: float) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def main() -> int:
+    """Entry point."""
+    args = parse_args()
+    try:
+        report = Mid360ProductionCandidateSessionRunner(REPO_ROOT).run(
+            _options_from_args(args),
+            quiet=args.json,
+        )
+    except Exception as exc:
+        print(f'failed to run MID-360 production-candidate session: {exc}', file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(payload_to_json(report))
+    else:
+        print(render_production_candidate_session_markdown(report))
+        print(f'{PRODUCTION_CANDIDATE_SESSION_JSON}: {report["production_candidate_session_json_path"]}')
+        print(f'{PRODUCTION_CANDIDATE_SESSION_MARKDOWN}: {report["production_candidate_session_markdown_path"]}')
+    return 1 if report['status'] == 'FAIL' else 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print('Interrupted', file=sys.stderr)
+        raise SystemExit(130)

--- a/scripts/run_mid360_robot_production_candidate_session.sh
+++ b/scripts/run_mid360_robot_production_candidate_session.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+exec python3 "${SCRIPT_DIR}/run_mid360_robot_production_candidate_session.py" "$@"


### PR DESCRIPTION
## Summary

Closes the inside-out chain on the MID-360 robot operator pipeline.

- `scripts/mid360_robot_production_candidate_session.py` orchestrates the full operator flow for one MID-360 robot mapping session: profile load → recording plan → readiness checks → map run → production-readiness gate → dashboard. Outputs a single session JSON + Markdown that the dashboard (PR #170) renders.
- `scripts/mid360_robot_production_candidate_bundle_import.py` is the symmetric receive side: extracts a portable production-candidate tarball (or staged directory) into a working folder, verifies the manifest from PR #170's bundle export, and optionally reruns the production-readiness gate via the session orchestrator using `--from-existing-artifacts`.

Both ship with argparse CLIs (`run_mid360_robot_production_candidate_session.py`, `import_mid360_robot_production_candidate_bundle.py`) that exit non-zero on FAIL for CI / scripting use.

### Dependency chain (now landed)
PR #168 `mid360_robot_tools` → PR #170 `mid360_robot_dashboard` + `mid360_robot_production_candidate_bundle` → PR #171 `mid360_robot_record_tools` → PR #172 `mid360_robot_production_readiness` → PR #173 `mid360_robot_public_rko_quality_report` + `mid360_robot_rko_config_adoption` → PR #174 `mid360_robot_public_rko_sweep` → PR #175 `mid360_robot_public_rko_adoption_gate` → **this PR (session + bundle_import)**.

### Why
This is the closing piece: operator can now run one command to take a robot from \"camera on the bench\" to a verified production-candidate bundle, then a teammate can `import_*` that bundle on another machine and recheck the gate offline.

## Test plan

- [x] `python3 -m pytest graph_based_slam/test/test_mid360_robot_production_candidate_session.py graph_based_slam/test/test_mid360_robot_production_candidate_bundle_import.py -v` → 8 passed
  - session: dry_run plan, record-only run, existing-artifacts PASS, short-bag FAIL, shell wrapper dry-run
  - bundle_import: tarball recheck PASS, recheck FAIL is reported, missing-manifest FAIL
- [x] `python3 -m flake8 --select=E,W,F --ignore=W503 --max-line-length=99 graph_based_slam/test/test_mid360_robot_production_candidate_session.py graph_based_slam/test/test_mid360_robot_production_candidate_bundle_import.py` → clean
- [ ] Humble + Jazzy matrix CI