### PR TITLE
ci: run the MID-360 robot runbook smoke test in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,6 +111,12 @@ jobs:
           print('All lanelet2 generator tests passed')
           "
 
+      - name: Smoke-test MID-360 robot runbook
+        shell: bash
+        run: |
+          python3 -m pip install --upgrade pyyaml
+          bash scripts/smoke_mid360_robot_runbook.sh
+
   default-workflow:
     name: ${{ matrix.ros_distro }} default workflow
     needs: docs-and-release-metadata


### PR DESCRIPTION
## What

Wires `scripts/smoke_mid360_robot_runbook.sh` into the existing no-ROS `docs-and-release-metadata` CI job.

## Why

The MID-360 operator toolkit ships 80+ scripts and a smoke test that exercises the **no-ROS dry-run chain** end-to-end — profile validation → recording dry-run → post-recording check → readiness → map dry-run — against a synthetic metadata-only rosbag2 directory. But the smoke was **never invoked by any workflow**, so regressions in that toolkit went uncaught by CI. This closes the v0.4 follow-up *"confirm the runbook smoke test exercises the chain in CI"* for the data-free portion of the chain.

## How

- Adds one step to the existing `docs-and-release-metadata` job (which already validates shell entrypoints and the lanelet2 generator on a plain `ubuntu-24.04` runner).
- The smoke launches **neither ROS nor SLAM**; its only non-stdlib dependency is PyYAML; it writes only to `mktemp` dirs (leaves the tree clean).
- Verified locally in a clean env (no ROS sourced) → `MID-360 robot runbook smoke: PASS`, exit 0.

## Scope

CI-only, no production code change. The public/production-gate + dashboard stages of the full chain need real maps and remain out of CI (data-gated), as before.