### PR TITLE
fix(gsplat): 3DGS アーク code review 指摘対応（robustness・性能・テスト）

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -268,6 +268,14 @@ if(BUILD_TESTING)
     test/test_jetson_mid360_host_readiness.py
     TIMEOUT 120
   )
+  # NOTE: the test_gaussian_splatting_* suites below cover tools/gaussian_splatting/
+  # (the opt-in 3DGS post-process toolkit), NOT this package. They live here only
+  # to borrow graph_based_slam's ament pytest harness, and reach the code under
+  # test via Path(__file__).parents[2] + sys.path. Consequences a maintainer
+  # should know: (1) `colcon test --packages-select graph_based_slam` runs these
+  # gsplat tests, and (2) moving/renaming tools/gaussian_splatting/ silently
+  # breaks the parents[2] path here. Relocating them to a dedicated test target
+  # next to the tool is tracked as a v0.4 structural cleanup.
   ament_add_pytest_test(
     test_gaussian_splatting_posed_images
     test/test_gaussian_splatting_posed_images.py

--- a/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
+++ b/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
@@ -99,10 +99,17 @@ def test_voxel_downsample_noop_when_zero():
 
 
 def test_voxel_downsample_keeps_rgb_alignment():
-    xyz = np.array([[0.0, 0.0, 0.0], [5.0, 5.0, 5.0]])
-    rgb = np.array([[10, 20, 30], [40, 50, 60]], dtype=np.uint8)
+    # Two points in distinct voxels plus a duplicate of the first; the kept rgb
+    # must stay paired with its own xyz (first occurrence wins). Asserting the
+    # actual values -- not just the row count -- is what pins the pairing.
+    xyz = np.array([[0.0, 0.0, 0.0], [5.0, 5.0, 5.0], [0.02, 0.0, 0.0]])
+    rgb = np.array([[10, 20, 30], [40, 50, 60], [70, 80, 90]], dtype=np.uint8)
     out, out_rgb = pcio.voxel_downsample(xyz, 0.1, rgb)
-    assert out.shape[0] == 2 and out_rgb.shape[0] == 2
+    assert out.shape[0] == 2
+    order = np.lexsort(out.T[::-1])  # stable order for comparison
+    np.testing.assert_allclose(out[order], [[0.0, 0.0, 0.0], [5.0, 5.0, 5.0]],
+                               atol=1e-6)
+    np.testing.assert_array_equal(out_rgb[order], [[10, 20, 30], [40, 50, 60]])
 
 
 # --------------------------------------------------------------------------- #

--- a/graph_based_slam/test/test_gaussian_splatting_train.py
+++ b/graph_based_slam/test/test_gaussian_splatting_train.py
@@ -211,6 +211,19 @@ def test_knn_scale_log_dense_smaller_than_sparse():
     assert tg.knn_scale_log(dense).mean() < tg.knn_scale_log(sparse).mean()
 
 
+def test_knn_scale_log_fallback_is_uniform_isotropic(monkeypatch):
+    # Force the scipy-absent branch (the path CI actually runs) and pin its
+    # contract: a single global spacing applied to every point, isotropic, and
+    # a warning so a silent degrade is visible. Real failures inside the k-NN
+    # query are no longer swallowed -- only ImportError reaches this fallback.
+    monkeypatch.setitem(sys.modules, 'scipy.spatial', None)
+    pts = np.random.default_rng(0).normal(size=(40, 3))
+    with pytest.warns(UserWarning, match='scipy.spatial unavailable'):
+        scales = tg.knn_scale_log(pts)
+    assert scales.shape == (40, 3)
+    assert np.all(scales == scales[0])  # one global spacing, every point/axis
+
+
 # --------------------------------------------------------------------------- #
 # make_ssim / _photometric_loss (torch needed; skipped where unavailable)
 # --------------------------------------------------------------------------- #

--- a/tools/gaussian_splatting/build_lidar_init.py
+++ b/tools/gaussian_splatting/build_lidar_init.py
@@ -85,12 +85,18 @@ def build(args: argparse.Namespace) -> dict:
         if args.max_range > 0:
             rng = np.linalg.norm(pts, axis=1)
             pts = pts[rng <= args.max_range]
-        chunks.append(transform_points(pts, world_T_body).astype(np.float32))
+        world_pts = transform_points(pts, world_T_body).astype(np.float32)
+        # Downsample each scan before accumulating so peak memory is bounded by
+        # the downsampled cloud, not the sum of every raw scan (a long bag is
+        # tens of millions of points before any reduction).
+        world_pts, _ = pcio.voxel_downsample(world_pts, args.voxel)
+        chunks.append(world_pts)
         used += 1
 
     if not chunks:
         raise RuntimeError('no scans accumulated; check --points-topic / trajectory')
     world = np.concatenate(chunks, axis=0)
+    # Final pass dedups points that fell in the same voxel across scan boundaries.
     world, _ = pcio.voxel_downsample(world, args.voxel)
     if args.max_points > 0 and world.shape[0] > args.max_points:
         rng = np.random.default_rng(0)

--- a/tools/gaussian_splatting/extract_posed_images.py
+++ b/tools/gaussian_splatting/extract_posed_images.py
@@ -113,8 +113,18 @@ def load_intrinsics_yaml(path: str | Path) -> pi.CameraIntrinsics:
 
     text = Path(path).read_text()
 
-    def grab(key: str, default: Optional[float] = None) -> float:
-        m = re.search(rf'\b{key}\s*:\s*([-+0-9.eE]+)', text)
+    def grab(key: str, default: Optional[float] = None,
+             after: Optional[str] = None) -> float:
+        # Scope the search to the text after ``after`` (e.g. the
+        # ``projection_parameters`` section header) so a stereo YAML's second
+        # camera, or a rectification block reusing the same field names, cannot
+        # win by appearing earlier in document order.
+        scope = text
+        if after is not None:
+            anchor = re.search(rf'\b{after}\b', text)
+            if anchor is not None:
+                scope = text[anchor.end():]
+        m = re.search(rf'\b{key}\s*:\s*([-+0-9.eE]+)', scope)
         if m is None:
             if default is None:
                 raise ValueError(f'{path}: missing intrinsics field {key!r}')
@@ -124,9 +134,14 @@ def load_intrinsics_yaml(path: str | Path) -> pi.CameraIntrinsics:
     return pi.CameraIntrinsics(
         width=int(grab('image_width')),
         height=int(grab('image_height')),
-        fx=grab('fx'), fy=grab('fy'), cx=grab('cx'), cy=grab('cy'),
-        distortion=(grab('k1', 0.0), grab('k2', 0.0),
-                    grab('p1', 0.0), grab('p2', 0.0), 0.0),
+        fx=grab('fx', after='projection_parameters'),
+        fy=grab('fy', after='projection_parameters'),
+        cx=grab('cx', after='projection_parameters'),
+        cy=grab('cy', after='projection_parameters'),
+        distortion=(grab('k1', 0.0, after='distortion_parameters'),
+                    grab('k2', 0.0, after='distortion_parameters'),
+                    grab('p1', 0.0, after='distortion_parameters'),
+                    grab('p2', 0.0, after='distortion_parameters'), 0.0),
     )
 
 
@@ -320,6 +335,14 @@ def extract(args: argparse.Namespace) -> dict:
         frames.append(pi.PosedImage(rel, world_T_cam, stamp))
         seen += 1
 
+    if not frames:
+        # Fail loudly here rather than writing an empty transforms.json that
+        # only blows up later as an opaque torch.stack([]) in train_gsplat.
+        raise RuntimeError(
+            f'no image resolved a pose ({dropped} dropped): the camera stamps '
+            'do not overlap the trajectory. Check --time-offset / '
+            '--clock-reference-topic, --extrinsic, and that the bag and TUM '
+            'trajectory cover the same interval.')
     pi.write_transforms(out_dir / 'transforms.json', out_intrinsics, frames)
     return {'kept': len(frames), 'dropped': dropped, 'out': str(out_dir)}
 

--- a/tools/gaussian_splatting/pointcloud_io.py
+++ b/tools/gaussian_splatting/pointcloud_io.py
@@ -151,7 +151,12 @@ def voxel_downsample(xyz: np.ndarray, voxel_size: float,
     xyz = np.asarray(xyz, dtype=np.float32)
     if voxel_size <= 0 or xyz.shape[0] == 0:
         return xyz, rgb
-    keys = np.floor(xyz / voxel_size).astype(np.int64)
-    _, first_idx = np.unique(keys, axis=0, return_index=True)
+    keys = np.ascontiguousarray(np.floor(xyz / voxel_size).astype(np.int64))
+    # Uniquify the (N,3) voxel keys via a 1D structured (void) view rather than
+    # np.unique(axis=0): the latter lexicographically sorts a 2D array
+    # row-by-row, which is far slower and more memory-hungry on the multi-
+    # million-point clouds build_lidar_init accumulates.
+    key_view = keys.view([('k', keys.dtype, 3)]).ravel()
+    _, first_idx = np.unique(key_view, return_index=True)
     first_idx.sort()
     return xyz[first_idx], (None if rgb is None else np.asarray(rgb)[first_idx])

--- a/tools/gaussian_splatting/train_gsplat.py
+++ b/tools/gaussian_splatting/train_gsplat.py
@@ -243,31 +243,14 @@ def train(dataset: dict, *, init_points: Optional[np.ndarray] = None,
         gts.append(torch.tensor(img[..., :3], device=dev))
     gts = torch.stack(gts)  # (C, H, W, 3)
 
-    # Seed means.
-    cam_centers = np.stack([np.linalg.inv(v)[:3, 3] for v in dataset['viewmats']])
-    center = cam_centers.mean(axis=0)
-    extent = float(np.linalg.norm(cam_centers - center, axis=1).max()) + 1e-3
-    if init_points is not None and len(init_points) > 0:
-        means0 = np.asarray(init_points, dtype=np.float32)
-    else:
-        rng = np.random.default_rng(0)
-        means0 = center + rng.normal(scale=extent * 0.5, size=(num_init, 3))
-    means0 = means0.astype(np.float32)
-
-    n = means0.shape[0]
-    means = torch.nn.Parameter(torch.tensor(means0, device=dev))
-    scales = torch.nn.Parameter(
-        torch.full((n, 3), float(np.log(extent / max(n, 1) ** (1 / 3) * 0.5)), device=dev)
-    )
-    quats = torch.nn.Parameter(
-        torch.tensor([[1.0, 0.0, 0.0, 0.0]], device=dev).repeat(n, 1)
-    )
-    opacities = torch.nn.Parameter(torch.full((n,), 0.1, device=dev))
-    if init_colors is not None and len(init_colors) == n:
-        c0 = np.clip(np.asarray(init_colors, dtype=np.float32), 1e-4, 1 - 1e-4)
-        colors = torch.nn.Parameter(torch.logit(torch.tensor(c0, device=dev)))
-    else:
-        colors = torch.nn.Parameter(torch.full((n, 3), 0.0, device=dev))
+    # Seed Gaussians via the shared initialiser (same logic as train_densify),
+    # so the fixed-count and densify paths can never drift apart.
+    seed, extent = _seed_params(dataset, init_points, init_colors, num_init, dev)
+    means = torch.nn.Parameter(seed['means'].to(dev))
+    scales = torch.nn.Parameter(seed['scales'].to(dev))
+    quats = torch.nn.Parameter(seed['quats'].to(dev))
+    opacities = torch.nn.Parameter(seed['opacities'].to(dev))
+    colors = torch.nn.Parameter(seed['colors'].to(dev))
 
     opt = torch.optim.Adam([
         {'params': [means], 'lr': lr * extent},
@@ -294,9 +277,13 @@ def train(dataset: dict, *, init_points: Optional[np.ndarray] = None,
         opt.zero_grad()
         loss.backward()
         opt.step()
-        loss_history.append(float(mse.detach().cpu()))
-        if log_every and (it % log_every == 0 or it == iters - 1):
-            print(f'iter {it:5d}  mse {loss_history[-1]:.6f}', flush=True)
+        # Only sync the loss to the host when we actually record/print it; a
+        # per-iter .cpu() would force a GPU->CPU stall every step. The final
+        # iter is always recorded so loss_history[-1] is the converged mse.
+        if it == iters - 1 or (log_every and it % log_every == 0):
+            loss_history.append(float(mse.detach().cpu()))
+            if log_every:
+                print(f'iter {it:5d}  mse {loss_history[-1]:.6f}', flush=True)
 
     metrics = _eval_views(render_view, gts, ssim_fn)
     return {
@@ -323,12 +310,20 @@ def knn_scale_log(points: np.ndarray, k: int = 3) -> np.ndarray:
     n = pts.shape[0]
     try:
         from scipy.spatial import cKDTree
+    except ImportError:
+        # scipy genuinely absent (e.g. CI): fall back to a global-spacing
+        # estimate. Only ImportError is swallowed -- a real failure inside the
+        # query below (OOM, bad shapes) must surface, not silently degrade to a
+        # uniform scale that defeats the point of --knn-scale-init.
+        import warnings
+        warnings.warn('scipy.spatial unavailable; knn_scale_log falls back to '
+                      'a single global spacing (per-point k-NN scale disabled)')
+        extent = float(np.linalg.norm(pts - pts.mean(axis=0), axis=1).max()) + 1e-3
+        mean_d = np.full(n, extent / max(n, 1) ** (1 / 3) * 0.5)
+    else:
         tree = cKDTree(pts)
         d, _ = tree.query(pts, k=min(k + 1, n))  # col 0 is self (dist 0)
         mean_d = d[:, 1:].mean(axis=1) if d.ndim == 2 and d.shape[1] > 1 else d.ravel()
-    except Exception:
-        extent = float(np.linalg.norm(pts - pts.mean(axis=0), axis=1).max()) + 1e-3
-        mean_d = np.full(n, extent / max(n, 1) ** (1 / 3) * 0.5)
     mean_d = np.clip(mean_d, 1e-4, None)
     return np.log(mean_d).astype(np.float32)[:, None].repeat(3, axis=1)
 
@@ -519,7 +514,6 @@ def train_densify(dataset: dict, *, init_points=None, init_colors=None,
             loss = (loss + 0.01 * torch.sigmoid(params['opacities']).abs().mean()
                     + 0.01 * torch.exp(params['scales']).abs().mean())
         loss.backward()
-        loss_history.append(float(mse.detach().cpu()))
         if not mcmc:
             strategy.step_post_backward(params, optimizers, state, it, info,
                                         packed=False)
@@ -533,9 +527,13 @@ def train_densify(dataset: dict, *, init_points=None, init_colors=None,
             # MCMC relocates after the optimiser step and needs the means LR.
             strategy.step_post_backward(params, optimizers, state, it, info,
                                         lr=lrs['means'])
-        if log_every and (it % log_every == 0 or it == iters - 1):
-            print(f'iter {it:5d}  mse {loss_history[-1]:.6f}  '
-                  f'gaussians {params["means"].shape[0]}', flush=True)
+        # Sync mse to the host only when recorded/printed (avoid a per-iter
+        # GPU->CPU stall); the final iter is always recorded.
+        if it == iters - 1 or (log_every and it % log_every == 0):
+            loss_history.append(float(mse.detach().cpu()))
+            if log_every:
+                print(f'iter {it:5d}  mse {loss_history[-1]:.6f}  '
+                      f'gaussians {params["means"].shape[0]}', flush=True)
 
     eval_vm = ((_se3_exp_torch(tau.detach()) @ viewmats[..., :, :])
                if optimize_extrinsic else None)
@@ -642,9 +640,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
           f'SSIM {params.get("ssim", float("nan")):.4f} -> {out}')
     if 'extrinsic_delta' in params:
         import yaml
+        from extract_posed_images import parse_extrinsic_dict
         base = np.eye(4)
         if args.extrinsic:
-            base = np.asarray(yaml.safe_load(Path(args.extrinsic).read_text())['matrix'])
+            # Reuse the extractor's parser so both 'matrix' and
+            # 'translation'+'rotation_xyzw' forms compose (the extractor accepts
+            # either, so reading only ['matrix'] here would KeyError at the very
+            # end of training on the translation/quaternion form).
+            base = parse_extrinsic_dict(
+                yaml.safe_load(Path(args.extrinsic).read_text()))
         refined = base @ params['extrinsic_delta']
         ext_path = Path(str(out) + '.extrinsic.yaml')
         ext_path.write_text(yaml.safe_dump(


### PR DESCRIPTION
## 概要

3DGS 後処理マップ成果物アーク (#195–#200) に対する high-effort code review で確定した指摘 10 件へまとめて対応。robustness（終端クラッシュ/サイレント劣化の解消）、性能（GPU 同期・メモリ・ソート）、テスト品質を中心に修正。SLAM 本体・標準 CI（CUDA/torch 非依存）への影響なし。

## 修正内容

**robustness（実害クラッシュ/誤出力）**
- `train_gsplat`: `--optimize-extrinsic` の base extrinsic を `parse_extrinsic_dict` で読み、`matrix` / `translation`+`rotation_xyzw` 両形式を受理。`translation` 形式を渡すと数千 iter の学習を完走した直後に `KeyError: 'matrix'` で落ちていたのを解消。
- `train_gsplat`: `knn_scale_log` の `except Exception` を `except ImportError` に限定。OOM や shape バグを握り潰して一様スケールへサイレント劣化するのを防ぎ、scipy 不在時は `warn` で可視化。
- `extract_posed_images`: 全画像が pose 解決に失敗した場合に明示 `RuntimeError`。空 `transforms.json` を書いて後段 `train_gsplat` で不可解な `torch.stack([])` として落ちる挙動を、原因の所で停止させる。
- `extract_posed_images`: intrinsics YAML の値取得をセクション（`projection_parameters` / `distortion_parameters`）単位に限定。stereo / rectification ブロックの同名フィールドを先頭一致で誤採用し静かに誤校正するのを防止。

**性能**
- `train_gsplat`: 学習ループの mse を毎 iter `.cpu()` 同期せず、記録/出力時のみ同期（`train` / `train_densify` 両方）。per-iter の GPU→CPU stall を除去。
- `pointcloud_io`: `voxel_downsample` を `np.unique(axis=0)` から 1D void-view ベースへ。多数点群での行ごとソート律速を解消。
- `build_lidar_init`: スキャン毎に voxel downsample してからの蓄積に変更。ピークメモリを「全生スキャン分」から「downsample 後」に抑制。

**保守性・テスト**
- `train_gsplat`: `train()` にインライン重複していた seeding を `_seed_params` 呼び出しへ統一（densify 経路との乖離を防止）。
- `graph_based_slam/CMakeLists.txt`: gsplat テストが本パッケージに同居する理由と `parents[2]` パス結合を注記。独立テストターゲット化は v0.4 構造課題として明記。
- tests: `test_voxel_downsample_keeps_rgb_alignment` を行数のみ → first-occurrence の実値で RGB/XYZ 対応を検証。scipy 不在を monkeypatch して `knn_scale_log` の fallback 経路（CI が実際に通る側）を明示テスト追加。

## 検証

```
python3 -m pytest graph_based_slam/test/test_gaussian_splatting_*.py -q
# 76 passed
```

- 全モジュール `py_compile` + import OK（GPU 経路含む構文確認）
- flake8（max-line-length=99）: 新規の実害違反なし

## スコープ外（注記のみ）

- gsplat テストの独立パッケージ化（CMakeLists の構造課題）は package.xml/CMakeLists 新設を伴い CI 影響があるため v0.4 へ温存。

レビューで反証/低重要として除外: stride 位相ずれ（誤検出）、selftest ゼロ除算、binary PLY KeyError、rosbag2 reader 未 close、undistort 5 係数切り詰め。