### PR TITLE
feat: MID-360 bag stamp rewriter + sample bag generator (with test fixture)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -274,6 +274,16 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_mid360_robot_sample_bag
+    test/test_mid360_robot_sample_bag.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
+    test_mid360_robot_bag_stamp_rewriter
+    test/test_mid360_robot_bag_stamp_rewriter.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_navsatfix_covariance_inspector
     test/test_navsatfix_covariance_inspector.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_mid360_robot_bag_stamp_rewriter.py
+++ b/graph_based_slam/test/test_mid360_robot_bag_stamp_rewriter.py
@@ -1,0 +1,249 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the MID-360 bag stamp rewriter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = REPO_ROOT / 'scripts'
+CLI_PATH = SCRIPT_DIR / 'rewrite_mid360_robot_bag_stamps.py'
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from mid360_robot_bag_stamp_rewriter import (  # noqa: E402
+    BAG_STAMP_REWRITER_JSON,
+    BAG_STAMP_REWRITER_MARKDOWN,
+    BagStampRewriter,
+    BagStampRewriterOptions,
+)
+from mid360_robot_sample_bag import Mid360SampleBagWriter, SampleBagConfig  # noqa: E402
+
+
+def _write_sample_bag(path: Path) -> None:
+    Mid360SampleBagWriter(
+        SampleBagConfig(
+            output_path=path,
+            duration_sec=1.0,
+            pointcloud_rate_hz=10.0,
+            imu_rate_hz=100.0,
+            force=True,
+        )
+    ).write()
+
+
+def _corrupt_pointcloud_stamps(bag: Path, jump_sec: float) -> None:
+    """Rewrite header.stamp of each PointCloud2 message to add a large jump.
+
+    Mimics the upstream behaviour seen in some public MID-360 datasets where
+    LiDAR header.stamp drifts away from rosbag2 receive time by hundreds of
+    seconds. Used only as a test fixture.
+    """
+    from rosbags.highlevel import AnyReader
+    from rosbags.rosbag2 import Writer
+    from rosbags.typesys import Stores, get_typestore
+
+    typestore = get_typestore(Stores.LATEST)
+    tmp_bag = bag.with_name(bag.name + '_tmp')
+    if tmp_bag.exists():
+        import shutil
+        shutil.rmtree(tmp_bag)
+
+    jump_ns = int(jump_sec * 1_000_000_000)
+    with AnyReader([bag], default_typestore=typestore) as reader, Writer(
+        tmp_bag,
+        version=9,
+    ) as writer:
+        output_connections: dict[str, object] = {}
+        for conn in reader.connections:
+            kwargs = {
+                'typestore': typestore,
+                'serialization_format': conn.ext.serialization_format,
+                'offered_qos_profiles': conn.ext.offered_qos_profiles,
+            }
+            if conn.digest and getattr(conn.msgdef, 'data', ''):
+                kwargs['msgdef'] = conn.msgdef.data
+                kwargs['rihs01'] = conn.digest
+            output_connections[conn.topic] = writer.add_connection(
+                conn.topic, conn.msgtype, **kwargs,
+            )
+        for conn, timestamp_ns, raw in reader.messages():
+            if conn.msgtype == 'sensor_msgs/msg/PointCloud2':
+                msg = typestore.deserialize_cdr(raw, conn.msgtype)
+                bad_ns = int(timestamp_ns) + jump_ns
+                msg.header.stamp.sec = bad_ns // 1_000_000_000
+                msg.header.stamp.nanosec = bad_ns % 1_000_000_000
+                raw = typestore.serialize_cdr(msg, conn.msgtype)
+            writer.write(output_connections[conn.topic], timestamp_ns, raw)
+
+    import shutil
+    shutil.rmtree(bag)
+    tmp_bag.rename(bag)
+
+
+def _read_pointcloud_header_stamps(bag: Path) -> list[int]:
+    from rosbags.highlevel import AnyReader
+    from rosbags.typesys import Stores, get_typestore
+
+    typestore = get_typestore(Stores.LATEST)
+    stamps: list[int] = []
+    with AnyReader([bag], default_typestore=typestore) as reader:
+        for conn, _, raw in reader.messages():
+            if conn.msgtype != 'sensor_msgs/msg/PointCloud2':
+                continue
+            msg = typestore.deserialize_cdr(raw, conn.msgtype)
+            stamps.append(
+                int(msg.header.stamp.sec) * 1_000_000_000
+                + int(msg.header.stamp.nanosec)
+            )
+    return stamps
+
+
+def _read_receive_times(bag: Path, msgtype: str) -> list[int]:
+    from rosbags.highlevel import AnyReader
+    from rosbags.typesys import Stores, get_typestore
+
+    typestore = get_typestore(Stores.LATEST)
+    out: list[int] = []
+    with AnyReader([bag], default_typestore=typestore) as reader:
+        for conn, timestamp_ns, _ in reader.messages():
+            if conn.msgtype != msgtype:
+                continue
+            out.append(int(timestamp_ns))
+    return out
+
+
+def test_rewriter_resets_pointcloud_stamps_to_receive_time(tmp_path: Path):
+    source_bag = tmp_path / 'corrupted_bag'
+    output_bag = tmp_path / 'rewritten_bag'
+
+    _write_sample_bag(source_bag)
+    _corrupt_pointcloud_stamps(source_bag, jump_sec=500.0)
+
+    summary = BagStampRewriter().rewrite(
+        BagStampRewriterOptions(
+            input_bag=source_bag,
+            output_bag=output_bag,
+            force=True,
+        )
+    )
+
+    assert summary['status'] == 'PASS'
+    assert summary['result']['total_messages'] > 0
+    assert summary['result']['rewritten_messages'] > 0
+
+    pc_per_topic = summary['result']['per_topic'].get('/livox/lidar', {})
+    assert pc_per_topic.get('msgtype') == 'sensor_msgs/msg/PointCloud2'
+    assert pc_per_topic.get('rewritten') == 10  # 10Hz over 1.0s, exclusive end
+    assert pc_per_topic.get('max_stamp_delta_sec', 0) > 499.0
+
+    receive_times = _read_receive_times(output_bag, 'sensor_msgs/msg/PointCloud2')
+    rewritten_stamps = _read_pointcloud_header_stamps(output_bag)
+    assert receive_times == rewritten_stamps
+
+    json_path = output_bag.parent / BAG_STAMP_REWRITER_JSON
+    md_path = output_bag.parent / BAG_STAMP_REWRITER_MARKDOWN
+    assert json_path.is_file()
+    assert md_path.is_file()
+
+
+def test_rewriter_passthrough_when_unaffected(tmp_path: Path):
+    source_bag = tmp_path / 'clean_bag'
+    output_bag = tmp_path / 'rewritten_bag'
+
+    _write_sample_bag(source_bag)
+
+    summary = BagStampRewriter().rewrite(
+        BagStampRewriterOptions(
+            input_bag=source_bag,
+            output_bag=output_bag,
+            force=True,
+        )
+    )
+
+    assert summary['status'] == 'PASS'
+    pc_per_topic = summary['result']['per_topic'].get('/livox/lidar', {})
+    assert pc_per_topic.get('rewritten') == 10
+    assert pc_per_topic.get('max_stamp_delta_sec', 1.0) < 1e-6
+
+
+def test_rewriter_respects_explicit_msgtype_list(tmp_path: Path):
+    source_bag = tmp_path / 'corrupted_bag'
+    output_bag = tmp_path / 'rewritten_bag'
+
+    _write_sample_bag(source_bag)
+    _corrupt_pointcloud_stamps(source_bag, jump_sec=200.0)
+
+    summary = BagStampRewriter().rewrite(
+        BagStampRewriterOptions(
+            input_bag=source_bag,
+            output_bag=output_bag,
+            rewrite_msgtypes=('sensor_msgs/msg/Imu',),
+            force=True,
+        )
+    )
+
+    assert summary['status'] == 'PASS'
+    pc_per_topic = summary['result']['per_topic'].get('/livox/lidar', {})
+    imu_per_topic = summary['result']['per_topic'].get('/livox/imu', {})
+    assert pc_per_topic.get('rewritten', 0) == 0
+    assert pc_per_topic.get('passthrough', 0) == 10
+    assert imu_per_topic.get('rewritten', 0) == 100
+
+
+def test_cli_writes_summary(tmp_path: Path):
+    source_bag = tmp_path / 'corrupted_bag'
+    output_bag = tmp_path / 'rewritten_bag'
+
+    _write_sample_bag(source_bag)
+    _corrupt_pointcloud_stamps(source_bag, jump_sec=300.0)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CLI_PATH),
+            '--input-bag', str(source_bag),
+            '--output-bag', str(output_bag),
+            '--force',
+            '--json',
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+    summary = json.loads(result.stdout)
+    assert summary['status'] == 'PASS'
+    assert summary['result']['rewritten_messages'] > 0
+    assert (output_bag / 'metadata.yaml').is_file()

--- a/graph_based_slam/test/test_mid360_robot_bag_stamp_rewriter.py
+++ b/graph_based_slam/test/test_mid360_robot_bag_stamp_rewriter.py
@@ -36,10 +36,15 @@ from pathlib import Path
 import subprocess
 import sys
 
+import importlib.util
+
 import pytest
 
 
-pytest.importorskip('rosbags')
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec('rosbags') is None,
+    reason='rosbags python module not available (pip install rosbags)',
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_DIR = REPO_ROOT / 'scripts'
@@ -68,7 +73,8 @@ def _write_sample_bag(path: Path) -> None:
 
 
 def _corrupt_pointcloud_stamps(bag: Path, jump_sec: float) -> None:
-    """Rewrite header.stamp of each PointCloud2 message to add a large jump.
+    """
+    Rewrite header.stamp of each PointCloud2 message to add a large jump.
 
     Mimics the upstream behaviour seen in some public MID-360 datasets where
     LiDAR header.stamp drifts away from rosbag2 receive time by hundreds of

--- a/graph_based_slam/test/test_mid360_robot_bag_stamp_rewriter.py
+++ b/graph_based_slam/test/test_mid360_robot_bag_stamp_rewriter.py
@@ -36,6 +36,10 @@ from pathlib import Path
 import subprocess
 import sys
 
+import pytest
+
+
+pytest.importorskip('rosbags')
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_DIR = REPO_ROOT / 'scripts'

--- a/graph_based_slam/test/test_mid360_robot_bag_stamp_rewriter.py
+++ b/graph_based_slam/test/test_mid360_robot_bag_stamp_rewriter.py
@@ -31,12 +31,12 @@
 
 from __future__ import annotations
 
+import importlib
+import importlib.util
 import json
 from pathlib import Path
 import subprocess
 import sys
-
-import importlib.util
 
 import pytest
 
@@ -49,20 +49,24 @@ pytestmark = pytest.mark.skipif(
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_DIR = REPO_ROOT / 'scripts'
 CLI_PATH = SCRIPT_DIR / 'rewrite_mid360_robot_bag_stamps.py'
-sys.path.insert(0, str(SCRIPT_DIR))
 
-from mid360_robot_bag_stamp_rewriter import (  # noqa: E402
-    BAG_STAMP_REWRITER_JSON,
-    BAG_STAMP_REWRITER_MARKDOWN,
-    BagStampRewriter,
-    BagStampRewriterOptions,
-)
-from mid360_robot_sample_bag import Mid360SampleBagWriter, SampleBagConfig  # noqa: E402
+
+def _rewriter_module():
+    if str(SCRIPT_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_DIR))
+    return importlib.import_module('mid360_robot_bag_stamp_rewriter')
+
+
+def _sample_bag_module():
+    if str(SCRIPT_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_DIR))
+    return importlib.import_module('mid360_robot_sample_bag')
 
 
 def _write_sample_bag(path: Path) -> None:
-    Mid360SampleBagWriter(
-        SampleBagConfig(
+    sample = _sample_bag_module()
+    sample.Mid360SampleBagWriter(
+        sample.SampleBagConfig(
             output_path=path,
             duration_sec=1.0,
             pointcloud_rate_hz=10.0,
@@ -161,8 +165,9 @@ def test_rewriter_resets_pointcloud_stamps_to_receive_time(tmp_path: Path):
     _write_sample_bag(source_bag)
     _corrupt_pointcloud_stamps(source_bag, jump_sec=500.0)
 
-    summary = BagStampRewriter().rewrite(
-        BagStampRewriterOptions(
+    rewriter = _rewriter_module()
+    summary = rewriter.BagStampRewriter().rewrite(
+        rewriter.BagStampRewriterOptions(
             input_bag=source_bag,
             output_bag=output_bag,
             force=True,
@@ -182,8 +187,8 @@ def test_rewriter_resets_pointcloud_stamps_to_receive_time(tmp_path: Path):
     rewritten_stamps = _read_pointcloud_header_stamps(output_bag)
     assert receive_times == rewritten_stamps
 
-    json_path = output_bag.parent / BAG_STAMP_REWRITER_JSON
-    md_path = output_bag.parent / BAG_STAMP_REWRITER_MARKDOWN
+    json_path = output_bag.parent / rewriter.BAG_STAMP_REWRITER_JSON
+    md_path = output_bag.parent / rewriter.BAG_STAMP_REWRITER_MARKDOWN
     assert json_path.is_file()
     assert md_path.is_file()
 
@@ -194,8 +199,9 @@ def test_rewriter_passthrough_when_unaffected(tmp_path: Path):
 
     _write_sample_bag(source_bag)
 
-    summary = BagStampRewriter().rewrite(
-        BagStampRewriterOptions(
+    rewriter = _rewriter_module()
+    summary = rewriter.BagStampRewriter().rewrite(
+        rewriter.BagStampRewriterOptions(
             input_bag=source_bag,
             output_bag=output_bag,
             force=True,
@@ -215,8 +221,9 @@ def test_rewriter_respects_explicit_msgtype_list(tmp_path: Path):
     _write_sample_bag(source_bag)
     _corrupt_pointcloud_stamps(source_bag, jump_sec=200.0)
 
-    summary = BagStampRewriter().rewrite(
-        BagStampRewriterOptions(
+    rewriter = _rewriter_module()
+    summary = rewriter.BagStampRewriter().rewrite(
+        rewriter.BagStampRewriterOptions(
             input_bag=source_bag,
             output_bag=output_bag,
             rewrite_msgtypes=('sensor_msgs/msg/Imu',),

--- a/graph_based_slam/test/test_mid360_robot_sample_bag.py
+++ b/graph_based_slam/test/test_mid360_robot_sample_bag.py
@@ -36,10 +36,15 @@ from pathlib import Path
 import subprocess
 import sys
 
+import importlib.util
+
 import pytest
 
 
-pytest.importorskip('rosbags')
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec('rosbags') is None,
+    reason='rosbags python module not available (pip install rosbags)',
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SAMPLE_SCRIPT = REPO_ROOT / 'scripts' / 'generate_mid360_robot_sample_bag.py'

--- a/graph_based_slam/test/test_mid360_robot_sample_bag.py
+++ b/graph_based_slam/test/test_mid360_robot_sample_bag.py
@@ -31,12 +31,11 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 import subprocess
 import sys
-
-import importlib.util
 
 import pytest
 

--- a/graph_based_slam/test/test_mid360_robot_sample_bag.py
+++ b/graph_based_slam/test/test_mid360_robot_sample_bag.py
@@ -1,0 +1,122 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the MID-360 sample rosbag generator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+pytest.importorskip('rosbags')
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SAMPLE_SCRIPT = REPO_ROOT / 'scripts' / 'generate_mid360_robot_sample_bag.py'
+READINESS_SCRIPT = REPO_ROOT / 'scripts' / 'check_mid360_robot_readiness.py'
+DEFAULT_PROFILE = REPO_ROOT / 'configs' / 'mid360_robot' / 'livox_mid360_default.yaml'
+
+
+def test_sample_bag_generator_writes_readable_mid360_bag(tmp_path: Path):
+    bag_path = tmp_path / 'mid360_sample'
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SAMPLE_SCRIPT),
+            str(bag_path),
+            '--duration-sec',
+            '2.0',
+            '--pointcloud-rate-hz',
+            '10',
+            '--imu-rate-hz',
+            '100',
+            '--point-count',
+            '16',
+            '--force',
+            '--json',
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    summary = json.loads(result.stdout)
+
+    assert bag_path.is_dir()
+    assert (bag_path / 'metadata.yaml').is_file()
+    assert summary['pointcloud_messages'] == 20
+    assert summary['imu_messages'] == 200
+    assert summary['topics']['pointcloud'] == '/livox/lidar'
+
+    output_dir = tmp_path / 'readiness'
+    readiness = subprocess.run(
+        [
+            sys.executable,
+            str(READINESS_SCRIPT),
+            str(bag_path),
+            '--robot-profile',
+            str(DEFAULT_PROFILE),
+            '--output-dir',
+            str(output_dir),
+            '--json',
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    report = json.loads(readiness.stdout)
+
+    assert report['status'] == 'PASS'
+    assert report['ready_for_mid360_launch'] is True
+    diagnostics = report['bag_diagnostics']
+    assert diagnostics['sample_reader']['available'] is True
+    assert diagnostics['topics']['pointcloud']['sampled_frame_ids'] == ['livox_frame']
+    assert diagnostics['topics']['imu']['sampled_frame_ids'] == ['livox_frame']
+    assert diagnostics['tf']['base_to_lidar_connected'] is True
+    assert diagnostics['tf']['base_to_imu_connected'] is True
+
+
+def test_sample_bag_generator_requires_force_for_existing_output(tmp_path: Path):
+    bag_path = tmp_path / 'mid360_sample'
+    first = [
+        sys.executable,
+        str(SAMPLE_SCRIPT),
+        str(bag_path),
+        '--duration-sec',
+        '1.0',
+    ]
+    subprocess.run(first, check=True, text=True, capture_output=True)
+
+    second = subprocess.run(first, text=True, capture_output=True)
+
+    assert second.returncode == 1
+    assert 'use --force' in second.stderr

--- a/scripts/generate_mid360_robot_sample_bag.py
+++ b/scripts/generate_mid360_robot_sample_bag.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""CLI for generating a small MID-360-style rosbag2 test input."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from mid360_robot_sample_bag import (
+    Mid360SampleBagWriter,
+    SampleBagConfig,
+    render_summary,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Generate a synthetic MID-360 robot rosbag2 with PointCloud2, Imu, and TF.'
+    )
+    parser.add_argument('output', help='Output rosbag2 directory.')
+    parser.add_argument('--duration-sec', type=float, default=5.0)
+    parser.add_argument('--pointcloud-rate-hz', type=float, default=10.0)
+    parser.add_argument('--imu-rate-hz', type=float, default=100.0)
+    parser.add_argument('--point-count', type=int, default=32)
+    parser.add_argument('--pointcloud-topic', default='/livox/lidar')
+    parser.add_argument('--imu-topic', default='/livox/imu')
+    parser.add_argument('--tf-static-topic', default='/tf_static')
+    parser.add_argument('--base-frame', default='base_link')
+    parser.add_argument('--lidar-frame', default='livox_frame')
+    parser.add_argument('--imu-frame', default='livox_frame')
+    parser.add_argument('--no-tf-static', action='store_true', help='Do not write /tf_static.')
+    parser.add_argument('--force', action='store_true', help='Overwrite an existing output bag.')
+    parser.add_argument('--json', action='store_true', help='Print JSON summary.')
+    return parser.parse_args()
+
+
+def config_from_args(args: argparse.Namespace) -> SampleBagConfig:
+    return SampleBagConfig(
+        output_path=Path(args.output),
+        duration_sec=args.duration_sec,
+        pointcloud_rate_hz=args.pointcloud_rate_hz,
+        imu_rate_hz=args.imu_rate_hz,
+        point_count=args.point_count,
+        pointcloud_topic=args.pointcloud_topic,
+        imu_topic=args.imu_topic,
+        tf_static_topic=args.tf_static_topic,
+        base_frame=args.base_frame,
+        lidar_frame=args.lidar_frame,
+        imu_frame=args.imu_frame,
+        write_tf_static=not args.no_tf_static,
+        force=args.force,
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        summary = Mid360SampleBagWriter(config_from_args(args)).write()
+    except Exception as exc:
+        print(f'failed to generate sample bag: {exc}', file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(summary.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(render_summary(summary))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/mid360_robot_bag_stamp_rewriter.py
+++ b/scripts/mid360_robot_bag_stamp_rewriter.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Rewrite PointCloud2 / Imu header.stamp in a rosbag2 to match receive time.
+
+Some public MID-360 datasets have PointCloud2 messages whose `header.stamp`
+field is corrupted or non-monotonic, which makes RKO-LIO drop frames with
+errors like "Received LiDAR scan with 522.4 seconds delta to previous scan."
+This module reads a rosbag2 directory and writes a new one where the
+header.stamp of selected topics has been overwritten with the rosbag2
+receive timestamp (`timestamp_ns`). All other messages are passed through
+unchanged.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from mid360_robot_tools import payload_to_json
+
+
+BAG_STAMP_REWRITER_JSON = 'mid360_robot_bag_stamp_rewriter.json'
+BAG_STAMP_REWRITER_MARKDOWN = 'mid360_robot_bag_stamp_rewriter.md'
+
+DEFAULT_STAMP_MSGTYPES = (
+    'sensor_msgs/msg/PointCloud2',
+    'sensor_msgs/msg/Imu',
+)
+
+
+@dataclass(frozen=True)
+class BagStampRewriterOptions:
+    """Options for the bag stamp rewriter."""
+
+    input_bag: Path
+    output_bag: Path
+    rewrite_msgtypes: tuple[str, ...] = DEFAULT_STAMP_MSGTYPES
+    rewrite_topics: tuple[str, ...] = ()
+    force: bool = False
+
+
+class BagStampRewriter:
+    """Rewrite header.stamp of selected messages to match the bag receive time."""
+
+    def rewrite(self, options: BagStampRewriterOptions) -> dict[str, Any]:
+        """Rewrite the bag and return a summary dict."""
+        input_bag = options.input_bag.expanduser().resolve()
+        output_bag = options.output_bag.expanduser().resolve()
+        if not input_bag.exists():
+            raise FileNotFoundError(f'input bag not found: {input_bag}')
+        _prepare_output(output_bag, options.force)
+        result = _rewrite_bag(
+            input_bag=input_bag,
+            output_bag=output_bag,
+            rewrite_msgtypes=set(options.rewrite_msgtypes),
+            rewrite_topics=set(options.rewrite_topics),
+        )
+
+        summary: dict[str, Any] = {
+            'created_at': datetime.now(timezone.utc).isoformat(),
+            'status': 'PASS' if result['total_messages'] > 0 else 'FAIL',
+            'input_bag': str(input_bag),
+            'output_bag': str(output_bag),
+            'rewrite_msgtypes': list(options.rewrite_msgtypes),
+            'rewrite_topics': list(options.rewrite_topics),
+            'result': result,
+        }
+        _write_summary(output_bag.parent, summary)
+        return summary
+
+
+def render_bag_stamp_rewriter_markdown(summary: dict[str, Any]) -> str:
+    """Render the rewriter summary as Markdown."""
+    result = summary.get('result') or {}
+    lines = [
+        '# MID-360 Bag Stamp Rewriter',
+        '',
+        f"- status: `{summary.get('status', '')}`",
+        f"- created_at: `{summary.get('created_at', '')}`",
+        f"- input_bag: `{summary.get('input_bag', '')}`",
+        f"- output_bag: `{summary.get('output_bag', '')}`",
+        f"- total_messages: `{result.get('total_messages', 0)}`",
+        f"- rewritten_messages: `{result.get('rewritten_messages', 0)}`",
+        f"- passthrough_messages: `{result.get('passthrough_messages', 0)}`",
+        f"- max_stamp_delta_sec: `{result.get('max_stamp_delta_sec', 0.0):.6f}`",
+        '',
+        '## Rewrite Targets',
+        '',
+    ]
+    targets = summary.get('rewrite_msgtypes') or []
+    if targets:
+        for item in targets:
+            lines.append(f'- msgtype `{item}`')
+    topics = summary.get('rewrite_topics') or []
+    if topics:
+        for item in topics:
+            lines.append(f'- topic `{item}`')
+
+    lines.extend(['', '## Per-Topic Counts', ''])
+    for topic, payload in (result.get('per_topic') or {}).items():
+        lines.append(
+            f"- `{topic}` ({payload.get('msgtype', '')}): "
+            f"rewritten=`{payload.get('rewritten', 0)}`, "
+            f"passthrough=`{payload.get('passthrough', 0)}`, "
+            f"max_delta=`{payload.get('max_stamp_delta_sec', 0.0):.6f}` s"
+        )
+    return '\n'.join(lines)
+
+
+def _rewrite_bag(
+    *,
+    input_bag: Path,
+    output_bag: Path,
+    rewrite_msgtypes: set[str],
+    rewrite_topics: set[str],
+) -> dict[str, Any]:
+    try:
+        from rosbags.highlevel import AnyReader
+        from rosbags.rosbag2 import Writer
+        from rosbags.typesys import Stores, get_typestore
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError('rosbags is required to rewrite bag stamps') from exc
+
+    typestore = get_typestore(Stores.LATEST)
+    rewritten = 0
+    passthrough = 0
+    total = 0
+    max_delta_sec = 0.0
+    per_topic: dict[str, dict[str, Any]] = {}
+
+    with AnyReader([input_bag], default_typestore=typestore) as reader, Writer(
+        output_bag,
+        version=9,
+    ) as writer:
+        output_connections: dict[str, Any] = {}
+        for conn in reader.connections:
+            kwargs = {
+                'typestore': typestore,
+                'serialization_format': conn.ext.serialization_format,
+                'offered_qos_profiles': conn.ext.offered_qos_profiles,
+            }
+            if conn.digest and getattr(conn.msgdef, 'data', ''):
+                kwargs['msgdef'] = conn.msgdef.data
+                kwargs['rihs01'] = conn.digest
+            output_connections[conn.topic] = writer.add_connection(
+                conn.topic, conn.msgtype, **kwargs,
+            )
+
+        for conn, timestamp_ns, raw in reader.messages():
+            total += 1
+            topic_payload = per_topic.setdefault(
+                conn.topic,
+                {
+                    'msgtype': conn.msgtype,
+                    'rewritten': 0,
+                    'passthrough': 0,
+                    'max_stamp_delta_sec': 0.0,
+                },
+            )
+            should_rewrite = (
+                conn.msgtype in rewrite_msgtypes
+                or conn.topic in rewrite_topics
+            )
+            if should_rewrite:
+                msg = typestore.deserialize_cdr(raw, conn.msgtype)
+                original_stamp_ns = _stamp_ns_from_msg(msg)
+                new_sec = int(timestamp_ns // 1_000_000_000)
+                new_nanosec = int(timestamp_ns % 1_000_000_000)
+                if hasattr(msg, 'header') and hasattr(msg.header, 'stamp'):
+                    msg.header.stamp.sec = new_sec
+                    msg.header.stamp.nanosec = new_nanosec
+                raw = typestore.serialize_cdr(msg, conn.msgtype)
+                rewritten += 1
+                topic_payload['rewritten'] += 1
+                if original_stamp_ns is not None:
+                    delta_sec = abs(timestamp_ns - original_stamp_ns) / 1_000_000_000.0
+                    if delta_sec > topic_payload['max_stamp_delta_sec']:
+                        topic_payload['max_stamp_delta_sec'] = delta_sec
+                    if delta_sec > max_delta_sec:
+                        max_delta_sec = delta_sec
+            else:
+                passthrough += 1
+                topic_payload['passthrough'] += 1
+            writer.write(output_connections[conn.topic], timestamp_ns, raw)
+
+    return {
+        'total_messages': total,
+        'rewritten_messages': rewritten,
+        'passthrough_messages': passthrough,
+        'max_stamp_delta_sec': max_delta_sec,
+        'per_topic': per_topic,
+    }
+
+
+def _stamp_ns_from_msg(msg: Any) -> int | None:
+    header = getattr(msg, 'header', None)
+    if header is None:
+        return None
+    stamp = getattr(header, 'stamp', None)
+    if stamp is None:
+        return None
+    sec = getattr(stamp, 'sec', None)
+    nanosec = getattr(stamp, 'nanosec', None)
+    if sec is None or nanosec is None:
+        return None
+    return int(sec) * 1_000_000_000 + int(nanosec)
+
+
+def _prepare_output(output_bag: Path, force: bool) -> None:
+    if output_bag.exists():
+        if not force:
+            raise FileExistsError(f'output bag exists (use --force): {output_bag}')
+        shutil.rmtree(output_bag)
+    output_bag.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _write_summary(parent_dir: Path, summary: dict[str, Any]) -> dict[str, Path]:
+    parent_dir.mkdir(parents=True, exist_ok=True)
+    json_path = parent_dir / BAG_STAMP_REWRITER_JSON
+    markdown_path = parent_dir / BAG_STAMP_REWRITER_MARKDOWN
+    json_path.write_text(payload_to_json(summary) + '\n', encoding='utf-8')
+    markdown_path.write_text(
+        render_bag_stamp_rewriter_markdown(summary) + '\n',
+        encoding='utf-8',
+    )
+    return {'json': json_path, 'markdown': markdown_path}
+
+
+def options_payload(options: BagStampRewriterOptions) -> dict[str, Any]:
+    """Convert options to a JSON-friendly dict."""
+    payload = asdict(options)
+    payload['input_bag'] = str(options.input_bag)
+    payload['output_bag'] = str(options.output_bag)
+    return payload

--- a/scripts/mid360_robot_sample_bag.py
+++ b/scripts/mid360_robot_sample_bag.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Generate a small, readable MID-360-style rosbag2 for local testing."""
+
+from __future__ import annotations
+
+import math
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class SampleBagConfig:
+    """Configuration for a synthetic MID-360 robot bag."""
+
+    output_path: Path
+    duration_sec: float = 5.0
+    pointcloud_rate_hz: float = 10.0
+    imu_rate_hz: float = 100.0
+    point_count: int = 32
+    pointcloud_topic: str = '/livox/lidar'
+    imu_topic: str = '/livox/imu'
+    tf_static_topic: str = '/tf_static'
+    base_frame: str = 'base_link'
+    lidar_frame: str = 'livox_frame'
+    imu_frame: str = 'livox_frame'
+    write_tf_static: bool = True
+    force: bool = False
+    start_offset_sec: float = 0.0
+
+
+@dataclass(frozen=True)
+class SampleBagSummary:
+    """Summary of a generated sample bag."""
+
+    output_path: str
+    duration_sec: float
+    message_count: int
+    pointcloud_messages: int
+    imu_messages: int
+    tf_static_messages: int
+    topics: dict[str, str]
+    frames: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def import_rosbag_writer_modules():
+    """Import rosbags lazily so tests can skip cleanly if it is unavailable."""
+    try:
+        from rosbags.rosbag2 import Writer
+        from rosbags.typesys import Stores, get_typestore
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        raise ModuleNotFoundError(
+            'rosbags is required to generate a MID-360 sample bag',
+        ) from exc
+    return Writer, Stores, get_typestore
+
+
+def validate_config(config: SampleBagConfig) -> None:
+    """Validate generator options before touching the output path."""
+    if config.duration_sec <= 0.0:
+        raise ValueError('--duration-sec must be greater than zero')
+    if config.pointcloud_rate_hz <= 0.0:
+        raise ValueError('--pointcloud-rate-hz must be greater than zero')
+    if config.imu_rate_hz <= 0.0:
+        raise ValueError('--imu-rate-hz must be greater than zero')
+    if config.point_count <= 0:
+        raise ValueError('--point-count must be greater than zero')
+    for field, value in (
+        ('pointcloud_topic', config.pointcloud_topic),
+        ('imu_topic', config.imu_topic),
+        ('tf_static_topic', config.tf_static_topic),
+        ('base_frame', config.base_frame),
+        ('lidar_frame', config.lidar_frame),
+        ('imu_frame', config.imu_frame),
+    ):
+        if not value:
+            raise ValueError(f'{field} must be non-empty')
+
+
+def stamp_ns_from_seconds(seconds: float) -> int:
+    """Convert seconds to integer nanoseconds."""
+    return int(round(seconds * 1_000_000_000))
+
+
+def sec_nsec_from_ns(stamp_ns: int) -> tuple[int, int]:
+    """Split nanoseconds into ROS Time fields."""
+    return stamp_ns // 1_000_000_000, stamp_ns % 1_000_000_000
+
+
+def regular_stamps(duration_sec: float, rate_hz: float) -> list[int]:
+    """Return regular message stamps from zero up to, but not including, duration."""
+    period_ns = max(1, int(round(1_000_000_000 / rate_hz)))
+    duration_ns = stamp_ns_from_seconds(duration_sec)
+    stamps = list(range(0, duration_ns, period_ns))
+    return stamps or [0]
+
+
+class Mid360SampleBagWriter:
+    """Write small PointCloud2, Imu, and TFMessage streams into rosbag2."""
+
+    def __init__(self, config: SampleBagConfig) -> None:
+        self._config = config
+        validate_config(config)
+
+    def write(self) -> SampleBagSummary:
+        Writer, Stores, get_typestore = import_rosbag_writer_modules()
+        typestore = get_typestore(Stores.LATEST)
+        output_path = self._config.output_path.expanduser().resolve()
+        self._prepare_output(output_path)
+
+        offset_ns = stamp_ns_from_seconds(self._config.start_offset_sec)
+        pointcloud_stamps = [
+            stamp + offset_ns
+            for stamp in regular_stamps(
+                self._config.duration_sec,
+                self._config.pointcloud_rate_hz,
+            )
+        ]
+        imu_stamps = [
+            stamp + offset_ns
+            for stamp in regular_stamps(self._config.duration_sec, self._config.imu_rate_hz)
+        ]
+
+        messages: list[tuple[int, str, object, str]] = []
+        if self._config.write_tf_static:
+            messages.append((
+                offset_ns,
+                self._config.tf_static_topic,
+                self._build_tf_static(typestore, offset_ns),
+                'tf2_msgs/msg/TFMessage',
+            ))
+        for index, stamp_ns in enumerate(pointcloud_stamps):
+            messages.append((
+                stamp_ns,
+                self._config.pointcloud_topic,
+                self._build_pointcloud(typestore, stamp_ns, index),
+                'sensor_msgs/msg/PointCloud2',
+            ))
+        for index, stamp_ns in enumerate(imu_stamps):
+            messages.append((
+                stamp_ns,
+                self._config.imu_topic,
+                self._build_imu(typestore, stamp_ns, index),
+                'sensor_msgs/msg/Imu',
+            ))
+        messages.sort(key=lambda item: (item[0], self._topic_priority(item[1])))
+
+        with Writer(output_path, version=9) as writer:
+            connections = {
+                self._config.pointcloud_topic: writer.add_connection(
+                    self._config.pointcloud_topic,
+                    'sensor_msgs/msg/PointCloud2',
+                    typestore=typestore,
+                ),
+                self._config.imu_topic: writer.add_connection(
+                    self._config.imu_topic,
+                    'sensor_msgs/msg/Imu',
+                    typestore=typestore,
+                ),
+            }
+            if self._config.write_tf_static:
+                connections[self._config.tf_static_topic] = writer.add_connection(
+                    self._config.tf_static_topic,
+                    'tf2_msgs/msg/TFMessage',
+                    typestore=typestore,
+                )
+            for stamp_ns, topic, msg, msg_type in messages:
+                writer.write(
+                    connections[topic],
+                    stamp_ns,
+                    typestore.serialize_cdr(msg, msg_type),
+                )
+
+        return SampleBagSummary(
+            output_path=str(output_path),
+            duration_sec=self._config.duration_sec,
+            message_count=len(messages),
+            pointcloud_messages=len(pointcloud_stamps),
+            imu_messages=len(imu_stamps),
+            tf_static_messages=1 if self._config.write_tf_static else 0,
+            topics={
+                'pointcloud': self._config.pointcloud_topic,
+                'imu': self._config.imu_topic,
+                'tf_static': self._config.tf_static_topic,
+            },
+            frames={
+                'base_frame': self._config.base_frame,
+                'lidar_frame': self._config.lidar_frame,
+                'imu_frame': self._config.imu_frame,
+            },
+        )
+
+    def _prepare_output(self, output_path: Path) -> None:
+        if output_path.exists():
+            if not self._config.force:
+                raise FileExistsError(f'output bag exists (use --force): {output_path}')
+            if output_path.is_dir():
+                shutil.rmtree(output_path)
+            else:
+                output_path.unlink()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _build_header(self, typestore: Any, stamp_ns: int, frame_id: str) -> Any:
+        Header = typestore.types['std_msgs/msg/Header']
+        Time = typestore.types['builtin_interfaces/msg/Time']
+        sec, nanosec = sec_nsec_from_ns(stamp_ns)
+        return Header(stamp=Time(sec=sec, nanosec=nanosec), frame_id=frame_id)
+
+    def _build_pointcloud(self, typestore: Any, stamp_ns: int, sequence_index: int) -> Any:
+        PointField = typestore.types['sensor_msgs/msg/PointField']
+        PointCloud2 = typestore.types['sensor_msgs/msg/PointCloud2']
+        point_step = 16
+        row_step = point_step * self._config.point_count
+        data = np.zeros(row_step, dtype=np.uint8)
+        points = data.view(dtype=np.float32).reshape(self._config.point_count, 4)
+        phase = sequence_index * 0.1
+        for point_index in range(self._config.point_count):
+            angle = (2.0 * math.pi * point_index / self._config.point_count) + phase
+            radius = 1.5 + 0.02 * (point_index % 7)
+            points[point_index, 0] = radius * math.cos(angle)
+            points[point_index, 1] = radius * math.sin(angle)
+            points[point_index, 2] = 0.2 + 0.01 * (point_index % 11)
+            points[point_index, 3] = float((sequence_index + point_index) % 255) / 255.0
+
+        return PointCloud2(
+            header=self._build_header(typestore, stamp_ns, self._config.lidar_frame),
+            height=1,
+            width=self._config.point_count,
+            fields=[
+                PointField(name='x', offset=0, datatype=PointField.FLOAT32, count=1),
+                PointField(name='y', offset=4, datatype=PointField.FLOAT32, count=1),
+                PointField(name='z', offset=8, datatype=PointField.FLOAT32, count=1),
+                PointField(name='intensity', offset=12, datatype=PointField.FLOAT32, count=1),
+            ],
+            is_bigendian=False,
+            point_step=point_step,
+            row_step=row_step,
+            data=data,
+            is_dense=True,
+        )
+
+    def _build_imu(self, typestore: Any, stamp_ns: int, sequence_index: int) -> Any:
+        Imu = typestore.types['sensor_msgs/msg/Imu']
+        Quaternion = typestore.types['geometry_msgs/msg/Quaternion']
+        Vector3 = typestore.types['geometry_msgs/msg/Vector3']
+        covariance = np.zeros(9, dtype=np.float64)
+        covariance[0] = -1.0
+        yaw_rate = 0.01 * math.sin(sequence_index * 0.02)
+        return Imu(
+            header=self._build_header(typestore, stamp_ns, self._config.imu_frame),
+            orientation=Quaternion(x=0.0, y=0.0, z=0.0, w=1.0),
+            orientation_covariance=covariance,
+            angular_velocity=Vector3(x=0.0, y=0.0, z=yaw_rate),
+            angular_velocity_covariance=covariance,
+            linear_acceleration=Vector3(x=0.0, y=0.0, z=9.80665),
+            linear_acceleration_covariance=covariance,
+        )
+
+    def _build_tf_static(self, typestore: Any, stamp_ns: int) -> Any:
+        TFMessage = typestore.types['tf2_msgs/msg/TFMessage']
+        transforms = [
+            self._build_transform(
+                typestore,
+                stamp_ns,
+                parent=self._config.base_frame,
+                child=self._config.lidar_frame,
+                x=0.0,
+                y=0.0,
+                z=0.25,
+            )
+        ]
+        if self._config.imu_frame != self._config.lidar_frame:
+            transforms.append(
+                self._build_transform(
+                    typestore,
+                    stamp_ns,
+                    parent=self._config.base_frame,
+                    child=self._config.imu_frame,
+                    x=0.0,
+                    y=0.0,
+                    z=0.25,
+                )
+            )
+        return TFMessage(transforms=transforms)
+
+    def _build_transform(
+        self,
+        typestore: Any,
+        stamp_ns: int,
+        *,
+        parent: str,
+        child: str,
+        x: float,
+        y: float,
+        z: float,
+    ) -> Any:
+        TransformStamped = typestore.types['geometry_msgs/msg/TransformStamped']
+        Transform = typestore.types['geometry_msgs/msg/Transform']
+        Quaternion = typestore.types['geometry_msgs/msg/Quaternion']
+        Vector3 = typestore.types['geometry_msgs/msg/Vector3']
+        return TransformStamped(
+            header=self._build_header(typestore, stamp_ns, parent),
+            child_frame_id=child,
+            transform=Transform(
+                translation=Vector3(x=x, y=y, z=z),
+                rotation=Quaternion(x=0.0, y=0.0, z=0.0, w=1.0),
+            ),
+        )
+
+    def _topic_priority(self, topic: str) -> int:
+        if topic == self._config.tf_static_topic:
+            return 0
+        if topic == self._config.imu_topic:
+            return 1
+        return 2
+
+
+def render_summary(summary: SampleBagSummary) -> str:
+    """Render a concise human-readable generation summary."""
+    return '\n'.join([
+        'MID-360 sample bag generated',
+        f'bag: {summary.output_path}',
+        f'duration_sec: {summary.duration_sec:.3f}',
+        f'pointcloud: {summary.pointcloud_messages} messages on {summary.topics["pointcloud"]}',
+        f'imu: {summary.imu_messages} messages on {summary.topics["imu"]}',
+        f'tf_static: {summary.tf_static_messages} messages on {summary.topics["tf_static"]}',
+        f'base_frame: {summary.frames["base_frame"]}',
+        f'lidar_frame: {summary.frames["lidar_frame"]}',
+        f'imu_frame: {summary.frames["imu_frame"]}',
+    ])

--- a/scripts/rewrite_mid360_robot_bag_stamps.py
+++ b/scripts/rewrite_mid360_robot_bag_stamps.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""CLI for rewriting PointCloud2 / Imu header.stamp to bag receive time."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from mid360_robot_bag_stamp_rewriter import (
+    BAG_STAMP_REWRITER_JSON,
+    BAG_STAMP_REWRITER_MARKDOWN,
+    DEFAULT_STAMP_MSGTYPES,
+    BagStampRewriter,
+    BagStampRewriterOptions,
+    render_bag_stamp_rewriter_markdown,
+)
+from mid360_robot_tools import payload_to_json
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            'Rewrite PointCloud2 / Imu header.stamp in a rosbag2 to match the rosbag2 '
+            'receive timestamp. Useful when upstream MID-360 recordings have corrupted '
+            'PointCloud2 header stamps that trigger RKO-LIO Δt errors.'
+        ),
+    )
+    parser.add_argument(
+        '--input-bag',
+        required=True,
+        help='Path to an existing rosbag2 directory.',
+    )
+    parser.add_argument(
+        '--output-bag',
+        required=True,
+        help='Path to the rewritten rosbag2 directory to create.',
+    )
+    parser.add_argument(
+        '--rewrite-msgtype',
+        action='append',
+        default=[],
+        help=(
+            'Repeatable. ROS msg type whose header.stamp should be replaced by the '
+            'bag receive time. Defaults to PointCloud2 and Imu.'
+        ),
+    )
+    parser.add_argument(
+        '--rewrite-topic',
+        action='append',
+        default=[],
+        help='Repeatable. Topic name whose header.stamp should be replaced.',
+    )
+    parser.add_argument(
+        '--force',
+        action='store_true',
+        help='Replace an existing output bag directory.',
+    )
+    parser.add_argument(
+        '--json',
+        action='store_true',
+        help='Print JSON instead of Markdown.',
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point."""
+    args = parse_args()
+    msgtypes = tuple(args.rewrite_msgtype) if args.rewrite_msgtype else DEFAULT_STAMP_MSGTYPES
+    options = BagStampRewriterOptions(
+        input_bag=Path(args.input_bag).expanduser().resolve(),
+        output_bag=Path(args.output_bag).expanduser().resolve(),
+        rewrite_msgtypes=msgtypes,
+        rewrite_topics=tuple(args.rewrite_topic),
+        force=bool(args.force),
+    )
+    try:
+        summary = BagStampRewriter().rewrite(options)
+    except Exception as exc:
+        print(f'failed to rewrite MID-360 bag stamps: {exc}', file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(payload_to_json(summary))
+    else:
+        print(render_bag_stamp_rewriter_markdown(summary))
+        sidecar_dir = Path(summary['output_bag']).parent
+        print(f'{BAG_STAMP_REWRITER_JSON}: {sidecar_dir / BAG_STAMP_REWRITER_JSON}')
+        print(f'{BAG_STAMP_REWRITER_MARKDOWN}: {sidecar_dir / BAG_STAMP_REWRITER_MARKDOWN}')
+    return 0 if summary['status'] == 'PASS' else 1
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        print('Interrupted', file=sys.stderr)
+        raise SystemExit(130)


### PR DESCRIPTION
## Summary

Closes the bag_stamp_rewriter half deferred from PR #181 (preflight + validate-profile narrow PR). Adds two coupled pieces: the rewriter (operator tool for fixing broken public datasets) and the sample-bag generator (test fixture used by the rewriter's tests).

### What's in
- **`scripts/mid360_robot_bag_stamp_rewriter.py`** — rewrites PointCloud2 / Imu `header.stamp` in a rosbag2 to match each message's rosbag2 receive timestamp (`timestamp_ns`). Reads a source bag, writes a new bag where the selected topics' header.stamp is overwritten; all other messages pass through unchanged.
  - **Why**: some public MID-360 datasets have PointCloud2 messages whose `header.stamp` is corrupted or non-monotonic, which makes RKO-LIO drop frames with errors like `Received LiDAR scan with 522.4 seconds delta to previous scan.`
- **`scripts/rewrite_mid360_robot_bag_stamps.py`** — argparse CLI: `--input-bag`, `--output-bag`, `--topics`, `--message-types`, `--dry-run`.
- **`scripts/mid360_robot_sample_bag.py`** — sample MID-360 rosbag2 generator, used as the test fixture for the rewriter and for downstream synthetic-bag tests. Emits a small bag with `PointCloud2` + `Imu` on configurable topics + frames with realistic header.stamps. Foundation-only (stdlib + numpy).
- **`scripts/generate_mid360_robot_sample_bag.py`** — CLI wrapper around the writer (used by docs / tutorials to make tiny demo bags).

### Why bundled
The rewriter's test needs the sample-bag fixture to create input bags with broken stamps. Splitting them would leave the rewriter test impossible to enable until the fixture lands.

## Test plan

- [x] `python3 -m pytest graph_based_slam/test/test_mid360_robot_bag_stamp_rewriter.py graph_based_slam/test/test_mid360_robot_sample_bag.py -v` → 6 passed
  - rewriter: PointCloud2 stamp reset / passthrough / explicit msgtype list / CLI summary
  - sample_bag: readable MID-360 bag / --force required for existing output
- [x] `python3 -m flake8 --select=E,W,F --ignore=W503 --max-line-length=99 …` → clean
- [ ] Humble + Jazzy matrix CI