### PR TITLE
feat(autoware): emit lanelet2_map.osm in the one-command map bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update \
       "ros-${ROS_DISTRO}-rosbag2-storage-default-plugins"; } \
   && apt-get install -y --no-install-recommends \
     "ros-${ROS_DISTRO}-rosbag2-storage-mcap" \
+    python3-scipy \
   && rm -rf /var/lib/apt/lists/*
 
 # Same package selection as scripts/run_default_ci_checks.sh (the Thirdparty

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ python3 scripts/verify_autoware_map.py output/.../pointcloud_map
 bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2
 ```
 
+One command turns the bag into a complete Autoware map bundle:
+`pointcloud_map/` tiles, `map_projector_info.yaml`, and a `lanelet2_map.osm`
+generated from the loop-closed trajectory.
+
 Or invoke the launch files directly:
 
 ```bash

--- a/docs/autoware-map-authoring.md
+++ b/docs/autoware-map-authoring.md
@@ -75,6 +75,15 @@ MID360 preset instead of the generic public YAMLs.
 - `pointcloud_map/` tiles
 - `pointcloud_map_metadata.yaml`
 - `map_projector_info.yaml`
+- `lanelet2_map.osm` — generated from the loop-closed trajectory
+  (`traj_corrected.tum`) by default. The origin defaults to a local `(0, 0)`
+  lat/lon (valid with `projector_type: local` through the `local_x`/`local_y`
+  node tags); pass `--origin-lat` / `--origin-lon` to
+  `run_rko_lio_graph_autoware_dogfood.sh` for a georeferenced map, or
+  `--generate-lanelet2 false` to skip it. Generation is best-effort: when the
+  corrected trajectory is missing or the generator fails, the run keeps the
+  pointcloud bundle and reports `lanelet2_map.osm MISSING` in the end-of-run
+  bundle summary instead of failing.
 - `PASS` / `FAIL` map verification via `scripts/verify_autoware_map.py`
 - benchmark/report artifacts for the same workflow family
 

--- a/lidarslam/test/test_simple_lanelet2_generator.py
+++ b/lidarslam/test/test_simple_lanelet2_generator.py
@@ -51,6 +51,15 @@ def _load_module():
     return module
 
 
+def test_parse_args_defaults_origin_to_local_zero():
+    module = _load_module()
+
+    args = module.parse_args(['--input', 'a.tum', '--output', 'b.osm'])
+
+    assert args.origin_lat == 0.0
+    assert args.origin_lon == 0.0
+
+
 def _straight_trajectory(n_pts: int = 80, dx: float = 1.0) -> np.ndarray:
     """Build a synthetic centreline along +x at 1 m spacing."""
     xs = np.arange(n_pts) * dx

--- a/scripts/run_autoware_map_from_bag.py
+++ b/scripts/run_autoware_map_from_bag.py
@@ -201,6 +201,9 @@ def print_next_steps(args: argparse.Namespace, output_dir: Path) -> None:
     if verify_log.is_file():
         print(f'  Verify log: {verify_log}')
     print(f'  Saved map:  {output_dir / "pointcloud_map"}')
+    lanelet2_map = output_dir / 'lanelet2_map.osm'
+    if lanelet2_map.is_file():
+        print(f'  Lanelet2:   {lanelet2_map}')
 
     if args.viewer == 'none':
         print(

--- a/scripts/run_rko_lio_graph_autoware_dogfood.sh
+++ b/scripts/run_rko_lio_graph_autoware_dogfood.sh
@@ -36,6 +36,10 @@ Options:
   --capture-corrected-path BOOL  Subscribe to /modified_path during the run and write
                                  traj_corrected.tum next to the map outputs (default: true).
   --corrected-path-topic TOPIC   nav_msgs/Path topic to capture (default: /modified_path).
+  --generate-lanelet2 BOOL       Generate lanelet2_map.osm from traj_corrected.tum (default: true).
+  --origin-lat <deg>             Origin latitude for lanelet2 local coordinates (default: 0.0).
+  --origin-lon <deg>             Origin longitude for lanelet2 local coordinates (default: 0.0).
+  --lane-width <m>               Lane width for generated lanelet2 map (default: 3.5).
   --reference-tum <file>         Reference TUM. When provided, ape_from_tum.py runs after
                                  /map_save and traj_corrected_ape.txt is written under the
                                  output directory.
@@ -90,6 +94,10 @@ WAIT_FOR_OFFLINE_COMPLETION=false
 SKIP_VIEWER=false
 CAPTURE_CORRECTED_PATH=true
 CORRECTED_PATH_TOPIC="/modified_path"
+GENERATE_LANELET2=true
+ORIGIN_LAT="0.0"
+ORIGIN_LON="0.0"
+LANE_WIDTH="3.5"
 REFERENCE_TUM=""
 
 while [[ $# -gt 0 ]]; do
@@ -214,6 +222,30 @@ while [[ $# -gt 0 ]]; do
       CORRECTED_PATH_TOPIC="$2"
       shift 2
       ;;
+    --generate-lanelet2)
+      [[ $# -ge 2 ]] || usage
+      case "${2,,}" in
+        true|1|yes) GENERATE_LANELET2=true ;;
+        false|0|no) GENERATE_LANELET2=false ;;
+        *) echo "--generate-lanelet2 expects true/false" >&2; usage ;;
+      esac
+      shift 2
+      ;;
+    --origin-lat)
+      [[ $# -ge 2 ]] || usage
+      ORIGIN_LAT="$2"
+      shift 2
+      ;;
+    --origin-lon)
+      [[ $# -ge 2 ]] || usage
+      ORIGIN_LON="$2"
+      shift 2
+      ;;
+    --lane-width)
+      [[ $# -ge 2 ]] || usage
+      LANE_WIDTH="$2"
+      shift 2
+      ;;
     --reference-tum)
       [[ $# -ge 2 ]] || usage
       REFERENCE_TUM=$(realpath -m "$2")
@@ -284,6 +316,7 @@ RKO_ROS_PARAM_FILE="${OUTPUT_DIR}/rko_params.ros.yaml"
 CORRECTED_TUM="${OUTPUT_DIR}/traj_corrected.tum"
 CORRECTED_LOG="${OUTPUT_DIR}/path_corrected_logger.log"
 CORRECTED_APE_REPORT="${OUTPUT_DIR}/traj_corrected_ape.txt"
+LANELET2_OSM="${OUTPUT_DIR}/lanelet2_map.osm"
 PATH_TO_TUM_SCRIPT="${REPO_ROOT}/scripts/path_to_tum.py"
 APE_FROM_TUM_SCRIPT="${REPO_ROOT}/scripts/ape_from_tum.py"
 LAUNCH_PID=""
@@ -604,6 +637,40 @@ if [[ -n "$CORRECTED_LOGGER_PID" ]]; then
   else
     echo "Warning: $CORRECTED_TUM was not produced (no /modified_path messages?)." >&2
   fi
+fi
+
+if [[ "$GENERATE_LANELET2" == true ]]; then
+  # A stale lanelet2_map.osm from an earlier run into the same output dir would
+  # pair a mismatched lanelet2 with this run's pointcloud map, and the generator
+  # writes its output before structural validation, so generate into a temp file
+  # and only move it in place on success.
+  rm -f "$LANELET2_OSM" "${LANELET2_OSM}.tmp"
+  if [[ -f "$CORRECTED_TUM" ]]; then
+    echo "Generating Lanelet2 map from corrected trajectory ..."
+    if python3 "$REPO_ROOT/scripts/simple_lanelet2_generator.py" \
+      --input "$CORRECTED_TUM" \
+      --output "${LANELET2_OSM}.tmp" \
+      --lane-width "$LANE_WIDTH" \
+      --origin-lat "$ORIGIN_LAT" \
+      --origin-lon "$ORIGIN_LON"; then
+      mv "${LANELET2_OSM}.tmp" "$LANELET2_OSM"
+      echo "Lanelet2 map written: $LANELET2_OSM"
+    else
+      rm -f "${LANELET2_OSM}.tmp"
+      echo "Warning: Lanelet2 map generation failed; continuing without lanelet2_map.osm." >&2
+    fi
+  else
+    echo "Warning: Lanelet2 generation skipped because $CORRECTED_TUM does not exist (--capture-corrected-path true is required)." >&2
+  fi
+fi
+
+echo "Autoware map bundle under $OUTPUT_DIR:"
+echo "  pointcloud_map/          $([[ -f "$OUTPUT_DIR/pointcloud_map/pointcloud_map_metadata.yaml" ]] && echo "OK" || echo "MISSING")"
+echo "  map_projector_info.yaml  $([[ -f "$OUTPUT_DIR/map_projector_info.yaml" ]] && echo "OK" || echo "MISSING")"
+if [[ "$GENERATE_LANELET2" == true ]]; then
+  echo "  lanelet2_map.osm         $([[ -f "$LANELET2_OSM" ]] && echo "OK" || echo "MISSING (see warnings above)")"
+else
+  echo "  lanelet2_map.osm         skipped (--generate-lanelet2 false)"
 fi
 
 if [[ -n "$REFERENCE_TUM" && -f "$CORRECTED_TUM" ]]; then

--- a/scripts/simple_lanelet2_generator.py
+++ b/scripts/simple_lanelet2_generator.py
@@ -431,8 +431,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument('--input', required=True, type=Path, help='TUM trajectory file')
     p.add_argument('--output', required=True, type=Path, help='Output OSM file path')
     p.add_argument('--lane-width', type=float, default=3.5, help='Lane width [m]')
-    p.add_argument('--origin-lat', type=float, required=True, help='Origin latitude [deg]')
-    p.add_argument('--origin-lon', type=float, required=True, help='Origin longitude [deg]')
+    p.add_argument('--origin-lat', type=float, default=0.0,
+                   help='Origin latitude [deg] for local map coordinates')
+    p.add_argument('--origin-lon', type=float, default=0.0,
+                   help='Origin longitude [deg] for local map coordinates')
     p.add_argument('--resolution', type=float, default=1.0, help='Resample spacing [m]')
     p.add_argument('--smooth-factor', type=float, default=0.0, help='Spline smoothing (0=interpolate)')
     p.add_argument('--speed-limit', type=float, default=10.0, help='Speed limit [km/h]')


### PR DESCRIPTION
## Summary
The beginner one-command path (`run_autoware_map_beginner.sh` → `run_autoware_map_from_bag.py` → `run_rko_lio_graph_autoware_dogfood.sh`) produced `pointcloud_map/` and `map_projector_info.yaml` but never `lanelet2_map.osm` — the trajectory→lanelet2 generator was only reachable through an orphaned helper script, so the "Autoware map bundle" claim was incomplete. One command now yields the complete bundle, for every entrypoint that flows through the dogfood script (quickstart, beginner runner, ghcr docker demo).

- `run_rko_lio_graph_autoware_dogfood.sh` generates `lanelet2_map.osm` from `traj_corrected.tum` after `/map_save`. New options: `--generate-lanelet2` (default true), `--origin-lat`/`--origin-lon` (default 0.0 = local origin for `projector_type: local`), `--lane-width` (default 3.5).
- Stale-artifact safety: the target is removed up front and the generator writes to a temp file that is only moved in place on success — a failed run can no longer leave a stale or structurally-invalid `lanelet2_map.osm` that pairs a mismatched lanelet2 with this run's pointcloud map.
- Generation is deliberately **best-effort** (warn, not fail): the script's whole tail is best-effort by design (corrected-path capture, APE, map_save fallback), and a missing lanelet2 should not discard an otherwise valid 10-minute SLAM run. Visibility instead comes from an end-of-run bundle summary (`pointcloud_map/ OK / map_projector_info.yaml OK / lanelet2_map.osm OK|MISSING`).
- `simple_lanelet2_generator.py`: `--origin-lat`/`--origin-lon` now optional (default 0.0).
- `run_autoware_map_from_bag.py` prints the lanelet2 path in next steps when present.
- Dockerfile installs `python3-scipy` (generator needs scipy splines; no rosdep dependency pulls it in) so the ghcr demo image emits the full bundle too.
- Docs: `docs/autoware-map-authoring.md` What-You-Get + README updated to match actual behaviour.

## Test plan
- Local CI: `run_default_ci_checks.sh` — 929 tests, 0 failures.
- New regression test: `--origin-lat/--origin-lon` optional (`test_parse_args_defaults_origin_to_local_zero`).
- Functional harness on the exact shipped block (extracted verbatim): stale file + valid trajectory → replaced with valid XML, no tmp leftover, summary OK; stale + missing trajectory → stale deleted, summary MISSING; stale + degenerate 1-pose trajectory (generator fails) → no file, no tmp, warning emitted, summary MISSING, script exits 0.
- Generator runs without origin args on a synthetic trajectory: structure validation PASS.