### PR TITLE
docs(release): v0.3.0 release notes — AWSIM × Autoware + MID-360 toolkit + triangle stack closeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 0.3.0 - 2026-05-25
+
+Public `v3` release. Carries forward the non-GPL default workflow from
+`v0.2.x` and adds end-to-end AWSIM × Autoware, the Livox MID-360 operator
+toolkit, an opt-in STD/BTC-style triangle descriptor research stack with
+variance-validated defaults, dogfood wrapper measurement plumbing, and a
+user-friendly README.
+
+### Highlights
+
+- **AWSIM × Autoware end-to-end pipeline** — sample-map and self-made-map
+  demos, one-command wrappers, lanelet2 generation from TUM trajectory; see
+  `docs/awsim-autonomous-driving-tutorial.md`
+- **Livox MID-360 operator toolkit** — Jetson-class robot-side recording →
+  SLAM → Autoware map workflow with host preflight, bag stamp rewriter,
+  recording / production-candidate sessions, public-dataset map runner, and
+  dashboards
+- **Opt-in STD/BTC-style triangle descriptor stack** — BSD-2 implementation
+  with `edge_3d` keypoint extractor for narrow-FOV / indoor, fine-grained ROS
+  params, a diagnostic `triangle_descriptor_skip_ransac` flag, and an
+  empirically validated MID-360 default of `max_pairs: 16`; default
+  `use_triangle_descriptor: false` on every preset
+- **Dogfood wrapper measurement plumbing** — frame overrides,
+  quiescence-based offline completion, graph-drain wait, corrected-path
+  capture, and reference-TUM APE evaluation
+- **User-friendly README** — 5-minute "try the public default" path, badges,
+  grouped feature lists, progressive disclosure of research tracks
+
+### Research closeout
+
+- 3-dataset variance evidence (NTU / MID-360 / Newer College) shows the
+  triangle stack does not yet provide a reproducible APE win — it is opt-in
+  research only
+- single-run APE claims on MID-360 triangle ablations are unreliable
+  (variance can exceed observed |Δ| by 8x); all reports in this release ran
+  ≥3 runs with mean ± std + `|Δ|/σ`
+- MID-360-specific `+1 m` APE drift was traced to RANSAC compute cost, not
+  the act of enabling the pipeline; `max_pairs: 32 → 16` on the MID-360 yaml
+  eliminates it (U-shaped sweep; `=16` is the empirical sweet spot)
+- full narrative: `docs/research/triangle-stack-2026-05-summary.md`
+
+### Notes
+
+- the recommended public workflow remains `RKO-LIO + graph_based_slam` with
+  distance-based loop closure
+- the default release path remains non-GPL and focused on pointcloud-map
+  generation for Autoware-compatible workflows
+- AWSIM and the triangle stack are additive — they do not change the default
+  public path
+
 ## 0.2.2 - 2026-03-28
 
 Public `v2 beta` patch release focused on release stability and cross-distro CI

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,104 @@
+# lidarslam_ros2 v0.3.0
+
+This is the `v3` public release for `lidarslam_ros2`. It carries forward the
+non-GPL default workflow from `v0.2.x` and adds: an end-to-end AWSIM ×
+Autoware demo, a Livox MID-360 operator toolkit (recording → SLAM → Autoware
+map), an opt-in STD/BTC-style triangle descriptor research stack with
+variance-validated defaults, dogfood wrapper measurement plumbing, and a
+user-friendly README.
+
+Date: `2026-05-25`
+
+## Highlights
+
+- **AWSIM × Autoware end-to-end pipeline**: lidarslam now drives the AWSIM
+  simulator → graph_based_slam map → Autoware self-driving loop. Sample maps
+  and self-made maps are both supported; one-command demo wrappers ship as
+  `scripts/run_awsim_autoware_demo.sh` and `scripts/run_awsim_selfmade_map_demo.sh`.
+  Lanelet2 generation from TUM trajectory ships as
+  `scripts/simple_lanelet2_generator.py`. See `docs/awsim-autonomous-driving-tutorial.md`.
+- **Livox MID-360 operator toolkit**: a robot-side recording → SLAM →
+  Autoware map workflow targeted at Jetson-class hosts. Includes host
+  readiness preflight, bag stamp rewriter, recording / production-candidate
+  session wrappers, public-dataset map runner, and dashboards. Defaults are
+  validated for Jetson AGX Orin + a single Livox MID-360 + ROS 2 Jazzy.
+- **Opt-in STD/BTC-style triangle descriptor stack** (research feature, default
+  `use_triangle_descriptor: false`): BSD-2 implementation of a 3-point
+  triangle hash + RANSAC place recognition, with `edge_3d` keypoint extractor
+  for narrow-FOV / indoor scenes. Ships ROS params for fine-grained tuning,
+  a diagnostic `triangle_descriptor_skip_ransac` flag, and an empirically
+  validated MID-360 default of `max_pairs: 16`. See
+  `docs/research/triangle-stack-2026-05-summary.md` for production take-aways.
+- **Dogfood wrapper measurement plumbing**: `scripts/run_rko_lio_graph_autoware_dogfood.sh`
+  now supports frame overrides (`--base-frame` / `--lidar-frame` / `--imu-frame`),
+  quiescence-based offline completion, graph-drain waits, corrected-path
+  capture, and APE evaluation against a reference TUM. Suitable for real-robot
+  bag end-to-end smoke tests.
+- **User-friendly README**: rewritten to lead with a 5-minute "try the public
+  default" path, badges, grouped feature lists, and progressive disclosure of
+  research / experimental tracks.
+
+## Public Snapshot
+
+- fixed public entrypoint: `bash scripts/run_autoware_quickstart.sh`
+- AWSIM × Autoware end-to-end demo: `bash scripts/run_awsim_selfmade_map_demo.sh`
+- MID-360 robot toolkit (recording → SLAM): `bash scripts/run_mid360_robot_field_session.sh`
+- map-authoring summary: `python3 scripts/generate_map_authoring_report.py`
+- triangle research closeout: `docs/research/triangle-stack-2026-05-summary.md`
+- NTU VIRAL current default APE RMSE: same baseline as `v0.2.2` (no regression
+  observed across 7+ runs)
+- MID360 GLIM cross-validation APE RMSE: same baseline as `v0.2.2`; opt-in
+  triangle stack does **not** improve APE on MID-360 (research finding,
+  variance-bounded)
+- release gate: `scripts/run_release_readiness_checks.sh` keeps the same
+  `APE <= 0.10 m` threshold for ground-truth-referenced runs
+
+## Supported Scope
+
+- ROS 2 LiDAR SLAM with a non-GPL default path (BSD-2)
+- pointcloud-map generation for Autoware-compatible workflows
+- AWSIM × Autoware self-driving demo (sample map + self-made map flows)
+- Livox MID-360 operator toolkit (Jetson AGX Orin + Jazzy validated)
+- `map_projector_info.yaml` output as `Local` without GNSS and `LocalCartesian`
+  with a stable GNSS origin
+- opt-in research features: STD/BTC-style triangle descriptor stack with
+  `edge_3d` keypoints; Scan Context / BEV / SOLiD rerank candidates (legacy
+  opt-in from `v0.2.x`)
+- release-readiness, map-authoring, dynamic-filter, exploration-closeout, and
+  MID-360 robot-toolkit reports from collected local artifacts
+
+## Known Limits
+
+- triangle descriptor stack is research-only and remains `use_triangle_descriptor: false`
+  by default on every preset; 3-dataset variance evidence (NTU / MID-360 /
+  Newer College) shows it does not yet provide a reproducible APE win
+- lanelet generation is out of scope as a public default; the
+  `simple_lanelet2_generator.py` shipped for AWSIM is a tutorial-grade tool,
+  not a production lanelet authoring path
+- MID360 evidence on the public GLIM bag is still cross-validation against
+  GLIM, not ground truth
+- classic-path improvements remain fallback-path evidence, not the main
+  public default
+
+## Research notes (closed-out)
+
+- **Single-run APE claims are unreliable on MID-360 / narrow-FOV triangle
+  ablations**. Variance can exceed observed |Δ| by 8x. All triangle ablation
+  reports in this release ran ≥3 runs and report mean ± std + `|Δ|/σ`.
+- **MID-360-specific `+1 m` APE drift was traced to RANSAC compute cost**, not
+  the act of enabling the triangle pipeline. `max_pairs: 32 → 16` on the
+  MID-360 yaml eliminates the drift; `max_pairs=8` brings it back (U-shaped
+  relationship; `=16` is the empirical sweet spot). The fix is MID-360-specific
+  — Newer College + NTU show no drift even at higher `max_pairs`.
+- **A diagnostic `triangle_descriptor_skip_ransac` ROS param ships** (default
+  false, production no-op) so future investigations can reproduce the
+  "executor scheduling vs RANSAC compute" split without re-implementing it.
+
+See `docs/research/triangle-stack-2026-05-summary.md` for the full narrative
+(7 PR table, ablation outputs, open research questions).
+
+## Recommended public workflow
+
+Unchanged from `v0.2.x`: `RKO-LIO + graph_based_slam` with distance-based
+loop closure. The triangle descriptor and AWSIM × Autoware demo are
+additive — they do not change the default public path.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Social:
       - v0.2.2 Post Kit: social/autoware_map_authoring_post_v0.2.2.md
   - Releases:
+      - v0.3.0: releases/v0.3.0.md
       - v0.2.2: releases/v0.2.2.md
       - v0.2.1: releases/v0.2.1.md
       - v0.2.0: releases/v0.2.0.md


### PR DESCRIPTION
## Summary
v0.2.2 (2026-03-28) からの 320 commits 分を release-ready 形式に整理した v0.3.0 release notes ドラフト。

## Major themes
- **AWSIM × Autoware end-to-end pipeline** (sample-map + self-made map demos, lanelet2 generator, tutorial docs)
- **Livox MID-360 operator toolkit** (Jetson-class robot-side recording → SLAM → Autoware map ワークフロー)
- **Opt-in STD/BTC-style triangle descriptor stack** (edge_3d keypoint extractor + variance-validated MID-360 default `max_pairs: 16`)
- **Dogfood wrapper measurement plumbing** (frame overrides / quiescence offline completion / graph-drain wait / APE eval)
- **User-friendly README rewrite**

## Research closeout (NEW in v0.3.0)
- 3-dataset variance evidence: triangle stack does NOT provide reproducible APE win → opt-in research only
- 単発 APE claims unreliable on MID-360 (`|Δ|/σ` can reach 8); ≥3 runs + variance reporting required
- MID-360 `+1m` drift traced to RANSAC compute cost; `max_pairs: 32 → 16` empirically validated as sweet spot (U-shape sweep)
- Full narrative: `docs/research/triangle-stack-2026-05-summary.md`

## What hasn't changed
- Recommended public workflow: still `RKO-LIO + graph_based_slam` with distance-based loop closure
- Default release path: non-GPL, focused on pointcloud-map generation for Autoware
- AWSIM and triangle stack are **additive** — they do not change the default public path
- `use_triangle_descriptor: false` on every preset

## Files
- `docs/releases/v0.3.0.md` (105 lines) — operator-facing release notes
- `CHANGELOG.md` — 0.3.0 entry above 0.2.2
- `mkdocs.yml` — `v0.3.0` nav entry

## Test plan
- [x] `colcon test --packages-select graph_based_slam --ctest-args -R "docs_entrypoints|benchmark_reporting"` pass (2/2)
- [x] Format consistent with `docs/releases/v0.2.2.md`
- [x] Each major item linked to closeout doc or runnable script