### PR TITLE
docs(dds): DDS / large-message tuning ページ + gitignore site/ (v0.4 §F)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Thirdparty/small_gicp/
 imgui.ini
 pose_graph.g2o
 slam_output/
+
+# mkdocs build output (docs-site.yml builds this in CI; never commit it)
+site/

--- a/docs/dds-tuning.md
+++ b/docs/dds-tuning.md
@@ -1,0 +1,107 @@
+# DDS / large-message tuning
+
+LiDAR SLAM publishes large `sensor_msgs/PointCloud2` messages (a single
+Ouster OS0-128 scan is **6 MB+**). Out of the box, ROS 2's default DDS settings
+are not tuned for messages this large, which can cause **dropped scans** and
+node-to-node delivery delay. This page explains the failure mode, the default
+that avoids it, and the config to set when you do need online streaming.
+
+## The failure mode
+
+- A 6 MB+ PointCloud2 is fragmented across many UDP datagrams. With the default
+  receive-buffer / fragment-reassembly limits, fragments are dropped under load
+  and the subscriber never assembles a complete message.
+- Symptoms: the front-end logs *"Subscribed …"* but never advances; scans are
+  silently dropped; nodes that should coexist (e.g. a streaming odometry node
+  alongside `graph_based_slam`) starve.
+- This is a **transport** problem, not a SLAM problem — the same bag replays
+  fine when read in-process.
+
+## Default that avoids it: the offline node reads the bag in-process
+
+The recommended public path (**RKO-LIO + graph_based_slam**) uses the
+**offline node**, which reads the rosbag2 **internally** rather than
+subscribing to a streamed topic. There is no large-PointCloud2 DDS hop, so the
+drop/delay class above does not occur. This is why the benchmark and map
+authoring scripts drive the offline node — it is the robust default, not a
+limitation.
+
+> If you only run the documented benchmark / map-authoring flows, you do **not**
+> need any of the DDS tuning below.
+
+## When you stream online: tune CycloneDDS + the kernel
+
+If you must run a streaming pipeline (e.g. live sensor → online SLAM, or the
+AWSIM × Autoware demo where AWSIM publishes the cloud over DDS), set both a
+CycloneDDS profile **and** the kernel socket/fragment limits. The values below
+are the ones validated in the AWSIM × Autoware demo
+(`docs/awsim-autonomous-driving-tutorial.md`) and are a sane starting point for
+loopback / single-host streaming.
+
+### CycloneDDS profile
+
+```bash
+cat > ~/cyclonedds.xml << 'EOF'
+<?xml version="1.0" encoding="UTF-8" ?>
+<CycloneDDS xmlns="https://cdds.io/config">
+  <Domain Id="any">
+    <General>
+      <Interfaces>
+        <NetworkInterface name="lo" priority="default" multicast="default" />
+      </Interfaces>
+      <AllowMulticast>default</AllowMulticast>
+      <MaxMessageSize>65500B</MaxMessageSize>
+    </General>
+    <Internal>
+      <SocketReceiveBufferSize min="10MB"/>
+      <Watermarks><WhcHigh>500kB</WhcHigh></Watermarks>
+    </Internal>
+  </Domain>
+</CycloneDDS>
+EOF
+
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+export CYCLONEDDS_URI=file://$HOME/cyclonedds.xml
+```
+
+- `SocketReceiveBufferSize` (10 MB) is the single most important knob for large
+  PointCloud2 — it gives the kernel room to hold fragments until reassembly.
+- The `lo` interface + `AllowMulticast` settings target single-host / loopback
+  streaming. For a real multi-host robot network, set the interface to your NIC
+  and size the buffers to the link.
+
+### Kernel socket / fragment limits (requires `sudo`)
+
+```bash
+sudo sysctl -w net.core.rmem_max=2147483647
+sudo sysctl -w net.ipv4.ipfrag_time=3
+sudo sysctl -w net.ipv4.ipfrag_high_thresh=134217728
+sudo ip link set lo multicast on
+```
+
+- `net.core.rmem_max` must be ≥ the CycloneDDS `SocketReceiveBufferSize`, or the
+  DDS request to enlarge the socket buffer is silently clamped.
+- `ipfrag_*` raise the IP fragment-reassembly budget so 6 MB clouds reassemble
+  under load instead of being dropped.
+
+Persist these in `/etc/sysctl.d/` for a real deployment rather than setting them
+per shell.
+
+## Intra-process composition
+
+Composing the SLAM nodes into one process with intra-process communication
+sidesteps DDS for in-process hops entirely (zero-copy pointer passing). This is
+the most robust answer for an online pipeline on a single host, but the public
+launch files currently run nodes as separate processes. Intra-process
+composition + FastDDS shared-memory / zero-copy transport is tracked as a future
+hardening item; until it ships, prefer the offline node (default) or the
+CycloneDDS + kernel tuning above for streaming.
+
+## Quick reference
+
+| Situation | What to do |
+|---|---|
+| Benchmark / map authoring (documented flows) | Nothing — the offline node reads the bag in-process |
+| Live sensor → online SLAM, single host | CycloneDDS profile + kernel sysctl above |
+| Multi-host robot network | Same, but size `SocketReceiveBufferSize` / `rmem_max` to the link and bind the real NIC |
+| Dropped scans despite tuning | Verify `rmem_max` ≥ CycloneDDS buffer; confirm `RMW_IMPLEMENTATION` / `CYCLONEDDS_URI` are exported in the node's environment |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
   - Operator Workflows: workflows.md
   - 3DGS Photoreal Map: 3dgs-map-tutorial.md
   - Benchmarking And Release Gate: benchmarking.md
+  - DDS / Large-Message Tuning: dds-tuning.md
   - Comparison: comparison.md
   - Social:
       - v0.2.2 Post Kit: social/autoware_map_authoring_post_v0.2.2.md

--- a/plan.md
+++ b/plan.md
@@ -247,8 +247,10 @@ cause / RANSAC async scheduling）は v0.4 §D1 reproducibility closeout の対�
 ### 7.1 DDS メッセージ遅延
 - **影響**: DLIO が他ノードと共存できない、online_node でスキャンドロップ
 - **原因**: 大きな PointCloud2 メッセージ (6MB+) の DDS 転送遅延
-- **回避策**: offline_node (RKO-LIO) でバッグを内部読み込み
+- **回避策**: offline_node (RKO-LIO) でバッグを内部読み込み（既定パスはこれ）
 - **根本解決**: FastDDS のシェアードメモリ設定、またはゼロコピー転送
+- ユーザー向けの失敗モード解説・CycloneDDS + kernel チューニング・intra-process
+  composition の状況は [`docs/dds-tuning.md`](docs/dds-tuning.md) に集約（v0.4 §F）。
 
 ### 7.2 MID-360 (固体 LiDAR) の限界
 - 非 360 FOV のため Scan Context が無効


### PR DESCRIPTION
## 概要

v0.4 roadmap workstream **F (engineering hygiene)** の残り 2 点を片付ける docs/config 更新。

## DDS / intra-process composition の doc 化

roadmap §F は「v0.3 で 'known issue, documented' のままだった DDS を、working config を出すか user-facing docs に codify する」とあった。後者を実施:

- **`docs/dds-tuning.md` を新規追加**（user-facing）:
  - 失敗モード — 大きな `PointCloud2`（6MB+）の DDS フラグメント転送で scan drop
  - 既定の **offline node が bag を in-process 読みするためこれを回避**する理由（＝既定パスでは何もチューニング不要）
  - online streaming 時の **CycloneDDS profile + kernel sysctl**（AWSIM × Autoware demo で検証済みの値を一般化）
  - intra-process composition の状況（将来 hardening 項目）
  - Quick reference 表
- mkdocs nav に `DDS / Large-Message Tuning` を追加
- `plan.md §7.1` を新 doc への pointer に更新（plan.md surgery と同じ live index パターン）

内容は plan.md §7.1 の既存記述 + AWSIM tutorial の検証済み CycloneDDS 設定に grounding（未検証の数値は持ち込まない）。

## untracked sweep

- `site/`（mkdocs build 出力、`docs-site.yml` が CI で生成する成果物）を `.gitignore` に追加。コミットされないようにする。
- `gpt_pro_context.md` はユーザーの scratch のため触らず untracked のまま。

## 検証

`mkdocs build --strict` → exit 0（新ページは nav 入り、内部リンク含め問題なし）。docs/config のみ、コード変更なし。