### PR TITLE
feat(v0.5): real MID-360 total-station GT profile from our own RKO-LIO run

### DIFF
--- a/configs/mid360_robot/rko_lio_rtk_slam_mid360.yaml
+++ b/configs/mid360_robot/rko_lio_rtk_slam_mid360.yaml
@@ -1,0 +1,20 @@
+# RKO-LIO config for the public RTK-SLAM dataset (Livox MID-360 + total-station
+# ground truth; arXiv:2604.07151, CC-BY 4.0). Used to produce our own estimate
+# trajectory for the mid360_gt_rtkslam_* release profiles (v0.5).
+#
+# Topics: /livox/points (sensor_msgs/PointCloud2) + /livox/imu (200 Hz).
+# Extrinsics are identity: the gate scores the SE(3)-aligned checkpoint RMSE, so
+# a constant livox_frame -> base offset is absorbed by the Umeyama alignment.
+#
+# deskew is OFF: the dataset's /livox/points carries a Livox `offset_time` field
+# rather than the per-point timestamp RKO-LIO deskew expects, so RKO-LIO falls
+# back to the scan header time anyway. voxel/range follow the validated MID-360
+# low-voxel preset.
+extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+extrinsic_lidar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+initialization_phase: false
+deskew: false
+voxel_size: 0.5
+min_range: 1.0
+max_range: 100.0
+double_downsample: true

--- a/docs/roadmap/v0.5.md
+++ b/docs/roadmap/v0.5.md
@@ -167,17 +167,45 @@ all classified `ground_truth`, `alignment: se3_umeyama`:
 These are *published-method* numbers, not ours — but they prove the pipeline
 produces sane absolute-accuracy RMSE on real total-station GT, and they bracket
 where our own RKO-LIO needs to land (roughly 0.05–0.23 m; construction_seq1 is
-the hard one). Thresholds (§4) still come from our own runs.
+the hard one).
+
+### 3.6 Our own RKO-LIO run (construction_seq2, landed)
+
+Ran RKO-LIO + graph_based_slam on the real `construction_seq2` bag
+(`configs/mid360_robot/rko_lio_rtk_slam_mid360.yaml`, `/livox/points` +
+`/livox/imu`) and scored against the total-station GT:
+
+| trajectory | paired | RMSE (m) | median | max | note |
+|---|---|---|---|---|---|
+| **raw odometry (dense)** | **16/16** | **0.154** | 0.061 | 0.452 | the gated number |
+| corrected (`/modified_path`) | <3 | — | — | — | too sparse to pair (below) |
+
+**Finding — score the dense trajectory.** The optimized `/modified_path` is a
+*submap-node* path (225 poses, mean 2.6 s gaps, up to 24.5 s). The big gaps fall
+exactly at the survey checkpoints — the operator dwells to be surveyed, so few
+submaps are created there — so the checkpoints land in gaps and < 3 pair even at
+a 3 s tolerance. The **dense** RKO-LIO odometry (≈10 Hz) pairs all 16, and is the
+same dense form the dataset's published baselines are scored in, so it is the
+fair, gated trajectory. The loop-closure benefit is not observable at these
+sparse dwell-point checkpoints; that is a property of the GT, not the optimizer.
+
+**Two enablers landed with this run:**
+- `run_rko_lio_graph_benchmark.sh --offline-timeout-secs` — the old hard-coded
+  1800 s offline-completion cap cut this compute-heavy ~600 s sequence off at
+  62 % of the bag (≈0.2× real time). Raised per-run; the full bag now completes.
+- The gate end-to-end: `benchmark_summary.py --release-profile` evaluates the
+  run's `metrics.json` as **PASS** (0.154 ≤ 0.30) for `mid360_gt_rtkslam_construction_seq2`.
 
 ## 4. Setting the threshold honestly
 
-`pass`/`target` come from the first real runs, not aspiration (same discipline
-as `[[project_release_gate_design]]`). Plan: run RKO-LIO on each sequence,
-record the SE(3)-aligned checkpoint RMSE, set `pass` near the upper envelope and
-`target` near the median across sequences. Expect a *wider* spread than a dense
-prism dataset because each gate sees only 16–36 points. The
-outdoor→GNSS-denied / indoor transitions make these genuinely hard sequences —
-do not assume the NTU/Newer-College range carries over.
+`pass`/`target` come from real runs, not aspiration (same discipline as
+`[[project_release_gate_design]]`). From construction_seq2 (raw RMSE 0.154 m,
+median 0.061) the profile is set `pass: 0.30 / target: 0.15` and kept
+**`report_only_until: v0.6`** — one sequence is one data point, and the sparse
+16-checkpoint metric is high-variance. Graduate to blocking once the other three
+sequences (construction_seq1 is the hard one, ~0.22 m published) confirm the
+threshold and give a mean ± spread. Do not assume the NTU/Newer-College range
+carries over.
 
 ## 5. Deliverables / acceptance criteria for v0.5
 
@@ -186,13 +214,14 @@ do not assume the NTU/Newer-College range carries over.
       confirm at swap.
 - [x] `scripts/download_rtk_slam_dataset.py` (HuggingFace bags + `--eval-assets`
       git clone of the GT CSVs / example trajectories; size-checked). Eval assets
-      fetched; `construction_seq2` bag (~10.7 GB) downloading for the first own
-      RKO-LIO run.
-- [x] Confirmed: point-cloud topic **`/livox/points`** (`sensor_msgs/PointCloud2`;
-      `/livox/lidar` is the Livox `CustomMsg`), and the checkpoint CSV `timestamp`
-      is the **Unix-epoch sensor clock**. **Still open:** the `livox_frame →
-      base-center` extrinsic (their TUM is base-center; `transform_imu_to_base.py`
-      + `configs/mid360_robot/` cover it — confirm against the bag's `/tf_static`).
+      fetched; `construction_seq2` bag (~10.7 GB) downloaded and run (§3.6).
+- [x] Confirmed on the bag: point-cloud topic **`/livox/points`**
+      (`sensor_msgs/PointCloud2`; `/livox/lidar` is the Livox `CustomMsg`), the
+      checkpoint CSV `timestamp` is the **Unix-epoch sensor clock** (bag, GT and
+      example trajectories share it), and there is **no `/tf_static`** — the
+      `livox_frame → base-center` extrinsic lives in the eval repo's
+      `transform_imu_to_base.py`, and is **moot for the SE(3)-aligned metric**
+      (Umeyama absorbs the constant offset), so identity extrinsics are used.
 - [x] `scripts/generate_rtk_slam_reference.py` → `output/rtk_slam_<seq>_gt.tum`
       (+ a reference JSON like the NTU one). Landed with
       `graph_based_slam/test/test_rtk_slam_reference.py`, whose integration test
@@ -200,11 +229,13 @@ do not assume the NTU/Newer-College range carries over.
       generator CLI → `write_aligned_trajectory_metrics.py` → ground-truth-
       classified, SE(3)-aligned checkpoint RMSE. **Also validated on the real GT
       CSVs** against the eval repo's example trajectories (§3.5).
-- [ ] Run RKO-LIO on the downloaded sequence(s) → our own SE(3)-aligned
-      checkpoint RMSE; set thresholds (observe-then-set, §4).
-- [ ] `mid360_gt_rtkslam_*` profile(s) in `release_profiles.yaml`,
-      `reference_kind: ground_truth`, thresholds from observed runs, **blocking**.
-- [ ] `mid360_vs_glim` demoted to non-blocking per D-GT-2.
+- [x] Ran RKO-LIO on `construction_seq2` → raw RMSE 0.154 m (16/16), gate PASS
+      (§3.6). Remaining: the other three sequences for a mean ± spread.
+- [x] `mid360_gt_rtkslam_construction_seq2` profile in `release_profiles.yaml`,
+      `reference_kind: ground_truth`, `pass 0.30 / target 0.15`, **report_only_until
+      v0.6** (graduate to blocking after the other three sequences).
+- [ ] `mid360_vs_glim` demoted to non-blocking per D-GT-2 (at the swap, once the
+      rtkslam profile is blocking).
 - [ ] Docs: `comparison.md` MID-360 row → `ape_rmse_gt_m` (true GT, total-station
       checkpoints) instead of the cross-val caveat; this roadmap → "done". A
       short methodology note under `docs/research/` (dataset, checkpoint metric,

--- a/scripts/release_profiles.yaml
+++ b/scripts/release_profiles.yaml
@@ -68,6 +68,28 @@ release_profiles:
     pass: 4.00
     target: 1.00
 
+  # v0.5: the real total-station GT profile that supersedes mid360_vs_glim's
+  # cross-validation. Scored against the public RTK-SLAM dataset's surveyed
+  # checkpoints (arXiv:2604.07151, CC-BY 4.0). The checkpoints are sparse and
+  # land at survey-dwell points where the optimized submap graph is sparse, so
+  # the gate scores the *dense* trajectory (RKO-LIO odometry) -- the same dense
+  # form the dataset's own published baselines are scored in. Run with
+  # --match-tolerance 2.0 (the dataset's max_dt). report_only_until is kept while
+  # only construction_seq2 is measured; graduate to blocking once the other
+  # three sequences confirm the threshold. Observed construction_seq2 raw RMSE
+  # 0.154 m (median 0.061), vs published fast_lio_sam 0.086 / okvis 0.075.
+  - name: mid360_gt_rtkslam_construction_seq2
+    description: Livox MID-360 vs total-station checkpoints, RTK-SLAM Construction Hall 2 (~600s, 16 chkpt, dense odometry)
+    match:
+      points_topic: /livox/points
+      reference_kind: ground_truth
+      reference_source_contains: rtk_slam_construction_seq2_gt
+      min_ape_pairs: 12
+    metric: ape_rmse_gt_m
+    pass: 0.30
+    target: 0.15
+    report_only_until: v0.6
+
   - name: leo_drive_applanix_velodyne_cross
     description: Leo Drive applanix/velodyne open data vs Applanix GSOF49 cross-validation
     match:

--- a/scripts/run_rko_lio_graph_benchmark.sh
+++ b/scripts/run_rko_lio_graph_benchmark.sh
@@ -20,6 +20,7 @@ Options:
   --run-name <name>              RKO-LIO run name
   --startup-timeout-secs <sec>   Timeout waiting for startup (default: 30)
   --save-timeout-secs <sec>      Timeout waiting for map outputs (default: 60)
+  --offline-timeout-secs <sec>   Max wall-clock for the offline node to finish the bag (default: 1800)
   --quiescence-secs <sec>        Treat the run as done after this many stable seconds (default: 20)
   --skip-map-save                Do not call /map_save or verify the map bundle
   --skip-reference-gen           Reuse an existing reference TUM/meta without regenerating it
@@ -64,6 +65,10 @@ RUN_NAME=""
 STARTUP_TIMEOUT_SECS=30
 SAVE_TIMEOUT_SECS=60
 QUIESCENCE_SECS=20
+# Max wall-clock to wait for the offline node to finish replaying the bag.
+# Long / compute-heavy sequences (e.g. dense indoor MID-360) can process well
+# below real time; raise this so the run is not cut off mid-bag.
+OFFLINE_TIMEOUT_SECS=1800
 SKIP_MAP_SAVE=false
 SKIP_REFERENCE_GEN=false
 PUBLISH_STATIC_TF=true
@@ -134,6 +139,11 @@ while [[ $# -gt 0 ]]; do
     --save-timeout-secs)
       [[ $# -ge 2 ]] || usage
       SAVE_TIMEOUT_SECS="$2"
+      shift 2
+      ;;
+    --offline-timeout-secs)
+      [[ $# -ge 2 ]] || usage
+      OFFLINE_TIMEOUT_SECS="$2"
       shift 2
       ;;
     --quiescence-secs)
@@ -501,7 +511,7 @@ if ! wait_for_log_pattern "[graph_based_slam]: initialization end" "$STARTUP_TIM
 fi
 
 echo "SLAM launch is up"
-if ! wait_for_offline_completion 1800; then
+if ! wait_for_offline_completion "$OFFLINE_TIMEOUT_SECS"; then
   echo "Launch terminated before offline node completed. Recent launch log:" >&2
   tail -n 120 "$LAUNCH_LOG" >&2 || true
   exit 1


### PR DESCRIPTION
## What

Closes the v0.5 loop on **real data**: ran RKO-LIO + graph_based_slam on the public RTK-SLAM `construction_seq2` bag and scored our own trajectory against the dataset's **geodetic total-station checkpoints**. The release gate now evaluates a real **ground-truth** MID-360 profile as **PASS** — the first time the MID-360 story rests on accuracy, not GLIM agreement.

## Result

| trajectory | paired | RMSE (m) | median | gate |
|---|---|---|---|---|
| **raw odometry (dense)** | **16/16** | **0.154** | 0.061 | **PASS** (≤ 0.30) |
| corrected (`/modified_path`) | <3 | — | — | unscored (sparse) |

Published baselines (loop-closed, dense): fast_lio_sam 0.086 / okvis_lvig 0.075.

## Changes

- **`release_profiles.yaml`**: `mid360_gt_rtkslam_construction_seq2` (`ape_rmse_gt_m`, `pass 0.30 / target 0.15`, **`report_only_until: v0.6`**). Kept non-blocking — one sequence is one high-variance data point (16 sparse checkpoints); graduate once the other three sequences give a mean ± spread (construction_seq1 is the hard one, ~0.22 m published).
- **`configs/mid360_robot/rko_lio_rtk_slam_mid360.yaml`**: the documented run config (identity extrinsics — the SE(3)-aligned metric absorbs the constant offset; deskew off, voxel 0.5).
- **`run_rko_lio_graph_benchmark.sh --offline-timeout-secs`**: the old hard-coded 1800 s offline-completion cap cut this compute-heavy ~600 s sequence off at 62 % (~0.2× real time). Raised per-run so the full bag completes. It was a **compute cutoff, not a SLAM divergence** — raw odometry ran clean 10 Hz to the cutoff with no error.

## Methodology — score the dense trajectory

The optimized `/modified_path` is a sparse *submap-node* path whose gaps (up to 24.5 s) fall exactly on the **survey-dwell checkpoints** (the operator stops to be surveyed → few submaps), so it cannot pair even at a 3 s tolerance. The **dense** RKO-LIO odometry pairs all 16 and is the same dense form the dataset's published baselines are scored in. Documented in `docs/roadmap/v0.5.md` §3.6.

## Reproduce the gate

```
bash scripts/run_rko_lio_graph_benchmark.sh --bag <construction_seq2> \
  --lidar-topic /livox/points --imu-topic /livox/imu \
  --rko-param configs/mid360_robot/rko_lio_rtk_slam_mid360.yaml \
  --reference-tum output/rtk_slam_construction_seq2_gt.tum --skip-reference-gen \
  --reference-source rtk_slam_construction_seq2_gt --offline-timeout-secs 5400 ...
python3 scripts/write_aligned_trajectory_metrics.py ... --corrected-tum traj_raw.tum \
  --points-topic /livox/points --match-tolerance 2.0
python3 scripts/benchmark_summary.py --root <run> --release-profile scripts/release_profiles.yaml
# -> mid360_gt_rtkslam_construction_seq2  PASS  0.154 <= 0.30
```

## Scope

Docs + one profile + one config + a benchmark CLI flag. No change to existing code paths; the profile is `report_only_until` so it cannot block release yet. `mkdocs build --strict` passes; `bash -n` clean.