### PR TITLE
feat: MID-360 robot post-recording check cascade (recording_check_tools + CLI)

### DIFF
--- a/configs/mid360_robot/livox_mid360_default.yaml
+++ b/configs/mid360_robot/livox_mid360_default.yaml
@@ -1,0 +1,10 @@
+robot_name: livox_mid360_default
+base_frame: base_link
+lidar_frame: livox_frame
+imu_frame: livox_frame
+expected_pointcloud_topic: /livox/lidar
+expected_imu_topic: /livox/imu
+mount:
+  xyz: [0.0, 0.0, 0.0]
+  q_xyzw: [0.0, 0.0, 0.0, 1.0]
+  note: Replace identity with measured base_link to livox_frame transform.

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -259,6 +259,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_mid360_robot_recording_check
+    test/test_mid360_robot_recording_check.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_navsatfix_covariance_inspector
     test/test_navsatfix_covariance_inspector.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_mid360_robot_recording_check.py
+++ b/graph_based_slam/test/test_mid360_robot_recording_check.py
@@ -1,0 +1,253 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""CLI tests for the MID-360 robot post-recording check."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RECORD_SCRIPT = REPO_ROOT / 'scripts' / 'record_mid360_robot_bag.sh'
+CHECK_SCRIPT = REPO_ROOT / 'scripts' / 'check_mid360_robot_recording.py'
+CHECK_WRAPPER = REPO_ROOT / 'scripts' / 'check_mid360_robot_recording.sh'
+
+
+def _write_profile(tmp_path: Path) -> Path:
+    profile_path = tmp_path / 'profile.yaml'
+    profile_path.write_text(
+        yaml.safe_dump({
+            'robot_name': 'record_check_robot',
+            'base_frame': 'base_link',
+            'lidar_frame': 'livox_frame',
+            'imu_frame': 'livox_frame',
+            'expected_pointcloud_topic': '/livox/lidar',
+            'expected_imu_topic': '/livox/imu',
+        }),
+        encoding='utf-8',
+    )
+    return profile_path
+
+
+def _write_metadata(
+    bag_dir: Path,
+    *,
+    pointcloud: bool = True,
+    imu: bool = True,
+    tf: bool = True,
+) -> None:
+    bag_dir.mkdir(parents=True, exist_ok=True)
+    topics = []
+    if pointcloud:
+        topics.append(('/livox/lidar', 'sensor_msgs/msg/PointCloud2', 50))
+    if imu:
+        topics.append(('/livox/imu', 'sensor_msgs/msg/Imu', 500))
+    if tf:
+        topics.append(('/tf_static', 'tf2_msgs/msg/TFMessage', 1))
+    metadata = {
+        'rosbag2_bagfile_information': {
+            'duration': {'nanoseconds': 5_000_000_000},
+            'message_count': sum(count for _, _, count in topics),
+            'topics_with_message_count': [
+                {
+                    'topic_metadata': {
+                        'name': name,
+                        'type': msg_type,
+                        'serialization_format': 'cdr',
+                        'offered_qos_profiles': '',
+                    },
+                    'message_count': count,
+                }
+                for name, msg_type, count in topics
+            ],
+        },
+    }
+    (bag_dir / 'metadata.yaml').write_text(yaml.safe_dump(metadata), encoding='utf-8')
+
+
+def _record_dry_run(tmp_path: Path, run_id: str = 'stand_01') -> tuple[Path, Path, Path]:
+    profile_path = _write_profile(tmp_path)
+    bag_root = tmp_path / 'bags'
+    subprocess.run(
+        [
+            'bash',
+            str(RECORD_SCRIPT),
+            '--robot-profile',
+            str(profile_path),
+            '--bag-root',
+            str(bag_root),
+            '--run-id',
+            run_id,
+            '--duration-sec',
+            '5',
+            '--dry-run',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    return (
+        bag_root / run_id,
+        bag_root / f'{run_id}_profile.yaml',
+        bag_root / f'{run_id}_record_plan.json',
+    )
+
+
+def test_recording_check_passes_and_writes_readiness_and_map_plan(tmp_path: Path):
+    bag_dir, profile_path, record_plan_path = _record_dry_run(tmp_path)
+    _write_metadata(bag_dir)
+    output_dir = tmp_path / 'out'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECK_SCRIPT),
+            '--bag',
+            str(bag_dir),
+            '--robot-profile',
+            str(profile_path),
+            '--record-plan',
+            str(record_plan_path),
+            '--output-dir',
+            str(output_dir),
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    report = json.loads(result.stdout)
+
+    assert report['status'] == 'PASS'
+    assert report['readiness_status'] == 'PASS'
+    assert report['recording_plan']['run_id'] == 'stand_01'
+    assert (output_dir / 'mid360_robot_recording_check.json').is_file()
+    assert (output_dir / 'mid360_robot_readiness.json').is_file()
+    assert (output_dir / 'mid360_robot_run_plan.json').is_file()
+
+
+def test_recording_check_warns_when_record_plan_is_missing(tmp_path: Path):
+    profile_path = _write_profile(tmp_path)
+    bag_dir = tmp_path / 'bags' / 'stand_no_plan'
+    _write_metadata(bag_dir)
+    output_dir = tmp_path / 'out'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECK_SCRIPT),
+            '--bag',
+            str(bag_dir),
+            '--robot-profile',
+            str(profile_path),
+            '--output-dir',
+            str(output_dir),
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    report = json.loads(result.stdout)
+
+    assert report['status'] == 'WARN'
+    assert report['readiness_status'] == 'PASS'
+    assert any(check['id'] == 'recording_plan' and check['status'] == 'warn'
+               for check in report['checks'])
+
+
+def test_recording_check_fails_when_bag_missing_imu(tmp_path: Path):
+    bag_dir, profile_path, record_plan_path = _record_dry_run(tmp_path, run_id='bad_imu')
+    _write_metadata(bag_dir, imu=False)
+    output_dir = tmp_path / 'out'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CHECK_SCRIPT),
+            '--bag',
+            str(bag_dir),
+            '--robot-profile',
+            str(profile_path),
+            '--record-plan',
+            str(record_plan_path),
+            '--output-dir',
+            str(output_dir),
+            '--json',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    report = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert report['status'] == 'FAIL'
+    assert report['readiness_status'] == 'FAIL'
+    assert any(check['id'] == 'map_dry_run_plan' and check['status'] == 'fail'
+               for check in report['checks'])
+
+
+def test_recording_check_shell_wrapper_outputs_human_report(tmp_path: Path):
+    bag_dir, profile_path, record_plan_path = _record_dry_run(tmp_path, run_id='stand_02')
+    _write_metadata(bag_dir)
+    output_dir = tmp_path / 'out'
+
+    result = subprocess.run(
+        [
+            'bash',
+            str(CHECK_WRAPPER),
+            '--bag',
+            str(bag_dir),
+            '--robot-profile',
+            str(profile_path),
+            '--record-plan',
+            str(record_plan_path),
+            '--output-dir',
+            str(output_dir),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert 'MID-360 Robot Recording Check' in result.stdout
+    assert 'Recording check JSON:' in result.stdout
+    assert (output_dir / 'mid360_robot_recording_check.md').is_file()

--- a/scripts/check_mid360_robot_recording.py
+++ b/scripts/check_mid360_robot_recording.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Check a recorded MID-360 robot bag and prepare the map dry-run plan."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from mid360_robot_recording_check_tools import (
+    Mid360RecordingCheckReporter,
+    RecordingCheckInputs,
+    auto_profile_snapshot_path,
+    auto_record_plan_path,
+    build_readiness_for_recording,
+    load_recording_plan,
+    write_readiness_artifacts,
+)
+from mid360_robot_tools import (
+    Mid360ReadinessReporter,
+    RobotProfileLoader,
+    payload_to_json,
+    resolve_robot_frames,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PROFILE = REPO_ROOT / 'configs' / 'mid360_robot' / 'livox_mid360_default.yaml'
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Post-check a recorded MID-360 robot rosbag2.'
+    )
+    parser.add_argument('--bag', required=True, help='Recorded rosbag2 directory.')
+    parser.add_argument(
+        '--robot-profile',
+        default='',
+        help='Robot profile YAML. Defaults to <bag_parent>/<bag_name>_profile.yaml when present.',
+    )
+    parser.add_argument(
+        '--record-plan',
+        default='',
+        help='Recording plan JSON. Defaults to <bag_parent>/<bag_name>_record_plan.json.',
+    )
+    parser.add_argument('--base-frame', default='', help='Override robot body frame.')
+    parser.add_argument('--lidar-frame', default='', help='Override MID-360 LiDAR frame.')
+    parser.add_argument('--imu-frame', default='', help='Override MID-360 IMU frame.')
+    parser.add_argument(
+        '--output-dir',
+        help='Directory for recording check, readiness, and run-plan outputs.',
+    )
+    parser.add_argument('--json', action='store_true', help='Print recording-check JSON.')
+    return parser.parse_args()
+
+
+def _output_dir(args: argparse.Namespace, bag_path: Path) -> Path:
+    if args.output_dir:
+        return Path(args.output_dir).expanduser().resolve()
+    return REPO_ROOT / 'output' / f'mid360_robot_recording_check_{bag_path.name}'
+
+
+def _profile_path(args: argparse.Namespace, bag_path: Path) -> Path:
+    if args.robot_profile:
+        return Path(args.robot_profile).expanduser().resolve()
+    snapshot = auto_profile_snapshot_path(bag_path)
+    if snapshot.is_file():
+        return snapshot.resolve()
+    return DEFAULT_PROFILE.resolve()
+
+
+def _record_plan_path(args: argparse.Namespace, bag_path: Path) -> Path:
+    if args.record_plan:
+        return Path(args.record_plan).expanduser().resolve()
+    return auto_record_plan_path(bag_path).resolve()
+
+
+def main() -> int:
+    args = parse_args()
+    bag_path = Path(args.bag).expanduser().resolve()
+    output_dir = _output_dir(args, bag_path)
+    profile_path: Path | None = None
+    record_plan_path: Path | None = None
+    reporter = Mid360RecordingCheckReporter()
+
+    try:
+        profile_path = _profile_path(args, bag_path)
+        record_plan_path = _record_plan_path(args, bag_path)
+        profile = RobotProfileLoader().load(profile_path)
+        frames = resolve_robot_frames(
+            base_frame=args.base_frame,
+            lidar_frame=args.lidar_frame,
+            imu_frame=args.imu_frame,
+            profile=profile,
+        )
+        recording_plan = load_recording_plan(record_plan_path)
+        inputs = RecordingCheckInputs(
+            bag_path=bag_path,
+            output_dir=output_dir,
+            profile_path=profile_path,
+            record_plan_path=record_plan_path,
+        )
+
+        try:
+            payload, readiness_report, _ = build_readiness_for_recording(
+                repo_root=REPO_ROOT,
+                bag_path=bag_path,
+                output_dir=output_dir,
+                profile=profile,
+                frames=frames,
+            )
+        except Exception as exc:
+            payload = {}
+            readiness_report = Mid360ReadinessReporter().build_error_report(
+                bag_path=bag_path,
+                output_dir=output_dir,
+                message=str(exc),
+            )
+
+        paths = write_readiness_artifacts(payload, readiness_report, output_dir)
+        report = reporter.build_report(
+            inputs=inputs,
+            profile=profile,
+            recording_plan=recording_plan,
+            readiness_report=readiness_report,
+            payload=payload,
+            paths=paths,
+        )
+    except Exception as exc:
+        report = reporter.build_error_report(
+            bag_path=bag_path,
+            output_dir=output_dir,
+            profile_path=profile_path,
+            record_plan_path=record_plan_path,
+            message=str(exc),
+        )
+
+    paths = reporter.write(report, output_dir)
+    if args.json:
+        print(payload_to_json(report))
+    else:
+        print(reporter.render_markdown(report))
+        print(f"Recording check JSON: {paths['json']}")
+        print(f"Recording check Markdown: {paths['markdown']}")
+
+    return 1 if report['status'] == 'FAIL' else 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print('Interrupted', file=sys.stderr)
+        raise SystemExit(130)

--- a/scripts/check_mid360_robot_recording.sh
+++ b/scripts/check_mid360_robot_recording.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+exec python3 "${SCRIPT_DIR}/check_mid360_robot_recording.py" "$@"

--- a/scripts/mid360_robot_recording_check_tools.py
+++ b/scripts/mid360_robot_recording_check_tools.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Post-recording checks for MID-360 robot bags."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from mid360_robot_tools import (
+    AutowarePreflightAdapter,
+    MapRunOptions,
+    Mid360MapRunPlanner,
+    Mid360ReadinessReporter,
+    Mid360RobotPreflight,
+    Mid360RunManifestWriter,
+    RobotFrames,
+    RobotProfile,
+    payload_to_json,
+)
+
+
+RECORDING_CHECK_JSON = 'mid360_robot_recording_check.json'
+RECORDING_CHECK_MARKDOWN = 'mid360_robot_recording_check.md'
+
+
+@dataclass(frozen=True)
+class RecordingCheck:
+    """A single post-recording consistency check."""
+
+    id: str
+    status: str
+    message: str
+
+
+@dataclass(frozen=True)
+class RecordingCheckInputs:
+    """Resolved inputs for post-recording checks."""
+
+    bag_path: Path
+    output_dir: Path
+    profile_path: Path
+    record_plan_path: Path | None = None
+
+
+def auto_record_plan_path(bag_path: Path) -> Path:
+    """Return the default sidecar recording plan path for a bag directory."""
+    return bag_path.parent / f'{bag_path.name}_record_plan.json'
+
+
+def auto_profile_snapshot_path(bag_path: Path) -> Path:
+    """Return the default sidecar profile snapshot path for a bag directory."""
+    return bag_path.parent / f'{bag_path.name}_profile.yaml'
+
+
+def load_recording_plan(path: Path | None) -> dict[str, Any]:
+    """Load a recording plan JSON sidecar when it exists."""
+    if path is None or not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding='utf-8'))
+
+
+def build_readiness_for_recording(
+    repo_root: Path,
+    bag_path: Path,
+    output_dir: Path,
+    profile: RobotProfile,
+    frames: RobotFrames,
+) -> tuple[dict[str, Any], dict[str, Any], str]:
+    """Build readiness and map-plan payloads for a recorded MID-360 bag."""
+    preflight = Mid360RobotPreflight(AutowarePreflightAdapter(repo_root))
+    preflight_payload = preflight.build_payload(bag_path, frames, profile=profile)
+    payload: dict[str, Any] = {'preflight': preflight_payload}
+    plan_error = ''
+
+    try:
+        plan = Mid360MapRunPlanner(repo_root).build_plan(
+            bag_path=bag_path,
+            payload=preflight_payload,
+            frames=frames,
+            options=MapRunOptions(output_dir=output_dir),
+        )
+        payload['plan'] = plan.to_dict()
+    except ValueError as exc:
+        plan_error = str(exc)
+
+    report = Mid360ReadinessReporter().build_report(
+        payload=payload,
+        output_dir=output_dir,
+        plan_error=plan_error,
+    )
+    return payload, report, plan_error
+
+
+class Mid360RecordingCheckReporter:
+    """Build and write post-recording check reports."""
+
+    def build_report(
+        self,
+        inputs: RecordingCheckInputs,
+        profile: RobotProfile | None,
+        recording_plan: dict[str, Any],
+        readiness_report: dict[str, Any],
+        payload: dict[str, Any],
+        paths: dict[str, str],
+    ) -> dict[str, Any]:
+        checks = self._build_checks(inputs, profile, recording_plan, readiness_report, payload)
+        check_payload = [asdict(check) for check in checks]
+        record_plan_path = inputs.record_plan_path or auto_record_plan_path(inputs.bag_path)
+        return {
+            'created_at': datetime.now(timezone.utc).isoformat(),
+            'status': self._status_from_checks(check_payload),
+            'bag_path': str(inputs.bag_path),
+            'output_dir': str(inputs.output_dir),
+            'profile_path': str(inputs.profile_path),
+            'record_plan_path': str(record_plan_path),
+            'recording_plan': self._recording_plan_summary(recording_plan),
+            'readiness_status': readiness_report.get('status', 'FAIL'),
+            'readiness_json_path': paths.get('readiness_json', ''),
+            'readiness_markdown_path': paths.get('readiness_markdown', ''),
+            'map_plan_json_path': paths.get('map_plan_json', ''),
+            'map_plan_markdown_path': paths.get('map_plan_markdown', ''),
+            'checks': check_payload,
+            'counts': self._count_checks(check_payload),
+            'selected_topics': readiness_report.get('selected_topics', {}),
+            'frames': readiness_report.get('frames', {}),
+        }
+
+    def build_error_report(
+        self,
+        bag_path: Path,
+        output_dir: Path,
+        profile_path: Path | None,
+        record_plan_path: Path | None,
+        message: str,
+    ) -> dict[str, Any]:
+        check = {
+            'id': 'recording_check_setup',
+            'status': 'fail',
+            'message': message,
+        }
+        return {
+            'created_at': datetime.now(timezone.utc).isoformat(),
+            'status': 'FAIL',
+            'bag_path': str(bag_path),
+            'output_dir': str(output_dir),
+            'profile_path': str(profile_path or ''),
+            'record_plan_path': str(record_plan_path or ''),
+            'recording_plan': {},
+            'readiness_status': 'FAIL',
+            'readiness_json_path': '',
+            'readiness_markdown_path': '',
+            'map_plan_json_path': '',
+            'map_plan_markdown_path': '',
+            'checks': [check],
+            'counts': self._count_checks([check]),
+            'selected_topics': {},
+            'frames': {},
+        }
+
+    def write(self, report: dict[str, Any], output_dir: Path) -> dict[str, Path]:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        json_path = output_dir / RECORDING_CHECK_JSON
+        markdown_path = output_dir / RECORDING_CHECK_MARKDOWN
+        json_path.write_text(payload_to_json(report) + '\n', encoding='utf-8')
+        markdown_path.write_text(self.render_markdown(report) + '\n', encoding='utf-8')
+        return {'json': json_path, 'markdown': markdown_path}
+
+    @staticmethod
+    def render_markdown(report: dict[str, Any]) -> str:
+        lines = [
+            '# MID-360 Robot Recording Check',
+            '',
+            f"- status: `{report['status']}`",
+            f"- created_at: `{report['created_at']}`",
+            f"- bag_path: `{report['bag_path']}`",
+            f"- profile_path: `{report['profile_path']}`",
+            f"- record_plan_path: `{report['record_plan_path']}`",
+            f"- readiness_status: `{report['readiness_status']}`",
+            '',
+            '## Outputs',
+            '',
+            f"- readiness_json: `{report['readiness_json_path']}`",
+            f"- readiness_markdown: `{report['readiness_markdown_path']}`",
+            f"- map_plan_json: `{report['map_plan_json_path']}`",
+            f"- map_plan_markdown: `{report['map_plan_markdown_path']}`",
+            '',
+            '## Checks',
+            '',
+        ]
+        for check in report['checks']:
+            lines.append(f"- `{check['status']}` `{check['id']}`: {check['message']}")
+
+        plan = report.get('recording_plan') or {}
+        if plan:
+            lines.extend([
+                '',
+                '## Recording Plan',
+                '',
+                f"- run_id: `{plan.get('run_id')}`",
+                f"- bag_path: `{plan.get('bag_path')}`",
+                f"- profile_snapshot_path: `{plan.get('profile_snapshot_path')}`",
+                '',
+                '### Recorded Topics',
+                '',
+            ])
+            for topic in plan.get('topics', []):
+                lines.append(f"- `{topic}`")
+        return '\n'.join(lines)
+
+    @staticmethod
+    def _build_checks(
+        inputs: RecordingCheckInputs,
+        profile: RobotProfile | None,
+        recording_plan: dict[str, Any],
+        readiness_report: dict[str, Any],
+        payload: dict[str, Any],
+    ) -> list[RecordingCheck]:
+        checks = [
+            RecordingCheck(
+                id='metadata_yaml',
+                status='ok' if (inputs.bag_path / 'metadata.yaml').is_file() else 'fail',
+                message=(
+                    f'metadata.yaml exists under {inputs.bag_path}'
+                    if (inputs.bag_path / 'metadata.yaml').is_file()
+                    else f'metadata.yaml is missing under {inputs.bag_path}'
+                ),
+            ),
+            Mid360RecordingCheckReporter._readiness_check(readiness_report),
+            RecordingCheck(
+                id='map_dry_run_plan',
+                status='ok' if 'plan' in payload else 'fail',
+                message=(
+                    'MID-360 map dry-run plan was generated.'
+                    if 'plan' in payload
+                    else 'MID-360 map dry-run plan was not generated.'
+                ),
+            ),
+        ]
+        checks.extend(
+            Mid360RecordingCheckReporter._record_plan_checks(
+                inputs,
+                profile,
+                recording_plan,
+            )
+        )
+        return checks
+
+    @staticmethod
+    def _readiness_check(readiness_report: dict[str, Any]) -> RecordingCheck:
+        status = readiness_report.get('status', 'FAIL')
+        if status == 'PASS':
+            return RecordingCheck('readiness_status', 'ok', 'Bag readiness passed.')
+        if status == 'WARN':
+            return RecordingCheck('readiness_status', 'warn', 'Bag readiness has warnings.')
+        return RecordingCheck('readiness_status', 'fail', 'Bag readiness failed.')
+
+    @staticmethod
+    def _record_plan_checks(
+        inputs: RecordingCheckInputs,
+        profile: RobotProfile | None,
+        recording_plan: dict[str, Any],
+    ) -> list[RecordingCheck]:
+        if not recording_plan:
+            return [
+                RecordingCheck(
+                    id='recording_plan',
+                    status='warn',
+                    message='Recording plan sidecar was not found; checking bag/profile only.',
+                )
+            ]
+
+        checks = [
+            Mid360RecordingCheckReporter._record_plan_bag_check(inputs, recording_plan),
+            Mid360RecordingCheckReporter._record_plan_profile_check(inputs, recording_plan),
+        ]
+        if profile is not None:
+            checks.append(
+                Mid360RecordingCheckReporter._record_plan_topics_check(profile, recording_plan)
+            )
+        return checks
+
+    @staticmethod
+    def _record_plan_bag_check(
+        inputs: RecordingCheckInputs,
+        recording_plan: dict[str, Any],
+    ) -> RecordingCheck:
+        planned_bag = Path(str(recording_plan.get('bag_path', ''))).expanduser()
+        if planned_bag == inputs.bag_path:
+            return RecordingCheck(
+                'recording_plan_bag_path', 'ok',
+                'Recording plan bag path matches.',
+            )
+        return RecordingCheck(
+            'recording_plan_bag_path',
+            'warn',
+            f'Recording plan bag path differs: {planned_bag} != {inputs.bag_path}',
+        )
+
+    @staticmethod
+    def _record_plan_profile_check(
+        inputs: RecordingCheckInputs,
+        recording_plan: dict[str, Any],
+    ) -> RecordingCheck:
+        planned_profile = Path(
+            str(recording_plan.get('profile_snapshot_path', ''))
+        ).expanduser()
+        if planned_profile == inputs.profile_path:
+            return RecordingCheck(
+                'recording_plan_profile_snapshot',
+                'ok',
+                'Profile snapshot path matches the recording plan.',
+            )
+        return RecordingCheck(
+            'recording_plan_profile_snapshot',
+            'warn',
+            (
+                'Profile path differs from recording plan snapshot: '
+                f'{planned_profile} != {inputs.profile_path}'
+            ),
+        )
+
+    @staticmethod
+    def _record_plan_topics_check(
+        profile: RobotProfile,
+        recording_plan: dict[str, Any],
+    ) -> RecordingCheck:
+        topics = set(recording_plan.get('topics') or [])
+        missing = [
+            topic for topic in (
+                profile.expected_pointcloud_topic,
+                profile.expected_imu_topic,
+            )
+            if topic and topic not in topics
+        ]
+        if not missing:
+            return RecordingCheck(
+                'recording_plan_topics',
+                'ok',
+                'Recording plan includes expected point cloud and IMU topics.',
+            )
+        return RecordingCheck(
+            'recording_plan_topics',
+            'warn',
+            f'Recording plan is missing expected topics: {", ".join(missing)}',
+        )
+
+    @staticmethod
+    def _recording_plan_summary(recording_plan: dict[str, Any]) -> dict[str, Any]:
+        if not recording_plan:
+            return {}
+        return {
+            'run_id': recording_plan.get('run_id', ''),
+            'bag_path': recording_plan.get('bag_path', ''),
+            'topics': recording_plan.get('topics', []),
+            'profile_snapshot_path': recording_plan.get('profile_snapshot_path', ''),
+        }
+
+    @staticmethod
+    def _status_from_checks(checks: list[dict[str, Any]]) -> str:
+        if any(check['status'] == 'fail' for check in checks):
+            return 'FAIL'
+        if any(check['status'] == 'warn' for check in checks):
+            return 'WARN'
+        return 'PASS'
+
+    @staticmethod
+    def _count_checks(checks: list[dict[str, Any]]) -> dict[str, int]:
+        return {
+            'ok': sum(1 for check in checks if check['status'] == 'ok'),
+            'warn': sum(1 for check in checks if check['status'] == 'warn'),
+            'fail': sum(1 for check in checks if check['status'] == 'fail'),
+        }
+
+
+def write_readiness_artifacts(
+    payload: dict[str, Any],
+    readiness_report: dict[str, Any],
+    output_dir: Path,
+) -> dict[str, str]:
+    """Write readiness and map-plan artifacts used by the recording check."""
+    paths = Mid360ReadinessReporter().write(readiness_report, output_dir)
+    result = {
+        'readiness_json': str(paths['json']),
+        'readiness_markdown': str(paths['markdown']),
+        'map_plan_json': '',
+        'map_plan_markdown': '',
+    }
+    if 'plan' in payload:
+        manifest_paths = Mid360RunManifestWriter().write(payload)
+        result['map_plan_json'] = str(manifest_paths['json'])
+        result['map_plan_markdown'] = str(manifest_paths['markdown'])
+    return result

--- a/scripts/plan_mid360_robot_record.py
+++ b/scripts/plan_mid360_robot_record.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Plan or run MID-360 robot rosbag2 recording."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from mid360_robot_record_tools import (
+    Mid360RecordManifestWriter,
+    Mid360RobotRecordPlanner,
+    RecordOptions,
+    record_plan_to_json,
+)
+from mid360_robot_tools import RobotProfileLoader
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PROFILE = REPO_ROOT / 'configs' / 'mid360_robot' / 'livox_mid360_default.yaml'
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Plan or run ros2 bag recording for a MID-360 robot.'
+    )
+    parser.add_argument(
+        '--robot-profile',
+        default=str(DEFAULT_PROFILE),
+        help='Robot profile YAML with expected MID-360 topics.',
+    )
+    parser.add_argument(
+        '--bag-root',
+        default=str(REPO_ROOT / 'output' / 'mid360_robot_bags'),
+        help='Directory where rosbag2 output and recording plan files are written.',
+    )
+    parser.add_argument('--run-id', default='', help='Recording run id and bag directory name.')
+    parser.add_argument(
+        '--duration-sec',
+        default='',
+        help='Optional timeout in seconds for ros2 bag record.',
+    )
+    parser.add_argument(
+        '--extra-topic',
+        action='append',
+        default=[],
+        help='Additional topic to record. Can be passed more than once.',
+    )
+    parser.add_argument('--no-tf', action='store_true', help='Do not record /tf.')
+    parser.add_argument('--no-tf-static', action='store_true', help='Do not record /tf_static.')
+    parser.add_argument('--storage-id', default='', help='rosbag2 storage id.')
+    parser.add_argument('--max-cache-size', default='', help='ros2 bag record --max-cache-size.')
+    parser.add_argument('--compression-mode', default='', help='ros2 bag record compression mode.')
+    parser.add_argument(
+        '--compression-format', default='',
+        help='ros2 bag record compression format.',
+    )
+    parser.add_argument(
+        '--dry-run', action='store_true',
+        help='Write plan and print command only.',
+    )
+    parser.add_argument(
+        '--json', action='store_true',
+        help='Print machine-readable recording plan JSON.',
+    )
+    return parser.parse_args()
+
+
+def _options_from_args(args: argparse.Namespace) -> RecordOptions:
+    return RecordOptions(
+        bag_root=Path(args.bag_root).expanduser().resolve(),
+        run_id=args.run_id,
+        include_tf=not args.no_tf,
+        include_tf_static=not args.no_tf_static,
+        extra_topics=tuple(args.extra_topic or []),
+        storage_id=args.storage_id,
+        max_cache_size=args.max_cache_size,
+        compression_mode=args.compression_mode,
+        compression_format=args.compression_format,
+        duration_sec=args.duration_sec,
+    )
+
+
+def _print_human_report(plan_payload: dict[str, object], paths: dict[str, Path]) -> None:
+    print('MID-360 robot recording plan:')
+    print(f"  run_id: {plan_payload['run_id']}")
+    print(f"  bag_path: {plan_payload['bag_path']}")
+    print('  topics:')
+    for topic in plan_payload['topics']:
+        print(f'    - {topic}')
+    print('Record command:')
+    print(f"  {plan_payload['command_shell']}")
+    print(f"Recording plan JSON: {paths['json']}", file=sys.stderr)
+    print(f"Recording plan Markdown: {paths['markdown']}", file=sys.stderr)
+    print(f"Profile snapshot: {paths['profile']}", file=sys.stderr)
+
+
+def main() -> int:
+    args = parse_args()
+    profile = RobotProfileLoader().load(Path(args.robot_profile).expanduser().resolve())
+    plan = Mid360RobotRecordPlanner().build_plan(profile, _options_from_args(args))
+    writer = Mid360RecordManifestWriter()
+    paths = writer.write(profile, plan)
+    plan_payload = writer.build_manifest(profile, plan)
+
+    if args.json:
+        print(record_plan_to_json(profile, plan))
+    else:
+        _print_human_report(plan_payload, paths)
+
+    if args.dry_run:
+        return 0
+
+    try:
+        subprocess.run(plan.command, check=True, cwd=REPO_ROOT)
+    except subprocess.CalledProcessError as exc:
+        if args.duration_sec and exc.returncode == 124:
+            return 0
+        raise
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/record_mid360_robot_bag.sh
+++ b/scripts/record_mid360_robot_bag.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+exec python3 "${SCRIPT_DIR}/plan_mid360_robot_record.py" "$@"


### PR DESCRIPTION
## Summary

Adds the post-recording check cascade that PR #176 (`mid360_robot_production_candidate_session`) calls from its `--record-only` and full `--run` paths. Foundation-only Layer A (depends on `mid360_robot_tools` + PyYAML).

### What's in
- **`scripts/mid360_robot_recording_check_tools.py`** — `Mid360RecordingCheckReporter` runs after a robot bag is recorded:
  - cross-validates the bag against the record plan + robot profile
  - computes bag diagnostics (topic frame ids, message counts, rates) via `mid360_robot_tools`
  - emits a recording-check JSON + a map dry-run readiness JSON for the next pipeline stage
- **`scripts/check_mid360_robot_recording.{sh,py}`** — operator CLI wrapper:
  - `--bag-path`, `--profile`, `--record-plan` options
  - JSON or human report
  - non-zero exit on FAIL for CI / scripting use

### Why
This is the recording cascade that PR #176's `test_production_candidate_record_only_run_records_fake_bag` was skipped on with `skipif(not RECORDING_SCRIPT.is_file())`. Once this lands the skipif re-enables that test automatically — the production-candidate session's `--record-only` mode then has true coverage of its downstream recording check.

## Test plan

- [x] `python3 -m pytest graph_based_slam/test/test_mid360_robot_recording_check.py -v` → 4 passed (PASS path, missing record-plan WARN, IMU-missing FAIL, shell-wrapper human-report)
- [x] `python3 -m flake8 --select=E,W,F --ignore=W503 --max-line-length=99 scripts/check_mid360_robot_recording.py scripts/mid360_robot_recording_check_tools.py graph_based_slam/test/test_mid360_robot_recording_check.py` → clean
- [ ] Humble + Jazzy matrix CI