### PR TITLE
feat(v0.5): real total-station GT for MID-360 — 4/4 RTK-SLAM sequences, indoor gates blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,17 @@ Every release is blocked in CI by these per-dataset thresholds.
 | Dataset | Sensor | Reference | APE RMSE | Gate (pass) |
 | --- | --- | --- | --- | --- |
 | NTU VIRAL `tnp_01` (outdoor, ~580 s) | Ouster OS1-16 + VN-100 | Leica prism ground truth | **0.95 m** (best 0.87) | ≤ 1.00 m |
-| RTK-SLAM Construction Hall 2 (indoor, ~600 s) | Livox MID-360 | total-station checkpoints¹ | **0.154 m** (median 0.061) | ≤ 0.30 m² |
-| RTK-SLAM Construction Hall 1 (indoor, ~741 s) | Livox MID-360 | total-station checkpoints¹ | **0.403 m** (median 0.263) | ≤ 0.55 m² |
-| MID-360 indoor loop (~277 s) | Livox MID-360 | cross-validation vs GLIM | 3.64 m | ≤ 4.00 m |
+| RTK-SLAM Construction Hall 2 (indoor, ~600 s) | Livox MID-360 | total-station checkpoints¹ | **0.154 m** (median 0.061) | ≤ 0.30 m |
+| RTK-SLAM Construction Hall 1 (indoor, ~741 s) | Livox MID-360 | total-station checkpoints¹ | **0.403 m** (median 0.263) | ≤ 0.55 m |
+| RTK-SLAM Stadtgarten 2 (outdoor park, ~876 s) | Livox MID-360 | total-station checkpoints¹ | **0.835 m** (median 0.327) | report-only² |
+| RTK-SLAM Stadtgarten 1 (outdoor park, ~1 km loop) | Livox MID-360 | total-station checkpoints¹ | **1.666 m** (median 1.511) | report-only² |
 | Newer College `math-hard` (~320 m loop) | Ouster OS0-128 | prism ground truth | reported separately | ≤ 0.10 m |
 
 ¹ Surveyed checkpoints from the public RTK-SLAM dataset (CC-BY 4.0); scored on the
 dense odometry trajectory, the same form as the dataset's published baselines.
-² Report-only until the remaining sequences validate (v0.6); see
-[docs/comparison.md](docs/comparison.md) for the full methodology and caveats.
+² Outdoor profiles soak as report-only before graduating; the former
+cross-validation gate vs GLIM (3.64 m) is also report-only since v0.5. Full
+methodology and caveats: [docs/comparison.md](docs/comparison.md).
 
 Reproduce locally:
 

--- a/configs/mid360_robot/rko_lio_rtk_slam_mid360_outdoor.yaml
+++ b/configs/mid360_robot/rko_lio_rtk_slam_mid360_outdoor.yaml
@@ -1,0 +1,18 @@
+# RKO-LIO outdoor config for the public RTK-SLAM dataset (Stadtgarten park
+# sequences; Livox MID-360 + total-station GT; arXiv:2604.07151, CC-BY 4.0).
+#
+# Identical to rko_lio_rtk_slam_mid360.yaml (the indoor preset) except
+# double_downsample is OFF: in the sparse park scene the second downsample
+# starves ICP of correspondences and the odometry drifts to 3.9 m RMSE on
+# stadtgarten_seq2; keeping every voxel sample brings it to 0.835 m
+# (median 0.327). Coarser voxels (1.0 m + 1.0 m correspondence distance)
+# scored worse (2.35 m) — keep voxel 0.5 and just stop discarding points.
+# Sweep record: docs/research/rtkslam-total-station-gt-methodology.md.
+extrinsic_imu2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+extrinsic_lidar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
+initialization_phase: false
+deskew: false
+voxel_size: 0.5
+min_range: 1.0
+max_range: 100.0
+double_downsample: false

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -14,18 +14,19 @@ heterogeneous datasets onto a single APE threshold. `v0.4` then **graduated the
 former research-track profiles to blocking** (decision 2026-06-07,
 `docs/roadmap/v0.4.md`):
 
-- **Release track (blocking)** — a FAIL blocks the release. As of v0.4 this is
-  every shipped profile: `Newer College math-hard` (ground truth),
-  `NTU VIRAL tnp_01` (ground truth), `MID-360` vs GLIM (cross-validation), the
-  Leo Drive applanix/velodyne open-data cross-validation, and the KITTI
-  Odometry 00/05/07 LO baseline comparison (non-regression).
-- **Interim caveat** — `MID-360` vs GLIM and the Leo Drive profile block on a
-  *cross-validation* reference rather than ground truth, an interim weakness
-  accepted knowingly. `MID-360` vs GLIM is slated to be replaced by a real
-  ground-truth `ape_rmse_gt_m` profile in v0.5.
-- **Research track (mechanism retained)** — `report_only_until` still downgrades
-  a FAIL to WARN, but **no shipped profile uses it as of v0.4**. It remains
-  available for any future dataset introduced mid-cycle.
+- **Release track (blocking)** — a FAIL blocks the release. As of v0.5 this is:
+  `Newer College math-hard` (ground truth), `NTU VIRAL tnp_01` (ground truth),
+  the two `mid360_gt_rtkslam_construction_*` profiles (**total-station ground
+  truth**, graduated in v0.5), the Leo Drive applanix/velodyne open-data
+  cross-validation, and the KITTI Odometry 00/05/07 LO baseline comparison
+  (non-regression).
+- **Report-only** — `MID-360` vs GLIM was demoted in v0.5 (decision D-GT-2,
+  `docs/roadmap/v0.5.md`): cross-validation against another SLAM estimate
+  measures agreement, not accuracy, and the same sensor is now gated on real
+  total-station checkpoints. It stays as a regression canary. The Leo Drive
+  profile keeps its cross-validation caveat (separate track). New profiles
+  introduced mid-cycle (e.g. the outdoor Stadtgarten pair) soak as report-only
+  before graduating.
 
 The distinction is exercised by `scripts/run_release_readiness_checks.sh`,
 which evaluates each profile in `scripts/release_profiles.yaml` and emits
@@ -97,10 +98,14 @@ from `WARN` to `PASS` without breaking the gate.
 | --- | --- | --- | --- | --- | --- |
 | `NTU VIRAL tnp_01` | current default | `ground_truth` | `0.952` | `PASS` (pass ≤ 1.00, target 0.30) | outdoor long-loop GT |
 | `NTU VIRAL tnp_01` | best observed   | `ground_truth` | `0.870` | `PASS` (same)                     | loop-gated backend run |
-| `MID-360` | current default                  | `cross_validation` vs GLIM | `3.641` | `PASS` (pass ≤ 4.00, target 1.00) | solid-state LiDAR, non-360° FOV |
-| `MID-360` | best observed                    | `cross_validation` vs GLIM | `3.590` | `PASS` (same)                     | rerun with same tuned backend family |
-| `MID-360` | Scan Context candidate           | `cross_validation` vs GLIM | `3.816` | `PASS`                            | fair current-code comparison; still opt-in |
-| `MID-360` | experimental BEV-assisted rerank | `cross_validation` vs GLIM | `3.607` | `PASS`                            | sensor-agnostic rerank of distance candidates; still opt-in |
+| `MID-360` RTK-SLAM Construction Hall 2 | indoor default | `ground_truth` (total station, 16 chkpt) | `0.154` (median 0.061) | `PASS` (pass ≤ 0.30, target 0.15) | dense odometry scored, `--match-tolerance 2.0` |
+| `MID-360` RTK-SLAM Construction Hall 1 | indoor default | `ground_truth` (total station, 16 chkpt) | `0.403` (median 0.263) | `PASS` (pass ≤ 0.55, target 0.30) | hardest indoor hall (published baselines ~0.22) |
+| `MID-360` RTK-SLAM Stadtgarten 2 | outdoor config | `ground_truth` (total station, 19 chkpt) | `0.835` (median 0.327) | report-only soak (pass ≤ 1.20) | outdoor park; `double_downsample: false` (see methodology note) |
+| `MID-360` RTK-SLAM Stadtgarten 1 | outdoor config | `ground_truth` (total station, 36 chkpt) | `1.666` (median 1.511) | report-only soak (pass ≤ 2.20) | 26 min / ~1 km park loop; raw odometry drift, no GNSS / loop closure |
+| `MID-360` | current default                  | `cross_validation` vs GLIM | `3.641` | report-only since v0.5 (D-GT-2)   | solid-state LiDAR, non-360° FOV |
+| `MID-360` | best observed                    | `cross_validation` vs GLIM | `3.590` | report-only (same)                | rerun with same tuned backend family |
+| `MID-360` | Scan Context candidate           | `cross_validation` vs GLIM | `3.816` | report-only                       | fair current-code comparison; still opt-in |
+| `MID-360` | experimental BEV-assisted rerank | `cross_validation` vs GLIM | `3.607` | report-only                       | sensor-agnostic rerank of distance candidates; still opt-in |
 | Leo Drive (applanix/velodyne) | current default | `cross_validation` vs Applanix GSOF49 | varies per bag | `PASS` (pass ≤ 1.50, target 0.50) | open-data Velodyne packet path |
 
 The Newer College `math-hard` profile (ground truth) is the tightest gate
@@ -110,9 +115,13 @@ baseline comparison is wired through `scripts/run_kitti_00_05_07_report.sh` and
 emits a non-regression report under
 `output/kitti_dev_<timestamp>/kitti_dev_report.md`.
 
-`MID-360` and Leo Drive now **do** feed the release gate (graduated in v0.4),
-blocking on their cross-validation thresholds; `MID-360` vs GLIM is slated to be
-replaced by a real ground-truth profile in v0.5.
+As of v0.5 the MID-360 release evidence is **real ground truth**: the two
+RTK-SLAM Construction Hall profiles block on SE(3)-aligned total-station
+checkpoint RMSE (`ape_rmse_gt_m`), the same metric family as NTU VIRAL and
+Newer College. `MID-360` vs GLIM is report-only (regression canary, D-GT-2);
+Leo Drive still blocks on its cross-validation threshold. Dataset, metric
+definition and attribution:
+`docs/research/rtkslam-total-station-gt-methodology.md`.
 
 Source artifacts:
 

--- a/docs/research/rtkslam-total-station-gt-methodology.md
+++ b/docs/research/rtkslam-total-station-gt-methodology.md
@@ -1,0 +1,83 @@
+# RTK-SLAM total-station GT — methodology for the mid360_gt_rtkslam_* profiles (v0.5)
+
+`mid360_vs_glim`（GLIM 推定との cross-validation）を実 GT に置換した v0.5 の
+リリースゲート方法論。データセット・メトリクス定義・帰属表記をここに固定する。
+経緯と検証ログは `docs/roadmap/v0.5.md` §3。
+
+## データセット
+
+**RTK-SLAM Dataset** — Zhang, Ress, Skuddis, Soergel, Haala (Univ. Stuttgart),
+arXiv:2604.07151, **CC-BY 4.0**。
+bags: huggingface.co/datasets/Willyzw/rtk-slam-dataset（ROS 2, 計 182 GB）/
+GT + 例軌跡: github.com/Willyzw/rtk-slam-eval（数 MB の git clone で取得可能、
+`scripts/download_rtk_slam_dataset.py --eval-assets`）。
+
+- センサ: Livox MID-360（`/livox/points` = PointCloud2、`/livox/lidar` は
+  CustomMsg なので使わない）+ `/livox/imu` 200 Hz。
+- GT: **geodetic total station が測量した疎な checkpoint**
+  （CSV `point_id,easting,northing,height,env,timestamp`、16–36 点/シーケンス）。
+  オンボード RTK から独立した測量器による third-party GT。
+- 4 シーケンス: Construction Hall 1/2（屋内、16 chkpt each）、
+  Stadtgarten 1/2（屋外公園、36/19 chkpt）。
+
+## メトリクス: SE(3)-aligned checkpoint RMSE
+
+- `scripts/generate_rtk_slam_reference.py` が checkpoint CSV を最古点原点の
+  sparse TUM に変換（identity quat）。timestamp は bag と同一 Unix-epoch
+  センサクロック（実測確認済み）。
+- `scripts/write_aligned_trajectory_metrics.py` が推定軌跡と最近傍時刻マッチ →
+  **Umeyama SE(3) アライン後の RMSE**（`evo.ape.rmse`、既存 `ape_rmse_gt_m`
+  と同一定義）。**`--match-tolerance 2.0` 必須**（dataset 公式の max_dt。
+  デフォルトの 0.05→0.15 s カスケードでは疎 checkpoint を silent drop する）。
+- dataset 公式の zero-aligned 絶対 RMSE / gap% は GNSS アンカーが前提
+  （RKO-LIO は LiDAR-inertial のみ）なので**ゲートには使わない**。SE(3)
+  アラインは `livox_frame → base` の定数 extrinsic も吸収する（identity で可）。
+- **dense トラジェクトリ（RKO-LIO raw odometry）を採点する**。loop-closed
+  `/modified_path` は submap ノード単位で疎になり、checkpoint（測量滞在 =
+  低速 = submap が立たない）がギャップに落ちて採点不能。公開ベースラインも
+  dense 形式で採点されており土俵が同じ。
+
+## 結果(自前 RKO-LIO、v0.5 時点)
+
+| シーケンス | 環境 | config | chkpt | RMSE (m) | median | 公開手法(参考) |
+|---|---|---|---|---|---|---|
+| construction_seq2 | 屋内 | indoor | 16/16 | **0.154** | 0.061 | fast_lio_sam 0.086 / okvis 0.075 |
+| construction_seq1 | 屋内(最難) | indoor | 16/16 | **0.403** | 0.263 | 0.221 / 0.227 |
+| stadtgarten_seq2 | 屋外公園 | outdoor | 19/19 | **0.835** | 0.327 | 0.070 / 0.083 |
+| stadtgarten_seq1 | 屋外公園(26分/1km) | outdoor | 36/36 | **1.666** | 1.511 | 0.071 / 0.054 |
+
+indoor config = `configs/mid360_robot/rko_lio_rtk_slam_mid360.yaml`
+（voxel 0.5, double_downsample on）。
+
+## outdoor config: double_downsample が律速だった
+
+indoor config のまま屋外公園を走らせると RMSE 3.903 m（median 1.37, max 11.7）
+まで漂流する。スイープの結果、**`double_downsample: false` の 1 点だけで
+0.835 m（4.7 倍改善）**。疎・遠方特徴の公園では間引き 2 段目が correspondence
+を飢餓させていた。voxel 1.0 + corr 1.0（rko_lio 屋外既定スケール）は 2.348 m で
+むしろ悪く、voxel 0.5 を維持して間引きだけ止めるのが正解だった。
+outdoor config = `configs/mid360_robot/rko_lio_rtk_slam_mid360_outdoor.yaml`。
+
+| stadtgarten_seq2 config | RMSE (m) | median | max |
+|---|---|---|---|
+| indoor（voxel 0.5, DD on） | 3.903 | 1.366 | 11.75 |
+| **voxel 0.5, DD off（採用）** | **0.835** | **0.327** | **3.05** |
+| voxel 1.0, corr 1.0, DD off | 2.348 | 0.468 | 8.96 |
+
+## ゲート構成(v0.5)
+
+- 屋内 2 profile（`mid360_gt_rtkslam_construction_seq{1,2}`）= **blocking**
+  に昇格（pass 0.55/0.30、4 シーケンス計測済み）。
+- 屋外 Stadtgarten pair = report-only で soak（実測 0.835 / 1.666 m に
+  indoor と同程度のヘッドルームで pass 1.20 / 2.20、target 0.90 / 1.70）。
+  屋外は公開手法(GNSS/loop closure 込み)に大差があり、ゲートというより
+  能力境界の正直な計測値。長尺 1km 周回(seq1)では LiDAR-inertial raw
+  odometry のドリフトが median 1.5 m まで積算する。
+- `mid360_vs_glim` = report-only に降格(D-GT-2)。cross-validation は
+  agreement しか測れないため、同一センサの回帰カナリアとして残置。
+
+## 帰属(CC-BY 4.0)
+
+データ出典: RTK-SLAM Dataset, Zhang, Ress, Skuddis, Soergel, Haala
+(University of Stuttgart), arXiv:2604.07151, CC-BY 4.0. 本リポジトリは bag と
+GT を再配布せず、ダウンロードスクリプト経由で利用者が直接取得する。

--- a/docs/roadmap/v0.5.md
+++ b/docs/roadmap/v0.5.md
@@ -1,14 +1,14 @@
 # lidarslam-ros2 v0.5 roadmap — MID-360 real ground truth
 
-> Status: **scoping, re-scoped onto a public dataset** (drafted 2026-06-07,
-> after the v0.4 D1 opt-in deterministic-scheduling impl landed, `507c367`/#208;
-> re-scoped 2026-06-07 once a public MID-360 + total-station dataset was found).
-> This is a planning document, not yet committed work. It turns v0.4's **locked
-> decision #1** — *"MID-360 evidence → pursue real ground truth"* — into a plan.
-> **D-GT-1 (GT source) is total-station ground truth, now acquired via the
-> public RTK-SLAM dataset** (§2) instead of borrowing a total station ourselves.
-> The remaining work is one reference script + one profile + a 182 GB download
-> (§3, §5) — no field capture, no equipment.
+> Status: **done — landed 2026-06-11** (drafted 2026-06-07 after the v0.4 D1
+> opt-in deterministic-scheduling impl landed, `507c367`/#208; re-scoped
+> 2026-06-07 onto the public RTK-SLAM dataset). v0.4's **locked decision #1**
+> — *"MID-360 evidence → pursue real ground truth"* — is delivered: all four
+> RTK-SLAM sequences are measured against total-station checkpoints, the two
+> indoor profiles **block** the release, the outdoor pair soaks as
+> report-only with a fixed outdoor config (§3.6), and `mid360_vs_glim` is
+> demoted to a report-only regression canary (D-GT-2). Methodology:
+> `docs/research/rtkslam-total-station-gt-methodology.md`.
 
 ## 0. Why this exists
 
@@ -186,11 +186,17 @@ MID-360 + RKO-LIO holds 0.15–0.40 m in the structured construction hall (raw
 odometry, no loop closure), but **drifts badly (3.9 m) in the open Stadtgarten
 park** — short MID-360 range (~40 m) against sparse, distant features starves the
 odometry. This is a real capability boundary, not a metric artifact (19/19
-paired, error grows monotonically to 11.7 m). The outdoor sequences need config
-work (range / deskew / downsampling) before they earn a gate; the **indoor pair
-is the credible GT validation set** for v0.5. Per-sequence thresholds reflect the
+paired, error grows monotonically to 11.7 m). Per-sequence thresholds reflect the
 genuine difficulty gap (construction_seq1's `pass` is looser than seq2's), the
 same way NTU (1.0 m) and Newer College (0.10 m) differ.
+
+**Resolved (2026-06-11) — the outdoor drift was correspondence starvation.**
+A config sweep on stadtgarten_seq2 found `double_downsample: false` alone takes
+the RMSE from 3.903 to **0.835 m** (median 0.327, max 3.05); coarser voxels
+(1.0 m + 1.0 m correspondence distance) scored worse (2.348 m). The outdoor
+preset is `configs/mid360_robot/rko_lio_rtk_slam_mid360_outdoor.yaml`; the full
+sweep record lives in
+`docs/research/rtkslam-total-station-gt-methodology.md`.
 
 The construction_seq2 trajectory detail (raw vs corrected):
 
@@ -256,17 +262,27 @@ Do not assume the NTU/Newer-College range carries over.
       CSVs** against the eval repo's example trajectories (§3.5).
 - [x] Ran RKO-LIO on three sequences (§3.6): construction_seq2 0.154, construction_seq1
       0.403 (both indoor, gate PASS), stadtgarten_seq2 3.903 (outdoor, drifts).
-      Remaining: stadtgarten_seq1 (26 min) + outdoor config work.
+- [x] **Outdoor config fixed (2026-06-11)**: the 3.9 m Stadtgarten drift was
+      correspondence starvation — `double_downsample: false` alone brings
+      stadtgarten_seq2 to **0.835 m** (median 0.327, max 3.05; 19/19
+      checkpoints). Coarser voxels (1.0 m + 1.0 m correspondence distance)
+      scored worse (2.348 m). Config:
+      `configs/mid360_robot/rko_lio_rtk_slam_mid360_outdoor.yaml`; sweep record
+      in `docs/research/rtkslam-total-station-gt-methodology.md`. Side fix: the
+      benchmark's offline-completion check now keys on the raw trajectory
+      reaching the bag end instead of log quiescence (TF-warning spam kept the
+      log busy forever and burned the whole `--offline-timeout-secs` budget).
 - [x] Two indoor GT profiles in `release_profiles.yaml`
       (`mid360_gt_rtkslam_construction_seq2` 0.30/0.15, `_construction_seq1`
-      0.55/0.30), `reference_kind: ground_truth`, **report_only_until v0.6**.
-      Outdoor profile deferred until the config drift is fixed (§3.6, §4).
-- [ ] Graduate the indoor pair to **blocking**, then `mid360_vs_glim` demoted to
-      non-blocking per D-GT-2.
-- [ ] Docs: `comparison.md` MID-360 row → `ape_rmse_gt_m` (true GT, total-station
-      checkpoints) instead of the cross-val caveat; this roadmap → "done". A
-      short methodology note under `docs/research/` (dataset, checkpoint metric,
-      SE(3)-aligned vs absolute, attribution per CC-BY).
+      0.55/0.30), `reference_kind: ground_truth`.
+- [x] Graduated the indoor pair to **blocking** (all four sequences measured),
+      and `mid360_vs_glim` demoted to report-only per D-GT-2 (regression
+      canary; cross-validation measures agreement, not accuracy).
+- [x] Docs: `comparison.md` MID-360 rows → `ape_rmse_gt_m` (true GT,
+      total-station checkpoints), README accuracy table updated, methodology
+      note at `docs/research/rtkslam-total-station-gt-methodology.md` (dataset,
+      checkpoint metric, SE(3)-aligned vs absolute, outdoor config sweep,
+      attribution per CC-BY).
 
 ## 6. Out of scope for v0.5 (explicit)
 

--- a/scripts/release_profiles.yaml
+++ b/scripts/release_profiles.yaml
@@ -12,13 +12,15 @@
 #     profiles (``ntu_viral_tnp_01``, ``mid360_vs_glim``,
 #     ``leo_drive_applanix_velodyne_cross``) graduated from ``report_only_until:
 #     v0.4`` to blocking at their current ``pass`` thresholds.
-#   - Caveat: ``mid360_vs_glim`` and ``leo_drive_applanix_velodyne_cross`` block
-#     on a *cross-validation* reference, not ground truth -- an interim weakness
-#     accepted knowingly. ``mid360_vs_glim`` is slated to be replaced by a real
-#     ground-truth ``ape_rmse_gt_m`` profile in v0.5.
-#   - ``report_only_until`` is retained as a mechanism (FAIL -> WARN while set)
-#     for any future profile introduced mid-cycle, but no shipped profile uses
-#     it as of v0.4.
+#   - As of v0.5 (docs/roadmap/v0.5.md), the MID-360 evidence is real ground
+#     truth: the ``mid360_gt_rtkslam_construction_*`` total-station profiles
+#     graduated to blocking (all four RTK-SLAM sequences measured), and
+#     ``mid360_vs_glim`` was demoted to report-only per decision D-GT-2
+#     (cross-validation only measures agreement, not accuracy; it stays as a
+#     regression canary). ``leo_drive_applanix_velodyne_cross`` keeps the
+#     cross-val caveat (separate track).
+#   - ``report_only_until`` is the demotion/soak mechanism (FAIL -> WARN while
+#     set); new profiles introduced mid-cycle soak as report-only first.
 #
 # Fields:
 #   name: short identifier (snake_case)
@@ -57,8 +59,12 @@ release_profiles:
     pass: 1.00
     target: 0.30
 
+  # Demoted to report-only in v0.5 (D-GT-2): superseded by the
+  # mid360_gt_rtkslam_* total-station profiles below. Cross-validation against
+  # another SLAM estimate measures agreement, not accuracy; kept as a
+  # regression canary on the same sensor.
   - name: mid360_vs_glim
-    description: Livox MID-360 vs GLIM cross-validation (~277s indoor loop)
+    description: Livox MID-360 vs GLIM cross-validation (~277s indoor loop; report-only since v0.5)
     match:
       points_topic: /livox/lidar
       reference_kind: cross_validation
@@ -67,6 +73,7 @@ release_profiles:
     metric: ape_rmse_vs_reference_m
     pass: 4.00
     target: 1.00
+    report_only_until: superseded-by-mid360-gt (D-GT-2)
 
   # v0.5: the real total-station GT profile that supersedes mid360_vs_glim's
   # cross-validation. Scored against the public RTK-SLAM dataset's surveyed
@@ -74,10 +81,9 @@ release_profiles:
   # land at survey-dwell points where the optimized submap graph is sparse, so
   # the gate scores the *dense* trajectory (RKO-LIO odometry) -- the same dense
   # form the dataset's own published baselines are scored in. Run with
-  # --match-tolerance 2.0 (the dataset's max_dt). report_only_until is kept while
-  # only construction_seq2 is measured; graduate to blocking once the other
-  # three sequences confirm the threshold. Observed construction_seq2 raw RMSE
-  # 0.154 m (median 0.061), vs published fast_lio_sam 0.086 / okvis 0.075.
+  # --match-tolerance 2.0 (the dataset's max_dt). Graduated to blocking in v0.5
+  # with all four RTK-SLAM sequences measured. Observed construction_seq2 raw
+  # RMSE 0.154 m (median 0.061), vs published fast_lio_sam 0.086 / okvis 0.075.
   - name: mid360_gt_rtkslam_construction_seq2
     description: Livox MID-360 vs total-station checkpoints, RTK-SLAM Construction Hall 2 (~600s, 16 chkpt, dense odometry)
     match:
@@ -88,15 +94,12 @@ release_profiles:
     metric: ape_rmse_gt_m
     pass: 0.30
     target: 0.15
-    report_only_until: v0.6
 
   # Companion indoor sequence (Construction Hall 1) -- the hardest of the two
   # halls (published baselines ~0.22 m, the highest). Our dense odometry pairs
   # 16/16 at RMSE 0.403 m (median 0.263), so the threshold is looser than
   # construction_seq2 by design: per-sequence difficulty, like NTU vs Newer
-  # College. report_only_until while the indoor pair is the only validated set
-  # (the outdoor Stadtgarten sequences drift badly with this indoor-tuned
-  # config -- 3.9 m on stadtgarten_seq2 -- and need config work before gating).
+  # College. Graduated to blocking in v0.5 together with construction_seq2.
   - name: mid360_gt_rtkslam_construction_seq1
     description: Livox MID-360 vs total-station checkpoints, RTK-SLAM Construction Hall 1 (~741s, 16 chkpt, dense odometry)
     match:
@@ -107,6 +110,37 @@ release_profiles:
     metric: ape_rmse_gt_m
     pass: 0.55
     target: 0.30
+
+  # Outdoor pair (Stadtgarten park) -- measured with the outdoor preset
+  # (configs/mid360_robot/rko_lio_rtk_slam_mid360_outdoor.yaml,
+  # double_downsample off; the indoor preset drifts to 3.9 m here). These are
+  # honest capability-boundary numbers for LiDAR-inertial raw odometry without
+  # GNSS or loop closure (published GNSS-anchored baselines sit at ~0.07 m):
+  # stadtgarten_seq2 0.835 m (median 0.327, 19 chkpt), stadtgarten_seq1
+  # 1.666 m (median 1.511, 36 chkpt, 26 min / ~1 km loop). Soak as
+  # report-only with indoor-like headroom before graduating.
+  - name: mid360_gt_rtkslam_stadtgarten_seq2
+    description: Livox MID-360 vs total-station checkpoints, RTK-SLAM Stadtgarten 2 (~876s outdoor park, 19 chkpt, dense odometry)
+    match:
+      points_topic: /livox/points
+      reference_kind: ground_truth
+      reference_source_contains: rtk_slam_stadtgarten_seq2_gt
+      min_ape_pairs: 12
+    metric: ape_rmse_gt_m
+    pass: 1.20
+    target: 0.90
+    report_only_until: v0.6
+
+  - name: mid360_gt_rtkslam_stadtgarten_seq1
+    description: Livox MID-360 vs total-station checkpoints, RTK-SLAM Stadtgarten 1 (~1603s outdoor park, 36 chkpt, dense odometry)
+    match:
+      points_topic: /livox/points
+      reference_kind: ground_truth
+      reference_source_contains: rtk_slam_stadtgarten_seq1_gt
+      min_ape_pairs: 24
+    metric: ape_rmse_gt_m
+    pass: 2.20
+    target: 1.70
     report_only_until: v0.6
 
   - name: leo_drive_applanix_velodyne_cross

--- a/scripts/run_rko_lio_graph_benchmark.sh
+++ b/scripts/run_rko_lio_graph_benchmark.sh
@@ -333,8 +333,45 @@ wait_for_map_outputs() {
   return 1
 }
 
+bag_end_stamp() {
+  # Unix-epoch end time of the bag (start + duration), from metadata.yaml.
+  python3 - "$BAG_PATH" <<'PY'
+import sys
+from pathlib import Path
+
+import yaml
+
+meta = yaml.safe_load((Path(sys.argv[1]) / 'metadata.yaml').read_text())
+info = meta['rosbag2_bagfile_information']
+start_ns = info['starting_time']['nanoseconds_since_epoch']
+dur_ns = info['duration']['nanoseconds']
+print((start_ns + dur_ns) / 1e9)
+PY
+}
+
+raw_tum_reached() {
+  # True once the last raw-trajectory stamp is within margin of the bag end.
+  local end_stamp="$1"
+  local margin="$2"
+  python3 - "$RAW_TUM" "$end_stamp" "$margin" <<'PY'
+import sys
+
+try:
+    with open(sys.argv[1], 'rb') as fh:
+        fh.seek(-256, 2)
+        last = fh.read().decode(errors='replace').strip().splitlines()[-1]
+    reached = float(last.split()[0]) >= float(sys.argv[2]) - float(sys.argv[3])
+except (OSError, IndexError, ValueError):
+    reached = False
+sys.exit(0 if reached else 1)
+PY
+}
+
 run_state_signature() {
-  python3 - "$RAW_TUM" "$CORRECTED_TUM" "$LAUNCH_LOG" <<'PY'
+  # Trajectory files only: the launch log keeps growing with TF warnings on
+  # some bags, which would starve a log-based quiescence check forever and
+  # burn the whole --offline-timeout-secs budget after the bag is processed.
+  python3 - "$RAW_TUM" "$CORRECTED_TUM" <<'PY'
 import os
 import sys
 
@@ -364,6 +401,13 @@ wait_for_offline_completion() {
   local last_signature=""
   local stable_since=0
   local deadline=$((SECONDS + timeout_secs))
+  # Primary completion signal: the raw trajectory has reached the bag end and
+  # gone quiet. Quiescence alone is NOT enough — buffered TUM writes can stall
+  # for tens of seconds mid-run and fake completion. A long stall (10x the
+  # quiescence window) is still accepted as a crash/abort fallback.
+  local end_stamp=""
+  end_stamp="$(bag_end_stamp 2>/dev/null)" || end_stamp=""
+  local stall_secs=$((QUIESCENCE_SECS * 10))
 
   while (( SECONDS < deadline )); do
     if [[ -s "$RKO_RESULT_TUM" ]]; then
@@ -384,8 +428,16 @@ wait_for_offline_completion() {
         stable_since=$SECONDS
       fi
       if (( SECONDS - stable_since >= QUIESCENCE_SECS )); then
-        echo "No new trajectory/log updates for ${QUIESCENCE_SECS}s; treating benchmark run as complete"
-        return 0
+        # 120 s margin: the lidar stream can end well before the bag's global
+        # end stamp (other topics keep recording; 62 s on stadtgarten_seq2).
+        if [[ -z "$end_stamp" ]] || raw_tum_reached "$end_stamp" 120.0; then
+          echo "Trajectory reached the bag end and stayed quiet for ${QUIESCENCE_SECS}s; treating benchmark run as complete"
+          return 0
+        fi
+        if (( SECONDS - stable_since >= stall_secs )); then
+          echo "Warning: trajectory stalled for ${stall_secs}s before the bag end; treating benchmark run as aborted-but-scoreable" >&2
+          return 0
+        fi
       fi
     else
       stable_since=0


### PR DESCRIPTION
## What

Closes out the v0.5 roadmap (`docs/roadmap/v0.5.md`): the MID-360 release evidence moves from GLIM cross-validation to **real total-station ground truth**, with all four RTK-SLAM sequences measured.

### Results (SE(3)-aligned checkpoint RMSE, dense raw odometry, `--match-tolerance 2.0`)

| sequence | env | chkpt | RMSE (m) | median | gate |
|---|---|---|---|---|---|
| construction_seq2 | indoor | 16/16 | **0.154** | 0.061 | **blocking** PASS (≤ 0.30) |
| construction_seq1 | indoor (hardest) | 16/16 | **0.403** | 0.263 | **blocking** PASS (≤ 0.55) |
| stadtgarten_seq2 | outdoor park | 19/19 | **0.835** | 0.327 | report-only soak (≤ 1.20) |
| stadtgarten_seq1 | outdoor, ~1 km loop | 36/36 | **1.666** | 1.511 | report-only soak (≤ 2.20) |

### The outdoor finding

The previously-reported 3.9 m Stadtgarten drift was **correspondence starvation, not a capability wall**: `double_downsample: false` alone brings it to 0.835 m (4.7x). Coarser voxels (1.0 m + 1.0 m correspondence distance) scored *worse* (2.348 m) — keep voxel 0.5, just stop discarding points. New preset: `configs/mid360_robot/rko_lio_rtk_slam_mid360_outdoor.yaml`. Full sweep record in the methodology note.

### Gate changes (`scripts/release_profiles.yaml`)

- `mid360_gt_rtkslam_construction_seq{1,2}` **graduated to blocking** (4/4 sequences measured, observe-then-set thresholds kept).
- `mid360_vs_glim` **demoted to report-only** per D-GT-2 — cross-validation measures agreement, not accuracy; stays as a regression canary.
- Stadtgarten pair added as report-only soak (`report_only_until: v0.6`).
- Verified end-to-end: `benchmark_summary.py --release-profile` over the real runs evaluates PASS / TARGET_MET / report-only exactly as intended.

### Benchmark robustness fix

`run_rko_lio_graph_benchmark.sh` offline-completion detection now keys on **the raw trajectory reaching the bag end** (plus quiescence) instead of log quiescence: TF-warning spam keeps the launch log growing forever, so the old check burned the entire `--offline-timeout-secs` budget (~3.3 h per outdoor run) after the bag was already done. Trajectory-only quiescence false-triggers on buffered-write stalls (observed: a run "completed" at 177 s of an 876 s bag), hence the bag-end check with a long-stall fallback.

### Docs

- New: `docs/research/rtkslam-total-station-gt-methodology.md` (dataset, checkpoint metric, SE(3)-aligned vs absolute, sweep record, CC-BY attribution).
- `docs/comparison.md` + README accuracy table now lead with the GT numbers; v0.5 roadmap marked done.

## Validation

- Local CI: 900 tests, 0 failures.
- Profile-related pytest (docs entrypoints, benchmark reporting tools): green.
- All four sequence runs completed full-bag (traj end stamps verified against bag metadata).

## Repro

```bash
python3 scripts/download_rtk_slam_dataset.py --sequence stadtgarten_seq2 --eval-assets
python3 scripts/generate_rtk_slam_reference.py --checkpoints datasets/rtk_slam_eval/ground_truth/stadtgarten_seq2.csv \
  --sequence stadtgarten_seq2 --out output/rtk_slam_stadtgarten_seq2_gt.tum
bash scripts/run_rko_lio_graph_benchmark.sh --bag datasets/rtk_slam/ros2/stadtgarten_seq2 \
  --lidar-topic /livox/points --imu-topic /livox/imu \
  --rko-param configs/mid360_robot/rko_lio_rtk_slam_mid360_outdoor.yaml \
  --reference-tum output/rtk_slam_stadtgarten_seq2_gt.tum --skip-reference-gen \
  --reference-source rtk_slam_stadtgarten_seq2_gt --output-dir output/rtkslam_sg2
python3 scripts/write_aligned_trajectory_metrics.py --out-dir output/rtkslam_sg2/score_raw \
  --bag datasets/rtk_slam/ros2/stadtgarten_seq2 --reference-tum output/rtk_slam_stadtgarten_seq2_gt.tum \
  --corrected-tum output/rtkslam_sg2/traj_raw.tum --reference-source rtk_slam_stadtgarten_seq2_gt \
  --points-topic /livox/points --match-tolerance 2.0
```

Data: RTK-SLAM Dataset (Zhang, Ress, Skuddis, Soergel, Haala, Univ. Stuttgart; arXiv:2604.07151, CC-BY 4.0).