### PR TITLE
feat(gate): research-track プロファイルを blocking に格上げ (v0.4 決定2)

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -9,23 +9,27 @@ system.
 
 ## Release Track vs Research Track
 
-`v0.3` separates evaluation into two tiers so the release gate stops squashing
-heterogeneous datasets onto a single APE threshold:
+`v0.3` introduced per-dataset release profiles so the gate stops squashing
+heterogeneous datasets onto a single APE threshold. `v0.4` then **graduated the
+former research-track profiles to blocking** (decision 2026-06-07,
+`docs/roadmap/v0.4.md`):
 
-- **Release track** — datasets where the release-profile gate enforces a
-  pass threshold. The current release-track datasets are `Newer College
-  math-hard` (hard gate) and the KITTI Odometry 00/05/07 LO baseline
-  comparison (non-regression).
-- **Research track** — datasets that are reported but do not block release
-  (`report_only_until: v0.4` in `scripts/release_profiles.yaml`). The current
-  research-track datasets are `NTU VIRAL tnp_01`, `MID-360` vs GLIM, the
-  Leo Drive applanix/velodyne open-data cross-validation, and the experimental
-  loop descriptor / NIS auto-scale paths.
+- **Release track (blocking)** — a FAIL blocks the release. As of v0.4 this is
+  every shipped profile: `Newer College math-hard` (ground truth),
+  `NTU VIRAL tnp_01` (ground truth), `MID-360` vs GLIM (cross-validation), the
+  Leo Drive applanix/velodyne open-data cross-validation, and the KITTI
+  Odometry 00/05/07 LO baseline comparison (non-regression).
+- **Interim caveat** — `MID-360` vs GLIM and the Leo Drive profile block on a
+  *cross-validation* reference rather than ground truth, an interim weakness
+  accepted knowingly. `MID-360` vs GLIM is slated to be replaced by a real
+  ground-truth `ape_rmse_gt_m` profile in v0.5.
+- **Research track (mechanism retained)** — `report_only_until` still downgrades
+  a FAIL to WARN, but **no shipped profile uses it as of v0.4**. It remains
+  available for any future dataset introduced mid-cycle.
 
 The distinction is exercised by `scripts/run_release_readiness_checks.sh`,
 which evaluates each profile in `scripts/release_profiles.yaml` and emits
-`PASS` / `FAIL` / `WARN` / `TARGET_MET` / `NO_DATA` per dataset. Profiles with
-`report_only_until` emit `WARN` instead of `FAIL` until the named release.
+`PASS` / `FAIL` / `WARN` / `TARGET_MET` / `NO_DATA` per dataset.
 
 ## Strategic Position
 
@@ -85,30 +89,30 @@ These numbers come from local artifacts currently checked under `output/`.
 
 ### Release-track datasets
 
+As of v0.4 every profile below is a blocking release-track profile. The current
+numbers all sit under their `pass` thresholds, so graduation flips their status
+from `WARN` to `PASS` without breaking the gate.
+
 | Dataset | Configuration | Reference kind | APE RMSE (m) | Profile gate | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `NTU VIRAL tnp_01` | current default | `ground_truth` | `0.952` | `WARN` (pass ≤ 1.00, target 0.30, `report_only_until: v0.4`) | outdoor long-loop GT |
-| `NTU VIRAL tnp_01` | best observed   | `ground_truth` | `0.870` | `WARN` (same)                                                | loop-gated backend run |
+| `NTU VIRAL tnp_01` | current default | `ground_truth` | `0.952` | `PASS` (pass ≤ 1.00, target 0.30) | outdoor long-loop GT |
+| `NTU VIRAL tnp_01` | best observed   | `ground_truth` | `0.870` | `PASS` (same)                     | loop-gated backend run |
+| `MID-360` | current default                  | `cross_validation` vs GLIM | `3.641` | `PASS` (pass ≤ 4.00, target 1.00) | solid-state LiDAR, non-360° FOV |
+| `MID-360` | best observed                    | `cross_validation` vs GLIM | `3.590` | `PASS` (same)                     | rerun with same tuned backend family |
+| `MID-360` | Scan Context candidate           | `cross_validation` vs GLIM | `3.816` | `PASS`                            | fair current-code comparison; still opt-in |
+| `MID-360` | experimental BEV-assisted rerank | `cross_validation` vs GLIM | `3.607` | `PASS`                            | sensor-agnostic rerank of distance candidates; still opt-in |
+| Leo Drive (applanix/velodyne) | current default | `cross_validation` vs Applanix GSOF49 | varies per bag | `PASS` (pass ≤ 1.50, target 0.50) | open-data Velodyne packet path |
 
-The Newer College `math-hard` profile is the only hard gate; numbers are not
-checked in to this repo and are reported separately on the long-form benchmark
-notes. The KITTI Odometry 00/05/07 LO baseline comparison is wired through
-`scripts/run_kitti_00_05_07_report.sh` and emits a non-regression report under
+The Newer College `math-hard` profile (ground truth) is the tightest gate
+(pass ≤ 0.10); its numbers are not checked in to this repo and are reported
+separately on the long-form benchmark notes. The KITTI Odometry 00/05/07 LO
+baseline comparison is wired through `scripts/run_kitti_00_05_07_report.sh` and
+emits a non-regression report under
 `output/kitti_dev_<timestamp>/kitti_dev_report.md`.
 
-### Research-track datasets (report-only until v0.4)
-
-| Dataset | Configuration | Reference kind | APE RMSE (m) | Profile gate | Notes |
-| --- | --- | --- | --- | --- | --- |
-| `MID-360` | current default                  | `cross_validation` vs GLIM | `3.641` | `WARN` (pass ≤ 4.00, target 1.00) | solid-state LiDAR, non-360° FOV |
-| `MID-360` | best observed                    | `cross_validation` vs GLIM | `3.590` | `WARN` (same)                     | rerun with same tuned backend family |
-| `MID-360` | Scan Context candidate           | `cross_validation` vs GLIM | `3.816` | `WARN`                            | fair current-code comparison; still opt-in |
-| `MID-360` | experimental BEV-assisted rerank | `cross_validation` vs GLIM | `3.607` | `WARN`                            | sensor-agnostic rerank of distance candidates; still opt-in |
-| Leo Drive (applanix/velodyne) | current default | `cross_validation` vs Applanix GSOF49 | varies per bag | `WARN` (pass ≤ 1.50, target 0.50) | open-data Velodyne packet path |
-
-`MID-360` and Leo Drive remain instructive evidence but no longer feed the
-release gate; the v0.3 default release path is judged on Autoware-compatible
-map authoring + Newer College + KITTI Odometry LO baseline.
+`MID-360` and Leo Drive now **do** feed the release gate (graduated in v0.4),
+blocking on their cross-validation thresholds; `MID-360` vs GLIM is slated to be
+replaced by a real ground-truth profile in v0.5.
 
 Source artifacts:
 

--- a/lidarslam/test/test_benchmark_summary_profiles.py
+++ b/lidarslam/test/test_benchmark_summary_profiles.py
@@ -74,6 +74,43 @@ def test_default_release_profiles_yaml_loads():
     assert 'mid360_vs_glim' in names
 
 
+def test_research_track_profiles_graduated_to_blocking():
+    """v0.4 decision (2026-06-07): the three former research-track profiles
+    graduated from report_only_until (WARN) to blocking (FAIL). Pin that no
+    shipped profile downgrades a regression anymore.
+    """
+    module = _load_module()
+    profiles = module.load_release_profiles(DEFAULT_PROFILE_YAML)
+    by_name = {p['name']: p for p in profiles}
+    graduated = (
+        'ntu_viral_tnp_01',
+        'mid360_vs_glim',
+        'leo_drive_applanix_velodyne_cross',
+    )
+    for name in graduated:
+        assert name in by_name, name
+        assert by_name[name].get('report_only_until') is None, (
+            f'{name} must block (no report_only_until) as of v0.4')
+    # No shipped profile may carry report_only_until at the v0.4 cut.
+    assert all(p.get('report_only_until') is None for p in profiles)
+
+
+def test_graduated_profile_fails_gate_on_regression():
+    """A mid360_vs_glim regression past its 4.0 m cross-val pass must now FAIL
+    (blocking), not WARN -- the observable effect of the graduation.
+    """
+    module = _load_module()
+    profiles = module.load_release_profiles(DEFAULT_PROFILE_YAML)
+    mid360 = next(p for p in profiles if p['name'] == 'mid360_vs_glim')
+    records = [
+        _rec(run='regressed', points_topic='/livox/lidar',
+             ape_ref_kind='cross_validation', ape_ref_src='glim_mid360_reference',
+             ape_rmse_m='5.00', ape_pairs=600),
+    ]
+    [result] = module.evaluate_release_profiles([mid360], records)
+    assert result['status'] == 'FAIL'
+
+
 def test_load_release_profiles_rejects_unknown_metric(tmp_path: Path):
     module = _load_module()
     bad = tmp_path / 'bad.yaml'

--- a/scripts/release_profiles.yaml
+++ b/scripts/release_profiles.yaml
@@ -7,12 +7,18 @@
 # NO_DATA per profile.
 #
 # Track convention (also documented in docs/comparison.md):
-#   - Release track:  no ``report_only_until`` (currently only
-#                     ``newer_college_math_hard``). A FAIL here blocks release.
-#   - Research track: ``report_only_until: v0.4`` (``ntu_viral_tnp_01``,
-#                     ``mid360_vs_glim``, ``leo_drive_applanix_velodyne_cross``).
-#                     A FAIL here is downgraded to WARN, so the gate reports
-#                     the regression without blocking the release cut.
+#   - As of v0.4 (decision 2026-06-07, docs/roadmap/v0.4.md), ALL profiles are
+#     release-track: a FAIL blocks the release. The three former research-track
+#     profiles (``ntu_viral_tnp_01``, ``mid360_vs_glim``,
+#     ``leo_drive_applanix_velodyne_cross``) graduated from ``report_only_until:
+#     v0.4`` to blocking at their current ``pass`` thresholds.
+#   - Caveat: ``mid360_vs_glim`` and ``leo_drive_applanix_velodyne_cross`` block
+#     on a *cross-validation* reference, not ground truth -- an interim weakness
+#     accepted knowingly. ``mid360_vs_glim`` is slated to be replaced by a real
+#     ground-truth ``ape_rmse_gt_m`` profile in v0.5.
+#   - ``report_only_until`` is retained as a mechanism (FAIL -> WARN while set)
+#     for any future profile introduced mid-cycle, but no shipped profile uses
+#     it as of v0.4.
 #
 # Fields:
 #   name: short identifier (snake_case)
@@ -50,7 +56,6 @@ release_profiles:
     metric: ape_rmse_gt_m
     pass: 1.00
     target: 0.30
-    report_only_until: v0.4
 
   - name: mid360_vs_glim
     description: Livox MID-360 vs GLIM cross-validation (~277s indoor loop)
@@ -62,7 +67,6 @@ release_profiles:
     metric: ape_rmse_vs_reference_m
     pass: 4.00
     target: 1.00
-    report_only_until: v0.4
 
   - name: leo_drive_applanix_velodyne_cross
     description: Leo Drive applanix/velodyne open data vs Applanix GSOF49 cross-validation
@@ -74,4 +78,3 @@ release_profiles:
     metric: ape_rmse_vs_reference_m
     pass: 1.50
     target: 0.50
-    report_only_until: v0.4


### PR DESCRIPTION
## 概要

v0.4 roadmap の **決定2（2026-06-07 locked）** の実装。research-track の 3 プロファイルを report-only から **release-blocking に格上げ**する。

## 変更

**`scripts/release_profiles.yaml`**
- `ntu_viral_tnp_01` / `mid360_vs_glim` / `leo_drive_applanix_velodyne_cross` から `report_only_until: v0.4` を撤去 → 閾値超過時に WARN ではなく **FAIL（release blocking）** になる。
- ヘッダの track 規約を更新: 全 profile が release-track。`mid360_vs_glim` / `leo_drive` は cross-val を gate にする暫定的弱さを明記、`mid360_vs_glim` は v0.5 で実 GT プロファイルに置換予定（決定1）。
- `report_only_until` 機構自体は将来の mid-cycle profile 用に保持（撤去ではなく未使用化）。

**`lidarslam/test/test_benchmark_summary_profiles.py`** — 回帰テスト 2 件追加
- `test_research_track_profiles_graduated_to_blocking`: shipped YAML の 3 profile が `report_only_until` を持たない（graduate 済）ことを pin。
- `test_graduated_profile_fails_gate_on_regression`: `mid360_vs_glim` が閾値超過（5.0 > 4.0m）で **FAIL**（WARN ではない）になることを検証。

**`docs/comparison.md`**
- Release/Research track 節とベンチスナップショットを更新。現状値（NTU 0.95/0.87 ≤ 1.00、MID-360 ~3.6 ≤ 4.00）は全て閾値内なので status は **WARN → PASS**（格上げしても gate は緑のまま、というクリーンな話）。

## CI 影響なし（検証済み）

gate は **FAIL のみ blocking**（WARN/NO_DATA は非 blocking）。CI の synthetic fixture（`synthetic_*_bag` / points_topic `/points` / source `synthetic_gt`）は **4 profile のどれにもマッチせず全 NO_DATA**。

```
$ python3 scripts/generate_sample_benchmark_metrics.py --root /tmp/fix --profile passing
$ python3 scripts/benchmark_summary.py --root /tmp/fix --release-profile scripts/release_profiles.yaml --fail-on-profiles
gate exit: 0    # 全 profile NO_DATA、非 blocking
```

格上げが効くのは **実 ntu/mid360/leo データに対する release 時 gate** のみ（= 決定2の意図そのもの）。

## 検証

profile gate テスト **14 passed**、flake8（max-line-length=99）実害違反なし、`mkdocs build --strict` exit 0。