### PR TITLE
feat: triangle_descriptor_skip_ransac diagnostic flag — RANSAC compute is the +1m APE drift source on MID-360

### DIFF
--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -320,6 +320,12 @@ private:
     // N-point Umeyama least-squares. Reduces translation noise by √N versus
     // keeping the single 3-point hypothesis.
     bool triangle_descriptor_refine_se3_with_all_inliers_ {false};
+    // Diagnostic-only: when true, run accumulateVotes (and submap_id selection)
+    // but skip the RANSAC findLoopCandidate inner loop. Used to isolate
+    // "executor scheduling cost of enabling triangle pipeline" from
+    // "RANSAC compute cost" when investigating APE drift on tuned configs.
+    // Default false (production).
+    bool triangle_descriptor_skip_ransac_ {false};
     double triangle_descriptor_inlier_translation_m_ {2.0};
     double triangle_descriptor_inlier_rotation_deg_ {5.0};
     int triangle_descriptor_exclude_recent_ {4};

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -218,6 +218,10 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter(
     "triangle_descriptor_refine_se3_with_all_inliers",
     triangle_descriptor_refine_se3_with_all_inliers_);
+  declare_parameter("triangle_descriptor_skip_ransac", false);
+  get_parameter(
+    "triangle_descriptor_skip_ransac",
+    triangle_descriptor_skip_ransac_);
   declare_parameter("triangle_descriptor_inlier_translation_m", 2.0);
   get_parameter(
     "triangle_descriptor_inlier_translation_m",
@@ -981,6 +985,8 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       triangle_descriptor_fourth_point_max_distance_m_ << std::endl;
     std::cout << "triangle_descriptor_refine_se3_with_all_inliers:" <<
       std::boolalpha << triangle_descriptor_refine_se3_with_all_inliers_ << std::endl;
+    std::cout << "triangle_descriptor_skip_ransac:" <<
+      std::boolalpha << triangle_descriptor_skip_ransac_ << std::endl;
     std::cout << "triangle_descriptor_inlier_translation_m:" <<
       triangle_descriptor_inlier_translation_m_ << std::endl;
     std::cout << "triangle_descriptor_inlier_rotation_deg:" <<
@@ -2103,7 +2109,8 @@ void GraphBasedSlamComponent::searchLoop()
       }
       if (
         chosen_submap_id >= 0 &&
-        chosen_votes >= triangle_descriptor_min_votes_)
+        chosen_votes >= triangle_descriptor_min_votes_ &&
+        !triangle_descriptor_skip_ransac_)
       {
         // Re-run verification scoped to the chosen submap to recover SE(3).
         vote_cfg.exclude_submap_id = -1;

--- a/plan.md
+++ b/plan.md
@@ -277,6 +277,33 @@ NTU v5 で確立した「単発結果は信用しない」を 2nd dataset (MID-3
 
 詳細: [`output/triangle_ablation_mid360_3run_tuned_20260524_093504/SUMMARY.md`](../output/triangle_ablation_mid360_3run_tuned_20260524_093504/SUMMARY.md)
 
+### MID-360 RANSAC cost isolation (2026-05-24, follow-up to MID-360 3-run)
+
+PR #184 で発見した「triangle pipeline 有効化だけで +1m drift」の根本原因を切り分け。diagnostic flag `triangle_descriptor_skip_ransac` (default false) を追加し、`accumulateVotes` (hash lookup) は実行するが `findLoopCandidate` (RANSAC) を skip するモードを実装。同じ MID-360 tuned config で 3-run:
+
+| condition | mean Δ APE [m] | std [m] | \|Δ\|/σ |
+|-----------|----------------|---------|---------|
+| RANSAC ON (PR #184 tuned)    | **+1.083** | **0.128** | **8.5** (有意) |
+| RANSAC OFF (skip_ransac=true) | +0.604 | 1.258 | 0.48 (variance 内) |
+
+**結論**: **RANSAC compute cost が systematic +1m drift の dominant source**。
+- RANSAC OFF にすると |Δ|/σ が 8.5 → 0.48 に落ち、baseline と区別不能 (variance 支配的)
+- mean Δ も 1.083 → 0.604 m に半減
+- 残った +0.6m は run-to-run noise (std 1.258m に拡大)
+- accumulateVotes (hash lookup, O(N)) は変動内、findLoopCandidate (RANSAC, O(N²) over max_pairs=32) が問題
+
+**改善候補** (未実装):
+- `triangle_descriptor_max_pairs` を narrow-FOV で 32 → 16 に縮小 (RANSAC O(N²) を 4 分の 1 に)
+- RANSAC を `std::async` で非同期化 (searchLoop hot path から外す)
+- MID-360 で "vote-only mode" — RANSAC skip して candidate submap_id を NDT に渡し、NDT に SE(3) 推定させる
+- `triangle_descriptor_skip_ransac` flag は diagnostic として default false で残す
+
+**運用判断は変わらず**:
+- MID-360 default は `use_triangle_descriptor: false` 維持
+- 改善 PR を出すなら max_pairs 縮小 + 別 dataset での再検証セット
+
+詳細: [`output/triangle_ablation_mid360_skipransac_20260524_101218/SUMMARY.md`](../output/triangle_ablation_mid360_skipransac_20260524_101218/SUMMARY.md)
+
 ---
 
 ## 1.3 追加トラック（2026-05）：Dogfood wrapper measurement plumbing (PR #166)


### PR DESCRIPTION
## Summary
- PR #184 で発見した MID-360 tuned config の「triangle accept=0 でも use_triangle=true で +1m APE drift」の原因切り分け
- 診断用 ROS param `triangle_descriptor_skip_ransac` (default false) を追加
- 同じ MID-360 tuned 3-run ablation で RANSAC ON/OFF を比較 → **RANSAC compute cost が dominant source** と確定

## Results

| condition | mean Δ APE [m] | std [m] | \|Δ\|/σ |
|-----------|----------------|---------|---------|
| RANSAC ON (PR #184 tuned)    | +1.083 | 0.128 | **8.5** (有意) |
| RANSAC OFF (skip_ransac=true) | +0.604 | 1.258 | 0.48 (variance 内) |

## 結論
- **RANSAC compute cost が systematic +1m drift の dominant source**
- RANSAC OFF にすると |Δ|/σ が 8.5 → 0.48 に落ち baseline と区別不能
- accumulateVotes (hash lookup, O(N)) 単体は variance 支配的
- findLoopCandidate の O(N²) over `max_pairs=32` が searchLoop hot path で重い → wall-clock timing shift → APE drift

## Code changes
- `triangle_descriptor_skip_ransac` ROS param (default false) を component に配線
- searchLoop で `findLoopCandidate` 呼び出しに `&& !triangle_descriptor_skip_ransac_` ガード追加
- 起動バナーに flag 表示
- production default false で挙動変化なし、診断用途

## 含意 (改善候補、別 PR で)
- `triangle_descriptor_max_pairs` を narrow-FOV で 32 → 16 縮小 (O(N²) を 1/4)
- RANSAC を `std::async` で非同期化 (hot path 分離)
- MID-360 で vote-only mode (RANSAC skip して candidate id だけ NDT に渡す)

## Test plan
- [x] colcon test lint (uncrustify / cppcheck / cpplint / lint_cmake) pass
- [x] colcon build graph_based_slam pass
- [x] 3-run MID-360 ablation with `skip_ransac:=true` 実行
- [x] SUMMARY.md (output/triangle_ablation_mid360_skipransac_20260524_101218/) 保存
- [x] plan.md §1.2 に follow-up section 追加