### PR TITLE
docs(3dgs): isuzu/NTU re-evaluation with the fixed means LR — negative result confirmed

### DIFF
--- a/docs/research/3dgs-isuzu-viewcount-notes.md
+++ b/docs/research/3dgs-isuzu-viewcount-notes.md
@@ -63,3 +63,25 @@ Autoware Leo Drive isuzu（`demo_data/autoware_leo_drive_isuzu/all-sensors-bag1_
 - `extract_posed_images.py` / `build_lidar_init.py`: FILE-compressed(zstd) bag 対応
   （Autoware 系 bag で再利用可能）。
 - `configs/gaussian_splatting/isuzu_camera_top_extrinsic.yaml`: TF 由来 extrinsic の例。
+
+## 追補 (2026-06-11): means LR 修正後の再評価 — 結論は変わらず
+
+PR #223 で見つかった means LR バグ（旧 `lr*extent`、INRIA の ~60 倍・減衰なし）が
+本ノートの数字にも効いていた可能性があったため、保存済みの transforms/lidar_init を
+そのまま使い、修正後 trainer（`--densify --sh-degree 1`）で再学習した。比較は
+**新旧 ply を同一評価器**（全 training view を再レンダして per-view PSNR）で実施。
+
+| 構成 | 旧 trainer | LR 修正後 |
+|------|-----------|----------|
+| first150 (12k iters) | mean 17.1 / median 16.4 dB | mean 17.1 / **median 19.6** dB |
+| 全区間 640v (12k) | mean 15.0 / median 14.5 dB | mean 12.0 / median 11.4 dB |
+| 全区間 640v (30k) | — | mean 11.9 / median 11.5 dB |
+
+- **first150**: LR 修正で typical view は +3.2dB 改善するが、mean は横ばいで
+  上限（max はむしろ 25.3→20.6 に低下）はキャプチャ品質の壁のまま。
+- **全区間**: LR 修正 + 2.5 倍学習でも旧値に届かない。ドリフト・ブラー入りの
+  長尺キャプチャでは、旧 LR の churn が偶然ノイズ正則化として働いていた可能性が
+  ある（フィットすべき教師信号自体が不整合なため）。
+- → 「視点数よりキャプチャ特性が支配的」という本ノートの結論は **LR 修正後も成立**。
+  rtkslam の歩行 photoreal 5 戦略全敗
+  （[[3dgs-trajectory-flythrough-notes]] 追補）とも整合する。

--- a/docs/research/3dgs-ntu-viral-notes.md
+++ b/docs/research/3dgs-ntu-viral-notes.md
@@ -41,3 +41,11 @@ end-to-end で通るが、3DGS 品質は低い（~10–11 dB）**。koide（~25d
 
 → 当面は **近接・密・カラーのシーン**（koide 型）が 3DGS 成果物に向く、という
 position を支持する結果。
+
+## 追補 (2026-06-11): means LR 修正後の再評価 — 結論は変わらず
+
+PR #223 の means LR 修正が本ノートの ~10–11dB に効いていたか、保存済み
+transforms/lidar_init で再学習（`--densify --sh-degree 1 --iters 12000`）し、
+新旧 ply を同一評価器（全 300 view の per-view PSNR）で比較した:
+旧 mean 11.4 / median 11.2 dB → 修正後 mean 10.9 / median 10.5 dB。**変化なし**。
+NTU の低品質は LR ではなく シーン性質（mono・75m 級広域・対応点疎）で確定。

--- a/docs/research/3dgs-trajectory-flythrough-notes.md
+++ b/docs/research/3dgs-trajectory-flythrough-notes.md
@@ -117,7 +117,10 @@ net 4-6m/窓)は s5 モデルで 12-15dB の霧。以下すべて失敗:
 
 ## 今後
 
-- isuzu / NTU VIRAL を LR 修正後の trainer で再評価（過去ノートの数字は旧 LR のもの）。
+- ~~isuzu / NTU VIRAL を LR 修正後の trainer で再評価~~ → 実施済み (2026-06-11)、
+  結論は不変: NTU は変化なし、isuzu は first150 の median こそ +3.2dB 改善するが
+  キャプチャ品質の壁は越えない。詳細は各ノートの追補
+  （`3dgs-isuzu-viewcount-notes.md` / `3dgs-ntu-viral-notes.md`）。
 - 歩行 photoreal の再挑戦はデータ側から: グローバルシャッター or 高速シャッターの
   カメラ + 高レート姿勢（IMU 統合）で自前撮影するか、静止スタンドポイントが
   歩行路に沿って密に並ぶデータを選ぶ。


### PR DESCRIPTION
## What

PR #223 fixed the means LR bug (`lr*extent`, ~60x INRIA, no decay) and left a question open in the research notes: were the old isuzu (14.5 dB) / NTU VIRAL (~10 dB) negatives an artifact of the broken LR?

Re-ran both datasets from the saved transforms + LiDAR-primed init clouds with the fixed trainer (`--densify --sh-degree 1`), and evaluated **old and new plys with one consistent evaluator** (re-render every training view, per-view PSNR):

| dataset | old trainer | LR-fixed |
|---|---|---|
| NTU 300v (12k) | mean 11.4 / median 11.2 dB | mean 10.9 / median 10.5 dB |
| isuzu first150 (12k) | mean 17.1 / median 16.4 dB | mean 17.1 / **median 19.6** dB |
| isuzu full 640v (12k) | mean 15.0 / median 14.5 dB | mean 12.0 / median 11.4 dB |
| isuzu full 640v (30k) | — | mean 11.9 / median 11.5 dB |

## Conclusion

The LR fix does **not** rescue either dataset. NTU is unchanged (mono, wide-area, sparse correspondences). isuzu improves typical views (+3.2 dB median on first150) but the motion-blur / drift ceiling stands; the full 640-view run is worse even with 2.5x training. The "capture characteristics dominate view count" position in both notes survives, consistent with the walking-photoreal negative result (PR #225).

## Changes

- `docs/research/3dgs-isuzu-viewcount-notes.md`: 追補 section with the table above
- `docs/research/3dgs-ntu-viral-notes.md`: 追補 section
- `docs/research/3dgs-trajectory-flythrough-notes.md`: tick off the re-eval bullet in 今後

Docs-only; no code changes.

## Repro

```bash
python3 tools/gaussian_splatting/train_gsplat.py \
  --transforms output/isuzu_3dgs/gsplat/transforms_first150.json \
  --init-ply output/isuzu_3dgs/gsplat/lidar_init.ply \
  --densify --sh-degree 1 --iters 12000 --out .../point_cloud_first150_lrfix.ply
```