### PR TITLE
docs(readme): lead with the drive-on-your-map value prop and real-GT accuracy table

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Builds the Autoware map bundle from your SLAM output, generates lanelet2 from th
 trajectory, and brings up AWSIM + Autoware to drive on it. Multi-terminal bringup
 and lanelet2 notes: [docs/awsim-autonomous-driving-tutorial.md](docs/awsim-autonomous-driving-tutorial.md).
 
+![Autoware map loaders rendering a pointcloud_map authored by this stack](lidarslam/images/autoware_map_loader_proof.png)
+
 ## Accuracy
 
 Current numbers from the release-gate profiles (`scripts/release_profiles.yaml`).

--- a/README.md
+++ b/README.md
@@ -3,14 +3,40 @@
 [![CI](https://github.com/rsasaki0109/lidarslam_ros2/actions/workflows/main.yml/badge.svg?branch=develop)](https://github.com/rsasaki0109/lidarslam_ros2/actions/workflows/main.yml)
 [![License: BSD-2-Clause](https://img.shields.io/badge/License-BSD--2--Clause-blue.svg)](https://opensource.org/licenses/BSD-2-Clause)
 [![ROS 2: Humble | Jazzy](https://img.shields.io/badge/ROS%202-Humble%20%7C%20Jazzy-22314E?logo=ros&logoColor=white)](#support-and-license)
+[![GitHub stars](https://img.shields.io/github/stars/rsasaki0109/lidarslam_ros2?style=flat&logo=github)](https://github.com/rsasaki0109/lidarslam_ros2/stargazers)
 
-ROS 2 LiDAR SLAM. Frontend is `RKO-LIO` (MIT), backend is `graph_based_slam` (BSD-2). Output is an Autoware-compatible `pointcloud_map/` directory plus `map_projector_info.yaml`. No GPL components on the default workflow.
+**Turn a rosbag into a map you can actually drive on.**
 
-`develop` tracks the current v2 alpha line. Latest tagged public beta: [v0.2.2 Release Notes](docs/releases/v0.2.2.md).
+ROS 2 LiDAR SLAM that outputs an Autoware-ready map bundle — `pointcloud_map/`,
+`map_projector_info.yaml`, and auto-generated lanelet2 — and proves it by driving
+autonomously on that map in AWSIM. Frontend is `RKO-LIO` (MIT), backend is
+`graph_based_slam` (BSD-2). No GPL components on the default workflow.
 
-![Autoware-compatible pointcloud_map rendered by Autoware map loaders](lidarslam/images/autoware_map_loader_proof.png)
+[![Autoware-compatible pointcloud-map authoring — click for the demo video](lidarslam/images/social_autoware_map_authoring.png)](lidarslam/images/social_autoware_map_authoring_demo.mp4)
 
-## Install
+*Click the card for the demo video. `develop` tracks the current v2 alpha line; latest tagged public beta: [v0.2.2 Release Notes](docs/releases/v0.2.2.md).*
+
+## Why lidarslam_ros2
+
+Most LiDAR SLAM stacks stop at a trajectory and a point cloud. This one ships the
+artifacts you need downstream:
+
+- **Autoware-ready output** — `pointcloud_map/` + `map_projector_info.yaml` open
+  directly in Autoware map loaders; `verify_autoware_map.py` prints
+  `map_verify: PASS` on every saved bundle.
+- **lanelet2 auto-generation** — drivable lanelets from the SLAM trajectory,
+  validated for multi-segment Autoware routing.
+- **Driven, not just plotted** — the map → autonomous-driving loop is dogfooded
+  end-to-end in AWSIM ([tutorial](docs/awsim-autonomous-driving-tutorial.md)).
+- **Surveyed ground truth** — releases are gated in CI by per-dataset APE
+  thresholds, including total-station checkpoints on a Livox MID-360
+  ([accuracy](#accuracy)).
+- **Loop closure, GPL-free** — built-in Scan Context by default, plus opt-in
+  BEV / SOLiD / STD/BTC-style Triangle descriptors and 3D-BBS verification.
+- **GNSS georeferencing** — optional GNSS constraints and projector metadata for
+  real-world coordinates.
+
+## Quickstart
 
 ```bash
 cd ~/ros2_ws/src
@@ -23,9 +49,8 @@ source install/setup.bash
 
 If you cloned without `--recursive`: `git -C src/lidarslam_ros2 submodule update --init --recursive`.
 
-## Quickstart
-
-Downloads NTU VIRAL `tnp_01` (~580 s outdoor bag) and runs RKO-LIO + graph_based_slam end to end into an Autoware-loadable map.
+Then run one public dataset end to end — NTU VIRAL `tnp_01` (~580 s outdoor bag)
+through RKO-LIO + graph_based_slam into an Autoware-loadable map:
 
 ```bash
 cd src/lidarslam_ros2
@@ -33,8 +58,6 @@ bash scripts/download_ntu_viral_tnp01.sh
 bash scripts/run_autoware_quickstart.sh
 python3 scripts/verify_autoware_map.py output/.../pointcloud_map
 ```
-
-`verify_autoware_map.py` prints `map_verify: PASS` when Autoware map loaders can open the result.
 
 ## Use your own bag
 
@@ -52,38 +75,51 @@ ros2 launch lidarslam rko_lio_slam.launch.py \
 ros2 service call /map_save std_srvs/srv/Empty
 ```
 
-Required topics, optional GNSS / IMU pre-integration, and the dynamic-object filter parameters are documented in [docs/workflows.md](docs/workflows.md).
+Required topics, optional GNSS / IMU pre-integration, and the dynamic-object
+filter parameters are documented in [docs/workflows.md](docs/workflows.md).
 
-## Features
-
-- Loop closure with built-in Scan Context (GPL-free), plus opt-in BEV / SOLiD / STD/BTC-style Triangle descriptors and optional 3D-BBS verification.
-- Optional GNSS georeferencing; writes `map_projector_info.yaml` for direct Autoware loading.
-- AWSIM → Autoware autonomous-driving demo on the map you build, including lanelet2 auto-generation from the SLAM trajectory.
-- Save-time dynamic-object filter and NIS-driven adjacent-edge auto-scaling.
-- Benchmark + release-gate tooling with per-dataset thresholds and report helpers.
-
-## AWSIM autonomous-driving pipeline
+## Drive on your map (AWSIM × Autoware)
 
 ```bash
 bash scripts/test_awsim_setup.sh
 bash scripts/run_awsim_selfmade_map_demo.sh
 ```
 
-Multi-terminal bringup and lanelet2 notes: [docs/awsim-autonomous-driving-tutorial.md](docs/awsim-autonomous-driving-tutorial.md).
+Builds the Autoware map bundle from your SLAM output, generates lanelet2 from the
+trajectory, and brings up AWSIM + Autoware to drive on it. Multi-terminal bringup
+and lanelet2 notes: [docs/awsim-autonomous-driving-tutorial.md](docs/awsim-autonomous-driving-tutorial.md).
 
-## Benchmarks
+## Accuracy
+
+Current numbers from the release-gate profiles (`scripts/release_profiles.yaml`).
+Every release is blocked in CI by these per-dataset thresholds.
+
+| Dataset | Sensor | Reference | APE RMSE | Gate (pass) |
+| --- | --- | --- | --- | --- |
+| NTU VIRAL `tnp_01` (outdoor, ~580 s) | Ouster OS1-16 + VN-100 | Leica prism ground truth | **0.95 m** (best 0.87) | ≤ 1.00 m |
+| RTK-SLAM Construction Hall 2 (indoor, ~600 s) | Livox MID-360 | total-station checkpoints¹ | **0.154 m** (median 0.061) | ≤ 0.30 m² |
+| RTK-SLAM Construction Hall 1 (indoor, ~741 s) | Livox MID-360 | total-station checkpoints¹ | **0.403 m** (median 0.263) | ≤ 0.55 m² |
+| MID-360 indoor loop (~277 s) | Livox MID-360 | cross-validation vs GLIM | 3.64 m | ≤ 4.00 m |
+| Newer College `math-hard` (~320 m loop) | Ouster OS0-128 | prism ground truth | reported separately | ≤ 0.10 m |
+
+¹ Surveyed checkpoints from the public RTK-SLAM dataset (CC-BY 4.0); scored on the
+dense odometry trajectory, the same form as the dataset's published baselines.
+² Report-only until the remaining sequences validate (v0.6); see
+[docs/comparison.md](docs/comparison.md) for the full methodology and caveats.
+
+Reproduce locally:
 
 ```bash
 bash scripts/run_rko_lio_graph_benchmark.sh
 bash scripts/run_release_readiness_checks.sh --fail-on-profiles
 ```
 
-Per-dataset pass / target thresholds live in `scripts/release_profiles.yaml`. Details and optional MID-360 / production-bundle gates: [docs/benchmarking.md](docs/benchmarking.md).
+Details and optional MID-360 / production-bundle gates: [docs/benchmarking.md](docs/benchmarking.md).
 
 ## Docs
 
 - **Getting started**: [Autoware quickstart](docs/autoware-quickstart.md) · [Operator workflows](docs/workflows.md) · [Autoware Foxglove](docs/autoware-foxglove.md)
-- **Pipelines**: [AWSIM autonomous-driving tutorial](docs/awsim-autonomous-driving-tutorial.md) · [Autoware-compatible map authoring](docs/autoware-map-authoring.md)
+- **Pipelines**: [AWSIM autonomous-driving tutorial](docs/awsim-autonomous-driving-tutorial.md) · [Autoware-compatible map authoring](docs/autoware-map-authoring.md) · [3DGS map tutorial](docs/3dgs-map-tutorial.md)
 - **Benchmarking**: [Benchmarking and release gate](docs/benchmarking.md) · [Comparison](docs/comparison.md)
 - **Project**: [v0.2.2 release notes](docs/releases/v0.2.2.md) · [Contributing](CONTRIBUTING.md) · [Changelog](CHANGELOG.md) · [Releasing](RELEASING.md)
 
@@ -96,7 +132,10 @@ Preview the doc site locally: `python3 -m mkdocs serve`.
 | Humble | 22.04 | default workflow build + package tests in CI |
 | Jazzy  | 24.04 | default workflow build + package tests in CI; Autoware dogfood exercised locally |
 
-`graph_based_slam` is BSD-2-Clause; `RKO-LIO`, `DLIO`, and the optional vendored `3D-BBS` are MIT; `FAST_GICP` is BSD-3-Clause; built-in Scan Context is implemented locally. The default workflow excludes GPL-only components — `Thirdparty/lio-sam` and `Thirdparty/3d_bbs` are gated by `COLCON_IGNORE`.
+`graph_based_slam` is BSD-2-Clause; `RKO-LIO`, `DLIO`, and the optional vendored
+`3D-BBS` are MIT; `FAST_GICP` is BSD-3-Clause; built-in Scan Context is implemented
+locally. The default workflow excludes GPL-only components — `Thirdparty/lio-sam`
+and `Thirdparty/3d_bbs` are gated by `COLCON_IGNORE`.
 
 ## Quality gates
 
@@ -106,3 +145,7 @@ bash scripts/run_release_readiness_checks.sh --ape-threshold 0.10
 ```
 
 Reference commands and parameter pointers live in [docs/workflows.md](docs/workflows.md).
+
+---
+
+If this project saves you mapping time, a ⭐ helps others find it.


### PR DESCRIPTION
## Summary

README conversion refresh — the first screen now answers "why this repo" in 10 seconds:

- **Tagline + hero**: "Turn a rosbag into a map you can actually drive on." The social card image links to the map-authoring demo video (`lidarslam/images/social_autoware_map_authoring_demo.mp4`).
- **Why lidarslam_ros2**: differentiator bullets (Autoware-ready bundle, lanelet2 auto-generation, AWSIM end-to-end dogfood, surveyed GT gating, GPL-free loop closure, GNSS georeferencing).
- **Accuracy table**: surfaces the v0.5 real total-station GT results (RTK-SLAM Construction Hall 2: 0.154 m / Hall 1: 0.403 m on MID-360) alongside NTU VIRAL GT and the per-dataset gate thresholds, with the dense-odometry / report-only caveats footnoted and linked to `docs/comparison.md`.
- **Structure**: Install merged into Quickstart, AWSIM section renamed "Drive on your map", benchmarks reproduce-commands kept. Stars badge + footer call-to-action added.

No code changes; claims follow the safe-claims guidance in `docs/comparison.md` (no universal-ranking statements, cross-validation rows labeled as such).

## Checks

- All relative links and image/video paths verified to exist
- `python3 -m mkdocs build --strict` passes (README triggers docs-site.yml)