### PR TITLE
fix(awsim): vehicle interface flag + departure unpause sequence + E2E pitfall docs

### DIFF
--- a/docs/awsim-autonomous-driving-tutorial.md
+++ b/docs/awsim-autonomous-driving-tutorial.md
@@ -281,6 +281,12 @@ bash scripts/run_awsim_selfmade_map_demo.sh true    # 動画付き
 | `vector map is not ready` | MGRS 投影でロード失敗 | `projector_type: local` を使用 |
 | `Goal's footprint exceeds lane` | 車両方向がレーンと不一致 | ゴールの orientation をレーン方向に合わせる |
 | `Failed to plan route` / `Failed to find a proper route` | lanelet 未接続 or 1つだけ | generator が分割＋境界ノード共有で対処済み。`--validate-routing` で起動前に `shortestPath` PASS を確認 |
+| engage しても車が動かない(actuation_cmd の publisher が 0) | `launch_vehicle_interface:=true` 欠落で raw_vehicle_cmd_converter 不在 | e2e_simulator.launch.xml に `launch_vehicle_interface:=true` を必ず付ける |
+| trajectory は GO なのに gate 出力が brake -1.5 | vehicle_cmd_gate が発進 pause 状態 | `/control/vehicle_cmd_gate/set_pause {pause: false}` + `/api/motion/accept_start` を発進まで繰り返す |
+| `velocity_factors: traffic-signal` で永久停止 | マップ上の信号がカメラ認識と紐づかない | preset で `launch_traffic_light_module: "false"`(シミュレータ検証時) |
+| 自己位置の yaw が 30° 以上ずれて舵が全切りになる | AWSIM 再起動で sim クロック巻き戻り → EKF 破壊 | AWSIM を再起動したら Autoware も必ず再起動する |
+| ルート上に存在しない歩行者で停止 | LiDAR 誤検出(幻オブジェクト) | デモ検証時は preset で obstacle stop 系モジュールを無効化 |
+| gear が P のまま / 外部 control_cmd・actuation_cmd を一切受け付けない | AWSIM Labs 側の ROS 購読バインドが起動ごとに不安定 | AWSIM を再起動し `gear_cmd`(DRIVE)連投 → 短いスロットルで動作確認してから本番を流す |
 
 ## 関連スクリプト
 

--- a/scripts/run_awsim_autoware_demo.sh
+++ b/scripts/run_awsim_autoware_demo.sh
@@ -68,10 +68,15 @@ case "${1:-help}" in
         ros2 launch autoware_launch e2e_simulator.launch.xml \
           vehicle_model:=awsim_labs_vehicle \
           sensor_model:=awsim_labs_sensor_kit \
-          map_path:=/autoware_map"
+          map_path:=/autoware_map \
+          launch_vehicle_interface:=true"
     ;;
 
   engage)
+    # launch_vehicle_interface:=true が無いと raw_vehicle_cmd_converter が起動せず
+    # /control/command/actuation_cmd の publisher が不在のまま車両は永遠に動かない。
+    # また vehicle_cmd_gate は発進時 pause 状態のため、engage に加えて
+    # set_pause(false) + accept_start の解除が必要(検証: 2026-06-10)。
     echo "=== Engaging autonomous driving ==="
     setup_dds
     docker run --rm --net=host \
@@ -80,7 +85,13 @@ case "${1:-help}" in
       -v "${HOME}/cyclonedds.xml:/cyclonedds.xml:ro" \
       "${AUTOWARE_IMAGE}" \
       bash -c "source /opt/ros/humble/setup.bash && source /opt/autoware/setup.bash && \
-        ros2 topic pub /autoware/engage autoware_vehicle_msgs/msg/Engage '{engage: True}' --once"
+        ros2 service call /api/operation_mode/change_to_autonomous autoware_adapi_v1_msgs/srv/ChangeOperationMode {} && \
+        ros2 topic pub /autoware/engage autoware_vehicle_msgs/msg/Engage '{engage: True}' --once && \
+        for i in \$(seq 1 30); do \
+          ros2 service call /control/vehicle_cmd_gate/set_pause tier4_control_msgs/srv/SetPause '{pause: false}' >/dev/null 2>&1; \
+          ros2 service call /api/motion/accept_start autoware_adapi_v1_msgs/srv/AcceptStart {} >/dev/null 2>&1; \
+          sleep 2; \
+        done"
     ;;
 
   help|*)

--- a/scripts/run_awsim_selfmade_map_demo.sh
+++ b/scripts/run_awsim_selfmade_map_demo.sh
@@ -63,6 +63,7 @@ KEEPAWAKE_PID=$!
 cleanup() {
     echo "Cleaning up..."
     kill ${KEEPAWAKE_PID} 2>/dev/null || true
+    kill ${UNPAUSE_PID:-} 2>/dev/null || true
     docker rm -f awsim_demo autoware_demo 2>/dev/null || true
     [ "${RECORD_VIDEO}" = "true" ] && kill %ffmpeg 2>/dev/null || true
 }
@@ -134,7 +135,8 @@ docker run -d --name autoware_demo \
         ros2 launch autoware_launch e2e_simulator.launch.xml \
             vehicle_model:=awsim_labs_vehicle \
             sensor_model:=awsim_labs_sensor_kit \
-            map_path:=/autoware_map"
+            map_path:=/autoware_map \
+            launch_vehicle_interface:=true"
 
 echo "  Waiting for Autoware to initialize (90s)..."
 sleep 90
@@ -173,9 +175,19 @@ echo "  Goal set"
 sleep 10
 
 # --- Engage ---
+# vehicle_cmd_gate は発進時 pause 状態のため、engage に加えて set_pause(false) +
+# accept_start の解除ループが必要(検証: 2026-06-10)。
 echo "[6/6] Engaging autonomous driving..."
 docker exec autoware_demo bash -c "source /opt/ros/humble/setup.bash && source /opt/autoware/setup.bash && \
+    ros2 service call /api/operation_mode/change_to_autonomous autoware_adapi_v1_msgs/srv/ChangeOperationMode {} >/dev/null 2>&1; \
     ros2 topic pub /autoware/engage autoware_vehicle_msgs/msg/Engage '{engage: True}' --once" >/dev/null 2>&1
+for i in $(seq 1 30); do
+    docker exec autoware_demo bash -c "source /opt/ros/humble/setup.bash && source /opt/autoware/setup.bash && \
+        ros2 service call /control/vehicle_cmd_gate/set_pause tier4_control_msgs/srv/SetPause '{pause: false}' >/dev/null 2>&1; \
+        ros2 service call /api/motion/accept_start autoware_adapi_v1_msgs/srv/AcceptStart {} >/dev/null 2>&1"
+    sleep 2
+done &
+UNPAUSE_PID=$!
 
 # Check state
 sleep 5


### PR DESCRIPTION
## Summary

2026-06-10 の AWSIM × Autoware E2E 実機検証(universe-cuda / AWSIM Labs v1.6.1)で判明した「engage しても車が動かない」根本原因群の修正。

- **`launch_vehicle_interface:=true` を両デモスクリプトに追加(最重要)**: これが無いと `raw_vehicle_cmd_converter` が起動せず `/control/command/actuation_cmd` の publisher が 0 のまま。AWSIM Labs はペダルレベル指令で動くため、**車両は永遠に発進しない**。従来スクリプトに欠けていた(= これまでフル E2E が通らなかった真因)。
- **engage 手順を実態に合わせて強化**: `vehicle_cmd_gate` は発進時 pause 状態のため、`change_to_autonomous` + engage に加えて `set_pause(false)` + `accept_start` の解除ループを追加。
- **トラブルシューティング表に検証済み 6 項目を追加**: vehicle interface 欠落 / gate pause / 未認識信号での永久停止 / AWSIM 再起動時のクロック巻き戻りで EKF 破壊(Autoware 同時再起動が必須)/ 幻オブジェクト停止 / AWSIM Labs の ROS 購読バインド不安定。

## 検証

- 実環境で各事象を再現・解消を確認(NDT 初期化成功、route SET、autonomous 遷移、actuation publisher 1、ギア DRIVE で 29m 走行確認)
- `bash -n` 両スクリプト pass / `test_docs_entrypoints.py` 6 passed / `mkdocs build --strict` pass

## 関連

残課題(別 issue 予定): AWSIM Labs 車両ブリッジの起動毎フレーキネス、start_planner の発進デッドロック、AWSIM bag(静止データ)の再録。