### PR TITLE
feat(graph_slam): opt-in deterministic loop-search scheduling (v0.4 D1)

### DIFF
--- a/docs/research/triangle-stack-2026-05-summary.md
+++ b/docs/research/triangle-stack-2026-05-summary.md
@@ -10,10 +10,12 @@ the variance / RANSAC-cost / max_pairs sweep that occurred 2026-05-24.
 > design-pinned** below (see *U-shape root cause: the tick-interval histogram*
 > and *Determinism root cause + the scheduling fix*). This is a research
 > closeout, **not** a default change: every preset still ships
-> `use_triangle_descriptor: false`. The remaining work (implementing the
-> deterministic scheduling refactor and validating it with an 8-vs-16
-> head-to-head benchmark) is a scoped follow-up that needs benchmark-data access;
-> it is intentionally not attempted as an unvalidated behavior change here.
+> `use_triangle_descriptor: false`. The deterministic scheduling refactor has
+> since **landed as an opt-in** (`deterministic_loop_scheduling`, default
+> **false** — behaviour-identical when off); the one remaining piece is the
+> 8-vs-16 head-to-head benchmark that would clear the flag to become a default.
+> That validation needs benchmark-data access and is intentionally not attempted
+> as an unvalidated behavior change here.
 
 If you only want the production take-aways, read **Production take-aways**
 below. If you want the research narrative (why the defaults are what they
@@ -242,13 +244,16 @@ principle but carries real risk that must be paid down with data, not asserted:
    only honest acceptance test is an **8-vs-16 head-to-head** (and an NTU /
    Newer 3-run) showing the interval histogram collapses toward a single mode
    and `|Δ|/σ` tightens. That requires benchmark-data access this session does
-   not have. Landing the refactor without that validation would replace a known,
-   documented stochasticity with an unverified one.
+   not have. Landing the refactor *as a default* without that validation would
+   replace a known, documented stochasticity with an unverified one.
 
 So D1 closes the *research* questions (root cause understood, fix specified) and
-hands the *implementation + validation* to a data-access follow-up. It should be
-an **opt-in** mode (default off) until the head-to-head confirms it, so the
-public default path is unchanged.
+the fix has **landed as an opt-in** (`deterministic_loop_scheduling`, default
+off): `searchLoop` is split into a scheduler + a per-query `searchLoopForLatest`,
+and the scheduler catches up over every un-queried submap index when the flag is
+on. With the flag off the path is byte-for-byte the historical single-latest
+query, so the public default is unchanged. Only the 8-vs-16 head-to-head — which
+would clear the flag to become a default — is handed to a data-access follow-up.
 
 ## Diagnostic flag remains
 
@@ -282,19 +287,21 @@ datasets / configs. It is not for production use.
    wall-clock-triggered and queries only `latest_idx = num_submaps - 1`, so
    timer-batched submap arrivals are skipped non-deterministically. Fix: a
    deterministic catch-up loop over un-queried submap indices (+ optional
-   `std::async` RANSAC), shipped opt-in. **Implementation + 8-vs-16 validation
-   is a benchmark-data follow-up** — not landed here to avoid an unvalidated
-   behavior change.
+   `std::async` RANSAC), shipped opt-in. **The catch-up scheduler has landed**
+   (`deterministic_loop_scheduling`, default off); the **8-vs-16 validation** (and
+   the optional `std::async` RANSAC half) is the benchmark-data follow-up before
+   the flag could become a default.
 3. ~~**Newer College APE at current develop HEAD**~~ — **answered 2026-05-25**
    via PR #192 (`--skip-reference-gen` plumbing). Post-v0.3.0 3-run gave
    Δ APE −0.0094 ± 0.0108 m (|Δ|/σ = 0.87), still variance-bounded but
    no regression introduced by the #183–#191 series; candidate variance
    ~halved vs the 2026-05-19 baseline.
 
-All three research questions from the 2026-05-24 sweep are now closed. The only
-remaining triangle work is the **opt-in deterministic-scheduling implementation
-+ its benchmark validation** (Q2), tracked as a v0.4/v0.5 follow-up that needs
-data access.
+All three research questions from the 2026-05-24 sweep are now closed, and the
+Q2 opt-in deterministic-scheduling implementation has landed (default off). The
+only remaining triangle work is the **8-vs-16 benchmark validation** that would
+clear `deterministic_loop_scheduling` to become a default, tracked as a v0.4/v0.5
+follow-up that needs data access.
 
 ## Files
 

--- a/docs/roadmap/v0.4.md
+++ b/docs/roadmap/v0.4.md
@@ -131,16 +131,23 @@ test, continuous kidnap-relocalization gate (#194). 81 `mid360` scripts on
   (`searchLoop` is wall-clock-triggered and queries only
   `latest_idx = num_submaps - 1`, so timer-batched submap arrivals are skipped
   non-deterministically) + design (deterministic catch-up loop over un-queried
-  indices, opt-in). **Remaining**: the *implementation* + 8-vs-16 benchmark
-  validation, deferred to a data-access follow-up (v0.4/v0.5) — deliberately
-  not landed as an unvalidated behavior change. No default change.
+  indices, opt-in). **Implementation landed** (opt-in
+  `deterministic_loop_scheduling`, default **false**): `searchLoop` is split into
+  a scheduler + a per-query `searchLoopForLatest`, and when the flag is on the
+  scheduler catches up over every un-queried submap index. Default off is
+  behaviourally identical to the historical single-latest query, so existing
+  benchmarks are unchanged. **Remaining**: the 8-vs-16 head-to-head
+  reproducibility validation (data-access follow-up) before the default could
+  ever flip; the optional `std::async` RANSAC half of the design is also still a
+  follow-up. No default change.
 - **D3**: publicly de-emphasize research-track place recognition for v0.4; RKO-LIO
   + distance-loop closure is the public default. Acknowledge GT-quality place
   recognition on narrow-FOV / indoor as an open research problem.
 - **D2 (new descriptor family) is explicitly deferred** out of v0.4.
 
-Size: D1 research closeout done (docs); the deterministic-scheduling
-implementation + head-to-head validation is the remaining data-access task.
+Size: D1 research closeout done (docs); deterministic-scheduling implementation
+landed (opt-in, default off); the 8-vs-16 head-to-head validation is the
+remaining data-access task.
 
 ### E. Accuracy / backend — ⬜ opportunistic (unchanged)
 
@@ -171,7 +178,8 @@ done     B  AWSIM route planner verify-or-close (#203)     ← only open ship-or
 done     F  plan.md surgery + DDS doc + gitignore (#204, #205)
 done     v0.4-rc graduate 3 research-track profiles to blocking (#206)
 done     D1 triangle reproducibility research closeout (docs) ← root cause + fix design pinned
-next     D1 impl: opt-in deterministic searchLoop scheduling + 8-vs-16 validation (needs data)
+done     D1 impl: opt-in deterministic searchLoop scheduling (default off, behaviour-identical)
+next     D1 validation: 8-vs-16 head-to-head reproducibility run to clear the flag for default (needs data)
 v0.5     MID-360 real-GT dataset → replace mid360_vs_glim with ape_rmse_gt_m
 ```
 

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -457,6 +457,11 @@ if(BUILD_TESTING)
     TIMEOUT 60
   )
   ament_add_pytest_test(
+    test_deterministic_loop_scheduling_defaults
+    test/test_deterministic_loop_scheduling_defaults.py
+    TIMEOUT 60
+  )
+  ament_add_pytest_test(
     test_triangle_ablation_runner
     test/test_triangle_ablation_runner.py
     TIMEOUT 60

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -167,6 +167,13 @@ private:
       const MapSaveRequest request,
       const MapSaveResponse response);
     void searchLoop();
+    // Per-query loop search body, factored out of searchLoop() so the scheduler
+    // can run it for one (default) or many (deterministic mode) query submaps.
+    void searchLoopForLatest(
+      const lidarslam_msgs::msg::MapArray & map_array_msg,
+      LoopEdges & loop_edges,
+      int num_submaps,
+      int latest_idx);
     bool snapshotGraphState(
       lidarslam_msgs::msg::MapArray & map_array_msg,
       LoopEdges & loop_edges,
@@ -196,6 +203,14 @@ private:
     // -1.0 = disabled / fall back to the generic cap.
     double loop_max_translation_delta_descriptor_ {-1.0};
     double loop_max_rotation_delta_deg_descriptor_ {-1.0};
+    // Deterministic loop scheduling (opt-in, v0.4 D1). When false (default),
+    // searchLoop queries only the single latest submap per timer tick — the
+    // historical wall-clock-driven behaviour, whose (query, db) pair set depends
+    // on timer batching rather than the map. When true, searchLoop catches up
+    // over every submap index not yet used as a query, so the set of loop-search
+    // queries is a pure function of the map regardless of tick timing.
+    bool deterministic_loop_scheduling_ {false};
+    int last_searched_submap_idx_ {-1};
 
     // pose graph optimization parameter
     int num_adjacent_pose_cnstraints_;

--- a/graph_based_slam/param/graphbasedslam.yaml
+++ b/graph_based_slam/param/graphbasedslam.yaml
@@ -4,6 +4,12 @@ graph_based_slam:
       ndt_resolution: 1.5
       voxel_leaf_size: 0.2
       loop_detection_period: 3000
+      # Opt-in (v0.4 D1). false = query only the latest submap per timer tick
+      # (historical wall-clock-driven behaviour). true = deterministically catch
+      # up over every un-queried submap so the loop-search query set no longer
+      # depends on timer batching. Default off; flip to true only after the
+      # 8-vs-16 reproducibility validation.
+      deterministic_loop_scheduling: false
       threshold_loop_closure_score: 1.5
       scan_context_loop_closure_score_threshold: -1.0
       distance_loop_closure: 30.0

--- a/graph_based_slam/param/graphbasedslam_indoor.yaml
+++ b/graph_based_slam/param/graphbasedslam_indoor.yaml
@@ -4,6 +4,12 @@ graph_based_slam:
       ndt_resolution: 1.5
       voxel_leaf_size: 0.2
       loop_detection_period: 3000
+      # Opt-in (v0.4 D1). false = query only the latest submap per timer tick
+      # (historical wall-clock-driven behaviour). true = deterministically catch
+      # up over every un-queried submap so the loop-search query set no longer
+      # depends on timer batching. Default off; flip to true only after the
+      # 8-vs-16 reproducibility validation.
+      deterministic_loop_scheduling: false
       threshold_loop_closure_score: 1.5
       scan_context_loop_closure_score_threshold: -1.0
       distance_loop_closure: 30.0

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -71,6 +71,8 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("ndt_num_threads", ndt_num_threads);
   declare_parameter("loop_detection_period", 1000);
   get_parameter("loop_detection_period", loop_detection_period_);
+  declare_parameter("deterministic_loop_scheduling", false);
+  get_parameter("deterministic_loop_scheduling", deterministic_loop_scheduling_);
   declare_parameter("threshold_loop_closure_score", 1.0);
   get_parameter("threshold_loop_closure_score", threshold_loop_closure_score_);
   declare_parameter("scan_context_loop_closure_score_threshold", -1.0);
@@ -1246,6 +1248,65 @@ bool GraphBasedSlamComponent::upsertLoopEdge(const LoopEdge & loop_edge)
   loop_edges_.push_back(normalized);
   return true;
 }
+namespace
+{
+struct LoopCandidate
+{
+  enum class Source
+  {
+    DISTANCE,
+    SCAN_CONTEXT,
+    BEV_DESCRIPTOR,
+    SOLID_DESCRIPTOR,
+    TRIANGLE_DESCRIPTOR
+  };
+
+  int index {-1};
+  double selection_metric {std::numeric_limits<double>::max()};
+  Source source {Source::DISTANCE};
+  double yaw_rad {0.0};
+  // Recovered SE(3) from the descriptor that proposed this candidate
+  // (currently only triangle). Identity unless populated. Used as the NDT
+  // initial guess instead of the pose-derived guess when source matches.
+  Eigen::Matrix4f relative_transform {Eigen::Matrix4f::Identity()};
+  bool has_relative_transform {false};
+};
+
+struct LoopCandidateResult
+{
+  bool valid {false};
+  int index {-1};
+  double selection_metric {std::numeric_limits<double>::max()};
+  double fitness_score {std::numeric_limits<double>::max()};
+  double travel_distance {0.0};
+  double euclidean_distance {0.0};
+  double translation_delta_m {0.0};
+  double rotation_delta_deg {0.0};
+  LoopCandidate::Source source {LoopCandidate::Source::DISTANCE};
+  bool used_3d_bbs {false};
+  double three_d_bbs_score_percentage {0.0};
+  double three_d_bbs_elapsed_msec {0.0};
+  Eigen::Matrix4f final_transformation {Eigen::Matrix4f::Identity()};
+};
+
+const char * candidate_source_name(LoopCandidate::Source source)
+{
+  switch (source) {
+    case LoopCandidate::Source::SCAN_CONTEXT:
+      return "scan_context";
+    case LoopCandidate::Source::BEV_DESCRIPTOR:
+      return "bev_descriptor";
+    case LoopCandidate::Source::SOLID_DESCRIPTOR:
+      return "solid_descriptor";
+    case LoopCandidate::Source::TRIANGLE_DESCRIPTOR:
+      return "triangle_descriptor";
+    case LoopCandidate::Source::DISTANCE:
+    default:
+      return "distance";
+  }
+}
+}  // namespace
+
 void GraphBasedSlamComponent::searchLoop()
 {
   lidarslam_msgs::msg::MapArray map_array_msg;
@@ -1260,62 +1321,6 @@ void GraphBasedSlamComponent::searchLoop()
   if (debug_flag_) {
     RCLCPP_INFO(get_logger(), "searching Loop, num_submaps:%d", num_submaps);
   }
-
-  struct LoopCandidate
-  {
-    enum class Source
-    {
-      DISTANCE,
-      SCAN_CONTEXT,
-      BEV_DESCRIPTOR,
-      SOLID_DESCRIPTOR,
-      TRIANGLE_DESCRIPTOR
-    };
-
-    int index {-1};
-    double selection_metric {std::numeric_limits<double>::max()};
-    Source source {Source::DISTANCE};
-    double yaw_rad {0.0};
-    // Recovered SE(3) from the descriptor that proposed this candidate
-    // (currently only triangle). Identity unless populated. Used as the NDT
-    // initial guess instead of the pose-derived guess when source matches.
-    Eigen::Matrix4f relative_transform {Eigen::Matrix4f::Identity()};
-    bool has_relative_transform {false};
-  };
-
-  struct LoopCandidateResult
-  {
-    bool valid {false};
-    int index {-1};
-    double selection_metric {std::numeric_limits<double>::max()};
-    double fitness_score {std::numeric_limits<double>::max()};
-    double travel_distance {0.0};
-    double euclidean_distance {0.0};
-    double translation_delta_m {0.0};
-    double rotation_delta_deg {0.0};
-    LoopCandidate::Source source {LoopCandidate::Source::DISTANCE};
-    bool used_3d_bbs {false};
-    double three_d_bbs_score_percentage {0.0};
-    double three_d_bbs_elapsed_msec {0.0};
-    Eigen::Matrix4f final_transformation {Eigen::Matrix4f::Identity()};
-  };
-
-  const auto candidate_source_name =
-    [](LoopCandidate::Source source) -> const char * {
-      switch (source) {
-        case LoopCandidate::Source::SCAN_CONTEXT:
-          return "scan_context";
-        case LoopCandidate::Source::BEV_DESCRIPTOR:
-          return "bev_descriptor";
-        case LoopCandidate::Source::SOLID_DESCRIPTOR:
-          return "solid_descriptor";
-        case LoopCandidate::Source::TRIANGLE_DESCRIPTOR:
-          return "triangle_descriptor";
-        case LoopCandidate::Source::DISTANCE:
-        default:
-          return "distance";
-      }
-    };
 
   const auto build_filtered_local_submap =
     [this, &map_array_msg](int ref_idx) -> pcl::PointCloud<pcl::PointXYZI>::Ptr {
@@ -1431,7 +1436,28 @@ void GraphBasedSlamComponent::searchLoop()
     triangle_descriptor_next_submap_idx_ = num_submaps;
   }
 
-  const int latest_idx = num_submaps - 1;
+  if (deterministic_loop_scheduling_) {
+    // Catch up over every submap not yet used as a loop-search query so the
+    // query set is a deterministic function of the map, independent of how the
+    // wall-clock timer batched submap arrivals (v0.4 D1 reproducibility fix).
+    int query_start = last_searched_submap_idx_ + 1;
+    if (query_start < 1) {query_start = 1;}
+    for (int q = query_start; q < num_submaps; ++q) {
+      searchLoopForLatest(map_array_msg, loop_edges, num_submaps, q);
+    }
+    last_searched_submap_idx_ = num_submaps - 1;
+  } else {
+    // Default (historical) behaviour: query only the single latest submap.
+    searchLoopForLatest(map_array_msg, loop_edges, num_submaps, num_submaps - 1);
+  }
+}
+
+void GraphBasedSlamComponent::searchLoopForLatest(
+  const lidarslam_msgs::msg::MapArray & map_array_msg,
+  LoopEdges & loop_edges,
+  int num_submaps,
+  int latest_idx)
+{
   const auto & latest_submap = map_array_msg.submaps[latest_idx];
   Eigen::Affine3d latest_affine;
   tf2::fromMsg(latest_submap.pose, latest_affine);

--- a/graph_based_slam/test/test_deterministic_loop_scheduling_defaults.py
+++ b/graph_based_slam/test/test_deterministic_loop_scheduling_defaults.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Regression tests for the deterministic_loop_scheduling default (v0.4 D1).
+
+deterministic_loop_scheduling is the opt-in flag that switches searchLoop from
+the historical wall-clock-driven single-latest query to a deterministic
+catch-up over every un-queried submap. It MUST default off so the published
+benchmark behaviour stays the validated single-latest path; flipping it on is a
+behaviour change that needs the 8-vs-16 reproducibility validation first.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+PARAM_FILES = [
+    REPO_ROOT / 'graph_based_slam' / 'param' / 'graphbasedslam.yaml',
+    REPO_ROOT / 'graph_based_slam' / 'param' / 'graphbasedslam_indoor.yaml',
+]
+
+
+def _load_graph_params(path: Path) -> dict:
+    data = yaml.safe_load(path.read_text(encoding='utf-8'))
+    assert 'graph_based_slam' in data, f'{path} missing graph_based_slam node'
+    params = data['graph_based_slam'].get('ros__parameters')
+    assert params is not None, f'{path} missing ros__parameters'
+    return params
+
+
+@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
+def test_deterministic_loop_scheduling_present(path):
+    params = _load_graph_params(path)
+    assert 'deterministic_loop_scheduling' in params, (
+        f'{path.name}: deterministic_loop_scheduling must be documented so '
+        'operators can discover the opt-in flag'
+    )
+
+
+@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
+def test_deterministic_loop_scheduling_defaults_off(path):
+    params = _load_graph_params(path)
+    assert params['deterministic_loop_scheduling'] is False, (
+        f'{path.name}: deterministic_loop_scheduling must default off so the '
+        'published single-latest benchmark behaviour stays unchanged until the '
+        '8-vs-16 reproducibility validation lands'
+    )


### PR DESCRIPTION
## What

Lands the implementation half of **v0.4 D1**. `searchLoop` was wall-clock-triggered (`create_wall_timer`) and queried only the single latest submap (`latest_idx = num_submaps - 1`), so timer-batched submap arrivals were skipped non-deterministically — the `(query, db)` pair set depended on tick timing rather than the map. That is the single root cause behind the triangle-ablation variance documented in the 2026-05 research closeout (PR #207).

## Change

- Split `searchLoop` into a **scheduler** + a per-query `searchLoopForLatest()`.
- Add opt-in parameter **`deterministic_loop_scheduling`** (default **false**).
  - **off (default):** the scheduler issues exactly one query for the latest submap — byte-for-byte the historical behaviour. Existing presets/benchmarks unchanged.
  - **on:** catches up over every un-queried submap index, so the loop-search query set is a deterministic function of the map regardless of timer batching.
- Relocated the local `LoopCandidate` / `LoopCandidateResult` structs and `candidate_source_name` to a file-scope anonymous namespace so the new per-query method can use them; the per-query body is otherwise unchanged.

**Default-off only — no behaviour change.** The 8-vs-16 head-to-head reproducibility validation that would clear the flag to become a default still needs benchmark data (follow-up); the optional `std::async` RANSAC half of the pinned design is likewise deferred.

## Validation

```
colcon build --packages-select graph_based_slam --cmake-args -DCMAKE_BUILD_TYPE=Release   # clean
ament_uncrustify / ament_cpplint  (component .cpp + .h)                                   # No problems found
ament_flake8 / ament_copyright / ament_pep257  (new test)                                # No problems found
ament_lint_cmake  (CMakeLists.txt)                                                        # No problems found
pytest test_triangle_descriptor_yaml_defaults.py test_deterministic_loop_scheduling_defaults.py  # 32 passed
mkdocs build --strict                                                                     # exit 0
```

## Docs / tests

- Documented the flag in `graphbasedslam.yaml` / `graphbasedslam_indoor.yaml`.
- New regression test asserts the flag is present and defaults off in both presets.
- Synced `docs/roadmap/v0.4.md` and `docs/research/triangle-stack-2026-05-summary.md` (D1 impl landed; only 8-vs-16 validation remains).