### PR TITLE
feat(rtk-slam): download tooling + sparse-checkpoint match tolerance, validated on real GT

### DIFF
--- a/docs/roadmap/v0.5.md
+++ b/docs/roadmap/v0.5.md
@@ -99,48 +99,75 @@ dataset is the faster, equipment-free path for the v0.5 gate.
 The existing APE path already does the right thing for sparse checkpoints, so
 the new code is small.
 
-1. **Download** — fetch the ROS2 `.db3` sequences (add a
-   `download_rtk_slam_dataset.py` following `download_mid360_robot_public_dataset.py`:
-   HuggingFace, per-file, hash-verified). 182 GB; can start with one sequence.
-2. **`scripts/generate_rtk_slam_reference.py`** (new) — read the checkpoint CSV
-   `point_id,easting,northing,height,env,timestamp` and emit a **sparse TUM**:
-   `timestamp easting' northing' height' 0 0 0 1` where `'` denotes subtracting
-   the first checkpoint's UTM as a **local origin** (keeps coordinates small;
-   `_rigid_align` already centers before SVD, but a local origin is cleaner).
-   Orientation columns are dummies — the APE metric is position-only, so they
-   are ignored. Source string `rtk_slam_<seq>_gt` → `_infer_reference_kind()`
-   maps `gt` → `ground_truth`. **Verify on download:** that the CSV `timestamp`
-   is on the sensor/bag clock (same stamps our SLAM output carries), else the
-   timestamp match in step 3 fails.
+1. **Get the data** (`scripts/download_rtk_slam_dataset.py`, landed). Key
+   discovery (2026-06-07): the **ground truth is not in the 182 GB dataset** —
+   the surveyed checkpoints are tiny CSVs (`ground_truth/<seq>.csv`, ~1–2 KB) in
+   the **eval repo** (`github.com/Willyzw/rtk-slam-eval`), which also ships
+   example SLAM trajectories. So `--eval-assets` (a few-MB git clone) is all the
+   reference pipeline needs; the per-sequence ROS2 `.db3` (`--sequence`, ~10–30
+   GB, smallest `construction_seq2` ~10.7 GB) is only needed to run **our own**
+   RKO-LIO and produce the estimate trajectory.
+2. **`scripts/generate_rtk_slam_reference.py`** (landed) — read the checkpoint
+   CSV `point_id,easting,northing,height,env,timestamp` and emit a **sparse
+   TUM**: `timestamp easting' northing' height' 0 0 0 1` where `'` subtracts the
+   first checkpoint's UTM as a **local origin**. Orientation columns are dummies
+   (the APE metric is position-only). Source `rtk_slam_<seq>_gt` →
+   `_infer_reference_kind()` maps `gt` → `ground_truth`. Verified on the real
+   CSVs: `timestamp` is the **Unix-epoch sensor clock** (matches the example
+   trajectories' stamps), and `env` includes a `transition` label besides
+   `outdoor`/`indoor`.
 3. **Score** — `write_aligned_trajectory_metrics.py --reference-tum
-   output/rtk_slam_<seq>_gt.tum --corrected-tum <slam>.tum`. The existing
-   `_match_rows` (tolerance 0.05 → 0.15 s) pairs each checkpoint to the nearest
-   SLAM pose; `_rigid_align` Umeyama-aligns the matched set; the output
-   `ape.rmse` with `alignment: se3_umeyama` **is exactly the dataset's "SE3"
-   checkpoint RMSE** — no evaluator change needed. Our SLAM output may need a
-   `livox_frame → base-center` transform first (their TUM is base-center; they
-   ship `transform_imu_to_base.py`); we have the MID-360 base extrinsic in
+   output/rtk_slam_<seq>_gt.tum --corrected-tum <slam>.tum
+   --match-tolerance 2.0`. `_rigid_align` Umeyama-aligns the timestamp-matched
+   set; the output `ape.rmse` with `alignment: se3_umeyama` **is exactly the
+   dataset's "SE3" checkpoint RMSE** — no evaluator change. The new
+   **`--match-tolerance`** (default keeps the 0.05 → 0.15 s cascade) reproduces
+   the dataset's `max_dt = 2.0 s` so a sparse checkpoint is not silently dropped
+   when the estimate is downsampled — without it, sparse third-party
+   trajectories lose checkpoints (e.g. 7/16 instead of 16/16; see §3.5). Our own
+   dense RKO-LIO output matches at the default tolerance. Our SLAM output may
+   need a `livox_frame → base-center` transform first (their TUM is base-center;
+   they ship `transform_imu_to_base.py`); we have the MID-360 base extrinsic in
    `configs/mid360_robot/`.
 4. **Metric semantics** — we adopt the **SE(3)-aligned** checkpoint RMSE as the
-   gate (matches our existing `ape_rmse_gt_m` definition for NTU / Newer
-   College). The dataset's zero-alignment *absolute* RMSE and its `Gap %` are
-   informative but require a GNSS-anchored estimate, which our LiDAR-inertial
-   config does not produce — so they are reported as context, not gated.
+   gate (matches our existing `ape_rmse_gt_m` for NTU / Newer College). The
+   dataset's zero-alignment *absolute* RMSE and its `Gap %` need a GNSS-anchored
+   estimate, which our LiDAR-inertial config does not produce — reported as
+   context, not gated.
 5. **New profile(s)** in `release_profiles.yaml`, one per chosen sequence:
    ```yaml
    - name: mid360_gt_rtkslam_stadtgarten1
      description: Livox MID-360 vs total-station checkpoints, RTK-SLAM Stadtgarten 1 (1.04 km, 36 chkpt)
      match:
-       points_topic: <confirm on download — likely /livox/lidar>
+       points_topic: /livox/points     # sensor_msgs/PointCloud2 (confirmed from README)
        reference_kind: ground_truth
        reference_source_contains: rtk_slam_stadtgarten1_gt
-       min_ape_pairs: 12          # ≤ checkpoint count; Umeyama needs ≥3
+       min_ape_pairs: 12               # <= checkpoint count; Umeyama needs >= 3
      metric: ape_rmse_gt_m
-     pass: <from first runs>
+     pass: <from first RKO-LIO runs>
      target: <stretch>
    ```
 6. **Retire** `mid360_vs_glim` (decision **D-GT-2**): keep as non-blocking
    agreement sanity check, not delete — cheap signal, no GT venue needed.
+
+### 3.5 Real-data validation (eval assets only, no 182 GB bag)
+
+Running the **landed** generator + scorer on the **real** GT CSVs against the
+eval repo's published example trajectories (`--match-tolerance 2.0`) already
+exercises the full v0.5 metric path end-to-end and gives a baseline anchor —
+all classified `ground_truth`, `alignment: se3_umeyama`:
+
+| Sequence | chkpt | `fast_lio_sam` RMSE (m) | `okvis_lvig` RMSE (m) |
+|---|---|---|---|
+| construction_seq1 | 16 | 0.221 | 0.227 |
+| construction_seq2 | 16 | 0.086 | 0.075 |
+| stadtgarten_seq1  | 36 | 0.071 (35 paired) | 0.054 |
+| stadtgarten_seq2  | 19 | 0.070 | 0.083 |
+
+These are *published-method* numbers, not ours — but they prove the pipeline
+produces sane absolute-accuracy RMSE on real total-station GT, and they bracket
+where our own RKO-LIO needs to land (roughly 0.05–0.23 m; construction_seq1 is
+the hard one). Thresholds (§4) still come from our own runs.
 
 ## 4. Setting the threshold honestly
 
@@ -157,18 +184,24 @@ do not assume the NTU/Newer-College range carries over.
 - [x] **D-GT-1** — total-station GT, acquired via the public RTK-SLAM dataset
       (re-scoped 2026-06-07). **D-GT-2** (GLIM fate): demote-to-report-only;
       confirm at swap.
-- [ ] `scripts/download_rtk_slam_dataset.py` (HuggingFace, hash-verified) and at
-      least one sequence fetched.
-- [ ] Confirm on download: LiDAR point-cloud topic name, that the checkpoint CSV
-      `timestamp` is the sensor/bag clock, and the `livox_frame → base-center`
-      extrinsic.
+- [x] `scripts/download_rtk_slam_dataset.py` (HuggingFace bags + `--eval-assets`
+      git clone of the GT CSVs / example trajectories; size-checked). Eval assets
+      fetched; `construction_seq2` bag (~10.7 GB) downloading for the first own
+      RKO-LIO run.
+- [x] Confirmed: point-cloud topic **`/livox/points`** (`sensor_msgs/PointCloud2`;
+      `/livox/lidar` is the Livox `CustomMsg`), and the checkpoint CSV `timestamp`
+      is the **Unix-epoch sensor clock**. **Still open:** the `livox_frame →
+      base-center` extrinsic (their TUM is base-center; `transform_imu_to_base.py`
+      + `configs/mid360_robot/` cover it — confirm against the bag's `/tf_static`).
 - [x] `scripts/generate_rtk_slam_reference.py` → `output/rtk_slam_<seq>_gt.tum`
       (+ a reference JSON like the NTU one). Landed with
       `graph_based_slam/test/test_rtk_slam_reference.py`, whose integration test
       proves the contract without the dataset: synthetic checkpoint CSV →
       generator CLI → `write_aligned_trajectory_metrics.py` → ground-truth-
-      classified, SE(3)-aligned checkpoint RMSE. Pending the real download:
-      thresholds and the profile (observe-then-set, §4).
+      classified, SE(3)-aligned checkpoint RMSE. **Also validated on the real GT
+      CSVs** against the eval repo's example trajectories (§3.5).
+- [ ] Run RKO-LIO on the downloaded sequence(s) → our own SE(3)-aligned
+      checkpoint RMSE; set thresholds (observe-then-set, §4).
 - [ ] `mid360_gt_rtkslam_*` profile(s) in `release_profiles.yaml`,
       `reference_kind: ground_truth`, thresholds from observed runs, **blocking**.
 - [ ] `mid360_vs_glim` demoted to non-blocking per D-GT-2.

--- a/graph_based_slam/test/test_rtk_slam_reference.py
+++ b/graph_based_slam/test/test_rtk_slam_reference.py
@@ -237,3 +237,64 @@ def test_generated_reference_scores_as_ground_truth(tmp_path):
     assert metrics['evo']['ape']['alignment'] == 'se3_umeyama'
     assert metrics['evo']['ape']['pairs'] == 12
     assert metrics['evo']['ape']['rmse'] < 1e-6
+
+
+def test_match_tolerance_recovers_offset_sparse_checkpoints(tmp_path):
+    """A wide --match-tolerance pairs checkpoints to a downsampled estimate."""
+    csv_path = tmp_path / 'checkpoints.csv'
+    csv_path.write_text(_synthetic_csv(12), encoding='utf-8')
+    ref_tum = tmp_path / 'gt.tum'
+    subprocess.run(
+        [
+            'python3', str(GENERATOR_PATH),
+            '--checkpoints', str(csv_path),
+            '--sequence', 'test',
+            '--out', str(ref_tum),
+            '--write-meta', str(tmp_path / 'ref.json'),
+        ],
+        capture_output=True, text=True, check=True, cwd=REPO_ROOT,
+    )
+
+    # Estimate timestamps sit 0.5 s off every checkpoint: beyond the default
+    # 0.15 s cascade, inside a 2.0 s tolerance. Positions are unchanged, so the
+    # wide-tolerance match recovers all 12 checkpoints.
+    ref_poses = _parse_tum_positions(ref_tum.read_text(encoding='utf-8'))
+    est_tum = tmp_path / 'est.tum'
+    est_tum.write_text(
+        '\n'.join(
+            f'{t + 0.5:.9f} {x:.9f} {y:.9f} {z:.9f} 0 0 0 1'
+            for t, x, y, z in ref_poses
+        ) + '\n',
+        encoding='utf-8',
+    )
+
+    bag_dir = tmp_path / 'bag'
+    bag_dir.mkdir(parents=True, exist_ok=True)
+    (bag_dir / 'metadata.yaml').write_text(
+        'rosbag2_bagfile_information:\n  duration:\n    nanoseconds: 1000000000\n',
+        encoding='utf-8',
+    )
+
+    def _score(out_dir, extra):
+        return subprocess.run(
+            [
+                'python3', str(SCORER_PATH),
+                '--out-dir', str(out_dir),
+                '--bag', str(bag_dir),
+                '--reference-tum', str(ref_tum),
+                '--corrected-tum', str(est_tum),
+                '--reference-source', 'rtk_slam_test_gt',
+            ] + extra,
+            capture_output=True, text=True, check=False, cwd=REPO_ROOT,
+        )
+
+    # The default cascade cannot pair anything 0.5 s away, so it fails.
+    default = _score(tmp_path / 'out_default', [])
+    assert default.returncode != 0
+
+    wide = _score(tmp_path / 'out_wide', ['--match-tolerance', '2.0'])
+    assert wide.returncode == 0, wide.stderr
+    metrics = json.loads(
+        (tmp_path / 'out_wide' / 'metrics.json').read_text(encoding='utf-8'),
+    )
+    assert metrics['evo']['ape']['pairs'] == 12

--- a/scripts/download_rtk_slam_dataset.py
+++ b/scripts/download_rtk_slam_dataset.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+
+"""
+Download the public RTK-SLAM dataset (Livox MID-360 + total-station GT).
+
+RTK-SLAM Dataset, Univ. Stuttgart ifp (arXiv:2604.07151, CC-BY 4.0):
+huggingface.co/datasets/Willyzw/rtk-slam-dataset. The bags are large
+(ROS2 .db3 from ~10 to ~30 GB per sequence), so fetch one sequence at a time.
+
+The ground-truth checkpoints are NOT in the dataset repo: they live in the
+small eval repo (github.com/Willyzw/rtk-slam-eval) as
+``ground_truth/<sequence>.csv``, alongside example SLAM trajectories. Use
+``--eval-assets`` to clone that repo (a few MB) — it is all that is needed to
+build a reference with ``generate_rtk_slam_reference.py``; the big bag is only
+needed to run our own SLAM and produce the estimate trajectory.
+
+Attribution (CC-BY 4.0): cite Zhang, Ress, Skuddis, Soergel, Haala, "An
+RTK-SLAM Dataset for Absolute Accuracy Evaluation in GNSS-Degraded
+Environments", arXiv:2604.07151.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+HF_REPO = 'Willyzw/rtk-slam-dataset'
+HF_RESOLVE = f'https://huggingface.co/datasets/{HF_REPO}/resolve/main'
+EVAL_REPO_URL = 'https://github.com/Willyzw/rtk-slam-eval.git'
+
+# Per-sequence ROS2 payloads (path under the repo -> expected size in bytes).
+# Sizes are from the HuggingFace tree API and double as a post-download check.
+SEQUENCES = {
+    'construction_seq2': 10656124000,
+    'construction_seq1': 13180900000,
+    'stadtgarten_seq2': 16793700000,
+    'stadtgarten_seq1': 30263600000,
+}
+
+
+def _human_gb(num_bytes: int) -> str:
+    return f'{num_bytes / 1e9:.1f} GB'
+
+
+def _download(url: str, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    # wget -c is resumable, which matters for multi-GB LFS payloads.
+    cmd = ['wget', '-c', '-O', str(dest), url]
+    print(f'  {url}\n    -> {dest}')
+    subprocess.run(cmd, check=True)
+
+
+def fetch_sequence(sequence: str, dest_root: Path, size_check: bool = True) -> None:
+    """Download one ROS2 sequence (.db3 + metadata.yaml) into dest_root/ros2/<seq>."""
+    if sequence not in SEQUENCES:
+        raise SystemExit(f'unknown sequence: {sequence} (choices: {list(SEQUENCES)})')
+    expected = SEQUENCES[sequence]
+    print(f'[{sequence}] ~{_human_gb(expected)} (ROS2 .db3)')
+    seq_dir = dest_root / 'ros2' / sequence
+    db3 = seq_dir / f'{sequence}.db3'
+    _download(f'{HF_RESOLVE}/ros2/{sequence}/{sequence}.db3', db3)
+    _download(f'{HF_RESOLVE}/ros2/{sequence}/metadata.yaml', seq_dir / 'metadata.yaml')
+    if size_check and db3.is_file():
+        actual = db3.stat().st_size
+        # Registry sizes are rounded; allow a 1% band rather than an exact match.
+        if abs(actual - expected) > max(expected * 0.01, 1_000_000):
+            print(
+                f'  WARNING: {db3.name} is {_human_gb(actual)}, '
+                f'expected ~{_human_gb(expected)}',
+                file=sys.stderr,
+            )
+
+
+def fetch_eval_assets(dest_root: Path) -> None:
+    """Clone the eval repo (ground-truth checkpoints + example trajectories)."""
+    target = dest_root / 'rtk_slam_eval'
+    if (target / '.git').is_dir():
+        print(f'[eval-assets] already present: {target}')
+        return
+    print(f'[eval-assets] cloning {EVAL_REPO_URL} -> {target}')
+    subprocess.run(
+        ['git', 'clone', '--depth', '1', EVAL_REPO_URL, str(target)],
+        check=True,
+    )
+
+
+def main() -> int:
+    """CLI entry point for fetching RTK-SLAM bags and/or eval assets."""
+    parser = argparse.ArgumentParser(
+        description='Download the public RTK-SLAM dataset (bags and/or eval assets).',
+    )
+    parser.add_argument(
+        '--sequence',
+        default='construction_seq2',
+        help="ROS2 sequence to fetch, or 'all'. Smallest is construction_seq2 "
+             '(~10.7 GB). Default: construction_seq2.',
+    )
+    parser.add_argument(
+        '--dest',
+        default='datasets/rtk_slam',
+        help='Destination root (default: datasets/rtk_slam, which is gitignored)',
+    )
+    parser.add_argument(
+        '--eval-assets',
+        action='store_true',
+        help='Also clone the eval repo (ground-truth CSVs + example trajectories)',
+    )
+    parser.add_argument(
+        '--eval-assets-only',
+        action='store_true',
+        help='Clone only the eval assets; skip the large bag download',
+    )
+    parser.add_argument(
+        '--list',
+        action='store_true',
+        help='List the available sequences and their sizes, then exit',
+    )
+    args = parser.parse_args()
+
+    if args.list:
+        for name, size in SEQUENCES.items():
+            print(f'{name:20s} ~{_human_gb(size)}')
+        return 0
+
+    dest_root = Path(args.dest).expanduser().resolve()
+
+    if args.eval_assets_only:
+        fetch_eval_assets(dest_root)
+        return 0
+
+    sequences = list(SEQUENCES) if args.sequence == 'all' else [args.sequence]
+    for sequence in sequences:
+        fetch_sequence(sequence, dest_root)
+
+    if args.eval_assets:
+        fetch_eval_assets(dest_root)
+
+    print('done. Ground truth + example trajectories come from --eval-assets; '
+          'build a reference with scripts/generate_rtk_slam_reference.py.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/write_aligned_trajectory_metrics.py
+++ b/scripts/write_aligned_trajectory_metrics.py
@@ -114,21 +114,37 @@ def _apply_alignment(
     return out
 
 
-def _ape_metrics(
+def _match_with_tolerance(
     ref_rows: list[dict[str, float]],
     est_rows: list[dict[str, float]],
-) -> dict[str, Any]:
+    match_tolerance: float | None,
+) -> list[tuple[dict[str, float], dict[str, float]]]:
+    # Default (match_tolerance is None): the historical 0.05 -> 0.15 s cascade,
+    # right for a dense estimate sampled near the reference. A single explicit
+    # tolerance is for sparse references (e.g. RTK-SLAM total-station
+    # checkpoints) scored against a downsampled trajectory, and to reproduce the
+    # dataset's own max_dt; it suppresses the silent dropping of checkpoints
+    # that have no estimate pose within 0.15 s.
+    if match_tolerance is not None:
+        return _match_rows(ref_rows, est_rows, tolerance=match_tolerance)
     pairs = _match_rows(ref_rows, est_rows, tolerance=0.05)
     if len(pairs) < 10:
         pairs = _match_rows(ref_rows, est_rows, tolerance=0.15)
+    return pairs
+
+
+def _ape_metrics(
+    ref_rows: list[dict[str, float]],
+    est_rows: list[dict[str, float]],
+    match_tolerance: float | None = None,
+) -> dict[str, Any]:
+    pairs = _match_with_tolerance(ref_rows, est_rows, match_tolerance)
     if len(pairs) < 3:
         raise RuntimeError('not enough matched poses for alignment')
 
     rot, trans = _rigid_align(pairs)
     est_aligned = _apply_alignment(est_rows, rot, trans)
-    aligned_pairs = _match_rows(ref_rows, est_aligned, tolerance=0.05)
-    if len(aligned_pairs) < 10:
-        aligned_pairs = _match_rows(ref_rows, est_aligned, tolerance=0.15)
+    aligned_pairs = _match_with_tolerance(ref_rows, est_aligned, match_tolerance)
     if len(aligned_pairs) < 3:
         raise RuntimeError('not enough matched poses after alignment')
 
@@ -302,6 +318,15 @@ def main() -> int:
         help='Reference kind label, for example ground_truth or cross_validation',
     )
     parser.add_argument(
+        '--match-tolerance',
+        type=float,
+        default=-1.0,
+        help='Single timestamp-match tolerance in seconds for reference/estimate '
+             'pairing. <= 0 keeps the default 0.05 -> 0.15 s cascade. Set a larger '
+             'value (e.g. 2.0) for sparse references such as RTK-SLAM total-station '
+             'checkpoints scored against a downsampled trajectory.',
+    )
+    parser.add_argument(
         '--reference-label',
         default='reference',
         help='Human-readable reference label stored in metrics.json',
@@ -358,12 +383,13 @@ def main() -> int:
     if not corrected_rows:
         raise SystemExit(f'corrected trajectory not found or empty: {corrected_tum}')
 
-    corrected_ape = _ape_metrics(ref_rows, corrected_rows)
+    match_tolerance = args.match_tolerance if args.match_tolerance > 0 else None
+    corrected_ape = _ape_metrics(ref_rows, corrected_rows, match_tolerance)
     raw_ape = None
     if raw_tum and raw_tum.is_file():
         raw_rows = _load_tum(raw_tum)
         if raw_rows:
-            raw_ape = _ape_metrics(ref_rows, raw_rows)
+            raw_ape = _ape_metrics(ref_rows, raw_rows, match_tolerance)
 
     bag_duration_sec = _bag_duration_seconds(bag_path / 'metadata.yaml')
     wall_sec = args.wall_sec


### PR DESCRIPTION
## What

Continues the v0.5 RTK-SLAM workstream: adds the dataset download tooling and a sparse-checkpoint match tolerance, **validated end-to-end on the real ground truth**.

## Key discovery from actually downloading

The **ground truth is not in the 182 GB dataset**. The surveyed total-station checkpoints are tiny CSVs (`ground_truth/<seq>.csv`, ~1–2 KB) in the **eval repo** (`Willyzw/rtk-slam-eval`), which also ships example SLAM trajectories. So the whole reference pipeline can be built and validated from a **few-MB git clone**; the multi-GB ROS2 bag is only needed to run our own RKO-LIO.

## Changes

- **`scripts/download_rtk_slam_dataset.py`** — fetch a ROS2 sequence (`.db3` + metadata, size-checked; smallest `construction_seq2` ~10.7 GB) and/or `--eval-assets` (clone the GT CSVs + example trajectories). Destination under `datasets/` (gitignored).
- **`write_aligned_trajectory_metrics.py` `--match-tolerance`** — default (`<= 0`) keeps the historical `0.05 → 0.15 s` cascade **exactly**; a single value (e.g. `2.0`) reproduces the dataset's `max_dt` and stops silently dropping a sparse checkpoint when the estimate is downsampled. Real data showed the bias: `fast_lio_sam`'s offline trajectory paired only **7/16** (construction_seq1) and **13/36** (stadtgarten1) at the default vs **all** checkpoints at 2.0 s. Our own dense RKO-LIO output matches at the default, so the gate path is unchanged.

## Validated on real GT

Generator → scorer on the **real** GT CSVs vs the eval repo's example trajectories (`--match-tolerance 2.0`), all classified `ground_truth`, `se3_umeyama`:

| Sequence | chkpt | `fast_lio_sam` (m) | `okvis_lvig` (m) |
|---|---|---|---|
| construction_seq1 | 16 | 0.221 | 0.227 |
| construction_seq2 | 16 | 0.086 | 0.075 |
| stadtgarten_seq1 | 36 | 0.071 | 0.054 |
| stadtgarten_seq2 | 19 | 0.070 | 0.083 |

Published-method numbers (not ours), but they prove the v0.5 metric path on real total-station GT and bracket where our RKO-LIO must land (~0.05–0.23 m; construction_seq1 hardest). Topic confirmed **`/livox/points`** (`sensor_msgs/PointCloud2`); checkpoint `timestamp` is the Unix-epoch sensor clock.

## Testing

Added a `--match-tolerance` regression test (sparse 0.5 s-offset estimate: default fails, `2.0` recovers all 12). **pytest 11/11**, `ament_flake8`/`pep257`/`copyright` clean, `colcon test` green. The default `0.05 → 0.15 s` cascade is byte-identical (existing `test_aligned_trajectory_metrics` still passes).

## Deferred

The profile and its `pass`/`target` thresholds wait for our own RKO-LIO runs on the downloaded bag (observe-then-set, `docs/roadmap/v0.5.md` §4).