### PR TITLE
feat(docker): one-command demo image (ghcr) — try SLAM without cloning or building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Keep the Docker build context to sources only: exclude VCS metadata,
+# colcon artifacts, datasets, and run outputs (regenerated inside the image).
+.git
+.github
+build/
+install/
+log/
+output/
+slam_output/
+datasets/
+demo_data/
+pointcloud_map/
+site/
+map/
+*.log
+gpt_pro_context.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,58 @@
+name: docker image
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - docker/**
+      - scripts/run_docker_demo.sh
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+concurrency:
+  group: docker-image-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: build${{ (github.event_name != 'pull_request') && ' and push' || '' }} (humble)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Pull requests only validate that the image builds; pushes to main
+      # (and manual dispatches) publish ghcr.io/<repo>:humble + :latest.
+      - name: Build (and push) image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          build-args: |
+            ROS_DISTRO=humble
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/${{ github.repository }}:humble
+            ghcr.io/${{ github.repository }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,8 @@ jobs:
           bash -n scripts/run_default_ci_checks.sh
           bash -n scripts/run_release_readiness_checks.sh
           bash -n scripts/run_rko_lio_graph_autoware_dogfood.sh
+          bash -n scripts/run_docker_demo.sh
+          bash -n docker/entrypoint.sh
           bash -n scripts/run_graph_slam_pointcloud_map_in_autoware.sh
           bash -n scripts/prepare_velodyne_pointcloud_overlay.sh
           bash -n scripts/run_open_data_applanix_velodyne_gnss_smoke.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ python3 scripts/simple_lanelet2_generator.py \
 | `run_rko_lio_graph_benchmark.sh` | ベンチマークパイプライン |
 | `run_autoware_quickstart.sh` | NTU VIRAL → Autoware マップ E2E |
 | `download_ntu_viral_tnp01.sh` | NTU VIRAL データダウンロード |
+| `run_docker_demo.sh` | Docker ワンコマンドデモ（MID-360 bag DL → headless SLAM）|
 
 ### AWSIM・Autoware
 | スクリプト | 用途 |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+# lidarslam_ros2 — prebuilt SLAM workspace + one-command demo.
+#
+#   docker run --rm -v "$PWD/lidarslam_output:/lidarslam_ws/output" \
+#     ghcr.io/rsasaki0109/lidar_slam_ros2:humble
+#
+# The default command downloads a public Livox MID-360 driving bag
+# (Zenodo 14841855, CC-BY 4.0, 517 MB) and runs RKO-LIO + graph_based_slam
+# headless, saving an Autoware-ready map under /lidarslam_ws/output.
+# Any other command runs inside the sourced workspace, e.g.:
+#
+#   docker run --rm -it ghcr.io/rsasaki0109/lidar_slam_ros2:humble \
+#     ros2 launch lidarslam lidarslam.launch.py
+#
+# Build (from a checkout with submodules): docker build -t lidar_slam_ros2 .
+ARG ROS_DISTRO=humble
+FROM ros:${ROS_DISTRO}-ros-core
+ARG ROS_DISTRO
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    git \
+    python3-colcon-common-extensions \
+    python3-rosdep \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /lidarslam_ws
+COPY . .
+
+# Same dependency set as .github/workflows/main.yml (default workflow).
+RUN apt-get update \
+  && if [ ! -e /etc/ros/rosdep/sources.list.d/20-default.list ]; then rosdep init; fi \
+  && rosdep update --rosdistro "${ROS_DISTRO}" \
+  && . "/opt/ros/${ROS_DISTRO}/setup.sh" \
+  && rosdep install -r -y \
+    --from-paths \
+      lidarslam \
+      lidarslam_msgs \
+      scanmatcher \
+      graph_based_slam \
+      Thirdparty/ndt_omp_ros2 \
+      Thirdparty/rko_lio \
+    --ignore-src \
+    --rosdistro "${ROS_DISTRO}" \
+  && { apt-get install -y --no-install-recommends \
+      "ros-${ROS_DISTRO}-rosbag2-storage-sqlite3" \
+    || apt-get install -y --no-install-recommends \
+      "ros-${ROS_DISTRO}-rosbag2-storage-default-plugins"; } \
+  && apt-get install -y --no-install-recommends \
+    "ros-${ROS_DISTRO}-rosbag2-storage-mcap" \
+  && rm -rf /var/lib/apt/lists/*
+
+# Same package selection as scripts/run_default_ci_checks.sh (the Thirdparty
+# tree carries extra research packages whose deps are not installed here).
+# No --symlink-install: a symlinked install/ dangles once build/ is removed.
+RUN . "/opt/ros/${ROS_DISTRO}/setup.sh" \
+  && colcon build --packages-up-to lidarslam rko_lio \
+    --cmake-args -DCMAKE_BUILD_TYPE=Release \
+  && rm -rf build log
+
+ENTRYPOINT ["/lidarslam_ws/docker/entrypoint.sh"]
+CMD ["bash", "scripts/run_docker_demo.sh"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ flowchart LR
 
 ## Quickstart
 
+### Try it with Docker (one command, no build)
+
+```bash
+docker run --rm -v "$PWD/lidarslam_output:/lidarslam_ws/output" \
+  ghcr.io/rsasaki0109/lidar_slam_ros2:humble
+```
+
+This pulls the prebuilt image, downloads a public Livox MID-360 driving bag
+(517 MB, [Zenodo](https://zenodo.org/records/14841855), CC-BY 4.0) and runs the
+full RKO-LIO + graph_based_slam pipeline headless — a few minutes later
+`./lidarslam_output/mid360_demo/` holds the Autoware-ready map
+(`map.pcd`, `pointcloud_map/` tiles, `map_projector_info.yaml`) and the
+loop-closed trajectory (`traj_corrected.tum`). Add
+`-v lidarslam_demo_data:/lidarslam_ws/datasets` to cache the bag between runs.
+Any other command works too, e.g.
+`docker run --rm -it ghcr.io/rsasaki0109/lidar_slam_ros2:humble bash`.
+
+### Build from source
+
 ```bash
 cd ~/ros2_ws/src
 git clone --recursive https://github.com/rsasaki0109/lidarslam_ros2.git

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Source ROS + the prebuilt lidarslam workspace, then run the given command.
+set -e
+
+# shellcheck source=/dev/null
+source "/opt/ros/${ROS_DISTRO}/setup.bash"
+if [[ -f /lidarslam_ws/install/setup.bash ]]; then
+  # shellcheck source=/dev/null
+  source /lidarslam_ws/install/setup.bash
+fi
+
+exec "$@"

--- a/scripts/run_docker_demo.sh
+++ b/scripts/run_docker_demo.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# One-command SLAM demo: download a public Livox MID-360 driving bag
+# (Zenodo 14841855, Koide, CC-BY 4.0, 517 MB zip) and run the flagship
+# RKO-LIO + graph_based_slam pipeline headless, saving an Autoware-ready
+# map (map.pcd, pointcloud_map/ tiles, map_projector_info.yaml) and the
+# corrected trajectory (traj_corrected.tum).
+#
+# Designed as the default command of the ghcr.io/rsasaki0109/lidar_slam_ros2
+# image, but works on any host with the workspace built and sourced:
+#
+#   bash scripts/run_docker_demo.sh
+#
+# Environment overrides:
+#   DEMO_DATA_DIR    dataset cache directory (default: <repo>/datasets/mid360_public)
+#   DEMO_OUTPUT_DIR  output directory        (default: <repo>/output/mid360_demo)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DATA_DIR="${DEMO_DATA_DIR:-${REPO_ROOT}/datasets/mid360_public}"
+OUT_DIR="${DEMO_OUTPUT_DIR:-${REPO_ROOT}/output/mid360_demo}"
+BAG_NAME="rosbag2_2024_04_16-14_17_01"
+
+echo "== [1/2] demo data: Driving SLAM Test with Livox MID360 =="
+echo "   (Koide, Zenodo DOI 10.5281/zenodo.14841855, CC-BY 4.0)"
+bag_dir="$(find "${DATA_DIR}" -type d -name "${BAG_NAME}" 2>/dev/null | head -n 1 || true)"
+if [[ -z "${bag_dir}" ]]; then
+  python3 "${REPO_ROOT}/scripts/download_mid360_robot_public_dataset.py" \
+    --dataset driving_slam_mid360 --dataset-root "${DATA_DIR}"
+  bag_dir="$(find "${DATA_DIR}" -type d -name "${BAG_NAME}" | head -n 1)"
+fi
+[[ -n "${bag_dir}" && -f "${bag_dir}/metadata.yaml" ]] || {
+  echo "error: demo bag not found under ${DATA_DIR}" >&2
+  exit 1
+}
+echo "   bag: ${bag_dir}"
+
+echo "== [2/2] RKO-LIO + graph_based_slam (headless, offline) =="
+bash "${REPO_ROOT}/scripts/run_rko_lio_graph_autoware_dogfood.sh" \
+  --bag "${bag_dir}" \
+  --lidar-topic /livox/lidar --imu-topic /livox/imu \
+  --base-frame livox_frame --lidar-frame livox_frame --imu-frame livox_frame \
+  --rko-param "${REPO_ROOT}/lidarslam/param/rko_lio_mid360.yaml" \
+  --lidarslam-param "${REPO_ROOT}/lidarslam/param/lidarslam_mid360_rko_graph.yaml" \
+  --wait-for-offline-completion --skip-viewer \
+  --output-dir "${OUT_DIR}" \
+  --run-name mid360_demo
+
+echo
+echo "== demo finished =="
+echo "outputs under ${OUT_DIR}:"
+echo "  map.pcd                  downsampled point-cloud map"
+echo "  pointcloud_map/          Autoware map tiles (+ metadata)"
+echo "  map_projector_info.yaml  Autoware projector info (local)"
+echo "  traj_corrected.tum       loop-closed trajectory (TUM format)"


### PR DESCRIPTION
## What

P0-2 of the star campaign: a prebuilt Docker image so anyone can try the flagship pipeline with one command — no clone, no colcon, no dataset hunting:

```bash
docker run --rm -v "$PWD/lidarslam_output:/lidarslam_ws/output" \
  ghcr.io/rsasaki0109/lidar_slam_ros2:humble
```

The default command downloads the public Livox MID-360 driving bag (Zenodo 14841855, Koide, **CC-BY 4.0**, 517 MB zip / 277 s) and runs RKO-LIO + graph_based_slam headless via the existing dogfood driver, saving the Autoware-ready bundle: `map.pcd`, `pointcloud_map/` tiles, `map_projector_info.yaml`, `traj_corrected.tum`.

## Changes

- **Dockerfile**: `ros:humble-ros-core` base, same rosdep recipe and package selection as CI (`--packages-up-to lidarslam rko_lio`). Entrypoint sources the workspace, so any `ros2 ...` command works too.
- **scripts/run_docker_demo.sh**: demo driver (download → headless SLAM → output summary); also runs on a host build. Registered in the CI `bash -n` entrypoint list.
- **.github/workflows/docker.yml**: PRs touching the docker files validate the build; pushes to `main` (and manual dispatch) publish `ghcr.io/rsasaki0109/lidar_slam_ros2:humble` + `:latest` with GHA layer cache.
- **README**: "Try it with Docker (one command, no build)" section at the top of Quickstart.
- **.dockerignore**: sources-only context (excludes datasets/outputs/colcon artifacts).

## Gotchas found while validating (baked into the Dockerfile)

1. `--symlink-install` + `rm -rf build` leaves a dangling `install/` (per-package `local_setup.bash` are symlinks into `build/`) → plain install.
2. `ros:*-ros-core` + rosdep does **not** provide the rosbag2 sqlite3 storage plugin → `rko_lio/offline_node` dies with *Could not load/open plugin with storage id 'sqlite3'*. Installed explicitly, with a humble/jazzy package-name fallback (`rosbag2-storage-sqlite3` | `rosbag2-storage-default-plugins`) + mcap.

## Validation

- Host run of `run_docker_demo.sh` path (same driver/params): 277 s bag → `map.pcd` 66 MB + 585-pose corrected trajectory in **~3 min** wall clock.
- In-container run of the exact image (local bag mounted to skip the download): completes end-to-end, `map.pcd` 62 MB + `pointcloud_map/` tiles + `traj_corrected.tum` written through the `/lidarslam_ws/output` volume. Image size 6.4 GB.
- `pytest graph_based_slam/test/test_docs_entrypoints.py`: 6 passed.

## Notes

- The image is published on the next push to `main` (or a manual `workflow_dispatch` of the docker workflow); the README command goes live then.
- Jazzy variant is a follow-up (`--build-arg ROS_DISTRO=jazzy` already supported by the Dockerfile).