### PR TITLE
feat: Jetson MID-360 host readiness preflight (jetson_mid360_host_tools + CLI)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -264,6 +264,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_jetson_mid360_host_readiness
+    test/test_jetson_mid360_host_readiness.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_navsatfix_covariance_inspector
     test/test_navsatfix_covariance_inspector.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_jetson_mid360_host_readiness.py
+++ b/graph_based_slam/test/test_jetson_mid360_host_readiness.py
@@ -1,0 +1,238 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for Jetson MID-360 host readiness checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / 'scripts'
+SCRIPT_PATH = REPO_ROOT / 'scripts' / 'check_jetson_mid360_host_readiness.py'
+
+
+def _load_module():
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    import jetson_mid360_host_tools
+
+    return jetson_mid360_host_tools
+
+
+def _write_fake_host_root(tmp_path: Path, *, temp_millideg: int = 45000) -> Path:
+    root = tmp_path / 'host'
+    (root / 'proc' / 'device-tree').mkdir(parents=True)
+    (root / 'proc' / 'device-tree' / 'model').write_text(
+        'NVIDIA Jetson Orin NX\x00',
+        encoding='utf-8',
+    )
+    (root / 'etc').mkdir()
+    (root / 'etc' / 'nv_tegra_release').write_text(
+        '# R36 (release), REVISION: 4.0',
+        encoding='utf-8',
+    )
+    (root / 'etc' / 'os-release').write_text(
+        'NAME="Ubuntu"\nVERSION_ID="22.04"\n',
+        encoding='utf-8',
+    )
+    (root / 'proc' / 'meminfo').write_text(
+        'MemTotal:       8388608 kB\nMemAvailable:   4194304 kB\n',
+        encoding='utf-8',
+    )
+
+    thermal = root / 'sys' / 'class' / 'thermal' / 'thermal_zone0'
+    thermal.mkdir(parents=True)
+    (thermal / 'type').write_text('gpu-thermal\n', encoding='utf-8')
+    (thermal / 'temp').write_text(f'{temp_millideg}\n', encoding='utf-8')
+
+    governor = root / 'sys' / 'devices' / 'system' / 'cpu' / 'cpu0' / 'cpufreq'
+    governor.mkdir(parents=True)
+    (governor / 'scaling_governor').write_text('performance\n', encoding='utf-8')
+    return root
+
+
+def _options(module, tmp_path: Path):
+    output_dir = tmp_path / 'out'
+    bag_dir = tmp_path / 'bags'
+    bag_dir.mkdir()
+    return module.HostReadinessOptions(
+        output_dir=output_dir,
+        bag_dir=bag_dir,
+        expected_bag_minutes=0.01,
+        estimated_bag_mbps=1.0,
+        bag_reserve_gb=0.0,
+        min_bag_free_gb=0.1,
+        min_output_free_gb=0.1,
+        min_memory_available_gb=0.1,
+    )
+
+
+def _disk_usage(free_gib: float = 100.0):
+    total = int(128 * 1024**3)
+    free = int(free_gib * 1024**3)
+    used = total - free
+    return shutil._ntuple_diskusage(total, used, free)
+
+
+def test_host_readiness_passes_with_fake_jetson(tmp_path: Path):
+    module = _load_module()
+    root = _write_fake_host_root(tmp_path)
+    checker = module.JetsonHostReadiness(
+        host_root=root,
+        which=lambda name: f'/usr/bin/{name}',
+        disk_usage=lambda path: _disk_usage(),
+        machine=lambda: 'aarch64',
+    )
+
+    report = checker.build_report(_options(module, tmp_path))
+
+    assert report['status'] == 'PASS'
+    assert report['host']['model'] == 'NVIDIA Jetson Orin NX'
+    assert report['storage']['estimated_recording_gb'] > 0.0
+    assert any(check['id'] == 'thermal_max_temp' and check['status'] == 'ok'
+               for check in report['checks'])
+
+
+def test_host_readiness_fails_when_ros2_missing(tmp_path: Path):
+    module = _load_module()
+    root = _write_fake_host_root(tmp_path)
+    checker = module.JetsonHostReadiness(
+        host_root=root,
+        which=lambda name: None if name == 'ros2' else f'/usr/bin/{name}',
+        disk_usage=lambda path: _disk_usage(),
+        machine=lambda: 'aarch64',
+    )
+
+    report = checker.build_report(_options(module, tmp_path))
+
+    assert report['status'] == 'FAIL'
+    assert any(check['id'] == 'tool_ros2' and check['status'] == 'fail'
+               for check in report['checks'])
+
+
+def test_host_readiness_fails_on_low_output_storage(tmp_path: Path):
+    module = _load_module()
+    root = _write_fake_host_root(tmp_path)
+    checker = module.JetsonHostReadiness(
+        host_root=root,
+        which=lambda name: f'/usr/bin/{name}',
+        disk_usage=lambda path: _disk_usage(free_gib=0.01),
+        machine=lambda: 'aarch64',
+    )
+
+    report = checker.build_report(_options(module, tmp_path))
+
+    assert report['status'] == 'FAIL'
+    assert any(check['id'] == 'storage_output_dir' and check['status'] == 'fail'
+               for check in report['checks'])
+
+
+def test_host_readiness_fails_when_bag_dir_is_missing(tmp_path: Path):
+    module = _load_module()
+    root = _write_fake_host_root(tmp_path)
+    options = _options(module, tmp_path)
+    missing_bag_dir = tmp_path / 'missing_bag_mount'
+    options = module.HostReadinessOptions(
+        output_dir=options.output_dir,
+        bag_dir=missing_bag_dir,
+        expected_bag_minutes=options.expected_bag_minutes,
+        estimated_bag_mbps=options.estimated_bag_mbps,
+        bag_reserve_gb=options.bag_reserve_gb,
+        min_bag_free_gb=options.min_bag_free_gb,
+        min_output_free_gb=options.min_output_free_gb,
+        min_memory_available_gb=options.min_memory_available_gb,
+    )
+    checker = module.JetsonHostReadiness(
+        host_root=root,
+        which=lambda name: f'/usr/bin/{name}',
+        disk_usage=lambda path: _disk_usage(),
+        machine=lambda: 'aarch64',
+    )
+
+    report = checker.build_report(options)
+
+    assert report['status'] == 'FAIL'
+    assert any(check['id'] == 'storage_bag_dir' and check['status'] == 'fail'
+               for check in report['checks'])
+
+
+def test_host_readiness_cli_writes_reports(tmp_path: Path):
+    root = _write_fake_host_root(tmp_path)
+    output_dir = tmp_path / 'out'
+    bag_dir = tmp_path / 'bags'
+    bag_dir.mkdir()
+    fake_bin = tmp_path / 'bin'
+    fake_bin.mkdir()
+    for name in ('ros2', 'colcon', 'tegrastats', 'nvpmodel', 'jetson_clocks'):
+        tool = fake_bin / name
+        tool.write_text('#!/usr/bin/env sh\nexit 0\n', encoding='utf-8')
+        tool.chmod(0o755)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            '--host-root',
+            str(root),
+            '--output-dir',
+            str(output_dir),
+            '--bag-dir',
+            str(bag_dir),
+            '--expected-bag-minutes',
+            '0.01',
+            '--estimated-bag-mbps',
+            '1.0',
+            '--bag-reserve-gb',
+            '0.0',
+            '--min-bag-free-gb',
+            '0.001',
+            '--min-output-free-gb',
+            '0.001',
+            '--min-memory-available-gb',
+            '0.001',
+            '--json',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        env={'PATH': str(fake_bin)},
+    )
+    report = json.loads((output_dir / 'jetson_mid360_host_readiness.json').read_text())
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout)['host']['model'] == 'NVIDIA Jetson Orin NX'
+    assert report['counts']['fail'] == 0
+    assert (output_dir / 'jetson_mid360_host_readiness.md').is_file()

--- a/scripts/check_jetson_mid360_host_readiness.py
+++ b/scripts/check_jetson_mid360_host_readiness.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Check Jetson host readiness before a MID-360 robot mapping run."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from jetson_mid360_host_tools import (
+    HostReadinessOptions,
+    JetsonHostReadiness,
+    payload_to_json,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Check Jetson host readiness for MID-360 robot mapping.'
+    )
+    parser.add_argument(
+        '--output-dir',
+        default=str(REPO_ROOT / 'output' / 'jetson_mid360_host_readiness'),
+        help='Directory for host-readiness report files.',
+    )
+    parser.add_argument(
+        '--bag-dir',
+        help='Bag recording directory or mount point to check for free space.',
+    )
+    parser.add_argument(
+        '--expected-bag-minutes',
+        type=float,
+        default=10.0,
+        help='Expected recording duration for storage estimate.',
+    )
+    parser.add_argument(
+        '--estimated-bag-mbps',
+        type=float,
+        default=50.0,
+        help='Estimated rosbag2 write rate in MB/s for storage estimate.',
+    )
+    parser.add_argument(
+        '--bag-reserve-gb',
+        type=float,
+        default=5.0,
+        help='Extra free-space reserve for bag recording.',
+    )
+    parser.add_argument(
+        '--min-bag-free-gb',
+        type=float,
+        default=20.0,
+        help='Minimum free space required on --bag-dir.',
+    )
+    parser.add_argument(
+        '--min-output-free-gb',
+        type=float,
+        default=5.0,
+        help='Minimum free space required for map output.',
+    )
+    parser.add_argument(
+        '--thermal-warn-c',
+        type=float,
+        default=75.0,
+        help='Warn when a thermal zone is at or above this temperature.',
+    )
+    parser.add_argument(
+        '--thermal-fail-c',
+        type=float,
+        default=85.0,
+        help='Fail when a thermal zone is at or above this temperature.',
+    )
+    parser.add_argument(
+        '--min-memory-available-gb',
+        type=float,
+        default=1.0,
+        help='Minimum MemAvailable required before mapping.',
+    )
+    parser.add_argument(
+        '--host-root',
+        default='/',
+        help='Host filesystem root to inspect; useful for tests and chroots.',
+    )
+    parser.add_argument('--json', action='store_true', help='Print report JSON.')
+    return parser.parse_args()
+
+
+def _options_from_args(args: argparse.Namespace) -> HostReadinessOptions:
+    return HostReadinessOptions(
+        output_dir=Path(args.output_dir).expanduser().resolve(),
+        bag_dir=Path(args.bag_dir).expanduser().resolve() if args.bag_dir else None,
+        expected_bag_minutes=args.expected_bag_minutes,
+        estimated_bag_mbps=args.estimated_bag_mbps,
+        bag_reserve_gb=args.bag_reserve_gb,
+        min_bag_free_gb=args.min_bag_free_gb,
+        min_output_free_gb=args.min_output_free_gb,
+        thermal_warn_c=args.thermal_warn_c,
+        thermal_fail_c=args.thermal_fail_c,
+        min_memory_available_gb=args.min_memory_available_gb,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    options = _options_from_args(args)
+    checker = JetsonHostReadiness(host_root=Path(args.host_root).expanduser().resolve())
+    report = checker.build_report(options)
+    paths = checker.write(report, options.output_dir)
+
+    if args.json:
+        print(payload_to_json(report))
+    else:
+        print(checker.render_markdown(report))
+        print(f"Host readiness JSON: {paths['json']}")
+        print(f"Host readiness Markdown: {paths['markdown']}")
+
+    return 1 if report['status'] == 'FAIL' else 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print('Interrupted', file=sys.stderr)
+        raise SystemExit(130)

--- a/scripts/jetson_mid360_host_tools.py
+++ b/scripts/jetson_mid360_host_tools.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""Jetson host readiness helpers for MID-360 robot mapping."""
+
+from __future__ import annotations
+
+import json
+import platform
+import shutil
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+HOST_READINESS_JSON = 'jetson_mid360_host_readiness.json'
+HOST_READINESS_MARKDOWN = 'jetson_mid360_host_readiness.md'
+
+
+@dataclass(frozen=True)
+class HostCheck:
+    """Single host-readiness check."""
+
+    id: str
+    status: str
+    message: str
+
+
+@dataclass(frozen=True)
+class HostReadinessOptions:
+    """Operator-tunable host readiness thresholds."""
+
+    output_dir: Path
+    bag_dir: Path | None = None
+    expected_bag_minutes: float = 10.0
+    estimated_bag_mbps: float = 50.0
+    bag_reserve_gb: float = 5.0
+    min_bag_free_gb: float = 20.0
+    min_output_free_gb: float = 5.0
+    thermal_warn_c: float = 75.0
+    thermal_fail_c: float = 85.0
+    min_memory_available_gb: float = 1.0
+
+
+class JetsonHostReadiness:
+    """Inspect host-level prerequisites before a MID-360 robot run."""
+
+    TOOL_SPECS = (
+        ('ros2', 'fail', 'ROS 2 CLI is required; source the workspace/setup files.'),
+        ('colcon', 'warn', 'colcon is useful for rebuilding on the Jetson.'),
+        ('tegrastats', 'warn', 'tegrastats is useful for runtime thermal/load monitoring.'),
+        ('nvpmodel', 'warn', 'nvpmodel is useful for confirming the power mode.'),
+        ('jetson_clocks', 'warn', 'jetson_clocks is useful for repeatable field runs.'),
+    )
+
+    def __init__(
+        self,
+        host_root: Path = Path('/'),
+        which: Callable[[str], str | None] | None = None,
+        disk_usage: Callable[[Path], Any] | None = None,
+        machine: Callable[[], str] | None = None,
+    ) -> None:
+        self._host_root = host_root
+        self._which = which or shutil.which
+        self._disk_usage = disk_usage or shutil.disk_usage
+        self._machine = machine or platform.machine
+
+    def build_report(self, options: HostReadinessOptions) -> dict[str, Any]:
+        """Build a JSON-serializable host readiness report."""
+        host = self._host_info()
+        tools = self._tool_info()
+        storage = self._storage_info(options)
+        thermals = self._thermal_info(options)
+        memory = self._memory_info(options)
+        cpu_governors = self._cpu_governor_info()
+
+        checks = []
+        checks.extend(self._host_checks(host))
+        checks.extend(self._tool_checks(tools))
+        checks.extend(self._storage_checks(storage))
+        checks.extend(self._thermal_checks(thermals, options))
+        checks.extend(self._memory_checks(memory, options))
+        checks.extend(self._cpu_governor_checks(cpu_governors))
+
+        check_payload = [asdict(check) for check in checks]
+        return {
+            'created_at': datetime.now(timezone.utc).isoformat(),
+            'status': self._status_from_checks(check_payload),
+            'output_dir': str(options.output_dir),
+            'options': self._options_payload(options),
+            'host': host,
+            'tools': tools,
+            'storage': storage,
+            'thermal': thermals,
+            'memory': memory,
+            'cpu_governors': cpu_governors,
+            'checks': check_payload,
+            'counts': self._count_checks(check_payload),
+        }
+
+    def write(self, report: dict[str, Any], output_dir: Path) -> dict[str, Path]:
+        """Write JSON and Markdown reports."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+        json_path = output_dir / HOST_READINESS_JSON
+        markdown_path = output_dir / HOST_READINESS_MARKDOWN
+        json_path.write_text(payload_to_json(report) + '\n', encoding='utf-8')
+        markdown_path.write_text(self.render_markdown(report) + '\n', encoding='utf-8')
+        return {'json': json_path, 'markdown': markdown_path}
+
+    @staticmethod
+    def render_markdown(report: dict[str, Any]) -> str:
+        """Render a concise operator-facing Markdown report."""
+        lines = [
+            '# Jetson MID-360 Host Readiness',
+            '',
+            f"- status: `{report['status']}`",
+            f"- created_at: `{report['created_at']}`",
+            f"- output_dir: `{report['output_dir']}`",
+            '',
+            '## Host',
+            '',
+            f"- model: `{report['host'].get('model') or 'unknown'}`",
+            f"- arch: `{report['host'].get('arch') or 'unknown'}`",
+            f"- l4t_release: `{report['host'].get('l4t_release') or 'unknown'}`",
+            '',
+            '## Checks',
+            '',
+        ]
+        for check in report['checks']:
+            lines.append(f"- `{check['status']}` `{check['id']}`: {check['message']}")
+
+        lines.extend(['', '## Storage', ''])
+        for target in report.get('storage', {}).get('targets', []):
+            lines.append(
+                f"- `{target['id']}` path `{target['path']}` free "
+                f"`{target.get('free_gb')}` GiB required `{target.get('required_free_gb')}` GiB"
+            )
+
+        lines.extend(['', '## Tools', ''])
+        for tool in report.get('tools', []):
+            lines.append(
+                f"- `{tool['name']}`: "
+                f"`{'found' if tool['found'] else 'missing'}`"
+            )
+        return '\n'.join(lines)
+
+    def _host_info(self) -> dict[str, Any]:
+        return {
+            'model': self._read_text('/proc/device-tree/model')
+            or self._read_text('/sys/firmware/devicetree/base/model'),
+            'arch': self._machine(),
+            'l4t_release': self._read_text('/etc/nv_tegra_release'),
+            'os_release': self._parse_os_release(),
+        }
+
+    def _tool_info(self) -> list[dict[str, Any]]:
+        tools = []
+        for name, severity, hint in self.TOOL_SPECS:
+            path = self._which(name)
+            tools.append({
+                'name': name,
+                'found': bool(path),
+                'path': path or '',
+                'missing_status': severity,
+                'hint': hint,
+            })
+        return tools
+
+    def _storage_info(self, options: HostReadinessOptions) -> dict[str, Any]:
+        targets = [
+            self._storage_target(
+                target_id='output_dir',
+                path=options.output_dir,
+                required_free_gb=options.min_output_free_gb,
+            )
+        ]
+        if options.bag_dir is not None:
+            recording_gb = self._estimated_recording_gb(options)
+            targets.append(
+                self._storage_target(
+                    target_id='bag_dir',
+                    path=options.bag_dir,
+                    required_free_gb=max(options.min_bag_free_gb, recording_gb),
+                )
+            )
+        return {
+            'expected_bag_minutes': options.expected_bag_minutes,
+            'estimated_bag_mbps': options.estimated_bag_mbps,
+            'bag_reserve_gb': options.bag_reserve_gb,
+            'estimated_recording_gb': self._estimated_recording_gb(options),
+            'targets': targets,
+        }
+
+    def _storage_target(
+        self,
+        target_id: str,
+        path: Path,
+        required_free_gb: float,
+    ) -> dict[str, Any]:
+        existing_path = self._nearest_existing_path(path)
+        payload = {
+            'id': target_id,
+            'path': str(path),
+            'checked_path': str(existing_path) if existing_path else '',
+            'exists': path.exists(),
+            'required_free_gb': round(required_free_gb, 3),
+            'free_gb': None,
+            'total_gb': None,
+        }
+        if existing_path is None:
+            return payload
+
+        usage = self._disk_usage(existing_path)
+        payload['free_gb'] = round(float(usage.free) / 1024**3, 3)
+        payload['total_gb'] = round(float(usage.total) / 1024**3, 3)
+        return payload
+
+    @staticmethod
+    def _estimated_recording_gb(options: HostReadinessOptions) -> float:
+        data_gb = (
+            options.estimated_bag_mbps
+            * options.expected_bag_minutes
+            * 60.0
+            / 1024.0
+        )
+        return round(data_gb + options.bag_reserve_gb, 3)
+
+    @staticmethod
+    def _nearest_existing_path(path: Path) -> Path | None:
+        current = path
+        while not current.exists():
+            parent = current.parent
+            if parent == current:
+                return None
+            current = parent
+        return current
+
+    def _thermal_info(self, options: HostReadinessOptions) -> dict[str, Any]:
+        zones = []
+        thermal_root = self._path('/sys/class/thermal')
+        if thermal_root.is_dir():
+            for zone_path in sorted(thermal_root.glob('thermal_zone*')):
+                temp_c = self._thermal_temp_c(zone_path / 'temp')
+                if temp_c is None:
+                    continue
+                zones.append({
+                    'name': zone_path.name,
+                    'type': self._read_file(zone_path / 'type') or zone_path.name,
+                    'temp_c': round(temp_c, 2),
+                })
+        max_temp_c = max((zone['temp_c'] for zone in zones), default=None)
+        return {
+            'warn_c': options.thermal_warn_c,
+            'fail_c': options.thermal_fail_c,
+            'max_temp_c': max_temp_c,
+            'zones': zones,
+        }
+
+    @staticmethod
+    def _thermal_temp_c(path: Path) -> float | None:
+        try:
+            raw = path.read_text(encoding='utf-8').strip()
+        except OSError:
+            return None
+        if not raw:
+            return None
+        value = float(raw)
+        return value / 1000.0 if value > 200.0 else value
+
+    def _memory_info(self, options: HostReadinessOptions) -> dict[str, Any]:
+        meminfo = self._parse_meminfo()
+        total_gb = self._kb_to_gib(meminfo.get('MemTotal'))
+        available_gb = self._kb_to_gib(meminfo.get('MemAvailable'))
+        return {
+            'min_available_gb': options.min_memory_available_gb,
+            'total_gb': total_gb,
+            'available_gb': available_gb,
+        }
+
+    def _cpu_governor_info(self) -> dict[str, Any]:
+        governors = {}
+        cpu_root = self._path('/sys/devices/system/cpu')
+        for path in sorted(cpu_root.glob('cpu*/cpufreq/scaling_governor')):
+            cpu_name = path.parts[-3]
+            governor = self._read_file(path)
+            if governor:
+                governors[cpu_name] = governor
+        unique = sorted(set(governors.values()))
+        return {
+            'available': bool(governors),
+            'governors': governors,
+            'unique_governors': unique,
+        }
+
+    @staticmethod
+    def _host_checks(host: dict[str, Any]) -> list[HostCheck]:
+        checks = []
+        model = str(host.get('model') or '')
+        if model and ('jetson' in model.lower() or 'nvidia' in model.lower()):
+            checks.append(HostCheck(
+                'jetson_model', 'ok', f'Jetson/NVIDIA model detected: {model}',
+            ))
+        elif model:
+            checks.append(HostCheck(
+                'jetson_model', 'warn', f'Host model is not Jetson-specific: {model}',
+            ))
+        else:
+            checks.append(HostCheck('jetson_model', 'warn', 'Jetson model file was not found.'))
+
+        arch = str(host.get('arch') or '')
+        checks.append(
+            HostCheck(
+                'host_arch',
+                'ok' if arch == 'aarch64' else 'warn',
+                f'Host architecture is {arch or "unknown"}.',
+            )
+        )
+        return checks
+
+    @staticmethod
+    def _tool_checks(tools: list[dict[str, Any]]) -> list[HostCheck]:
+        checks = []
+        for tool in tools:
+            if tool['found']:
+                checks.append(HostCheck(
+                    f"tool_{tool['name']}", 'ok',
+                    f"{tool['name']} found at {tool['path']}",
+                ))
+            else:
+                checks.append(
+                    HostCheck(
+                        f"tool_{tool['name']}",
+                        tool['missing_status'],
+                        f"{tool['name']} not found. {tool['hint']}",
+                    )
+                )
+        return checks
+
+    @staticmethod
+    def _storage_checks(storage: dict[str, Any]) -> list[HostCheck]:
+        checks = []
+        for target in storage.get('targets', []):
+            check_id = f"storage_{target['id']}"
+            if target['id'] == 'bag_dir' and not target.get('exists'):
+                checks.append(
+                    HostCheck(
+                        check_id,
+                        'fail',
+                        f"Bag storage path does not exist: {target['path']}.",
+                    )
+                )
+                continue
+            if target['checked_path'] == '':
+                checks.append(
+                    HostCheck(
+                        check_id,
+                        'fail',
+                        f"No existing parent found for storage path {target['path']}.",
+                    )
+                )
+                continue
+            free_gb = target.get('free_gb')
+            required_gb = float(target['required_free_gb'])
+            if free_gb is None:
+                checks.append(HostCheck(
+                    check_id, 'fail',
+                    f"Disk usage unavailable for {target['path']}.",
+                ))
+            elif float(free_gb) < required_gb:
+                checks.append(
+                    HostCheck(
+                        check_id,
+                        'fail',
+                        f"{target['id']} has {free_gb} GiB free; require {required_gb:.3f} GiB.",
+                    )
+                )
+            elif float(free_gb) < required_gb * 1.5:
+                checks.append(
+                    HostCheck(
+                        check_id,
+                        'warn',
+                        f"{target['id']} has limited free space: {free_gb} GiB.",
+                    )
+                )
+            else:
+                checks.append(HostCheck(
+                    check_id, 'ok',
+                    f"{target['id']} free space is {free_gb} GiB.",
+                ))
+        return checks
+
+    @staticmethod
+    def _thermal_checks(
+        thermals: dict[str, Any],
+        options: HostReadinessOptions,
+    ) -> list[HostCheck]:
+        max_temp_c = thermals.get('max_temp_c')
+        if max_temp_c is None:
+            return [HostCheck(
+                'thermal_zones', 'warn',
+                'No thermal zone temperatures were readable.',
+            )]
+        if float(max_temp_c) >= options.thermal_fail_c:
+            return [
+                HostCheck(
+                    'thermal_max_temp',
+                    'fail',
+                    f'Max thermal zone temperature is {max_temp_c} C.',
+                )
+            ]
+        if float(max_temp_c) >= options.thermal_warn_c:
+            return [
+                HostCheck(
+                    'thermal_max_temp',
+                    'warn',
+                    f'Max thermal zone temperature is {max_temp_c} C.',
+                )
+            ]
+        return [HostCheck(
+            'thermal_max_temp', 'ok',
+            f'Max thermal zone temperature is {max_temp_c} C.',
+        )]
+
+    @staticmethod
+    def _memory_checks(
+        memory: dict[str, Any],
+        options: HostReadinessOptions,
+    ) -> list[HostCheck]:
+        available_gb = memory.get('available_gb')
+        if available_gb is None:
+            return [HostCheck('memory_available', 'warn', 'MemAvailable was not readable.')]
+        if float(available_gb) < options.min_memory_available_gb:
+            return [
+                HostCheck(
+                    'memory_available',
+                    'fail',
+                    (
+                        f'MemAvailable is {available_gb} GiB; '
+                        f'require {options.min_memory_available_gb:.3f} GiB.'
+                    ),
+                )
+            ]
+        return [HostCheck('memory_available', 'ok', f'MemAvailable is {available_gb} GiB.')]
+
+    @staticmethod
+    def _cpu_governor_checks(cpu_governors: dict[str, Any]) -> list[HostCheck]:
+        if not cpu_governors.get('available'):
+            return [HostCheck('cpu_governor', 'warn', 'CPU governor files were not readable.')]
+        unique = cpu_governors.get('unique_governors') or []
+        if 'powersave' in unique:
+            return [HostCheck(
+                'cpu_governor', 'warn',
+                f'CPU governors include powersave: {", ".join(unique)}',
+            )]
+        return [HostCheck('cpu_governor', 'ok', f'CPU governors: {", ".join(unique)}')]
+
+    @staticmethod
+    def _status_from_checks(checks: list[dict[str, Any]]) -> str:
+        if any(check['status'] == 'fail' for check in checks):
+            return 'FAIL'
+        if any(check['status'] == 'warn' for check in checks):
+            return 'WARN'
+        return 'PASS'
+
+    @staticmethod
+    def _count_checks(checks: list[dict[str, Any]]) -> dict[str, int]:
+        return {
+            'ok': sum(1 for check in checks if check['status'] == 'ok'),
+            'warn': sum(1 for check in checks if check['status'] == 'warn'),
+            'fail': sum(1 for check in checks if check['status'] == 'fail'),
+        }
+
+    @staticmethod
+    def _options_payload(options: HostReadinessOptions) -> dict[str, Any]:
+        return {
+            'bag_dir': str(options.bag_dir) if options.bag_dir else '',
+            'expected_bag_minutes': options.expected_bag_minutes,
+            'estimated_bag_mbps': options.estimated_bag_mbps,
+            'bag_reserve_gb': options.bag_reserve_gb,
+            'min_bag_free_gb': options.min_bag_free_gb,
+            'min_output_free_gb': options.min_output_free_gb,
+            'thermal_warn_c': options.thermal_warn_c,
+            'thermal_fail_c': options.thermal_fail_c,
+            'min_memory_available_gb': options.min_memory_available_gb,
+        }
+
+    def _parse_os_release(self) -> dict[str, str]:
+        text = self._read_text('/etc/os-release')
+        values = {}
+        for line in text.splitlines():
+            if '=' not in line:
+                continue
+            key, value = line.split('=', 1)
+            values[key] = value.strip().strip('"')
+        return values
+
+    def _parse_meminfo(self) -> dict[str, int]:
+        text = self._read_text('/proc/meminfo')
+        values = {}
+        for line in text.splitlines():
+            parts = line.split()
+            if len(parts) >= 2 and parts[0].endswith(':'):
+                values[parts[0][:-1]] = int(parts[1])
+        return values
+
+    @staticmethod
+    def _kb_to_gib(value: int | None) -> float | None:
+        if value is None:
+            return None
+        return round(float(value) / 1024**2, 3)
+
+    def _read_text(self, absolute_path: str) -> str:
+        return self._read_file(self._path(absolute_path))
+
+    @staticmethod
+    def _read_file(path: Path) -> str:
+        try:
+            return path.read_text(encoding='utf-8').replace('\x00', '').strip()
+        except OSError:
+            return ''
+
+    def _path(self, absolute_path: str) -> Path:
+        return self._host_root / absolute_path.lstrip('/')
+
+
+def payload_to_json(payload: dict[str, Any]) -> str:
+    """Serialize report payloads consistently."""
+    return json.dumps(payload, indent=2, sort_keys=True)


### PR DESCRIPTION
## Summary

Adds the Jetson host preflight that the MID-360 production-candidate session (PR #176) calls *before* recording when `--skip-host-readiness` is not passed. Stdlib-only (no PyYAML, no `mid360_robot_tools` dep), so it's a true Layer-A piece on top of the foundation chain.

### What's in
- **`scripts/jetson_mid360_host_tools.py`** — `Mid360JetsonHostReadiness` probes:
  - `/proc/device-tree/model` + `/etc/nv_tegra_release` for Jetson identity
  - `/proc/meminfo` MemAvailable vs threshold
  - `/sys/class/thermal/thermal_zone*/temp` max vs warn / fail thresholds
  - `/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor` (warn on `powersave`)
  - `shutil.which()` for the tooling the chain needs (`ros2`, `colcon`, `evo`, ...)
  - disk free space on bag-root + map-output directories
  - bag-root directory existence
- Emits PASS / WARN / FAIL `HostCheck` per probe and rolls up a status.
- **`scripts/check_jetson_mid360_host_readiness.py`** — operator CLI:
  - `--bag-root`, `--output-dir`, `--min-memory-gb`, `--thermal-warn-c`, ...
  - JSON or Markdown report
  - Non-zero exit on FAIL

### Why
This is the natural next-up from §10.5 in plan.md. Until now the production-candidate session (PR #176) had to be invoked with `--skip-host-readiness` to bypass this missing preflight; landing this PR closes that hole so the chain runs end-to-end on a real Jetson without the bypass flag.

## Test plan

- [x] `python3 -m pytest graph_based_slam/test/test_jetson_mid360_host_readiness.py -v` → 5 passed
  - PASS path with a faked /sys+/proc tree
  - ROS2 missing FAIL
  - Low output-storage FAIL
  - Missing bag-dir FAIL
  - CLI subprocess writes JSON + Markdown reports
- [x] `python3 -m flake8 --select=E,W,F --ignore=W503 --max-line-length=99 scripts/jetson_mid360_host_tools.py scripts/check_jetson_mid360_host_readiness.py graph_based_slam/test/test_jetson_mid360_host_readiness.py` → clean
- [ ] Humble + Jazzy matrix CI