### PR TITLE
feat(scripts): RTK-SLAM checkpoint → sparse TUM ground-truth reference

### DIFF
--- a/docs/roadmap/v0.5.md
+++ b/docs/roadmap/v0.5.md
@@ -162,8 +162,13 @@ do not assume the NTU/Newer-College range carries over.
 - [ ] Confirm on download: LiDAR point-cloud topic name, that the checkpoint CSV
       `timestamp` is the sensor/bag clock, and the `livox_frame → base-center`
       extrinsic.
-- [ ] `scripts/generate_rtk_slam_reference.py` → `output/rtk_slam_<seq>_gt.tum`
-      (+ a small reference JSON like the NTU one).
+- [x] `scripts/generate_rtk_slam_reference.py` → `output/rtk_slam_<seq>_gt.tum`
+      (+ a reference JSON like the NTU one). Landed with
+      `graph_based_slam/test/test_rtk_slam_reference.py`, whose integration test
+      proves the contract without the dataset: synthetic checkpoint CSV →
+      generator CLI → `write_aligned_trajectory_metrics.py` → ground-truth-
+      classified, SE(3)-aligned checkpoint RMSE. Pending the real download:
+      thresholds and the profile (observe-then-set, §4).
 - [ ] `mid360_gt_rtkslam_*` profile(s) in `release_profiles.yaml`,
       `reference_kind: ground_truth`, thresholds from observed runs, **blocking**.
 - [ ] `mid360_vs_glim` demoted to non-blocking per D-GT-2.

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -372,6 +372,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_rtk_slam_reference
+    test/test_rtk_slam_reference.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_benchmark_reporting_tools
     test/test_benchmark_reporting_tools.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_rtk_slam_reference.py
+++ b/graph_based_slam/test/test_rtk_slam_reference.py
@@ -1,0 +1,239 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Unit and integration tests for the RTK-SLAM reference generator.
+
+The unit tests cover the pure CSV->sparse-TUM logic (column-name mapping,
+local-origin subtraction, identity orientation, ground-truth source naming).
+The integration test proves the end-to-end contract without the 182 GB
+dataset: it runs the generator CLI on a synthetic checkpoint CSV, then scores
+the result with write_aligned_trajectory_metrics.py and asserts the reference
+is classified as ground truth and yields an SE(3)-aligned checkpoint RMSE.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR_PATH = REPO_ROOT / 'scripts' / 'generate_rtk_slam_reference.py'
+SCORER_PATH = REPO_ROOT / 'scripts' / 'write_aligned_trajectory_metrics.py'
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location(
+        'generate_rtk_slam_reference',
+        GENERATOR_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _synthetic_csv(count: int, shuffle_columns: bool = False) -> str:
+    """Build a checkpoint CSV with large UTM coordinates, like the real dataset."""
+    if shuffle_columns:
+        header = 'timestamp,point_id,env,height,northing,easting'
+    else:
+        header = 'point_id,easting,northing,height,env,timestamp'
+    lines = [header]
+    for i in range(count):
+        easting = 513000.0 + i
+        northing = 5403000.0 + 2.0 * i
+        height = 250.0 + 0.1 * i
+        env = 'park' if i % 2 == 0 else 'hall'
+        timestamp = float(i)
+        if shuffle_columns:
+            lines.append(
+                f'{timestamp:.6f},cp{i},{env},{height:.3f},{northing:.3f},{easting:.3f}',
+            )
+        else:
+            lines.append(
+                f'cp{i},{easting:.3f},{northing:.3f},{height:.3f},{env},{timestamp:.6f}',
+            )
+    return '\n'.join(lines) + '\n'
+
+
+def _parse_tum_positions(text: str) -> list[tuple[float, float, float, float]]:
+    poses = []
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) < 8:
+            continue
+        t, x, y, z = (float(parts[0]), float(parts[1]), float(parts[2]), float(parts[3]))
+        poses.append((t, x, y, z))
+    return poses
+
+
+def test_parse_checkpoints_maps_columns_by_name():
+    """Column order must not matter; columns are mapped by header name."""
+    module = _load_generator()
+    rows = module.parse_checkpoints(_synthetic_csv(3, shuffle_columns=True))
+    assert len(rows) == 3
+    assert rows[0]['point_id'] == 'cp0'
+    assert rows[0]['easting'] == 513000.0
+    assert rows[0]['env'] == 'park'
+
+
+def test_parse_checkpoints_rejects_missing_columns():
+    """A CSV missing a required column should raise a clear error."""
+    module = _load_generator()
+    bad = 'point_id,easting,northing,height,timestamp\ncp0,1,2,3,0.0\n'
+    raised = False
+    try:
+        module.parse_checkpoints(bad)
+    except ValueError as exc:
+        raised = True
+        assert 'env' in str(exc)
+    assert raised
+
+
+def test_parse_checkpoints_skips_blank_rows():
+    """Blank or numerically empty rows are skipped, not fatal."""
+    module = _load_generator()
+    text = (
+        'point_id,easting,northing,height,env,timestamp\n'
+        'cp0,513000,5403000,250,park,0.0\n'
+        '\n'
+        'cp1,513001,5403002,250.1,hall,1.0\n'
+    )
+    rows = module.parse_checkpoints(text)
+    assert len(rows) == 2
+
+
+def test_localize_sorts_by_time_and_subtracts_origin():
+    """The earliest checkpoint becomes the local origin; UTM shrinks to small."""
+    module = _load_generator()
+    checkpoints = module.parse_checkpoints(_synthetic_csv(4))
+    # Reverse to confirm localize sorts by timestamp rather than input order.
+    local, origin = module.localize(list(reversed(checkpoints)))
+    assert origin['easting'] == 513000.0
+    assert local[0]['timestamp'] == 0.0
+    assert local[0]['x'] == 0.0 and local[0]['y'] == 0.0 and local[0]['z'] == 0.0
+    # Coordinates are now metres-scale, not 1e5-scale UTM.
+    assert abs(local[-1]['x']) < 100.0
+    assert abs(local[-1]['y']) < 100.0
+
+
+def test_to_tum_lines_have_identity_orientation_and_eight_columns():
+    """Each TUM line has 8 columns with an identity (0 0 0 1) quaternion."""
+    module = _load_generator()
+    local, _ = module.localize(module.parse_checkpoints(_synthetic_csv(3)))
+    lines = module.to_tum_lines(local)
+    assert len(lines) == 3
+    for line in lines:
+        parts = line.split()
+        assert len(parts) == 8
+        assert parts[4:] == ['0.000000000', '0.000000000', '0.000000000', '1.000000000']
+
+
+def test_source_name_contains_gt_token():
+    """The source slug must contain 'gt' so the scorer infers ground_truth."""
+    module = _load_generator()
+    assert module.source_name('Stadtgarten 1') == 'rtk_slam_stadtgarten_1_gt'
+    assert 'gt' in module.source_name('hall-2')
+
+
+def test_env_breakdown_counts_per_label():
+    """env_breakdown tallies checkpoints per environment label."""
+    module = _load_generator()
+    local, _ = module.localize(module.parse_checkpoints(_synthetic_csv(4)))
+    counts = module.env_breakdown(local)
+    assert counts == {'park': 2, 'hall': 2}
+
+
+def test_generated_reference_scores_as_ground_truth(tmp_path):
+    """Generator CLI output scores as an SE(3)-aligned ground-truth checkpoint RMSE."""
+    csv_path = tmp_path / 'checkpoints.csv'
+    csv_path.write_text(_synthetic_csv(12), encoding='utf-8')
+
+    ref_tum = tmp_path / 'rtk_slam_test_gt.tum'
+    meta_path = tmp_path / 'rtk_slam_test_reference.json'
+    gen = subprocess.run(
+        [
+            'python3', str(GENERATOR_PATH),
+            '--checkpoints', str(csv_path),
+            '--sequence', 'test',
+            '--out', str(ref_tum),
+            '--write-meta', str(meta_path),
+        ],
+        capture_output=True, text=True, check=False, cwd=REPO_ROOT,
+    )
+    assert gen.returncode == 0, gen.stderr
+    meta = json.loads(meta_path.read_text(encoding='utf-8'))
+    assert meta['source'] == 'rtk_slam_test_gt'
+    assert meta['kind'] == 'ground_truth'
+    assert meta['checkpoint_count'] == 12
+
+    # Build an estimate that differs from GT by a pure rigid translation, which
+    # SE(3) alignment removes -> RMSE ~ 0 over the sparse checkpoint set.
+    ref_poses = _parse_tum_positions(ref_tum.read_text(encoding='utf-8'))
+    assert len(ref_poses) == 12
+    est_tum = tmp_path / 'est.tum'
+    est_lines = []
+    for t, x, y, z in ref_poses:
+        est_lines.append(
+            f'{t:.9f} {x + 1.5:.9f} {y - 2.0:.9f} {z + 0.5:.9f} 0 0 0 1',
+        )
+    est_tum.write_text('\n'.join(est_lines) + '\n', encoding='utf-8')
+
+    bag_dir = tmp_path / 'bag'
+    bag_dir.mkdir(parents=True, exist_ok=True)
+    (bag_dir / 'metadata.yaml').write_text(
+        'rosbag2_bagfile_information:\n  duration:\n    nanoseconds: 1000000000\n',
+        encoding='utf-8',
+    )
+
+    out_dir = tmp_path / 'output' / 'bench'
+    # Omit --reference-kind so the kind is inferred from the source slug.
+    score = subprocess.run(
+        [
+            'python3', str(SCORER_PATH),
+            '--out-dir', str(out_dir),
+            '--bag', str(bag_dir),
+            '--reference-tum', str(ref_tum),
+            '--corrected-tum', str(est_tum),
+            '--reference-source', 'rtk_slam_test_gt',
+        ],
+        capture_output=True, text=True, check=False, cwd=REPO_ROOT,
+    )
+    assert score.returncode == 0, score.stderr
+    metrics = json.loads((out_dir / 'metrics.json').read_text(encoding='utf-8'))
+    assert metrics['reference']['kind'] == 'ground_truth'
+    assert metrics['reference']['source'] == 'rtk_slam_test_gt'
+    assert metrics['evo']['ape']['alignment'] == 'se3_umeyama'
+    assert metrics['evo']['ape']['pairs'] == 12
+    assert metrics['evo']['ape']['rmse'] < 1e-6

--- a/scripts/generate_rtk_slam_reference.py
+++ b/scripts/generate_rtk_slam_reference.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+
+"""
+Build a sparse ground-truth reference from RTK-SLAM dataset checkpoints.
+
+The RTK-SLAM dataset (Univ. Stuttgart, arXiv:2604.07151, CC-BY 4.0) ships its
+ground truth as sparse geodetic-total-station checkpoints in a CSV with the
+columns ``point_id,easting,northing,height,env,timestamp``. This converts that
+CSV into a sparse TUM trajectory (one pose per checkpoint, identity
+orientation) that ``write_aligned_trajectory_metrics.py`` scores exactly like
+the NTU VIRAL / Newer College prism references: each checkpoint is
+timestamp-matched to the estimate and the matched set is SE(3)-aligned
+(Umeyama) before the per-point RMSE. That SE(3)-aligned checkpoint RMSE is the
+v0.5 gate metric (``ape_rmse_gt_m``); the dataset's zero-alignment absolute
+RMSE needs a GNSS-anchored estimate, which a LiDAR-inertial config does not
+produce, so it is out of scope here.
+
+UTM eastings/northings are large (~1e5..1e6 m); the first checkpoint by time is
+subtracted as a local origin so the emitted coordinates stay small and
+readable. ``_rigid_align`` already centers before its SVD, so the alignment is
+invariant to this offset. The source string contains ``gt`` so
+``_infer_reference_kind`` classifies the reference as ground truth.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+from pathlib import Path
+
+REQUIRED_COLUMNS = ('point_id', 'easting', 'northing', 'height', 'env', 'timestamp')
+_NUMERIC_REQUIRED = ('easting', 'northing', 'height', 'timestamp')
+
+
+def parse_checkpoints(text: str) -> list[dict]:
+    """Parse RTK-SLAM checkpoint CSV text into a list of dicts (by column name)."""
+    reader = csv.DictReader(io.StringIO(text))
+    if reader.fieldnames is None:
+        raise ValueError('checkpoint CSV has no header row')
+    fieldmap = {name.strip(): name for name in reader.fieldnames}
+    missing = [column for column in REQUIRED_COLUMNS if column not in fieldmap]
+    if missing:
+        raise ValueError(f'checkpoint CSV missing columns: {missing}')
+
+    rows: list[dict] = []
+    for raw in reader:
+        values = {column: raw.get(fieldmap[column]) for column in REQUIRED_COLUMNS}
+        if any(values[column] is None or str(values[column]).strip() == ''
+               for column in _NUMERIC_REQUIRED):
+            continue
+        rows.append({
+            'point_id': str(values['point_id']).strip(),
+            'easting': float(values['easting']),
+            'northing': float(values['northing']),
+            'height': float(values['height']),
+            'env': str(values['env']).strip(),
+            'timestamp': float(values['timestamp']),
+        })
+    if not rows:
+        raise ValueError('checkpoint CSV has no usable data rows')
+    return rows
+
+
+def localize(checkpoints: list[dict]) -> tuple[list[dict], dict]:
+    """Sort checkpoints by time and subtract the first one as a local origin."""
+    ordered = sorted(checkpoints, key=lambda checkpoint: checkpoint['timestamp'])
+    origin = {
+        'easting': ordered[0]['easting'],
+        'northing': ordered[0]['northing'],
+        'height': ordered[0]['height'],
+    }
+    local: list[dict] = []
+    for checkpoint in ordered:
+        local.append({
+            'timestamp': checkpoint['timestamp'],
+            'x': checkpoint['easting'] - origin['easting'],
+            'y': checkpoint['northing'] - origin['northing'],
+            'z': checkpoint['height'] - origin['height'],
+            'env': checkpoint['env'],
+            'point_id': checkpoint['point_id'],
+        })
+    return local, origin
+
+
+def to_tum_lines(local_rows: list[dict]) -> list[str]:
+    """Render localized checkpoints as TUM lines with identity orientation."""
+    lines: list[str] = []
+    for row in local_rows:
+        lines.append(
+            f"{row['timestamp']:.9f} "
+            f"{row['x']:.9f} {row['y']:.9f} {row['z']:.9f} "
+            '0.000000000 0.000000000 0.000000000 1.000000000',
+        )
+    return lines
+
+
+def source_name(sequence: str) -> str:
+    """Return the reference source string; contains 'gt' so kind == ground_truth."""
+    slug = sequence.strip().lower().replace(' ', '_').replace('-', '_')
+    return f'rtk_slam_{slug}_gt'
+
+
+def env_breakdown(local_rows: list[dict]) -> dict:
+    """Count checkpoints per environment label."""
+    counts: dict = {}
+    for row in local_rows:
+        counts[row['env']] = counts.get(row['env'], 0) + 1
+    return counts
+
+
+def build_reference(csv_path: Path, sequence: str) -> tuple[list[str], dict]:
+    """Read a checkpoint CSV and return (tum_lines, metadata-without-paths)."""
+    checkpoints = parse_checkpoints(csv_path.read_text(encoding='utf-8'))
+    local, origin = localize(checkpoints)
+    tum_lines = to_tum_lines(local)
+    meta = {
+        'source': source_name(sequence),
+        'kind': 'ground_truth',
+        'dataset': 'rtk_slam',
+        'dataset_citation': (
+            'RTK-SLAM Dataset, Univ. Stuttgart, arXiv:2604.07151 (CC-BY 4.0)'
+        ),
+        'sequence': sequence,
+        'frame': 'local_enu_from_utm',
+        'units': 'meters',
+        'local_origin_utm': origin,
+        'checkpoint_count': len(local),
+        'env_breakdown': env_breakdown(local),
+        'metric_note': (
+            'Score with write_aligned_trajectory_metrics.py; the SE(3)-aligned '
+            'checkpoint RMSE is the v0.5 gate metric (ape_rmse_gt_m).'
+        ),
+    }
+    return tum_lines, meta
+
+
+def main() -> int:
+    """CLI entry point: checkpoint CSV -> sparse TUM + reference JSON sidecar."""
+    parser = argparse.ArgumentParser(
+        description=(
+            'Convert an RTK-SLAM checkpoint CSV into a sparse TUM ground-truth '
+            'reference scorable by write_aligned_trajectory_metrics.py.'
+        ),
+    )
+    parser.add_argument(
+        '--checkpoints',
+        required=True,
+        help='Path to the RTK-SLAM checkpoint CSV '
+             '(point_id,easting,northing,height,env,timestamp)',
+    )
+    parser.add_argument(
+        '--sequence',
+        required=True,
+        help='Sequence name, e.g. stadtgarten1 (used in the source slug)',
+    )
+    parser.add_argument(
+        '--out',
+        default=None,
+        help='Output TUM path (default: output/rtk_slam_<sequence>_gt.tum)',
+    )
+    parser.add_argument(
+        '--write-meta',
+        default=None,
+        help='JSON sidecar path (default: output/rtk_slam_<sequence>_reference.json)',
+    )
+    args = parser.parse_args()
+
+    csv_path = Path(args.checkpoints).expanduser().resolve()
+    slug = args.sequence.strip().lower().replace(' ', '_').replace('-', '_')
+    out_path = Path(args.out).expanduser().resolve() if args.out else \
+        Path(f'output/rtk_slam_{slug}_gt.tum').resolve()
+    meta_path = Path(args.write_meta).expanduser().resolve() if args.write_meta else \
+        Path(f'output/rtk_slam_{slug}_reference.json').resolve()
+
+    tum_lines, meta = build_reference(csv_path, args.sequence)
+    meta['reference_tum_path'] = str(out_path)
+    meta['csv_path'] = str(csv_path)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text('\n'.join(tum_lines) + ('\n' if tum_lines else ''), encoding='utf-8')
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_path.write_text(json.dumps(meta, indent=2) + '\n', encoding='utf-8')
+
+    print(f'reference_tum: {out_path}')
+    print(f'checkpoints: {meta["checkpoint_count"]} env={meta["env_breakdown"]}')
+    print(f'reference_meta: {meta_path}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## What

First v0.5 implementation step: `scripts/generate_rtk_slam_reference.py` turns the public **RTK-SLAM dataset**'s sparse total-station checkpoint CSV into a sparse TUM ground-truth trajectory that the existing scorer already understands — moving the MID-360 gate from GLIM cross-validation toward a true `ape_rmse_gt_m` profile (scoped in `docs/roadmap/v0.5.md`).

## How it fits the existing scorer with no evaluator change

- CSV `point_id,easting,northing,height,env,timestamp` → columns mapped **by header name** (order-independent).
- First checkpoint by time subtracted as a **local origin** so large UTM coordinates stay small (the scorer's `_rigid_align` also centers before its SVD).
- **Identity orientation** — the APE metric is position-only.
- Source slug contains `gt`, so `write_aligned_trajectory_metrics.py`'s `_infer_reference_kind` classifies it as **ground truth** with no explicit kind passed.
- The scorer then timestamp-matches each checkpoint to the estimate and **SE(3)-aligns (Umeyama)** before the per-point RMSE — exactly the dataset's "SE3" checkpoint metric.

## Testing

`graph_based_slam/test/test_rtk_slam_reference.py` (registered in CMakeLists):
- Pure-logic units: column-name mapping, missing-column rejection, blank-row skip, time-sort + local-origin subtraction, identity-quaternion TUM, `gt` source naming, env tally.
- **Integration test that proves the whole contract without the 182 GB download**: synthetic checkpoint CSV → generator CLI → `write_aligned_trajectory_metrics.py` → asserts `reference.kind == ground_truth`, `alignment == se3_umeyama`, `rmse < 1e-6` (pure-translation estimate), `pairs == 12`.

Local: pytest **8/8**, `ament_flake8` / `ament_pep257` / `ament_copyright` clean, `colcon test` green.

## Deliberately deferred

The release profile and its `pass`/`target` thresholds wait for the first real runs (observe-then-set, `docs/roadmap/v0.5.md` §4), and the 182 GB download confirms the point-cloud topic name, the checkpoint-timestamp clock, and the `livox_frame → base-center` extrinsic.

## Scope

One new script + its test + CMakeLists registration + a roadmap checkbox. No change to existing code paths or the evaluator.