### PR TITLE
feat: MID-360 robot bag preflight + profile validator CLIs

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -269,6 +269,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_mid360_robot_preflight
+    test/test_mid360_robot_preflight.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_navsatfix_covariance_inspector
     test/test_navsatfix_covariance_inspector.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_mid360_robot_preflight.py
+++ b/graph_based_slam/test/test_mid360_robot_preflight.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Regression tests for the MID-360 robot preflight wrapper."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / 'scripts'
+SCRIPT_PATH = REPO_ROOT / 'scripts' / 'preflight_mid360_robot_bag.py'
+
+
+def _load_module():
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    return importlib.import_module('preflight_mid360_robot_bag')
+
+
+def _write_metadata(tmp_path: Path, topics: list[tuple[str, str, int]]) -> Path:
+    bag_dir = tmp_path / 'mid360_robot_bag'
+    bag_dir.mkdir()
+    metadata = {
+        'rosbag2_bagfile_information': {
+            'duration': {'nanoseconds': 5_000_000_000},
+            'message_count': sum(count for _, _, count in topics),
+            'topics_with_message_count': [
+                {
+                    'topic_metadata': {
+                        'name': name,
+                        'type': msg_type,
+                        'serialization_format': 'cdr',
+                        'offered_qos_profiles': '',
+                    },
+                    'message_count': count,
+                }
+                for name, msg_type, count in topics
+            ],
+        },
+    }
+    (bag_dir / 'metadata.yaml').write_text(yaml.safe_dump(metadata), encoding='utf-8')
+    return bag_dir
+
+
+def test_mid360_robot_preflight_emits_tuned_launch(tmp_path: Path):
+    module = _load_module()
+    bag_dir = _write_metadata(
+        tmp_path,
+        [
+            ('/livox/lidar', 'sensor_msgs/msg/PointCloud2', 50),
+            ('/livox/imu', 'sensor_msgs/msg/Imu', 500),
+            ('/tf_static', 'tf2_msgs/msg/TFMessage', 1),
+        ],
+    )
+
+    payload = module.build_mid360_robot_payload(
+        bag_dir,
+        base_frame='base_link',
+        lidar_frame='livox_frame',
+        imu_frame='livox_frame',
+    )
+
+    assert payload['ready_for_mid360_launch'] is True
+    assert 'lidarslam_mid360_rko_graph.yaml' in payload['launch_command']
+    assert 'rko_lio_mid360.yaml' in payload['launch_command']
+    assert 'lidar_topic:=/livox/lidar' in payload['launch_command']
+    assert 'imu_topic:=/livox/imu' in payload['launch_command']
+    assert any(
+        check['id'] == 'mid360_preset' and check['status'] == 'ok'
+        for check in payload['checks']
+    )
+
+
+def test_mid360_robot_preflight_json_cli_reports_missing_imu(tmp_path: Path):
+    bag_dir = _write_metadata(
+        tmp_path,
+        [
+            ('/livox/lidar', 'sensor_msgs/msg/PointCloud2', 50),
+        ],
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(bag_dir), '--json'],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+
+    assert payload['ready_for_mid360_launch'] is False
+    assert payload['launch_command'] == ''
+    assert any(
+        check['id'] == 'imu' and check['status'] == 'fail'
+        for check in payload['checks']
+    )

--- a/scripts/preflight_mid360_robot_bag.py
+++ b/scripts/preflight_mid360_robot_bag.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Preflight a Livox MID-360 robot bag for the Jetson legged-robot path."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+from mid360_robot_tools import (
+    AutowarePreflightAdapter,
+    Mid360RobotPreflight,
+    RobotFrames,
+    RobotProfileLoader,
+    payload_to_json,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def build_mid360_robot_payload(
+    bag_path: Path,
+    base_frame: str,
+    lidar_frame: str,
+    imu_frame: str,
+    robot_profile: Path | None = None,
+) -> dict[str, Any]:
+    """Compatibility wrapper for tests and external imports."""
+    profile = RobotProfileLoader().load(robot_profile) if robot_profile else None
+    return _build_preflight().build_payload(
+        bag_path,
+        RobotFrames(
+            base_frame=base_frame or (profile.frames.base_frame if profile else 'base_link'),
+            lidar_frame=lidar_frame or (profile.frames.lidar_frame if profile else 'livox_frame'),
+            imu_frame=imu_frame or (profile.frames.imu_frame if profile else 'livox_frame'),
+        ),
+        profile=profile,
+    )
+
+
+def render_text_report(payload: dict[str, Any]) -> str:
+    """Compatibility wrapper for tests and external imports."""
+    return _build_preflight().render_text_report(payload)
+
+
+def _build_preflight() -> Mid360RobotPreflight:
+    return Mid360RobotPreflight(AutowarePreflightAdapter(REPO_ROOT))
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description='Inspect a MID-360 robot rosbag2 and emit the legged-robot launch path.'
+    )
+    parser.add_argument('bag', help='Path to a rosbag2 directory that contains metadata.yaml.')
+    parser.add_argument(
+        '--robot-profile',
+        help='Robot profile YAML for expected topics and frames.',
+    )
+    parser.add_argument('--base-frame', default='', help='Robot body frame.')
+    parser.add_argument('--lidar-frame', default='', help='MID-360 LiDAR frame.')
+    parser.add_argument('--imu-frame', default='', help='MID-360 IMU frame.')
+    parser.add_argument('--json', action='store_true', help='Emit machine-readable JSON.')
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point."""
+    args = parse_args()
+    payload = build_mid360_robot_payload(
+        Path(args.bag).expanduser().resolve(),
+        args.base_frame,
+        args.lidar_frame,
+        args.imu_frame,
+        Path(args.robot_profile).expanduser().resolve() if args.robot_profile else None,
+    )
+    if args.json:
+        print(payload_to_json(payload))
+    else:
+        print(render_text_report(payload))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/validate_mid360_robot_profile.py
+++ b/scripts/validate_mid360_robot_profile.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Validate and print a MID-360 robot profile."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from mid360_robot_tools import (
+    RobotProfileLoader,
+    payload_to_json,
+    render_robot_profile_report,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Validate a MID-360 robot profile YAML.')
+    parser.add_argument('profile', help='Path to a robot profile YAML.')
+    parser.add_argument('--json', action='store_true', help='Emit normalized profile JSON.')
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    profile = RobotProfileLoader().load(Path(args.profile).expanduser().resolve())
+    if args.json:
+        print(payload_to_json(profile.to_dict()))
+    else:
+        print(render_robot_profile_report(profile))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Two thin CLIs around `mid360_robot_tools` (foundation, PR #168) — both pre-mapping operator tools that catch issues before the chain (#176) is invoked.

### What's in
- **`scripts/preflight_mid360_robot_bag.py`** — pre-mapping bag inspector. Uses `Mid360RobotPreflight` to scan a rosbag2 dir, match it against an optional robot profile (expected topics + frames), and print the suggested RKO-LIO launch args (deskew, IMU, start-time) + JSON report on `--json`. Operator runs this on a freshly recorded bag to confirm it's mappable before kicking off the full pipeline.
- **`scripts/validate_mid360_robot_profile.py`** — thin CLI around `RobotProfileLoader`. Parses + validates a robot profile YAML, exits non-zero on missing required fields. Useful before recording / mapping to catch typos in the profile early (e.g. `expected_pointcloud_topic` typo would otherwise only surface during the record cascade in PR #177).

Both depend only on `mid360_robot_tools` (foundation, PR #168). No `yaml` direct dep; profile parsing goes through the foundation loader.

### Why
Operator surface gap from §10.5: even with the full chain landed (PR #168-#180), there was no quick \"is this bag mappable / is this profile valid\" check that runs in milliseconds without invoking the full session orchestrator. These two CLIs cover that gap.

### Out of scope (will follow as a separate PR)
- `scripts/rewrite_mid360_robot_bag_stamps.py` + `scripts/mid360_robot_bag_stamp_rewriter.py` (336 lines) — the test fixture depends on `mid360_robot_sample_bag` (also untracked, 336 lines + numpy), so deferring those keeps this PR narrow.

## Test plan

- [x] `python3 -m pytest graph_based_slam/test/test_mid360_robot_preflight.py -v` → 2 passed (tuned launch emission path, missing-IMU JSON CLI report)
- [x] `python3 -m flake8 --select=E,W,F --ignore=W503 --max-line-length=99 scripts/preflight_mid360_robot_bag.py scripts/validate_mid360_robot_profile.py graph_based_slam/test/test_mid360_robot_preflight.py` → clean
- [ ] Humble + Jazzy matrix CI