### PR TITLE
fix(ci): publish the docker image on develop pushes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: docker image
 on:
   push:
     branches:
-      - main
+      - develop
   pull_request:
     paths:
       - Dockerfile
@@ -42,7 +42,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Pull requests only validate that the image builds; pushes to main
+      # Pull requests only validate that the image builds; pushes to develop
       # (and manual dispatches) publish ghcr.io/<repo>:humble + :latest.
       - name: Build (and push) image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- The docker workflow's `push` trigger pointed at a `main` branch that does not exist (default branch is `develop`), so the ghcr image could only be published by manual dispatch.
- Point the trigger at `develop` so `ghcr.io/rsasaki0109/lidar_slam_ros2:{humble,latest}` stays in sync with the branch the README installs from.

## Context
The first image was published today via `workflow_dispatch` (run 27321717672) and anonymous pull is verified working (`docker manifest` 200). This PR makes future refreshes automatic.

## Test plan
- Workflow-only change; the docker workflow itself does not run its build on this PR (paths filter matches `.github/workflows/docker.yml`, so the PR build validates it).