### PR TITLE
docs(roadmap): scope v0.5 MID-360 real ground-truth dataset

### DIFF
--- a/docs/roadmap/v0.4.md
+++ b/docs/roadmap/v0.4.md
@@ -118,7 +118,8 @@ test, continuous kidnap-relocalization gate (#194). 81 `mid360` scripts on
    total station / surveyed control points — cost) and produce a true
    `ape_rmse_gt_m` profile. Land the profile swap in v0.5.
    **Scoped in `docs/roadmap/v0.5.md`** (GT-source matrix + reference-pipeline
-   plan; decision D-GT-1 is the open call on the GT source).
+   plan; decision D-GT-1 settled on a **robotic total station** tracking a 360°
+   prism over the canonical indoor loop).
 2. (v0.4) confirm the runbook smoke test exercises the full
    record → readiness → mapping → public gate → production gate → dashboard
    chain end-to-end in CI (not just the wrapper happy path).
@@ -183,7 +184,7 @@ done     D1 triangle reproducibility research closeout (docs) ← root cause + f
 done     D1 impl: opt-in deterministic searchLoop scheduling (default off, behaviour-identical)
 next     D1 validation: 8-vs-16 head-to-head reproducibility run to clear the flag for default (needs data)
 v0.5     MID-360 real-GT dataset → replace mid360_vs_glim with ape_rmse_gt_m
-         (scoped in docs/roadmap/v0.5.md — GT-source decision D-GT-1 pending)
+         (scoped in docs/roadmap/v0.5.md — GT source = robotic total station)
 ```
 
 E (accuracy / backend) opportunistically anywhere.

--- a/docs/roadmap/v0.4.md
+++ b/docs/roadmap/v0.4.md
@@ -117,6 +117,8 @@ test, continuous kidnap-relocalization gate (#194). 81 `mid360` scripts on
    MID-360 evidence. Scope the capture (environment, GT source — prism /
    total station / surveyed control points — cost) and produce a true
    `ape_rmse_gt_m` profile. Land the profile swap in v0.5.
+   **Scoped in `docs/roadmap/v0.5.md`** (GT-source matrix + reference-pipeline
+   plan; decision D-GT-1 is the open call on the GT source).
 2. (v0.4) confirm the runbook smoke test exercises the full
    record → readiness → mapping → public gate → production gate → dashboard
    chain end-to-end in CI (not just the wrapper happy path).
@@ -181,6 +183,7 @@ done     D1 triangle reproducibility research closeout (docs) ← root cause + f
 done     D1 impl: opt-in deterministic searchLoop scheduling (default off, behaviour-identical)
 next     D1 validation: 8-vs-16 head-to-head reproducibility run to clear the flag for default (needs data)
 v0.5     MID-360 real-GT dataset → replace mid360_vs_glim with ape_rmse_gt_m
+         (scoped in docs/roadmap/v0.5.md — GT-source decision D-GT-1 pending)
 ```
 
 E (accuracy / backend) opportunistically anywhere.

--- a/docs/roadmap/v0.5.md
+++ b/docs/roadmap/v0.5.md
@@ -1,10 +1,12 @@
 # lidarslam-ros2 v0.5 roadmap — MID-360 real ground truth
 
-> Status: **scoping** (drafted 2026-06-07, right after the v0.4 D1 opt-in
-> deterministic-scheduling impl landed, `507c367`/#208).
+> Status: **scoping, GT source decided** (drafted 2026-06-07, right after the
+> v0.4 D1 opt-in deterministic-scheduling impl landed, `507c367`/#208).
 > This is a planning document, not yet committed work. Its purpose is to turn
 > v0.4's **locked decision #1** — *"MID-360 evidence → pursue real ground
-> truth"* — into a concrete, costed plan with the open decisions surfaced.
+> truth"* — into a concrete, costed plan. **D-GT-1 (GT source) is now decided:
+> robotic total station** (§2); the remaining work is the capture + one
+> reference script + one profile (§3, §5).
 
 ## 0. Why this exists
 
@@ -65,45 +67,54 @@ accuracy claim becomes apples-to-apples across all three datasets. **C
 the cost of changing the route to outdoors. Options B/D are situational; E does
 **not** count as GT and is explicitly excluded as a v0.5 *gate* source.
 
-> Open decision **D-GT-1**: which GT source. Drives everything below. Needs the
-> user's call on available equipment / budget / venue.
+> **Decision D-GT-1 — DECIDED (2026-06-07): Option A, robotic total station.**
+> Keeps the canonical indoor MID-360 loop *and* yields dense true-GT poses
+> directly comparable to NTU VIRAL / Newer College (both prism-surveyed), so the
+> README accuracy claim is apples-to-apples across all three datasets. The
+> capture mounts a single **360° prism** on the robot; an auto-tracking total
+> station logs its world-frame XYZ. Remaining sub-detail: source the tracking
+> total station (rental/borrow) and decide the time-sync transport (§3.1).
+> Options B–E recorded above for the record; not pursued for v0.5.
 
-## 3. Reference pipeline plan (once a GT source is chosen)
+## 3. Reference pipeline plan (robotic total station)
 
 Mirror the NTU VIRAL template so the new dataset drops into the existing gate
 with zero evaluator changes:
 
 1. **Capture** — record the MID-360 bag with the existing
-   `record_mid360_robot_bag.sh` + robot profile, *and simultaneously* log the GT
-   stream (total-station prism log / mocap topic / RTK fix / checkpoint stamps)
-   on a shared clock (PTP or a common ROS time source — sync strategy is part of
-   D-GT-1's chosen-source detail).
-2. **`scripts/generate_mid360_<env>_reference.py`** (new, sibling of
+   `record_mid360_robot_bag.sh` + robot profile over the canonical **indoor
+   loop** (the ~277 s route already used for the GLIM cross-val / kidnap gate),
+   *and simultaneously* log the **total-station prism XYZ** (5–20 Hz) on a shared
+   clock. Sync transport TBD — PTP, a common ROS time source, or a recorded
+   sync pulse; whichever the borrowed total station supports. The prism gives
+   position GT (3-DoF); orientation is recovered by the rigid-alignment step, as
+   with NTU VIRAL's Leica prism reference.
+2. **`scripts/generate_mid360_indoor_reference.py`** (new, sibling of
    `generate_ntu_viral_tnp01_reference.py`):
-   - read the GT source → poses in a world frame,
-   - apply the rigid **`livox_frame` → GT-marker offset** (a `mid360_gt_extrinsic.yaml`,
-     analogous to `leica_prism.yaml`; this is the prism/marker mount transform),
-   - emit `output/mid360_<env>_gt.tum`.
+   - read the total-station prism log → positions in a world frame,
+   - apply the rigid **`livox_frame` → prism offset** (a `mid360_gt_extrinsic.yaml`,
+     analogous to `leica_prism.yaml`; the prism mount transform),
+   - emit `output/mid360_indoor_gt.tum`.
 3. **Score** — `write_aligned_trajectory_metrics.py --reference-tum
-   output/mid360_<env>_gt.tum --corrected-tum <slam>.tum` → `metrics.json` with
+   output/mid360_indoor_gt.tum --corrected-tum <slam>.tum` → `metrics.json` with
    `reference.kind: ground_truth`. `_infer_reference_kind()` already maps a
    source string containing `gt`/`ground_truth` to `ground_truth`, so naming the
-   source `mid360_<env>_gt` is sufficient — **no evaluator change needed**.
+   source `mid360_indoor_gt` is sufficient — **no evaluator change needed**.
 4. **New profile** in `release_profiles.yaml`:
    ```yaml
-   - name: mid360_gt_<env>
-     description: Livox MID-360 vs <GT source> ground truth (<route>)
+   - name: mid360_gt_indoor
+     description: Livox MID-360 vs robotic total-station prism GT (~277s indoor loop)
      match:
        points_topic: /livox/lidar
        reference_kind: ground_truth
-       reference_source_contains: mid360_<env>_gt
+       reference_source_contains: mid360_indoor_gt
        min_ape_pairs: <set from GT density>
      metric: ape_rmse_gt_m
      pass: <from first GT runs>
      target: <stretch>
    ```
 5. **Retire** `mid360_vs_glim`: keep it as a *report-only* cross-check (drop it
-   back to `report_only_until` / non-blocking) or delete it once `mid360_gt_<env>`
+   back to `report_only_until` / non-blocking) or delete it once `mid360_gt_indoor`
    blocks. Decision **D-GT-2** — recommend keeping GLIM as a non-blocking
    agreement sanity check, not deleting (cheap signal, no GT venue needed).
 
@@ -115,16 +126,18 @@ runs (same discipline as `project_release_gate_design`: thresholds are
 mean ± std APE, set `pass` near the upper envelope and `target` near the mean,
 mirroring how NTU tnp_01 landed at `pass 1.00 / target 0.30` and Newer College
 at `pass 0.10 / target 0.08`. The MID-360 number will likely sit *between*
-those given the short range and indoor-or-outdoor route — but that is a
-prediction to verify, not a threshold to assert.
+those given the short range and the indoor loop — but that is a prediction to
+verify, not a threshold to assert.
 
 ## 5. Deliverables / acceptance criteria for v0.5
 
-- [ ] **D-GT-1 decided** (GT source) and **D-GT-2 decided** (GLIM profile fate).
-- [ ] A captured MID-360 bag + synchronized GT log (≥3 runs of the chosen route).
-- [ ] `scripts/generate_mid360_<env>_reference.py` + `mid360_gt_extrinsic.yaml`,
-      producing `output/mid360_<env>_gt.tum`.
-- [ ] `mid360_gt_<env>` profile in `release_profiles.yaml`, `reference_kind:
+- [x] **D-GT-1 decided** — robotic total station (2026-06-07). **D-GT-2**
+      (GLIM profile fate) recommended demote-to-report-only; confirm at swap.
+- [ ] A captured MID-360 bag + synchronized total-station prism log (≥3 runs of
+      the canonical ~277 s indoor loop).
+- [ ] `scripts/generate_mid360_indoor_reference.py` + `mid360_gt_extrinsic.yaml`,
+      producing `output/mid360_indoor_gt.tum`.
+- [ ] `mid360_gt_indoor` profile in `release_profiles.yaml`, `reference_kind:
       ground_truth`, thresholds set from observed runs, **blocking**.
 - [ ] `mid360_vs_glim` demoted to non-blocking (or removed) per D-GT-2.
 - [ ] Docs: `comparison.md` updated so the MID-360 row reads `ape_rmse_gt_m`

--- a/docs/roadmap/v0.5.md
+++ b/docs/roadmap/v0.5.md
@@ -1,0 +1,157 @@
+# lidarslam-ros2 v0.5 roadmap — MID-360 real ground truth
+
+> Status: **scoping** (drafted 2026-06-07, right after the v0.4 D1 opt-in
+> deterministic-scheduling impl landed, `507c367`/#208).
+> This is a planning document, not yet committed work. Its purpose is to turn
+> v0.4's **locked decision #1** — *"MID-360 evidence → pursue real ground
+> truth"* — into a concrete, costed plan with the open decisions surfaced.
+
+## 0. Why this exists
+
+v0.4 graduated three research-track release profiles to **blocking** gates
+(decision #2, #206). Two of them — `mid360_vs_glim` and
+`leo_drive_applanix_velodyne_cross` — block on a **cross-validation** reference,
+not ground truth. That was an *interim weakness accepted knowingly*: GLIM is a
+strong SLAM system, but `ape_rmse_vs_reference_m` against another SLAM estimate
+measures *agreement*, not *accuracy*. A systematic error shared by both systems
+(e.g. a common deskew or extrinsic bias) is invisible to it.
+
+The single deliverable that retires that weakness for the MID-360 story is a
+dataset with **independent ground truth**, scored with `ape_rmse_gt_m` exactly
+like NTU VIRAL and Newer College already are. That is the spine of v0.5.
+
+```
+v0.4 (shipped)   mid360_vs_glim   metric: ape_rmse_vs_reference_m   pass 4.00   reference_kind: cross_validation
+v0.5 (target)    mid360_gt_<env>  metric: ape_rmse_gt_m             pass ?.??   reference_kind: ground_truth
+```
+
+## 1. What already exists (we are not starting from zero)
+
+The plumbing to *consume* a GT dataset is fully built. v0.5 is a data-and-one-
+profile problem, not an infrastructure problem.
+
+| Layer | Artifact | State |
+|---|---|---|
+| Profile schema + evaluator | `scripts/release_profiles.yaml`, `scripts/benchmark_summary.py` (`evaluate_release_profiles`) | ✅ supports `ape_rmse_gt_m` whenever `reference.kind == ground_truth` |
+| Gate runner | `scripts/run_release_readiness_checks.sh` (`--release-profile`, `--fail-on-profiles`) | ✅ |
+| APE computation | `scripts/write_aligned_trajectory_metrics.py` (Umeyama SE(3) align → per-pose Euclidean APE → `metrics.json`) | ✅ sensor-agnostic |
+| Reference extraction **template** | `scripts/generate_ntu_viral_tnp01_reference.py` (rosbag topic → TUM, plus a rigid sensor→GT-marker offset from a YAML) | ✅ the pattern v0.5 must mirror |
+| MID-360 capture toolkit | 81 `mid360`-scoped scripts (record → readiness → mapping → public/production gate → dashboard), robot profiles, `configs/mid360_robot/rko_lio_mid360_*.yaml` | ✅ (v0.4) |
+
+**The gap is exactly two things:** (a) a captured MID-360 bag *with a
+synchronized independent-GT trajectory*, and (b) a `generate_*_reference.py`
+sibling that turns that GT into a TUM file the existing APE path can score.
+
+## 2. The core scoping decision — what is the GT source?
+
+This is the decision that drives cost, environment, and route. MID-360 is a
+low-cost short-range (≤ ~40 m, ~59° vertical FOV) sensor; the GT method has to
+suit a small mobile robot, and ideally be *repeatable on our own hardware* so
+the dataset can be regenerated, not a one-off.
+
+| Option | GT mechanism | Env | Accuracy | Cost / access | Verdict for us |
+|---|---|---|---|---|---|
+| **A. Robotic total station** tracking a 360° prism on the robot | auto-tracking theodolite logs prism XYZ at 5–20 Hz | indoor **or** outdoor | ~mm–cm (matches NTU/Newer College class) | needs a tracking total station (rental/borrow); 1 prism | **Strongest GT**, mirrors existing prism datasets; logistics-heavy |
+| **B. Motion capture** (OptiTrack / Vicon) | marker rigid body → pose stream | indoor, **bounded volume** | sub-mm | needs a mocap room; route limited to the volume | Gold standard but route is tiny → weak for a *loop* dataset |
+| **C. RTK-GNSS** on the robot | RTK fix → ENU trajectory via existing `LocalCartesian` path | **outdoor only**, open sky | ~cm with fixed solution | RTK receiver + base/NTRIP; affordable | **Cheapest credible GT**, but forces an outdoor route (changes the canonical MID-360 story from the indoor loop) |
+| **D. Surveyed control points** (sparse) | robot passes known surveyed marks; APE only at those poses | either | cm at checkpoints only | tape/total-station survey of N marks | Sparse APE (`min_ape_pairs` small) — weaker statistics, but very low cost |
+| **E. Higher-grade reference SLAM** (e.g. survey-grade scanner registration) | register against a TLS prior map | either | cm-ish but **still a reference, not independent GT** | a TLS scan | This is *better cross-validation*, **not** `ground_truth` — does not retire the weakness |
+
+**Recommendation to decide on:** **A (robotic total station)** if we can borrow
+one for a day — it keeps the canonical indoor loop *and* yields dense,
+true-GT poses directly comparable to NTU VIRAL / Newer College, so the README
+accuracy claim becomes apples-to-apples across all three datasets. **C
+(RTK-GNSS outdoor)** is the pragmatic fallback that needs no special venue, at
+the cost of changing the route to outdoors. Options B/D are situational; E does
+**not** count as GT and is explicitly excluded as a v0.5 *gate* source.
+
+> Open decision **D-GT-1**: which GT source. Drives everything below. Needs the
+> user's call on available equipment / budget / venue.
+
+## 3. Reference pipeline plan (once a GT source is chosen)
+
+Mirror the NTU VIRAL template so the new dataset drops into the existing gate
+with zero evaluator changes:
+
+1. **Capture** — record the MID-360 bag with the existing
+   `record_mid360_robot_bag.sh` + robot profile, *and simultaneously* log the GT
+   stream (total-station prism log / mocap topic / RTK fix / checkpoint stamps)
+   on a shared clock (PTP or a common ROS time source — sync strategy is part of
+   D-GT-1's chosen-source detail).
+2. **`scripts/generate_mid360_<env>_reference.py`** (new, sibling of
+   `generate_ntu_viral_tnp01_reference.py`):
+   - read the GT source → poses in a world frame,
+   - apply the rigid **`livox_frame` → GT-marker offset** (a `mid360_gt_extrinsic.yaml`,
+     analogous to `leica_prism.yaml`; this is the prism/marker mount transform),
+   - emit `output/mid360_<env>_gt.tum`.
+3. **Score** — `write_aligned_trajectory_metrics.py --reference-tum
+   output/mid360_<env>_gt.tum --corrected-tum <slam>.tum` → `metrics.json` with
+   `reference.kind: ground_truth`. `_infer_reference_kind()` already maps a
+   source string containing `gt`/`ground_truth` to `ground_truth`, so naming the
+   source `mid360_<env>_gt` is sufficient — **no evaluator change needed**.
+4. **New profile** in `release_profiles.yaml`:
+   ```yaml
+   - name: mid360_gt_<env>
+     description: Livox MID-360 vs <GT source> ground truth (<route>)
+     match:
+       points_topic: /livox/lidar
+       reference_kind: ground_truth
+       reference_source_contains: mid360_<env>_gt
+       min_ape_pairs: <set from GT density>
+     metric: ape_rmse_gt_m
+     pass: <from first GT runs>
+     target: <stretch>
+   ```
+5. **Retire** `mid360_vs_glim`: keep it as a *report-only* cross-check (drop it
+   back to `report_only_until` / non-blocking) or delete it once `mid360_gt_<env>`
+   blocks. Decision **D-GT-2** — recommend keeping GLIM as a non-blocking
+   agreement sanity check, not deleting (cheap signal, no GT venue needed).
+
+## 4. Setting the threshold honestly
+
+We **cannot** pre-set `pass`/`target` — they must come from the first real GT
+runs (same discipline as `project_release_gate_design`: thresholds are
+*observed-then-set*, not aspirational). Plan: capture ≥3 runs, compute
+mean ± std APE, set `pass` near the upper envelope and `target` near the mean,
+mirroring how NTU tnp_01 landed at `pass 1.00 / target 0.30` and Newer College
+at `pass 0.10 / target 0.08`. The MID-360 number will likely sit *between*
+those given the short range and indoor-or-outdoor route — but that is a
+prediction to verify, not a threshold to assert.
+
+## 5. Deliverables / acceptance criteria for v0.5
+
+- [ ] **D-GT-1 decided** (GT source) and **D-GT-2 decided** (GLIM profile fate).
+- [ ] A captured MID-360 bag + synchronized GT log (≥3 runs of the chosen route).
+- [ ] `scripts/generate_mid360_<env>_reference.py` + `mid360_gt_extrinsic.yaml`,
+      producing `output/mid360_<env>_gt.tum`.
+- [ ] `mid360_gt_<env>` profile in `release_profiles.yaml`, `reference_kind:
+      ground_truth`, thresholds set from observed runs, **blocking**.
+- [ ] `mid360_vs_glim` demoted to non-blocking (or removed) per D-GT-2.
+- [ ] Docs: `comparison.md` updated so the MID-360 row reads `ape_rmse_gt_m`
+      (true GT) instead of the cross-val caveat; this roadmap moved to "done".
+- [ ] A short methodology note under `docs/research/` describing the GT capture
+      (source, extrinsic, sync) so the dataset is reproducible — same bar we hold
+      NTU VIRAL / Newer College to.
+
+## 6. Out of scope for v0.5 (explicit)
+
+Survey-grade dense reconstruction as a *product*; multi-sensor GT fusion; a
+public dataset *release* (licensing/hosting is a separate effort); replacing the
+GLIM cross-val for `leo_drive` (that dataset already ships its own Applanix
+reference and is a separate track). v0.5 is scoped to **one** MID-360 GT
+dataset and the one profile it unlocks.
+
+## 7. Carry-over from v0.4 (not blocking v0.5, tracked here so it isn't lost)
+
+- **D1 8-vs-16 validation** — the head-to-head reproducibility run that would
+  clear `deterministic_loop_scheduling` (#208) to flip default-on; needs
+  benchmark-data access. Independent of MID-360 GT; do opportunistically.
+- **E (accuracy / backend)** — KITTI LO baseline report + covariance-driven
+  `adjacent_edge_info_weight`; still opportunistic, unchanged from v0.4 §3.E.
+
+---
+
+(Related memory: `[[project_mid360_robot_toolkit_stack]]`,
+`[[project_release_gate_design]]`, `[[project_v0_4_roadmap_draft]]`,
+`[[project_v0_3_positioning]]`, `[[project_place_recognition_license]]`,
+`[[project_goal]]`.)


### PR DESCRIPTION
## What

Adds `docs/roadmap/v0.5.md` — a scoping document that turns v0.4's **locked decision #1** (*MID-360 evidence → pursue real ground truth*) into a concrete, costed plan, and points `v0.4.md` at it.

## Why

`mid360_vs_glim` currently blocks on a **GLIM cross-validation** reference (`ape_rmse_vs_reference_m`, `pass 4.00`). That measures *agreement* with another SLAM estimate, not *accuracy* — a systematic error shared by both systems is invisible to it. The one deliverable that retires this weakness is a dataset with **independent ground truth**, scored by `ape_rmse_gt_m` exactly like NTU VIRAL and Newer College.

## What the doc covers

- **What already exists**: profile schema + evaluator (`release_profiles.yaml`, `benchmark_summary.py`), the sensor-agnostic APE path (`write_aligned_trajectory_metrics.py`), the NTU reference-extraction template, and the 81-script MID-360 toolkit — so v0.5 is a *data + one-profile* problem, not an infrastructure one.
- **GT-source decision matrix** (robotic total station / motion capture / RTK-GNSS / surveyed control points / reference-SLAM) with trade-offs and a recommendation. **D-GT-1** (which GT source) is the open call that drives cost/route.
- **Reference-pipeline plan** mirroring `generate_ntu_viral_tnp01_reference.py` → `generate_mid360_<env>_reference.py` + `mid360_gt_extrinsic.yaml` → `output/mid360_<env>_gt.tum`, scored with zero evaluator changes (`_infer_reference_kind()` maps a `*_gt` source to `ground_truth`).
- **Threshold discipline** (observe-then-set from ≥3 runs), acceptance criteria, and explicit scope cuts.

## Scope

Docs-only. No code, no behavior change. `mkdocs build --strict` passes (roadmap pages are nav-omitted → INFO, not a strict error, consistent with `v0.4.md`).