### PR TITLE
feat(v0.5): construction_seq1 GT profile + 3-sequence indoor/outdoor results

### DIFF
--- a/docs/roadmap/v0.5.md
+++ b/docs/roadmap/v0.5.md
@@ -169,11 +169,30 @@ produces sane absolute-accuracy RMSE on real total-station GT, and they bracket
 where our own RKO-LIO needs to land (roughly 0.05–0.23 m; construction_seq1 is
 the hard one).
 
-### 3.6 Our own RKO-LIO run (construction_seq2, landed)
+### 3.6 Our own RKO-LIO runs (landed)
 
-Ran RKO-LIO + graph_based_slam on the real `construction_seq2` bag
-(`configs/mid360_robot/rko_lio_rtk_slam_mid360.yaml`, `/livox/points` +
-`/livox/imu`) and scored against the total-station GT:
+Ran RKO-LIO + graph_based_slam (`configs/mid360_robot/rko_lio_rtk_slam_mid360.yaml`,
+`/livox/points` + `/livox/imu`) on three real sequences, scoring the dense raw
+odometry against the total-station GT (`--match-tolerance 2.0`):
+
+| sequence | env | paired | our RMSE (m) | median | published (fast_lio / okvis) |
+|---|---|---|---|---|---|
+| construction_seq2 | indoor hall | 16/16 | **0.154** | 0.061 | 0.086 / 0.075 |
+| construction_seq1 | indoor hall (hard) | 16/16 | **0.403** | 0.263 | 0.221 / 0.227 |
+| stadtgarten_seq2 | **outdoor park** | 19/19 | **3.903** | 1.366 | 0.070 / 0.083 |
+
+**Finding — indoor strong, open-outdoor weak.** With this indoor-tuned config the
+MID-360 + RKO-LIO holds 0.15–0.40 m in the structured construction hall (raw
+odometry, no loop closure), but **drifts badly (3.9 m) in the open Stadtgarten
+park** — short MID-360 range (~40 m) against sparse, distant features starves the
+odometry. This is a real capability boundary, not a metric artifact (19/19
+paired, error grows monotonically to 11.7 m). The outdoor sequences need config
+work (range / deskew / downsampling) before they earn a gate; the **indoor pair
+is the credible GT validation set** for v0.5. Per-sequence thresholds reflect the
+genuine difficulty gap (construction_seq1's `pass` is looser than seq2's), the
+same way NTU (1.0 m) and Newer College (0.10 m) differ.
+
+The construction_seq2 trajectory detail (raw vs corrected):
 
 | trajectory | paired | RMSE (m) | median | max | note |
 |---|---|---|---|---|---|
@@ -199,13 +218,19 @@ sparse dwell-point checkpoints; that is a property of the GT, not the optimizer.
 ## 4. Setting the threshold honestly
 
 `pass`/`target` come from real runs, not aspiration (same discipline as
-`[[project_release_gate_design]]`). From construction_seq2 (raw RMSE 0.154 m,
-median 0.061) the profile is set `pass: 0.30 / target: 0.15` and kept
-**`report_only_until: v0.6`** — one sequence is one data point, and the sparse
-16-checkpoint metric is high-variance. Graduate to blocking once the other three
-sequences (construction_seq1 is the hard one, ~0.22 m published) confirm the
-threshold and give a mean ± spread. Do not assume the NTU/Newer-College range
-carries over.
+`[[project_release_gate_design]]`). Two **indoor** profiles are set from observed
+runs and kept **`report_only_until: v0.6`** (the sparse 16-checkpoint metric is
+high-variance, so we want more confidence before blocking):
+
+- `mid360_gt_rtkslam_construction_seq2` — observed 0.154 m → `pass 0.30 / target 0.15`.
+- `mid360_gt_rtkslam_construction_seq1` — observed 0.403 m (the hard hall) →
+  `pass 0.55 / target 0.30`.
+
+The **outdoor** `stadtgarten_seq2` (3.9 m) is deliberately **not** given a profile
+yet: a 4 m+ `pass` would be a meaningless gate (the same loose-threshold weakness
+we are retiring from `mid360_vs_glim`). It needs outdoor config work first (§3.6).
+Graduate the indoor pair to blocking, and add outdoor profiles, once that lands.
+Do not assume the NTU/Newer-College range carries over.
 
 ## 5. Deliverables / acceptance criteria for v0.5
 
@@ -229,13 +254,15 @@ carries over.
       generator CLI → `write_aligned_trajectory_metrics.py` → ground-truth-
       classified, SE(3)-aligned checkpoint RMSE. **Also validated on the real GT
       CSVs** against the eval repo's example trajectories (§3.5).
-- [x] Ran RKO-LIO on `construction_seq2` → raw RMSE 0.154 m (16/16), gate PASS
-      (§3.6). Remaining: the other three sequences for a mean ± spread.
-- [x] `mid360_gt_rtkslam_construction_seq2` profile in `release_profiles.yaml`,
-      `reference_kind: ground_truth`, `pass 0.30 / target 0.15`, **report_only_until
-      v0.6** (graduate to blocking after the other three sequences).
-- [ ] `mid360_vs_glim` demoted to non-blocking per D-GT-2 (at the swap, once the
-      rtkslam profile is blocking).
+- [x] Ran RKO-LIO on three sequences (§3.6): construction_seq2 0.154, construction_seq1
+      0.403 (both indoor, gate PASS), stadtgarten_seq2 3.903 (outdoor, drifts).
+      Remaining: stadtgarten_seq1 (26 min) + outdoor config work.
+- [x] Two indoor GT profiles in `release_profiles.yaml`
+      (`mid360_gt_rtkslam_construction_seq2` 0.30/0.15, `_construction_seq1`
+      0.55/0.30), `reference_kind: ground_truth`, **report_only_until v0.6**.
+      Outdoor profile deferred until the config drift is fixed (§3.6, §4).
+- [ ] Graduate the indoor pair to **blocking**, then `mid360_vs_glim` demoted to
+      non-blocking per D-GT-2.
 - [ ] Docs: `comparison.md` MID-360 row → `ape_rmse_gt_m` (true GT, total-station
       checkpoints) instead of the cross-val caveat; this roadmap → "done". A
       short methodology note under `docs/research/` (dataset, checkpoint metric,

--- a/scripts/release_profiles.yaml
+++ b/scripts/release_profiles.yaml
@@ -90,6 +90,25 @@ release_profiles:
     target: 0.15
     report_only_until: v0.6
 
+  # Companion indoor sequence (Construction Hall 1) -- the hardest of the two
+  # halls (published baselines ~0.22 m, the highest). Our dense odometry pairs
+  # 16/16 at RMSE 0.403 m (median 0.263), so the threshold is looser than
+  # construction_seq2 by design: per-sequence difficulty, like NTU vs Newer
+  # College. report_only_until while the indoor pair is the only validated set
+  # (the outdoor Stadtgarten sequences drift badly with this indoor-tuned
+  # config -- 3.9 m on stadtgarten_seq2 -- and need config work before gating).
+  - name: mid360_gt_rtkslam_construction_seq1
+    description: Livox MID-360 vs total-station checkpoints, RTK-SLAM Construction Hall 1 (~741s, 16 chkpt, dense odometry)
+    match:
+      points_topic: /livox/points
+      reference_kind: ground_truth
+      reference_source_contains: rtk_slam_construction_seq1_gt
+      min_ape_pairs: 12
+    metric: ape_rmse_gt_m
+    pass: 0.55
+    target: 0.30
+    report_only_until: v0.6
+
   - name: leo_drive_applanix_velodyne_cross
     description: Leo Drive applanix/velodyne open data vs Applanix GSOF49 cross-validation
     match:


### PR DESCRIPTION
## What

Two more RTK-SLAM sequences run through RKO-LIO and scored against the total-station GT, plus the construction_seq1 ground-truth profile.

## Results (dense odometry vs total-station GT, `--match-tolerance 2.0`)

| sequence | env | paired | our RMSE (m) | median | published (fast_lio / okvis) |
|---|---|---|---|---|---|
| construction_seq2 | indoor hall | 16/16 | 0.154 | 0.061 | 0.086 / 0.075 |
| construction_seq1 | indoor hall (hard) | 16/16 | **0.403** | 0.263 | 0.221 / 0.227 |
| stadtgarten_seq2 | **outdoor park** | 19/19 | **3.903** | 1.366 | 0.070 / 0.083 |

## Finding — indoor strong, open-outdoor weak

With the indoor-tuned config the MID-360 + RKO-LIO holds **0.15–0.40 m** in the structured construction hall (raw odometry, no loop closure), but **drifts to 3.9 m in the open Stadtgarten park** — the short MID-360 range (~40 m) against sparse, distant features starves the odometry. Real capability boundary, not a metric artifact: 19/19 paired, error grows monotonically to 11.7 m.

## Changes

- **`mid360_gt_rtkslam_construction_seq1`** (`pass 0.55 / target 0.30`, `report_only_until v0.6`). Per-sequence thresholds reflect the genuine difficulty gap — the same way NTU (1.0 m) and Newer College (0.10 m) differ. Both indoor profiles evaluate **PASS** on their runs.
- **Stadtgarten is deliberately not given a profile**: a 4 m+ `pass` would be a meaningless gate — the same loose-threshold weakness being retired from `mid360_vs_glim`. It needs outdoor config work (range / deskew / downsampling) first.
- Docs (`v0.5.md` §3.6/§4/§5): full results table, the indoor/outdoor boundary, and the remaining path (stadtgarten_seq1 + outdoor config → graduate the indoor pair to blocking → demote glim).

## Scope

Docs + one report-only profile. No code paths touched; `mkdocs build --strict` passes. Gate reproduced: `benchmark_summary.py --release-profile` → `mid360_gt_rtkslam_construction_seq1 PASS 0.403 ≤ 0.55`.