### PR TITLE
fix(mid360): triangle_descriptor_max_pairs 32 → 16 — eliminates +1m APE drift

### DIFF
--- a/lidarslam/param/lidarslam_mid360_rko_graph.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph.yaml
@@ -81,10 +81,18 @@ graph_based_slam:
     triangle_descriptor_min_votes: 8
     triangle_descriptor_min_inliers: 5
     # MID-360 narrower FOV / fewer keypoints means evaluated pair counts are
-    # already lower than a spinning 360° LiDAR; cap max_pairs at 32 so
-    # min_inlier_ratio (when set) is more informative for the operator.
+    # already lower than a spinning 360° LiDAR; cap max_pairs at 16 so
+    # min_inlier_ratio (when set) is more informative for the operator,
+    # and so findLoopCandidate's O(N^2) RANSAC inner loop stays cheap.
+    # 2026-05-24 ablation: dropping max_pairs from 32 to 16 turned a
+    # systematic +1.083 ± 0.128 m APE regression (when use_triangle:=true
+    # with tuned min_inliers=3) into a -0.292 ± 0.607 m result (within
+    # variance). RANSAC wall-clock cost was the dominant root cause; halving
+    # max_pairs cuts O(N^2) work to 1/4 with no observed accept-rate loss
+    # on MID-360 narrow-FOV (NDT rejects all triangle emits on this scene
+    # anyway, so the smaller sample budget costs nothing in production).
     triangle_descriptor_min_inlier_ratio: 0.0
-    triangle_descriptor_max_pairs: 32
+    triangle_descriptor_max_pairs: 16
     # 4-point consensus (default 0 = off). When enabled, MID-360's smaller
     # keypoint set means a sensible target is around 2-3 agreements.
     triangle_descriptor_min_4th_point_agreements: 0

--- a/plan.md
+++ b/plan.md
@@ -292,10 +292,10 @@ PR #184 で発見した「triangle pipeline 有効化だけで +1m drift」の�
 - 残った +0.6m は run-to-run noise (std 1.258m に拡大)
 - accumulateVotes (hash lookup, O(N)) は変動内、findLoopCandidate (RANSAC, O(N²) over max_pairs=32) が問題
 
-**改善候補** (未実装):
-- `triangle_descriptor_max_pairs` を narrow-FOV で 32 → 16 に縮小 (RANSAC O(N²) を 4 分の 1 に)
-- RANSAC を `std::async` で非同期化 (searchLoop hot path から外す)
-- MID-360 で "vote-only mode" — RANSAC skip して candidate submap_id を NDT に渡し、NDT に SE(3) 推定させる
+**改善候補** (PR #186 で実装・確認済):
+- ✅ MID-360 yaml で `triangle_descriptor_max_pairs: 32 → 16` 縮小 (RANSAC O(N²) を 1/4)
+- RANSAC を `std::async` で非同期化 (searchLoop hot path から外す) — 未実装
+- MID-360 で "vote-only mode" — RANSAC skip して candidate submap_id を NDT に渡す
 - `triangle_descriptor_skip_ransac` flag は diagnostic として default false で残す
 
 **運用判断は変わらず**:
@@ -303,6 +303,34 @@ PR #184 で発見した「triangle pipeline 有効化だけで +1m drift」の�
 - 改善 PR を出すなら max_pairs 縮小 + 別 dataset での再検証セット
 
 詳細: [`output/triangle_ablation_mid360_skipransac_20260524_101218/SUMMARY.md`](../output/triangle_ablation_mid360_skipransac_20260524_101218/SUMMARY.md)
+
+### max_pairs=16 fix 検証 (2026-05-24)
+
+PR #185 で発見した「RANSAC compute cost が +1m drift の dominant source」を受けて、最も actionable な改善 (`max_pairs: 32 → 16`) を実装・3-run で検証。同じ MID-360 tuned config:
+
+| condition | mean Δ APE [m] | std [m] | \|Δ\|/σ | emit/3 |
+|-----------|----------------|---------|---------|--------|
+| `max_pairs=32` (PR #184) | **+1.083** | 0.128 | **8.5** (有意悪化) | 2 |
+| RANSAC OFF (PR #185) | +0.604 | 1.258 | 0.48 (variance 内) | 0 |
+| **`max_pairs=16`** | **-0.292** | 0.607 | **0.48** (variance 内、僅か良化方向) | 0 |
+
+**結果**: `max_pairs=16` で mean Δ APE が +1.083 → -0.292 m に swing (1.4m 改善方向)、|Δ|/σ が 8.5 → 0.48 に落ち **systematic regression が消えて variance 内に収まる**。
+
+**Production trade-off**:
+- emit reach は 2 → 0 に減るが、MID-360 narrow-FOV では NDT が triangle emit を 100% reject していたので **production accept rate は元々 0 で変化なし**
+- `use_triangle_descriptor: false` (default) のユーザーには無影響
+- opt-in したユーザーは APE regression に当たらなくなる = strict 改善
+
+**Why max_pairs=16 が直接効くか**:
+- findLoopCandidate は N² の `transformAgrees` (32² = 1024 vs 16² = 256, 4x 削減)
+- tuned config では vote threshold を超える tick が頻発 → 毎回 1024 比較が wall-clock dominate
+- 256 比較なら ROS executor scheduling が perturb されず、distance loop verification timing 維持 → APE 安定
+
+**Open questions**:
+- `graphbasedslam_indoor.yaml` (Newer College) でも同じ fix が効くか? 未検証
+- generic `graphbasedslam.yaml` (NTU 系 outdoor 360°) は drift が観測されてないので変更しない
+
+詳細: [`output/triangle_ablation_mid360_maxpairs16_20260524_175503/SUMMARY.md`](../output/triangle_ablation_mid360_maxpairs16_20260524_175503/SUMMARY.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- PR #185 で発見した「MID-360 tuned config で use_triangle=true 時に APE が +1m systematic regression」の根本 fix
- `lidarslam_mid360_rko_graph.yaml` で `triangle_descriptor_max_pairs: 32 → 16` に縮小
- 3-run ablation で **|Δ|/σ が 8.5 → 0.48** に落ち、systematic regression が variance 内に消えることを確認

## Why this works
- findLoopCandidate は O(N²) over max_pairs triangle pairs
- 32² = 1024 → 16² = 256 (4x 削減)
- tuned config では vote threshold を超える tick が頻発 → 1024 比較が wall-clock dominate
- 256 比較に減らすと ROS executor scheduling が perturb されず distance loop verification timing 維持 → APE 安定

## Results

| condition       | mean Δ APE [m] | std [m] | \|Δ\|/σ | emit/3 |
|-----------------|----------------|---------|---------|--------|
| max_pairs=32 (PR #184) | **+1.083** | 0.128 | **8.5** (有意) | 2 |
| max_pairs=16 (this fix) | **-0.292** | 0.607 | **0.48** (variance 内) | 0 |

mean Δ APE swing は +1.083 → -0.292 m (1.4m 改善方向、ただし variance 内のため「改善」とは主張しない)。

## Production trade-off
- emit reach 2 → 0 だが、MID-360 narrow-FOV では NDT が triangle emit を **100% reject** (corridor flip yaw 178°) していたので **accept rate 元々 0 で変化なし**
- `use_triangle_descriptor: false` (default) のユーザーには無影響
- opt-in したユーザーは APE regression に当たらなくなる = **strict 改善**

## Scope
- ✅ `lidarslam_mid360_rko_graph.yaml` (narrow-FOV) のみ変更
- ⛔ generic `graphbasedslam.yaml` (NTU 系 outdoor 360°) は drift 観測されてないので変更しない (PR #183 で確認)
- 🔜 `graphbasedslam_indoor.yaml` (Newer College) は未検証、同 fix の余地あり

## Test plan
- [x] yaml regression test pass (`test_triangle_descriptor_yaml_defaults.py`)
- [x] 3-run ablation で systematic regression 消失確認
- [x] SUMMARY.md (output/triangle_ablation_mid360_maxpairs16_20260524_175503/) 保存
- [x] plan.md §1.2 に検証結果追加