### PR TITLE
docs(roadmap): re-scope v0.5 onto the public RTK-SLAM MID-360 GT dataset

### DIFF
--- a/docs/roadmap/v0.4.md
+++ b/docs/roadmap/v0.4.md
@@ -117,9 +117,10 @@ test, continuous kidnap-relocalization gate (#194). 81 `mid360` scripts on
    MID-360 evidence. Scope the capture (environment, GT source — prism /
    total station / surveyed control points — cost) and produce a true
    `ape_rmse_gt_m` profile. Land the profile swap in v0.5.
-   **Scoped in `docs/roadmap/v0.5.md`** (GT-source matrix + reference-pipeline
-   plan; decision D-GT-1 settled on a **robotic total station** tracking a 360°
-   prism over the canonical indoor loop).
+   **Scoped in `docs/roadmap/v0.5.md`** — D-GT-1 settled on **total-station GT**,
+   now acquired via the **public RTK-SLAM dataset** (Livox MID-360 + geodetic
+   total-station checkpoints, CC-BY 4.0) instead of self-capture, so v0.5 needs
+   no field equipment — just a download + one reference script + one profile.
 2. (v0.4) confirm the runbook smoke test exercises the full
    record → readiness → mapping → public gate → production gate → dashboard
    chain end-to-end in CI (not just the wrapper happy path).
@@ -184,7 +185,7 @@ done     D1 triangle reproducibility research closeout (docs) ← root cause + f
 done     D1 impl: opt-in deterministic searchLoop scheduling (default off, behaviour-identical)
 next     D1 validation: 8-vs-16 head-to-head reproducibility run to clear the flag for default (needs data)
 v0.5     MID-360 real-GT dataset → replace mid360_vs_glim with ape_rmse_gt_m
-         (scoped in docs/roadmap/v0.5.md — GT source = robotic total station)
+         (scoped in docs/roadmap/v0.5.md — total-station GT via public RTK-SLAM dataset)
 ```
 
 E (accuracy / backend) opportunistically anywhere.

--- a/docs/roadmap/v0.5.md
+++ b/docs/roadmap/v0.5.md
@@ -1,17 +1,19 @@
 # lidarslam-ros2 v0.5 roadmap — MID-360 real ground truth
 
-> Status: **scoping, GT source decided** (drafted 2026-06-07, right after the
-> v0.4 D1 opt-in deterministic-scheduling impl landed, `507c367`/#208).
-> This is a planning document, not yet committed work. Its purpose is to turn
-> v0.4's **locked decision #1** — *"MID-360 evidence → pursue real ground
-> truth"* — into a concrete, costed plan. **D-GT-1 (GT source) is now decided:
-> robotic total station** (§2); the remaining work is the capture + one
-> reference script + one profile (§3, §5).
+> Status: **scoping, re-scoped onto a public dataset** (drafted 2026-06-07,
+> after the v0.4 D1 opt-in deterministic-scheduling impl landed, `507c367`/#208;
+> re-scoped 2026-06-07 once a public MID-360 + total-station dataset was found).
+> This is a planning document, not yet committed work. It turns v0.4's **locked
+> decision #1** — *"MID-360 evidence → pursue real ground truth"* — into a plan.
+> **D-GT-1 (GT source) is total-station ground truth, now acquired via the
+> public RTK-SLAM dataset** (§2) instead of borrowing a total station ourselves.
+> The remaining work is one reference script + one profile + a 182 GB download
+> (§3, §5) — no field capture, no equipment.
 
 ## 0. Why this exists
 
 v0.4 graduated three research-track release profiles to **blocking** gates
-(decision #2, #206). Two of them — `mid360_vs_glim` and
+(decision #2, #206). Two — `mid360_vs_glim` and
 `leo_drive_applanix_velodyne_cross` — block on a **cross-validation** reference,
 not ground truth. That was an *interim weakness accepted knowingly*: GLIM is a
 strong SLAM system, but `ape_rmse_vs_reference_m` against another SLAM estimate
@@ -19,12 +21,12 @@ measures *agreement*, not *accuracy*. A systematic error shared by both systems
 (e.g. a common deskew or extrinsic bias) is invisible to it.
 
 The single deliverable that retires that weakness for the MID-360 story is a
-dataset with **independent ground truth**, scored with `ape_rmse_gt_m` exactly
-like NTU VIRAL and Newer College already are. That is the spine of v0.5.
+dataset with **independent ground truth**, scored with `ape_rmse_gt_m`. We now
+have one without capturing it ourselves (§2).
 
 ```
-v0.4 (shipped)   mid360_vs_glim   metric: ape_rmse_vs_reference_m   pass 4.00   reference_kind: cross_validation
-v0.5 (target)    mid360_gt_<env>  metric: ape_rmse_gt_m             pass ?.??   reference_kind: ground_truth
+v0.4 (shipped)   mid360_vs_glim       metric: ape_rmse_vs_reference_m   pass 4.00   reference_kind: cross_validation
+v0.5 (target)    mid360_gt_rtkslam_*  metric: ape_rmse_gt_m             pass ?.??   reference_kind: ground_truth
 ```
 
 ## 1. What already exists (we are not starting from zero)
@@ -36,135 +38,168 @@ profile problem, not an infrastructure problem.
 |---|---|---|
 | Profile schema + evaluator | `scripts/release_profiles.yaml`, `scripts/benchmark_summary.py` (`evaluate_release_profiles`) | ✅ supports `ape_rmse_gt_m` whenever `reference.kind == ground_truth` |
 | Gate runner | `scripts/run_release_readiness_checks.sh` (`--release-profile`, `--fail-on-profiles`) | ✅ |
-| APE computation | `scripts/write_aligned_trajectory_metrics.py` (Umeyama SE(3) align → per-pose Euclidean APE → `metrics.json`) | ✅ sensor-agnostic |
-| Reference extraction **template** | `scripts/generate_ntu_viral_tnp01_reference.py` (rosbag topic → TUM, plus a rigid sensor→GT-marker offset from a YAML) | ✅ the pattern v0.5 must mirror |
+| APE computation | `scripts/write_aligned_trajectory_metrics.py` (Umeyama SE(3) align → per-pose Euclidean APE → `metrics.json`) | ✅ sensor-agnostic; **reusable for sparse checkpoints** (see §3) |
+| Reference extraction **template** | `scripts/generate_ntu_viral_tnp01_reference.py` (rosbag topic → TUM + rigid sensor→GT-marker offset) | ✅ the pattern to mirror |
 | MID-360 capture toolkit | 81 `mid360`-scoped scripts (record → readiness → mapping → public/production gate → dashboard), robot profiles, `configs/mid360_robot/rko_lio_mid360_*.yaml` | ✅ (v0.4) |
 
-**The gap is exactly two things:** (a) a captured MID-360 bag *with a
-synchronized independent-GT trajectory*, and (b) a `generate_*_reference.py`
-sibling that turns that GT into a TUM file the existing APE path can score.
+**The gap is now just:** (a) download the public RTK-SLAM dataset, (b) a
+`generate_rtk_slam_reference.py` that turns its surveyed-checkpoint CSV into a
+sparse TUM the existing APE path can score, (c) one new profile. No field
+capture.
 
-## 2. The core scoping decision — what is the GT source?
+## 2. GT source — total station, via the public RTK-SLAM dataset
 
-This is the decision that drives cost, environment, and route. MID-360 is a
-low-cost short-range (≤ ~40 m, ~59° vertical FOV) sensor; the GT method has to
-suit a small mobile robot, and ideally be *repeatable on our own hardware* so
-the dataset can be regenerated, not a one-off.
+v0.4 decision #1 settled on **total-station ground truth**. The original plan
+(§2.2) was to borrow a tracking total station and capture our own indoor loop.
+A public dataset now delivers exactly that GT mechanism on the exact sensor —
+so D-GT-1 is satisfied **without equipment or capture**.
 
-| Option | GT mechanism | Env | Accuracy | Cost / access | Verdict for us |
-|---|---|---|---|---|---|
-| **A. Robotic total station** tracking a 360° prism on the robot | auto-tracking theodolite logs prism XYZ at 5–20 Hz | indoor **or** outdoor | ~mm–cm (matches NTU/Newer College class) | needs a tracking total station (rental/borrow); 1 prism | **Strongest GT**, mirrors existing prism datasets; logistics-heavy |
-| **B. Motion capture** (OptiTrack / Vicon) | marker rigid body → pose stream | indoor, **bounded volume** | sub-mm | needs a mocap room; route limited to the volume | Gold standard but route is tiny → weak for a *loop* dataset |
-| **C. RTK-GNSS** on the robot | RTK fix → ENU trajectory via existing `LocalCartesian` path | **outdoor only**, open sky | ~cm with fixed solution | RTK receiver + base/NTRIP; affordable | **Cheapest credible GT**, but forces an outdoor route (changes the canonical MID-360 story from the indoor loop) |
-| **D. Surveyed control points** (sparse) | robot passes known surveyed marks; APE only at those poses | either | cm at checkpoints only | tape/total-station survey of N marks | Sparse APE (`min_ape_pairs` small) — weaker statistics, but very low cost |
-| **E. Higher-grade reference SLAM** (e.g. survey-grade scanner registration) | register against a TLS prior map | either | cm-ish but **still a reference, not independent GT** | a TLS scan | This is *better cross-validation*, **not** `ground_truth` — does not retire the weakness |
+### 2.1 The dataset (verified 2026-06-07)
 
-**Recommendation to decide on:** **A (robotic total station)** if we can borrow
-one for a day — it keeps the canonical indoor loop *and* yields dense,
-true-GT poses directly comparable to NTU VIRAL / Newer College, so the README
-accuracy claim becomes apples-to-apples across all three datasets. **C
-(RTK-GNSS outdoor)** is the pragmatic fallback that needs no special venue, at
-the cost of changing the route to outdoors. Options B/D are situational; E does
-**not** count as GT and is explicitly excluded as a v0.5 *gate* source.
+**RTK-SLAM Dataset** — *"An RTK-SLAM Dataset for Absolute Accuracy Evaluation
+in GNSS-Degraded Environments"*, Zhang, Ress, Skuddis, Soergel, Haala (Univ.
+Stuttgart ifp), arXiv 2604.07151 (2026).
 
-> **Decision D-GT-1 — DECIDED (2026-06-07): Option A, robotic total station.**
-> Keeps the canonical indoor MID-360 loop *and* yields dense true-GT poses
-> directly comparable to NTU VIRAL / Newer College (both prism-surveyed), so the
-> README accuracy claim is apples-to-apples across all three datasets. The
-> capture mounts a single **360° prism** on the robot; an auto-tracking total
-> station logs its world-frame XYZ. Remaining sub-detail: source the tracking
-> total station (rental/borrow) and decide the time-sync transport (§3.1).
-> Options B–E recorded above for the record; not pursued for v0.5.
+| Property | Value | Why it fits |
+|---|---|---|
+| LiDAR | **Livox MID-360** (10 Hz) + integrated IMU (200 Hz, `/livox/imu`) | exact sensor — not Avia/Mid-70 |
+| Ground truth | **geodetic total station**, independent of the onboard RTK (RTK is system *input* only) | true independent GT, mm–cm class |
+| GT form | **sparse surveyed checkpoints** — CSV `point_id,easting,northing,height,env,timestamp`, **16–36 per sequence** | absolute control points, not a dense trajectory |
+| Formats | **ROS1 `.bag`, ROS2 `.db3`**, extended-EuRoC | drops onto our ROS 2 stack directly |
+| License | **CC-BY 4.0** | commercial-friendly (better than KITTI / MCD, both NC) |
+| Size | **182 GB**, 4 sequences | one-time download |
+| Sequences | Stadtgarten park 1 (26:42, 1.04 km, 36 chkpt) · Stadtgarten park 2 (14:36, 0.46 km, 19) · Construction Hall 1 (12:21, 0.48 km, 16) · Construction Hall 2 (9:59, 0.39 km, 16) | outdoor→GNSS-denied & outdoor-to-indoor — a real SLAM stress, not a clean loop |
 
-## 3. Reference pipeline plan (robotic total station)
+Project page `rtk-slam-dataset.github.io` · data `huggingface.co/datasets/Willyzw/rtk-slam-dataset` · eval `github.com/Willyzw/rtk-slam-eval`.
 
-Mirror the NTU VIRAL template so the new dataset drops into the existing gate
-with zero evaluator changes:
+### 2.2 What we give up vs self-capture (honest trade)
 
-1. **Capture** — record the MID-360 bag with the existing
-   `record_mid360_robot_bag.sh` + robot profile over the canonical **indoor
-   loop** (the ~277 s route already used for the GLIM cross-val / kidnap gate),
-   *and simultaneously* log the **total-station prism XYZ** (5–20 Hz) on a shared
-   clock. Sync transport TBD — PTP, a common ROS time source, or a recorded
-   sync pulse; whichever the borrowed total station supports. The prism gives
-   position GT (3-DoF); orientation is recovered by the rigid-alignment step, as
-   with NTU VIRAL's Leica prism reference.
-2. **`scripts/generate_mid360_indoor_reference.py`** (new, sibling of
-   `generate_ntu_viral_tnp01_reference.py`):
-   - read the total-station prism log → positions in a world frame,
-   - apply the rigid **`livox_frame` → prism offset** (a `mid360_gt_extrinsic.yaml`,
-     analogous to `leica_prism.yaml`; the prism mount transform),
-   - emit `output/mid360_indoor_gt.tum`.
+- **Route is not our canonical ~277 s indoor loop** — it's a German park /
+  construction site. The "canonical MID-360 story" shifts to this public route.
+  Acceptable: it is real total-station GT on a MID-360, which the indoor loop
+  never had. Self-capture of our own loop drops to an **optional later
+  complement**, not a v0.5 blocker.
+- **GT is sparse** (16–36 points/seq) → fewer matched pairs, wider RMSE
+  confidence interval than a dense prism log. Mitigated by reporting across all
+  4 sequences (87 checkpoints total) and stating mean ± spread.
+- **GNSS-free metric only** (see §3.4): we report the SE(3)-aligned checkpoint
+  RMSE, not the dataset's zero-alignment absolute RMSE (our RKO-LIO has no GNSS
+  to land in the surveyed frame). Still a strict upgrade over GLIM cross-val.
+
+### 2.3 Alternatives, for the record
+
+The original GT-source matrix (robotic total station self-capture / motion
+capture / RTK-GNSS / surveyed control points / reference-SLAM) is retained in
+git history (`docs/roadmap/v0.5.md` pre-rescope). Self-capture remains the
+fallback if we later want GT on *our own* indoor environment; the public
+dataset is the faster, equipment-free path for the v0.5 gate.
+
+## 3. Reference pipeline plan (sparse checkpoint RMSE)
+
+The existing APE path already does the right thing for sparse checkpoints, so
+the new code is small.
+
+1. **Download** — fetch the ROS2 `.db3` sequences (add a
+   `download_rtk_slam_dataset.py` following `download_mid360_robot_public_dataset.py`:
+   HuggingFace, per-file, hash-verified). 182 GB; can start with one sequence.
+2. **`scripts/generate_rtk_slam_reference.py`** (new) — read the checkpoint CSV
+   `point_id,easting,northing,height,env,timestamp` and emit a **sparse TUM**:
+   `timestamp easting' northing' height' 0 0 0 1` where `'` denotes subtracting
+   the first checkpoint's UTM as a **local origin** (keeps coordinates small;
+   `_rigid_align` already centers before SVD, but a local origin is cleaner).
+   Orientation columns are dummies — the APE metric is position-only, so they
+   are ignored. Source string `rtk_slam_<seq>_gt` → `_infer_reference_kind()`
+   maps `gt` → `ground_truth`. **Verify on download:** that the CSV `timestamp`
+   is on the sensor/bag clock (same stamps our SLAM output carries), else the
+   timestamp match in step 3 fails.
 3. **Score** — `write_aligned_trajectory_metrics.py --reference-tum
-   output/mid360_indoor_gt.tum --corrected-tum <slam>.tum` → `metrics.json` with
-   `reference.kind: ground_truth`. `_infer_reference_kind()` already maps a
-   source string containing `gt`/`ground_truth` to `ground_truth`, so naming the
-   source `mid360_indoor_gt` is sufficient — **no evaluator change needed**.
-4. **New profile** in `release_profiles.yaml`:
+   output/rtk_slam_<seq>_gt.tum --corrected-tum <slam>.tum`. The existing
+   `_match_rows` (tolerance 0.05 → 0.15 s) pairs each checkpoint to the nearest
+   SLAM pose; `_rigid_align` Umeyama-aligns the matched set; the output
+   `ape.rmse` with `alignment: se3_umeyama` **is exactly the dataset's "SE3"
+   checkpoint RMSE** — no evaluator change needed. Our SLAM output may need a
+   `livox_frame → base-center` transform first (their TUM is base-center; they
+   ship `transform_imu_to_base.py`); we have the MID-360 base extrinsic in
+   `configs/mid360_robot/`.
+4. **Metric semantics** — we adopt the **SE(3)-aligned** checkpoint RMSE as the
+   gate (matches our existing `ape_rmse_gt_m` definition for NTU / Newer
+   College). The dataset's zero-alignment *absolute* RMSE and its `Gap %` are
+   informative but require a GNSS-anchored estimate, which our LiDAR-inertial
+   config does not produce — so they are reported as context, not gated.
+5. **New profile(s)** in `release_profiles.yaml`, one per chosen sequence:
    ```yaml
-   - name: mid360_gt_indoor
-     description: Livox MID-360 vs robotic total-station prism GT (~277s indoor loop)
+   - name: mid360_gt_rtkslam_stadtgarten1
+     description: Livox MID-360 vs total-station checkpoints, RTK-SLAM Stadtgarten 1 (1.04 km, 36 chkpt)
      match:
-       points_topic: /livox/lidar
+       points_topic: <confirm on download — likely /livox/lidar>
        reference_kind: ground_truth
-       reference_source_contains: mid360_indoor_gt
-       min_ape_pairs: <set from GT density>
+       reference_source_contains: rtk_slam_stadtgarten1_gt
+       min_ape_pairs: 12          # ≤ checkpoint count; Umeyama needs ≥3
      metric: ape_rmse_gt_m
-     pass: <from first GT runs>
+     pass: <from first runs>
      target: <stretch>
    ```
-5. **Retire** `mid360_vs_glim`: keep it as a *report-only* cross-check (drop it
-   back to `report_only_until` / non-blocking) or delete it once `mid360_gt_indoor`
-   blocks. Decision **D-GT-2** — recommend keeping GLIM as a non-blocking
-   agreement sanity check, not deleting (cheap signal, no GT venue needed).
+6. **Retire** `mid360_vs_glim` (decision **D-GT-2**): keep as non-blocking
+   agreement sanity check, not delete — cheap signal, no GT venue needed.
 
 ## 4. Setting the threshold honestly
 
-We **cannot** pre-set `pass`/`target` — they must come from the first real GT
-runs (same discipline as `project_release_gate_design`: thresholds are
-*observed-then-set*, not aspirational). Plan: capture ≥3 runs, compute
-mean ± std APE, set `pass` near the upper envelope and `target` near the mean,
-mirroring how NTU tnp_01 landed at `pass 1.00 / target 0.30` and Newer College
-at `pass 0.10 / target 0.08`. The MID-360 number will likely sit *between*
-those given the short range and the indoor loop — but that is a prediction to
-verify, not a threshold to assert.
+`pass`/`target` come from the first real runs, not aspiration (same discipline
+as `[[project_release_gate_design]]`). Plan: run RKO-LIO on each sequence,
+record the SE(3)-aligned checkpoint RMSE, set `pass` near the upper envelope and
+`target` near the median across sequences. Expect a *wider* spread than a dense
+prism dataset because each gate sees only 16–36 points. The
+outdoor→GNSS-denied / indoor transitions make these genuinely hard sequences —
+do not assume the NTU/Newer-College range carries over.
 
 ## 5. Deliverables / acceptance criteria for v0.5
 
-- [x] **D-GT-1 decided** — robotic total station (2026-06-07). **D-GT-2**
-      (GLIM profile fate) recommended demote-to-report-only; confirm at swap.
-- [ ] A captured MID-360 bag + synchronized total-station prism log (≥3 runs of
-      the canonical ~277 s indoor loop).
-- [ ] `scripts/generate_mid360_indoor_reference.py` + `mid360_gt_extrinsic.yaml`,
-      producing `output/mid360_indoor_gt.tum`.
-- [ ] `mid360_gt_indoor` profile in `release_profiles.yaml`, `reference_kind:
-      ground_truth`, thresholds set from observed runs, **blocking**.
-- [ ] `mid360_vs_glim` demoted to non-blocking (or removed) per D-GT-2.
-- [ ] Docs: `comparison.md` updated so the MID-360 row reads `ape_rmse_gt_m`
-      (true GT) instead of the cross-val caveat; this roadmap moved to "done".
-- [ ] A short methodology note under `docs/research/` describing the GT capture
-      (source, extrinsic, sync) so the dataset is reproducible — same bar we hold
-      NTU VIRAL / Newer College to.
+- [x] **D-GT-1** — total-station GT, acquired via the public RTK-SLAM dataset
+      (re-scoped 2026-06-07). **D-GT-2** (GLIM fate): demote-to-report-only;
+      confirm at swap.
+- [ ] `scripts/download_rtk_slam_dataset.py` (HuggingFace, hash-verified) and at
+      least one sequence fetched.
+- [ ] Confirm on download: LiDAR point-cloud topic name, that the checkpoint CSV
+      `timestamp` is the sensor/bag clock, and the `livox_frame → base-center`
+      extrinsic.
+- [ ] `scripts/generate_rtk_slam_reference.py` → `output/rtk_slam_<seq>_gt.tum`
+      (+ a small reference JSON like the NTU one).
+- [ ] `mid360_gt_rtkslam_*` profile(s) in `release_profiles.yaml`,
+      `reference_kind: ground_truth`, thresholds from observed runs, **blocking**.
+- [ ] `mid360_vs_glim` demoted to non-blocking per D-GT-2.
+- [ ] Docs: `comparison.md` MID-360 row → `ape_rmse_gt_m` (true GT, total-station
+      checkpoints) instead of the cross-val caveat; this roadmap → "done". A
+      short methodology note under `docs/research/` (dataset, checkpoint metric,
+      SE(3)-aligned vs absolute, attribution per CC-BY).
 
 ## 6. Out of scope for v0.5 (explicit)
 
-Survey-grade dense reconstruction as a *product*; multi-sensor GT fusion; a
-public dataset *release* (licensing/hosting is a separate effort); replacing the
-GLIM cross-val for `leo_drive` (that dataset already ships its own Applanix
-reference and is a separate track). v0.5 is scoped to **one** MID-360 GT
-dataset and the one profile it unlocks.
+Survey-grade dense reconstruction as a *product*; multi-sensor GT fusion;
+re-hosting the dataset (we consume it under CC-BY with attribution, not
+redistribute); replacing the GLIM cross-val for `leo_drive` (separate track);
+self-capturing our own indoor GT loop (optional later complement, §2.3). v0.5 is
+scoped to the RTK-SLAM MID-360 GT profile(s) and the swap they unlock.
 
-## 7. Carry-over from v0.4 (not blocking v0.5, tracked here so it isn't lost)
+## 7. Carry-over from v0.4 (not blocking v0.5)
 
-- **D1 8-vs-16 validation** — the head-to-head reproducibility run that would
-  clear `deterministic_loop_scheduling` (#208) to flip default-on; needs
-  benchmark-data access. Independent of MID-360 GT; do opportunistically.
-- **E (accuracy / backend)** — KITTI LO baseline report + covariance-driven
-  `adjacent_edge_info_weight`; still opportunistic, unchanged from v0.4 §3.E.
+- **E — KITTI LO baseline report**: **not data-blocked** — `datasets/KITTI_odometry/`
+  is present locally (seq 00–21, GT poses 00–10, seq00 = 4541 scans), the
+  workspace is built, and the infra exists (`run_kitti_00_05_07_report.sh`,
+  `kitti_odometry_prepare.py`, `kitti_metrics.py`). Runnable now. Caveat: KITTI
+  is **CC-BY-NC-SA** (non-commercial) → fine for a README/internal LO baseline,
+  **not** shippable as a release gate.
+- **E — covariance-driven `adjacent_edge_info_weight`**: largely **superseded**
+  by the existing NIS-driven `adjacent_edge_info_auto_scale*` (residual-adaptive
+  weighting, with `test_adjacent_edge_auto_scale.cpp`). A "true" covariance
+  version needs a `SubMap.msg` carrier + scanmatcher change (cross-package) and
+  benchmark data to validate — **data/scope-gated**, not opportunistic code.
+- **D1 8-vs-16 validation** — clears `deterministic_loop_scheduling` (#208) for
+  default-on; needs a benchmark run. The RTK-SLAM sequences could double as the
+  reproducibility substrate once ingested.
 
 ---
 
-(Related memory: `[[project_mid360_robot_toolkit_stack]]`,
-`[[project_release_gate_design]]`, `[[project_v0_4_roadmap_draft]]`,
-`[[project_v0_3_positioning]]`, `[[project_place_recognition_license]]`,
-`[[project_goal]]`.)
+(Related memory: `[[project_v0_5_mid360_gt_scoping]]`,
+`[[project_mid360_robot_toolkit_stack]]`, `[[project_release_gate_design]]`,
+`[[project_v0_4_roadmap_draft]]`, `[[project_v0_3_positioning]]`,
+`[[project_place_recognition_license]]`, `[[project_goal]]`.)


### PR DESCRIPTION
## What

Re-scopes `docs/roadmap/v0.5.md` around a **public** Livox MID-360 + total-station ground-truth dataset, so v0.5 needs **no field equipment and no self-capture** — just a download, one reference script, and one profile.

## The find

Searching public sources turned up the **RTK-SLAM Dataset** (Univ. Stuttgart ifp, arXiv 2604.07151, 2026), verified via its HuggingFace + project pages:

| Property | Value |
|---|---|
| LiDAR | **Livox MID-360** (exact sensor) + IMU 200 Hz |
| Ground truth | **geodetic total station**, independent of onboard RTK |
| GT form | sparse surveyed checkpoints (CSV, 16–36/seq, 87 total) |
| Formats | ROS1 `.bag`, **ROS2 `.db3`**, extended-EuRoC |
| License | **CC-BY 4.0** (commercial-friendly) |
| Size | 182 GB, 4 sequences (park / construction hall, outdoor→GNSS-denied) |

This delivers the exact total-station GT mechanism D-GT-1 settled on, on the exact sensor, without borrowing a total station or capturing our own loop.

## Why the harness already fits

`write_aligned_trajectory_metrics.py` needs **no change**: it centers before the Umeyama SVD (UTM-safe), matches a sparse reference to the dense estimate by timestamp tolerance, and emits an `se3_umeyama`-aligned RMSE — exactly the dataset's "SE3" checkpoint metric. New code is just `generate_rtk_slam_reference.py` (CSV → sparse local-ENU TUM) and a profile with a lowered `min_ape_pairs`.

We gate the **SE(3)-aligned** checkpoint RMSE (matches our existing `ape_rmse_gt_m`); the dataset's zero-alignment absolute RMSE needs a GNSS-anchored estimate our LiDAR-inertial config doesn't produce, so it's reported as context, not gated.

## Honest trades (in the doc)

- Route shifts from our indoor loop to the dataset's outdoor→GNSS-denied / outdoor-to-indoor sequences (a real SLAM stress). Self-capture drops to an optional later complement.
- Sparse GT → wider RMSE spread; mitigated by reporting across all 4 sequences.
- Open items deferred to download: point-cloud topic name, checkpoint-timestamp clock, `livox_frame → base-center` extrinsic.

Also records (§7) that **E's KITTI LO baseline is not data-blocked** — KITTI data + build + infra are all present locally (CC-BY-NC-SA limits it to a README baseline, not a shipped gate).

## Scope

Docs-only. `mkdocs build --strict` passes.