### PR TITLE
docs(roadmap): v0.4 roadmap を実態に同期 + 2026-06-07 決定を記録

### DIFF
--- a/docs/roadmap/v0.4.md
+++ b/docs/roadmap/v0.4.md
@@ -1,250 +1,175 @@
-# lidarslam-ros2 v0.4 roadmap (draft, 2026-05-25)
+# lidarslam-ros2 v0.4 roadmap
 
-> Status: **draft for discussion**. Not yet committed. Written immediately
-> after v0.3.0 tag (`5b57fed`) + triangle stack research closeout (PRs #190,
-> #193) to capture continuity items and propose next-bundle scope.
+> Status: **decisions locked, in progress** (reconciled 2026-06-07).
+> Originally drafted 2026-05-25 right after the v0.3.0 tag (`5b57fed`) +
+> triangle stack research closeout (PRs #190, #193). This revision updates the
+> draft to the **actual** repo state — several proposed workstreams have since
+> landed — and records the four strategic decisions taken on 2026-06-07.
 
-## 1. v0.3 closure status
+## 0. What changed since the 2026-05-25 draft
 
-What v0.3.0 actually shipped (per `docs/releases/v0.3.0.md`):
+The original draft proposed workstreams A–F. Two of them have already landed on
+`develop`, so the live status differs materially from the draft:
 
-- AWSIM × Autoware end-to-end demo (sample map + self-made map flows,
-  one-command wrappers)
-- Livox MID-360 operator toolkit (recording → SLAM → Autoware map; Jetson
-  AGX Orin + Jazzy validated)
-- Opt-in STD/BTC-style triangle descriptor stack with `edge_3d` keypoint
-  mode, MID-360 default `max_pairs: 16`, diagnostic skip-ransac flag
-- Dogfood wrapper measurement plumbing (frame overrides, quiescence-based
-  completion, graph-drain, corrected-path capture, APE eval)
-- User-friendly README rewrite
-
-What was planned for v0.3 but **deferred / not landed**:
-
-| Item | Source | Why deferred |
+| Workstream | 2026-05-25 draft | **Actual state (2026-06-07)** |
 |---|---|---|
-| Release gate → dataset profile YAML (PASS/WARN/TARGET) | `[[project_release_gate_design]]` | Single `APE <= 0.10 m` threshold still in `scripts/run_release_readiness_checks.sh` |
-| KITTI 00/05/07 single-config report (LO baseline) | `[[project_v0_3_positioning]]` priority #3, plan.md §1.1 | TUM-empty / QoS / launch override fixes landed, full sweep not run |
-| `adjacent_edge_info_weight` → covariance-driven | `[[project_v0_3_positioning]]` priority #4 | Not started |
-| Triangle stack open question #1 (max_pairs=8 U-shape root cause) | `docs/research/triangle-stack-2026-05-summary.md` §Outstanding | Tick-interval histogram gives 1 of 3 hypotheses partial support, not conclusive |
-| Triangle stack open question #2 (RANSAC async / map_array-driven scheduling) | same | Not started |
-| AWSIM lanelet2 route planner stability (`Failed to find a proper route`) | `[[project_awsim_pipeline]]` | **STATUS UNCLEAR**: v0.3.0 notes claim self-driving loop shipped, but memory says route planner was blocker; needs verify-or-close |
+| **A. Release gate dataset profile YAML** | top-priority TODO | ✅ **Landed** — `scripts/release_profiles.yaml` (PASS/WARN/TARGET, release-track vs research-track), wired into `run_release_readiness_checks.sh` / `benchmark_summary.py --release-profile` (`e4dd803`) |
+| **C. MID-360 toolkit grow-out + dogfood** | grow-out needed | ✅ **Largely landed** — 81 `mid360`-scoped scripts, `smoke_mid360_robot_runbook.sh` + smoke test, continuous kidnap-relocalization gate (#194) |
+| **B. AWSIM route planner verify-or-close** | ½-day investigation | ⬜ Untouched since the draft |
+| **D. Place recognition reset** | choose D1/D2/D3 | Triangle closeout done; strategic call now taken (see §2) |
+| **E. Accuracy / backend** | opportunistic | ⬜ Untouched |
+| **F. plan.md surgery** | split 783 lines | ⬜ Untouched (now **960 lines**) |
 
-## 2. Proposed v0.4 1st claim
+So v0.4's remaining engineering surface is smaller than the draft implied: the
+reporting infrastructure (A) and the operator toolkit (C) already exist. v0.4
+is now about **graduating the gate to honest blocking thresholds**, **closing
+the one open ship-or-not ambiguity (B)**, and **hygiene (F)** — plus the
+strategic direction decisions below.
+
+## 1. v0.4 1st claim (unchanged)
 
 Continue the v0.3 positioning (**"Commercial-friendly ROS 2 LiDAR SLAM map
-authoring pipeline for Autoware"**) but **harden** it from "demo works" →
+authoring pipeline for Autoware"**) and **harden** it from "demo works" →
 "operators can trust it":
 
-- **Honest, per-dataset release gate** instead of single global threshold
-- **Production loop closed** for at least one operator scenario
-  (MID-360 robot → map → Autoware route → engage, all in CI-runnable form)
-- **Documented variance discipline** baked into every published number
-  (every APE claim ships `mean ± std + |Δ|/σ` from ≥3 runs, no single-run
-  claims allowed)
+- Honest, per-dataset release gate (✅ infra landed; §3 graduates it to blocking)
+- Production loop closed for at least one MID-360 operator scenario (✅ smoke
+  test landed; real ground-truth evidence is the v0.5 follow-up, §2)
+- Documented variance discipline on every published number (`mean ± std + |Δ|/σ`
+  from ≥3 runs, no single-run claims)
 
-This is **not** "win SOTA on KITTI / Newer". The 3-dataset triangle work
-established empirically that swing-for-the-fences place recognition wins
-are stochastic at our variance floor. v0.4 should buy reliability and
-operator-facing trust, not headline APE numbers.
+This is **not** a SOTA push on KITTI / Newer. The 3-dataset triangle work
+established that swing-for-the-fences place recognition wins are stochastic at
+our variance floor. v0.4 buys reliability and operator trust, not headline APE.
 
-(2nd claim — accuracy — remains "DLIO-class on Newer, roadmap on
-MID-360 / NTU".)
+## 2. Locked decisions (2026-06-07)
 
-## 3. Workstreams (proposed)
+1. **MID-360 evidence → pursue real ground truth.** The current
+   `mid360_vs_glim` profile is GLIM *cross-validation*, not true GT. We will
+   pursue a real ground-truth MID-360 dataset (prism / total-station class) and
+   **replace** `mid360_vs_glim` with a true `ape_rmse_gt_m` profile. Target:
+   land the GT swap in **v0.5**. v0.4 keeps the cross-val profile but graduates
+   it to blocking at its current honest (loose) threshold — see decision 2.
+2. **Graduate all three research-track profiles to hard gates in v0.4.**
+   `ntu_viral_tnp_01`, `mid360_vs_glim`, `leo_drive_applanix_velodyne_cross`
+   currently carry `report_only_until: v0.4` (FAIL → WARN). At the v0.4 cut they
+   become **release-blocking at their current `pass` thresholds**. Explicit
+   caveat recorded here: two of the three (`mid360_vs_glim`,
+   `leo_drive_*`) are *cross-validation*, so the v0.4 gate blocks on a
+   cross-val number — an interim weakness we accept knowingly. The MID-360 one
+   is replaced by real GT in v0.5 (decision 1); `leo_drive` stays cross-val
+   until/unless its Applanix GSOF49 reference is treated as GT-grade.
+3. **Place recognition → D1 + D3 (close out + de-emphasize).** Land the triangle
+   reproducibility infra (the two open questions) as a research-closeout PR, and
+   publicly de-emphasize research-track place recognition for the v0.4 cycle.
+   RKO-LIO + distance-loop closure stays the public default. No new descriptor
+   family (D2) this cycle.
+4. **Immediate next action → reconcile this roadmap to reality** (this document).
 
-Ordered by recommended sequencing.
+## 3. Workstreams (revised)
 
-### A. Release gate dataset profile YAML (carry-over, high impact)
+### A. Release gate dataset profile YAML — ✅ DONE
 
-Implement the design from `[[project_release_gate_design]]`. Replace the
-single `--ape-threshold 0.10` flag in `scripts/run_release_readiness_checks.sh`
-with a YAML-driven profile:
+`scripts/release_profiles.yaml` already implements the design from
+`[[project_release_gate_design]]`: per-dataset PASS / WARN / TARGET / NO_DATA,
+release-track vs research-track separation, match predicates
+(`bag_name_contains`, `points_topic`, `reference_kind`, …). Live profiles:
 
-```yaml
-release_profiles:
-  newer_college_math_hard:
-    metric: ape_rmse_gt_m
-    pass: 0.10
-    target: 0.08
-  ntu_viral_tnp_01:
-    metric: ape_rmse_gt_m
-    pass: 1.00
-    target: 0.30
-    report_only_until: v0.5
-  mid360_vs_glim:
-    metric: ape_rmse_vs_reference_m
-    pass: 4.00
-    regression_tolerance: 0.20
-    target: 1.00
-    report_only_until: v0.5
-  kitti_odometry:
-    metric: kitti_t_rel_percent_avg
-    sequences: [00, 05, 07]
-    pass: non_regression
-```
+| Profile | Track | Reference | Metric | pass | target |
+|---|---|---|---|---|---|
+| `newer_college_math_hard` | release | ground_truth | `ape_rmse_gt_m` | 0.10 | 0.08 |
+| `ntu_viral_tnp_01` | research → **release in v0.4** | ground_truth | `ape_rmse_gt_m` | 1.00 | 0.30 |
+| `mid360_vs_glim` | research → **release in v0.4** | cross_validation | `ape_rmse_vs_reference_m` | 4.00 | 1.00 |
+| `leo_drive_applanix_velodyne_cross` | research → **release in v0.4** | cross_validation | `ape_rmse_vs_reference_m` | 1.50 | 0.50 |
 
-PASS / WARN / TARGET 3-tier semantics. README publishes both absolute and
-relative improvement (NTU 24-30%, MID 65%) but only absolute is the gate.
+**Remaining (the graduation, decision 2):** drop `report_only_until: v0.4` from
+the three research-track profiles so their FAIL blocks the release cut. Small,
+done at the v0.4-rc cut (1 PR: YAML edit + a gate regression test that asserts
+each graduated profile now blocks). Keep this *out* of the docs-only reconcile
+PR so the blocking change is reviewed on its own.
 
-**Why first**: every other v0.4 workstream produces numbers; without this,
-they all land against the same 0.10 m gate and either spuriously fail or
-spuriously "pass". This unblocks honest reporting for everything else.
+### B. AWSIM route planner: verify or close — ⬜ OPEN (next engineering item)
 
-**Estimated size**: 1 PR (YAML schema + loader + script rewire) + 1 PR
-(README + docs/benchmarking.md update). Tests: yaml regression + 1 e2e
-on a fixture profile.
+Reconcile the contradiction between v0.3.0 release notes ("self-driving loop
+shipped") and `[[project_awsim_pipeline]]` ("route planner blocker open"):
 
-### B. AWSIM route planner: verify or close
+- **(B1)** if resolved during v0.3 prep, confirm with one end-to-end run, update
+  the memory, close the item; **or**
+- **(B2)** if still flaky, productionize: lanelet boundary node-sharing,
+  `autoware_lanelet2_validation` in the demo script, `--validate-routing` mode
+  in `simple_lanelet2_generator.py`.
 
-Reconcile the contradiction between v0.3.0 release notes ("self-driving
-loop shipped") and `[[project_awsim_pipeline]]` memory ("route planner
-blocker open"). Either:
+**Why this is the next code item**: it is the only v0.3 "shipped" claim with a
+memory-vs-docs divergence; resolve before any v0.4 positioning leans on AWSIM.
+Size: ½-day investigation + (if B2) 1–2 PR.
 
-- **(B1)** the issue was resolved in `simple_lanelet2_generator.py` / docs
-  during v0.3 prep — confirm with one end-to-end run, update the memory,
-  close the item, **or**
-- **(B2)** it's still flaky — productionize: lanelet boundary node-sharing,
-  `autoware_lanelet2_validation` invocation as part of the demo script,
-  `--validate-routing` mode in `simple_lanelet2_generator.py`.
+### C. MID-360 toolkit — ✅ LARGELY DONE; remainder is the GT dataset (→ v0.5)
 
-**Why next**: this is the one v0.3 "shipped" claim that has memory-vs-docs
-divergence. Resolve before v0.4 strategy doc gets written, or any v0.4
-positioning that leans on AWSIM will inherit the ambiguity.
+Landed: foundation/analyzer/dashboard/record/readiness/public-RKO/session/bundle
+layers (PR #168–#177), Jetson host readiness (#180), preflight + profile
+validator (#181), bag stamp rewriter + sample generator (#182), runbook smoke
+test, continuous kidnap-relocalization gate (#194). 81 `mid360` scripts on
+`develop`; runbook / scope / static-tf-worksheet docs are tracked.
 
-**Estimated size**: ½ day investigation + (if B2) 1-2 PR for validator
-plumbing.
+**Remaining for the MID-360 story (decision 1, mostly v0.5):**
 
-### C. MID-360 toolkit grow-out + dogfood loop
+1. **Real ground-truth dataset** to replace GLIM cross-validation as the primary
+   MID-360 evidence. Scope the capture (environment, GT source — prism /
+   total station / surveyed control points — cost) and produce a true
+   `ape_rmse_gt_m` profile. Land the profile swap in v0.5.
+2. (v0.4) confirm the runbook smoke test exercises the full
+   record → readiness → mapping → public gate → production gate → dashboard
+   chain end-to-end in CI (not just the wrapper happy path).
 
-`[[project_mid360_robot_toolkit_stack]]` lists landed phases 1+2 (PR #168-#177).
-Remaining inferred from git status (untracked tests):
+### D. Place recognition — D1 + D3 (decision 3)
 
-- `test_jetson_mid360_host_readiness.py` (host readiness preflight — code
-  may already be in PR #180, but test file is untracked locally)
-- `test_mid360_robot_*_*.py` (~20 test files, untracked)
-- `test_mid360_robot_field_session.py`, `test_mid360_robot_public_*.py`
-- `docs/jetson-mid360-robot-runbook.md`, `scope.md`, `static-tf-worksheet.md`
-  (3 untracked docs)
-- `configs/` subtree (untracked configs)
+- **D1**: land the two open triangle questions (max_pairs=8 U-shape root cause +
+  RANSAC async / map_array-driven scheduling) as a **research-closeout PR**, not
+  a default change. Buys reproducibility infra for any future place recognition.
+- **D3**: publicly de-emphasize research-track place recognition for v0.4; RKO-LIO
+  + distance-loop closure is the public default. Acknowledge GT-quality place
+  recognition on narrow-FOV / indoor as an open research problem.
+- **D2 (new descriptor family) is explicitly deferred** out of v0.4.
 
-**Subtasks:**
+Size: D1 is 1–2 PR (instrumentation + 8-vs-16 head-to-head log analysis).
 
-1. Triage untracked tests: which correspond to landed PR features (just
-   weren't pushed) vs which test in-progress code not yet on develop. Land
-   the former, decide on the latter.
-2. Land jetson MID-360 runbook + scope + static-tf-worksheet docs.
-3. **Dogfood loop**: pick one operator scenario (e.g. "record a 2-min
-   indoor MID-360 bag on Jetson → produce production-candidate bundle →
-   import on dev machine → load in Autoware") and make it a single
-   wrapper script + a CI smoke test using a fixture bag.
+### E. Accuracy / backend — ⬜ opportunistic (unchanged)
 
-**Why third**: completes the v0.3 toolkit story. Closes the gap between
-"toolkit exists" (v0.3) and "toolkit is the way we operate" (v0.4).
+- KITTI 00/05/07 single-config report (LO baseline for the README accuracy claim)
+- `adjacent_edge_info_weight` → covariance-driven (modest expected APE delta)
 
-**Estimated size**: 2-3 PR (untracked triage / docs / dogfood wrapper),
-sized by how much untracked code wants to land.
+Neither is a v0.4 must-have. Pick if there is a quiet week.
 
-### D. Place recognition reset (research track, post-triangle)
+### F. Engineering hygiene — ⬜ OPEN (now more relevant)
 
-Triangle stack closeout: opt-in feature, 3 datasets all variance-bounded,
-v0.3.0 default-off everywhere. v0.4 should **not** keep iterating on
-triangle defaults. Options for the next research swing (pick at most one
-for v0.4):
+- **plan.md surgery**: now **960 lines** (was 783). Split into `docs/research/`
+  per-arc summaries + a shorter live `plan.md`.
+- **DDS / intra-process composition documentation**: ship a working config or
+  codify what to set in user-facing docs.
+- **untracked file sweep**: keep the working tree clean at each arc boundary.
 
-- **(D1)** Land the two open triangle questions (max_pairs=8 root cause
-  + RANSAC async / map_array-driven scheduling) as a **research closeout
-  PR**, not as a default change. This buys reproducibility infra (any
-  future place recognition will benefit) but doesn't try to win APE.
-- **(D2)** Try a new descriptor family: e.g. **Quatro** (BSD), **OverlapNet**
-  reimpl, or **MinkLoc** (MIT). License is the gate per
-  `[[project_place_recognition_license]]`.
-- **(D3)** Drop the place recognition push for v0.4 entirely; rely on
-  RKO-LIO + distance-loop closure as the public default. Acknowledge that
-  ground-truth-quality place recognition on narrow-FOV / indoor is an
-  open research problem.
+## 4. Out of scope for v0.4 (explicit, unchanged)
 
-**Recommendation**: D1 + D3 combined (do the reproducibility infra,
-publicly de-emphasize research-track place recognition for the v0.4 cycle).
-This is the honest read of the 3-dataset evidence.
+KITTI SOTA push · multi-LiDAR fusion · IMU pre-integration replacement · GNSS
+fusion beyond `LocalCartesian` origin · new simulators beyond AWSIM · 3D
+bounding-box detection · **new place-recognition descriptor family (D2)**.
 
-**Why fourth**: research swings should not block release engineering.
-
-**Estimated size**: D1 alone is 1-2 PR (instrumentation + 8 vs 16 head-to-head
-log analysis); D2 is multi-week.
-
-### E. Accuracy / backend (lower priority for v0.4)
-
-Carry-over from v0.3:
-
-- KITTI 00/05/07 single-config report (LO baseline establishment for the
-  README accuracy claim)
-- `adjacent_edge_info_weight` → covariance-driven (backend reasoning
-  improvement, modest expected APE delta)
-
-Both are "would be nice", neither is a v0.4 must-have. Pick if there's a
-quiet week.
-
-### F. Engineering hygiene
-
-- **DDS / intra-process composition documentation**: v0.3 left as "known
-  issue, documented". v0.4 either ships a working config or codifies what
-  to set in user-facing docs.
-- **plan.md surgery**: 783 lines of historical analysis; split into
-  `docs/research/` per-arc summaries and a shorter live `plan.md`.
-- **untracked file sweep**: `git status` currently shows ~30 untracked
-  files (mostly tests + configs/ + 3 docs). Triage end-to-end at the
-  start of v0.4 work so the working tree starts clean.
-
-## 4. Out of scope for v0.4 (explicit)
-
-- KITTI SOTA push (no headline KITTI claim; we publish the report, not the
-  ranking)
-- Multi-LiDAR fusion
-- IMU pre-integration replacement (RKO-LIO's IMU handling stays)
-- GNSS fusion beyond `LocalCartesian` origin (the v0.3.0 supported scope)
-- New simulator support beyond AWSIM
-- 3D bounding box detection integration (despite 3D-BBS notes in plan.md
-  §10 — research-track, not v0.4 product scope)
-
-## 5. Open questions for the user
-
-1. **AWSIM route planner status (B)**: should I run a verification pass
-   now to determine whether it's actually shipped or still flaky? This
-   would consume ½ day and answers the only "ship-or-not-shipped" ambiguity
-   in the v0.3.0 release notes.
-2. **Place recognition direction (D)**: D1 + D3 (close out, publicly
-   de-emphasize) is the honest read but is a strategic call. If the
-   long-term repo identity should still include "interesting place
-   recognition", D2 (try a new descriptor family) needs to be sequenced
-   in by mid-v0.4.
-3. **Release cadence**: v0.3 was a large release (10+ ship items). v0.4
-   could be the same or could be smaller (release gate + AWSIM
-   verify-or-close + MID-360 dogfood loop only) and ship in ~4 weeks.
-   Preference?
-4. **MID-360 vs ground truth**: do we want to pursue a public MID-360
-   ground-truth dataset to replace the GLIM cross-validation as the
-   primary MID-360 evidence? (Currently the GLIM bag is the only thing
-   we have; cross-val is a weaker claim than vs-GT.)
-
-## 6. Sequencing proposal
-
-If accepted as-is, the proposed sequencing is:
+## 5. Sequencing (revised)
 
 ```
-week 1   A (release gate YAML) — unblocks reporting for everything else
-week 1   B investigation (½ day) — verify AWSIM route planner state
-week 2-3 C (MID-360 toolkit grow-out + dogfood loop)
-week 3   D1 (triangle reproducibility infra closeout, if approved)
-week 4   F (plan.md surgery, DDS doc, hygiene)
-         tag v0.4-rc
+now      reconcile this roadmap (docs-only PR)           ← decision 4 (in progress)
+next     B  AWSIM route planner verify-or-close (½ day)   ← only open ship-or-not
+then     D1 triangle reproducibility closeout PR
+         F  plan.md surgery + DDS doc + untracked sweep
+v0.4-rc  graduate the 3 research-track profiles to blocking (drop report_only_until)
+v0.5     MID-360 real-GT dataset → replace mid360_vs_glim with ape_rmse_gt_m
 ```
 
-E (accuracy / backend) opportunistically anywhere. D2 only if explicitly
-chosen.
+E (accuracy / backend) opportunistically anywhere.
 
 ---
 
 (Related memory: `[[project_v0_3_positioning]]`, `[[project_goal]]`,
 `[[project_release_gate_design]]`, `[[project_awsim_pipeline]]`,
 `[[project_mid360_robot_toolkit_stack]]`, `[[project_triangle_descriptor_stack]]`,
-`[[project_place_recognition_license]]`.)
+`[[project_place_recognition_license]]`, `[[project_3dgs_map_deliverable]]`.)


### PR DESCRIPTION
## 概要

`docs/roadmap/v0.4.md`（2026-05-25 draft）が実態より遅れていたため現状に同期し、2026-06-07 の戦略判断 4 件を記録する docs-only 更新。

## 実態への同期

5/25 draft が提案した workstream のうち 2 つは既に landed していたため、ライブ状態に合わせて書き直し:

- **A. release gate dataset profile YAML → ✅ DONE**: `scripts/release_profiles.yaml`（PASS/WARN/TARGET、release-track vs research-track）が `e4dd803` で landed・`run_release_readiness_checks.sh` / `benchmark_summary.py --release-profile` に配線済み。draft の "最優先 TODO" / "not yet committed" は誤記だったので解消。
- **C. MID-360 toolkit → ✅ largely done**: 81 `mid360` スクリプト + `smoke_mid360_robot_runbook.sh` + smoke test + continuous kidnap-relocalization gate (#194)。残りは実 GT データセット（v0.5）。
- B (AWSIM verify-or-close) と F (plan.md surgery, 現 960 行) は未着手のまま。

## 記録した決定（2026-06-07）

1. **MID-360 evidence → 実 GT を狙う**: 現 `mid360_vs_glim` は GLIM cross-val なので、真の `ape_rmse_gt_m` プロファイルに **v0.5 で置換**。
2. **research-track 3 プロファイル(ntu/mid360/leo)を v0.4 で hard gate 化**: `report_only_until: v0.4` 撤去で release-blocking 化。うち 2 つ（mid360/leo）は cross-val を gate にする暫定的弱さを明記の上で受容。実 YAML 編集は v0.4-rc の別 PR（gate 回帰テスト付き）。
3. **place recognition → D1+D3**: triangle reproducibility closeout + research-track を公的に de-emphasize。D2（新 descriptor family）は v0.4 スコープ外。
4. immediate next action = この roadmap 同期（本 PR）。

## sequencing 改訂

```
now      roadmap 同期（本 PR）
next     B  AWSIM route planner verify-or-close（½日）
then     D1 triangle reproducibility closeout / F plan.md surgery
v0.4-rc  3 プロファイルを blocking 化（report_only_until 撤去）
v0.5     MID-360 実 GT → mid360_vs_glim を ape_rmse_gt_m に置換
```

## 検証

- `mkdocs build --strict` → exit 0（roadmap/v0.4.md が nav 外なのは pre-existing な INFO、本 PR で不変）
- docs-only、コード・ベンチ変更なし