### PR TITLE
docs(plan): NTU skip_ransac 3-run confirms RANSAC cost is MID-360-specific

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -329,6 +329,7 @@ PR #185 で発見した「RANSAC compute cost が +1m drift の dominant source�
 **Generalization to other datasets (確認済)**:
 - ✅ `graphbasedslam_indoor.yaml` (Newer College math_hard) は max_pairs=64 でも 2026-05-19 3-run で **Δ APE +0.004 ± 0.022 m (variance 内)** = drift 観測されない (variance_summary.json)。post-#186 でも Newer 経路に C++ 変更なし → 結果有効。**同 fix 不要**
 - ✅ generic `graphbasedslam.yaml` (NTU 系 outdoor 360°) も PR #183 で variance 内 = **変更不要**
+- ✅ **NTU skip_ransac 3-run (2026-05-24)** で **RANSAC compute が NTU APE に影響しないことを直接実験で裏付け**: RANSAC ON Δ -0.019 ± 0.125m vs RANSAC OFF Δ -0.013 ± 0.047m (両方 variance 内、mean 同等)。PR #187 の「MID-360 specific」結論を independent experiment で確証 (skip_ransac で std が 3x tighter = wall-clock variability 減少示唆)
 
 **Generalization finding**: `+1m APE drift` は **MID-360 narrow-FOV 特有**で、indoor (Newer College) / outdoor 360° (NTU) には generalize しない。仮説:
 - APE スケールが違う: MID-360 base ~3-5m vs Newer ~0.1m vs NTU ~1.4m


### PR DESCRIPTION
## Summary
PR #187 で「+1m APE drift は MID-360 narrow-FOV 特有」と結論したのを、NTU で skip_ransac 直接実験 (3-run) で independent に裏付け。

| condition | mean Δ APE [m] | std [m] | \|Δ\|/σ |
|-----------|----------------|---------|---------|
| NTU RANSAC ON (PR #183 MT) | -0.019 | 0.125 | 0.15 |
| **NTU RANSAC OFF (this)** | **-0.013** | **0.047** | **0.28** |

両方とも variance 内、mean 同等。**RANSAC compute は NTU APE に effect しない** ことを直接確証。

## 副次観察
skip_ransac で std が 3x tighter (0.125 → 0.047) — RANSAC overhead を取ると wall-clock variability 減少示唆。NTU でも RANSAC は SLAM jitter source ではあるが APE には effect しない (MID-360 narrow-FOV だけが triangle pipeline 発火頻度高く wall-clock cost が APE level で visible)。

## 含意
- PR #187 の「MID-360 specific」結論を direct experiment で裏付け
- max_pairs=16 fix (PR #186) を MID-360 yaml に限定する判断が正しいことを再確認
- 他データセット (Newer + NTU) で max_pairs を縮小する PR は不要

## Test plan
- [x] NTU 3-run with skip_ransac:=true 実走
- [x] PR #183 baseline (MT 3-run) と比較
- [x] plan.md §1.2 generalization section に追加