### PR TITLE
fix(scripts): forward --skip-reference-gen / --reference-source from run_triangle_ablation.sh

### DIFF
--- a/graph_based_slam/test/test_triangle_ablation_runner.py
+++ b/graph_based_slam/test/test_triangle_ablation_runner.py
@@ -63,6 +63,107 @@ def test_script_help_exits_with_usage():
     assert 'candidate' in combined
 
 
+def test_script_help_documents_skip_reference_gen():
+    """Help banner documents the non-NTU forwarding flags.
+
+    --skip-reference-gen / --reference-source must surface in the help banner so
+    operators running on non-NTU bags (Newer College, MID-360, custom) can
+    discover the forwarding path without grepping the script body.
+    """
+    result = subprocess.run(
+        ['bash', str(SCRIPT), '--help'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert '--skip-reference-gen' in combined
+    assert '--reference-source' in combined
+    # Operators must understand the wiring without reading the script body.
+    assert 'NTU' in combined or 'Newer' in combined
+
+
+def test_script_accepts_and_forwards_skip_reference_gen(tmp_path: Path):
+    """Forwarded flags reach the inner benchmark script.
+
+    --skip-reference-gen / --reference-source must reach the inner
+    run_rko_lio_graph_benchmark.sh invocation. We stub the inner script with a
+    shim that records argv so the test stays hermetic (no ros2 / no bag).
+    """
+    stub_dir = tmp_path / 'scripts'
+    stub_dir.mkdir()
+    # Copy the runner so we can swap the inner benchmark script via PATH.
+    runner = stub_dir / SCRIPT.name
+    runner.write_bytes(SCRIPT.read_bytes())
+    runner.chmod(0o755)
+
+    inner_log = tmp_path / 'inner_args.log'
+    inner_stub = stub_dir / 'run_rko_lio_graph_benchmark.sh'
+    inner_stub.write_text(
+        '#!/usr/bin/env bash\n'
+        f'printf "%s\\n" "$@" > {inner_log}\n'
+        'metrics_dir=""\n'
+        'while [[ $# -gt 0 ]]; do\n'
+        '  if [[ "$1" == "--output-dir" ]]; then metrics_dir="$2"; fi\n'
+        '  shift\n'
+        'done\n'
+        '[[ -n "$metrics_dir" ]] && mkdir -p "$metrics_dir" \\\n'
+        '  && echo "{}" > "$metrics_dir/metrics.json"\n',
+        encoding='utf-8',
+    )
+    inner_stub.chmod(0o755)
+    # Stub the report generator too — it parses metrics.json and would fail.
+    report_stub = stub_dir / 'generate_place_recognition_report.py'
+    report_stub.write_text('#!/usr/bin/env python3\nimport sys; sys.exit(0)\n', encoding='utf-8')
+    report_stub.chmod(0o755)
+
+    base_yaml = tmp_path / 'base.yaml'
+    base_yaml.write_text(
+        yaml.safe_dump(
+            {'graph_based_slam': {'ros__parameters': {'use_triangle_descriptor': False}}},
+            sort_keys=False,
+        ),
+        encoding='utf-8',
+    )
+    ref_tum = tmp_path / 'ref.tum'
+    ref_tum.write_text('# timestamp tx ty tz qx qy qz qw\n', encoding='utf-8')
+    ref_meta = tmp_path / 'ref.json'
+    ref_meta.write_text('{}\n', encoding='utf-8')
+    bag_dir = tmp_path / 'bag'
+    bag_dir.mkdir()
+    (bag_dir / 'metadata.yaml').write_text('version: 5\n', encoding='utf-8')
+    out_dir = tmp_path / 'out'
+
+    result = subprocess.run(
+        [
+            'bash', str(runner),
+            '--bag', str(bag_dir),
+            '--reference-tum', str(ref_tum),
+            '--reference-meta', str(ref_meta),
+            '--lidar-topic', '/os_cloud_node/points',
+            '--imu-topic', '/os_cloud_node/imu',
+            '--base-param', str(base_yaml),
+            '--output-dir', str(out_dir),
+            '--skip-reference-gen',
+            '--reference-source', 'newer_college_gt',
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ},
+    )
+    # The runner may exit non-zero if downstream steps it does NOT stub fail,
+    # but the inner benchmark script must have been invoked with the new flags.
+    assert inner_log.exists(), (
+        f'inner stub never ran. stdout={result.stdout!r} stderr={result.stderr!r}'
+    )
+    forwarded = inner_log.read_text(encoding='utf-8').splitlines()
+    assert '--skip-reference-gen' in forwarded
+    assert '--reference-source' in forwarded
+    src_idx = forwarded.index('--reference-source')
+    assert forwarded[src_idx + 1] == 'newer_college_gt'
+
+
 def test_script_rejects_missing_args():
     """Missing required arguments must exit non-zero with the usage banner."""
     result = subprocess.run(

--- a/graph_based_slam/test/test_triangle_ablation_runner.py
+++ b/graph_based_slam/test/test_triangle_ablation_runner.py
@@ -64,7 +64,8 @@ def test_script_help_exits_with_usage():
 
 
 def test_script_help_documents_skip_reference_gen():
-    """Help banner documents the non-NTU forwarding flags.
+    """
+    Help banner documents the non-NTU forwarding flags.
 
     --skip-reference-gen / --reference-source must surface in the help banner so
     operators running on non-NTU bags (Newer College, MID-360, custom) can
@@ -84,7 +85,8 @@ def test_script_help_documents_skip_reference_gen():
 
 
 def test_script_accepts_and_forwards_skip_reference_gen(tmp_path: Path):
-    """Forwarded flags reach the inner benchmark script.
+    """
+    Forwarded flags reach the inner benchmark script.
 
     --skip-reference-gen / --reference-source must reach the inner
     run_rko_lio_graph_benchmark.sh invocation. We stub the inner script with a

--- a/scripts/run_triangle_ablation.sh
+++ b/scripts/run_triangle_ablation.sh
@@ -53,7 +53,16 @@ Required:
 
 Optional:
   --rko-param <file>         RKO-LIO parameter YAML (forwarded)
-  --reference-bag <dir>      reference bag (forwarded)
+  --reference-bag <dir>      reference bag (forwarded; only required when the
+                             NTU VIRAL reference generator is invoked, i.e.
+                             when --skip-reference-gen is NOT passed)
+  --skip-reference-gen       Reuse the provided --reference-tum / --reference-meta
+                             without invoking the NTU-VIRAL-specific reference
+                             generator. Required when running on non-NTU bags
+                             (Newer College, MID-360, custom).
+  --reference-source <label> Label stored in metrics.json (forwarded; e.g.
+                             "newer_college_gt", default in benchmark script:
+                             "leica_prism_gt")
   --report-out <file>        markdown report path
                              (default: <output-dir>/triangle_ablation_report.md)
   --keep-yaml                keep the derived baseline / candidate YAMLs
@@ -76,6 +85,8 @@ RKO_PARAM=""
 OUTPUT_DIR=""
 REPORT_OUT=""
 KEEP_YAML=false
+SKIP_REFERENCE_GEN=false
+REFERENCE_SOURCE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -90,6 +101,8 @@ while [[ $# -gt 0 ]]; do
     --output-dir)     OUTPUT_DIR="$2"; shift 2;;
     --report-out)     REPORT_OUT="$2"; shift 2;;
     --keep-yaml)      KEEP_YAML=true; shift;;
+    --skip-reference-gen) SKIP_REFERENCE_GEN=true; shift;;
+    --reference-source)   REFERENCE_SOURCE="$2"; shift 2;;
     --help|-h)        usage;;
     *) echo "Unknown argument: $1" >&2; usage;;
   esac
@@ -164,6 +177,12 @@ run_one() {
   fi
   if [[ -n "$RKO_PARAM" ]]; then
     args+=(--rko-param "$RKO_PARAM")
+  fi
+  if [[ "$SKIP_REFERENCE_GEN" == "true" ]]; then
+    args+=(--skip-reference-gen)
+  fi
+  if [[ -n "$REFERENCE_SOURCE" ]]; then
+    args+=(--reference-source "$REFERENCE_SOURCE")
   fi
   echo "=== Running ${label} ==="
   bash "${SCRIPT_DIR}/run_rko_lio_graph_benchmark.sh" "${args[@]}"


### PR DESCRIPTION
## Summary

- `run_triangle_ablation.sh` previously always invoked the NTU-hardcoded `generate_ntu_viral_tnp01_reference.py` even when callers supplied a pre-built `--reference-tum` / `--reference-meta`, blocking triangle-stack 3-run variance validation on **Newer College** and other non-NTU bags
- The inner `run_rko_lio_graph_benchmark.sh` already supports `--skip-reference-gen` and `--reference-source`; this PR plumbs both flags through the ablation wrapper
- Forwarded to both `baseline_no_triangle` and `candidate_with_triangle` legs, so metrics are correctly labelled (`reference_source` field in `metrics.json`)

## Why

`docs/research/triangle-stack-2026-05-summary.md` flagged Newer College 3-run variance at current HEAD as an outstanding research question after v0.3.0 closeout. The blocker was infrastructure-only: the ablation runner could not be re-used on Newer's bag without a script fix. This PR removes that blocker; no functional change to NTU runs (skip flag defaults to `false`).

## Changes

| file | change |
|------|--------|
| `scripts/run_triangle_ablation.sh` | adds `--skip-reference-gen` + `--reference-source <label>` parsing and forwarding to inner benchmark script |
| `graph_based_slam/test/test_triangle_ablation_runner.py` | adds 2 tests: help banner advertises both flags + names non-NTU use case; hermetic shim of inner benchmark captures argv to verify forwarding |

## Test plan

- [x] `pytest graph_based_slam/test/test_triangle_ablation_runner.py` → 6/6 pass
- [x] `ament_flake8 --linelength 99` on the test file → clean
- [x] `ament_copyright` on touched files → clean
- [ ] follow-up (separate effort): Newer College 3-run with `--skip-reference-gen` to validate triangle stack generalization at current HEAD

## Notes

- backward-compatible: existing NTU invocations (no `--skip-reference-gen`) keep generating the leica reference exactly as before
- the `--reference-source` label flows into `metrics.json` so per-dataset reports stay distinguishable