### PR TITLE
docs(research): close D1 with the 8-vs-16 head-to-head under deterministic scheduling

### DIFF
--- a/docs/research/triangle-stack-2026-05-summary.md
+++ b/docs/research/triangle-stack-2026-05-summary.md
@@ -12,10 +12,13 @@ the variance / RANSAC-cost / max_pairs sweep that occurred 2026-05-24.
 > closeout, **not** a default change: every preset still ships
 > `use_triangle_descriptor: false`. The deterministic scheduling refactor has
 > since **landed as an opt-in** (`deterministic_loop_scheduling`, default
-> **false** — behaviour-identical when off); the one remaining piece is the
+> **false** — behaviour-identical when off); the one remaining piece was the
 > 8-vs-16 head-to-head benchmark that would clear the flag to become a default.
-> That validation needs benchmark-data access and is intentionally not attempted
-> as an unvalidated behavior change here.
+> **That benchmark ran 2026-06-11** (see *8-vs-16 head-to-head under
+> deterministic scheduling* below): the flag works as designed mechanically but
+> does **not** improve accuracy or reproducibility on the MID-360 substrate, so
+> it **stays opt-in / default off** and `max_pairs: 16` stays the preset value.
+> D1 is fully closed.
 
 If you only want the production take-aways, read **Production take-aways**
 below. If you want the research narrative (why the defaults are what they
@@ -255,6 +258,67 @@ on. With the flag off the path is byte-for-byte the historical single-latest
 query, so the public default is unchanged. Only the 8-vs-16 head-to-head — which
 would clear the flag to become a default — is handed to a data-access follow-up.
 
+## 8-vs-16 head-to-head under deterministic scheduling (2026-06-11) — flag stays opt-in
+
+The validation that was handed off as a data-access follow-up. Setup: same
+GLIM MID-360 bag (277 s) and the same tuned effective config as the 2026-05-24
+sweep (`min_votes=6, min_inliers=3`, reproduced from the archived
+`graph_params.effective.yaml`, **not** the current shipped preset), 3 runs per
+arm via `run_triangle_ablation_mid360.sh`, APE vs the GLIM cross-validation
+reference. Arms: a freshness control (`off/16`), the flag at the preset
+`max_pairs` (`on/16`), and the U-shape probe (`on/8`). Raw data:
+`output/d1_sched_bench_20260611/`.
+
+| arm | cand APE m ± σ | Δ APE m ± σ | tri candidates/run | baseline accepted loops/run |
+|---|---|---|---|---|
+| off/16 (control) | 4.343 ± **0.066** | +0.096 ± 0.481 | 2, 2, 2 | 2, 2, 2 |
+| on/16 | 4.402 ± 0.259 | +0.187 ± 0.511 | 6, 7, 6 | 1, 1, 1 |
+| on/8 | 5.318 ± 1.154 | +0.698 ± **2.139** | 4, 0, 1 | 2, 4, **0** |
+| off/8 (2026-05-24) | 4.643 ± 0.254 | +0.768 ± 0.167 | — | — |
+
+The freshness control behaves like the May `off/16` arm on the
+delta-vs-own-baseline metric (−0.292 ± 0.607 then, +0.096 ± 0.481 now — the
+means sit well inside each other's spread), so the same-day comparison is not
+confounded by an obvious pipeline shift since May. This is a delta-level
+sanity check, not an absolute-APE no-drift proof.
+
+**Three verdicts:**
+
+1. **No material APE regression from the flag at `max_pairs=16`** — candidate
+   mean 4.402 (on) vs 4.343 (off): the on-arm is nominally 0.06 m worse, but
+   the difference is small relative to the 0.40 m noise envelope. Turning the
+   flag on is APE-safe at the preset config.
+2. **No reproducibility win — the flag's payoff thesis fails on this
+   substrate.** Candidate σ *grows* (0.066 → 0.259). Mechanically the
+   catch-up scheduler does exactly what it promises — triangle candidate
+   queries jump from 2 to 6–7 per run because every submap is now queried —
+   but more querying changes *which* candidate pairs reach verification and
+   when. Deterministic *scheduling* did not translate into deterministic
+   *outcomes*: baseline distance-loop acceptance drops from a stable 2 per run
+   to 1, and two flag-on executions — both in the `on/8` arm (run2 candidate,
+   run3 baseline) — attempted **zero** loops end-to-end. The
+   natural-timing-window sensitivity documented for the wall-clock path is
+   still present under catch-up scheduling, just relocated.
+3. **The mp8 systematic-regression signature does not survive deterministic
+   scheduling — but mp8 is not rescued, and the root cause is not proven.**
+   The May `off/8` result was a tight, systematic +0.768 ± 0.167; under the
+   flag the mean is similar (+0.698) but the spread explodes to ± 2.139, with
+   one run beating its own baseline by 1.7 m. So what deterministic scheduling
+   removes is the *low-variance systematic* signature, replacing it with
+   instability — consistent with scheduling being a major contributor to the
+   May mp8 behaviour (hypothesis A), but not proof that it was the root cause.
+   Operationally mp8 under the flag is erratic (σ 2.1 m, zero-loop runs), so
+   `max_pairs: 16` remains the only stable choice either way.
+
+**Decision: `deterministic_loop_scheduling` stays default off; `max_pairs: 16`
+stays the MID-360 preset.** The flag remains available for research use (it is
+the only way to get full submap query coverage), but it is not an accuracy or
+reproducibility improvement on this substrate, and an honest default flip
+would require it to win on at least one. The optional `std::async` RANSAC half
+of the original design is unimplemented and now low-priority: with the
+catch-up scheduler showing no variance win, there is no evidence the async
+half would change the conclusion.
+
 ## Diagnostic flag remains
 
 `triangle_descriptor_skip_ransac` (default false) stays in the tree
@@ -288,20 +352,22 @@ datasets / configs. It is not for production use.
    timer-batched submap arrivals are skipped non-deterministically. Fix: a
    deterministic catch-up loop over un-queried submap indices (+ optional
    `std::async` RANSAC), shipped opt-in. **The catch-up scheduler has landed**
-   (`deterministic_loop_scheduling`, default off); the **8-vs-16 validation** (and
-   the optional `std::async` RANSAC half) is the benchmark-data follow-up before
-   the flag could become a default.
+   (`deterministic_loop_scheduling`, default off), and the **8-vs-16 validation
+   ran 2026-06-11** (see the head-to-head section above): mechanically correct,
+   no accuracy/reproducibility win → the flag stays default off.
 3. ~~**Newer College APE at current develop HEAD**~~ — **answered 2026-05-25**
    via PR #192 (`--skip-reference-gen` plumbing). Post-v0.3.0 3-run gave
    Δ APE −0.0094 ± 0.0108 m (|Δ|/σ = 0.87), still variance-bounded but
    no regression introduced by the #183–#191 series; candidate variance
    ~halved vs the 2026-05-19 baseline.
 
-All three research questions from the 2026-05-24 sweep are now closed, and the
-Q2 opt-in deterministic-scheduling implementation has landed (default off). The
-only remaining triangle work is the **8-vs-16 benchmark validation** that would
-clear `deterministic_loop_scheduling` to become a default, tracked as a v0.4/v0.5
-follow-up that needs data access.
+All three research questions from the 2026-05-24 sweep are closed, the Q2
+opt-in deterministic-scheduling implementation has landed (default off), and
+the 8-vs-16 head-to-head validation ran 2026-06-11 with a clear negative
+result for a default flip. **There is no remaining triangle-stack work item**:
+the public default (`use_triangle_descriptor: false`,
+`deterministic_loop_scheduling: false`, `max_pairs: 16` when opted in) is the
+empirically supported configuration.
 
 ## Files
 
@@ -317,4 +383,6 @@ follow-up that needs data access.
   - `output/triangle_ablation_mid360_skipransac_20260524_101218/SUMMARY.md`
   - `output/triangle_ablation_mid360_maxpairs16_20260524_175503/SUMMARY.md`
   - `output/triangle_ablation_mid360_maxpairs8_20260524_213619/SUMMARY.md`
+  - `output/d1_sched_bench_20260611/` (8-vs-16 head-to-head under
+    deterministic scheduling; `aggregate.py --verdict` reproduces the tables)
   - `output/triangle_ablation_ntu_v5_skipransac_20260524_222141/`

--- a/docs/roadmap/v0.4.md
+++ b/docs/roadmap/v0.4.md
@@ -140,10 +140,14 @@ test, continuous kidnap-relocalization gate (#194). 81 `mid360` scripts on
   a scheduler + a per-query `searchLoopForLatest`, and when the flag is on the
   scheduler catches up over every un-queried submap index. Default off is
   behaviourally identical to the historical single-latest query, so existing
-  benchmarks are unchanged. **Remaining**: the 8-vs-16 head-to-head
-  reproducibility validation (data-access follow-up) before the default could
-  ever flip; the optional `std::async` RANSAC half of the design is also still a
-  follow-up. No default change.
+  benchmarks are unchanged. **The 8-vs-16 head-to-head validation ran
+  2026-06-11** (3 runs × {off/16, on/16, on/8} on the GLIM MID-360 bag, May
+  tuned config reproduced): no material APE regression from the flag at 16
+  (difference small vs the noise envelope), but no reproducibility win either
+  (candidate σ 0.066 → 0.259), and the mp8 systematic-regression signature
+  dissolves into instability rather than health — so the **default stays off**
+  and the `std::async` RANSAC half is dropped to low priority. Full write-up:
+  `docs/research/triangle-stack-2026-05-summary.md`. No default change.
 - **D3**: publicly de-emphasize research-track place recognition for v0.4; RKO-LIO
   + distance-loop closure is the public default. Acknowledge GT-quality place
   recognition on narrow-FOV / indoor as an open research problem.
@@ -183,7 +187,7 @@ done     F  plan.md surgery + DDS doc + gitignore (#204, #205)
 done     v0.4-rc graduate 3 research-track profiles to blocking (#206)
 done     D1 triangle reproducibility research closeout (docs) ← root cause + fix design pinned
 done     D1 impl: opt-in deterministic searchLoop scheduling (default off, behaviour-identical)
-next     D1 validation: 8-vs-16 head-to-head reproducibility run to clear the flag for default (needs data)
+done     D1 validation: 8-vs-16 head-to-head ran 2026-06-11 — no reproducibility win, flag stays default off (closed)
 v0.5     MID-360 real-GT dataset → replace mid360_vs_glim with ape_rmse_gt_m
          (scoped in docs/roadmap/v0.5.md — total-station GT via public RTK-SLAM dataset)
 ```

--- a/plan.md
+++ b/plan.md
@@ -22,8 +22,9 @@ total-station GT 化（§11）— 4/4 sequence 計測済み、indoor 2 profile �
 実カメラ色のマップフライスルー GIF（§12、PR #229/#230/#231）。
 
 次の主要アクション: bloom リリース実行（ndt_omp_ros2 fork 先行、
-`docs/rosdistro-release.md` のランブック）、発信（P2-8、ユーザー本人）、
-D1 8-vs-16 再現性ベンチ（`deterministic_loop_scheduling` default 判断）。
+`docs/rosdistro-release.md` のランブック、maintainer の GitHub 操作）と
+発信（P2-8、ユーザー本人）。D1 8-vs-16 ベンチは 2026-06-11 実施済み —
+`deterministic_loop_scheduling` は default off 維持で D1 完全クローズ（§1.2）。
 
 ---
 
@@ -49,8 +50,12 @@ discipline、PR #159-#189）の研究記録は
 に集約。
 
 **現状（live）**: 全プリセットで default-off（opt-in）。3-dataset で variance-bounded、
-SOTA は狙わない honest stance。残る 2 つの open question（max_pairs=8 U-shape root
-cause / RANSAC async scheduling）は v0.4 §D1 reproducibility closeout の対象。
+SOTA は狙わない honest stance。open question は**全決着**: U-shape root cause（wall-clock
+floor 仮説）と scheduling fix は v0.4 §D1 で closeout、最後に残っていた 8-vs-16
+head-to-head 検証も 2026-06-11 に実施 — `deterministic_loop_scheduling` は機械的には
+正しく動くが精度・再現性とも勝たず **default off 維持で完全クローズ**。mp8 の系統的
+regression 署名は flag 下で消える（スケジューリングが主要因子であることと整合、
+ただし根本原因の証明までは届かない）（research summary 参照）。
 
 ---
 
@@ -316,7 +321,7 @@ indoor で 0.15–0.40m（真 GT, agreement でなく accuracy）。outdoor の�
 | 0a | ~~v0.5 outdoor config 調整 → stadtgarten 再 run~~ | ✅ 2026-06-11 解決。`double_downsample: false` で 3.903→0.835m、outdoor preset 化（§11.8 A） |
 | 0b | ~~v0.5 indoor pair を blocking 昇格 + mid360_vs_glim 降格~~ | ✅ PR #228。4/4 seq 計測、indoor blocking、glim は report-only canary（§11.8 C） |
 | 0c | **bloom リリース実行（P2-7 後半）** | repo 側 prep 完了（0.5.0 整列 + ランブック `docs/rosdistro-release.md`）。残り = ndt_omp_ros2 fork の package.xml 整備 → 先行 bloom → 本体 bloom → ros/rosdistro PR（maintainer の GitHub 操作が必要、§13） |
-| 0d | **D1 8-vs-16 再現性ベンチ** | `deterministic_loop_scheduling`（#208, opt-in）を default-on にするか判定。RTK-SLAM bag が手元にありデータブロッカー解消済み |
+| 0d | ~~D1 8-vs-16 再現性ベンチ~~ | ✅ 2026-06-11 実施（GLIM MID-360 bag、3 run × {off/16, on/16, on/8}）。on/16 は APE 実質無回帰（差 0.06m ≪ noise 0.40m）だが分散縮小なし（σ 0.066→0.259）、on/8 arm の 2 実行で loop 試行ゼロ。mp8 の系統的 regression 署名は消滅し乱高下に置換（スケジューリング主要因子と整合、根本原因の証明ではない）。**default off 維持で D1 完全クローズ**（§1.2、research summary） |
 | 0e | **発信（P2-8）** | ghcr ワンコマンド + lanelet2 完全バンドル + 実 GT 数値が揃い、発信material は完成状態。ROS Discourse / Reddit / X はユーザー本人が実施。事前に B2 social preview 設定（Web UI 1 分） |
 | 1 | **GNSS 付きデータセットで GNSS 制約テスト** | Autoware の地理座標系マッピング機能が未検証。RTK-SLAM bag は `/gnss/fix` を持つので流用候補 |
 | 2 | ~~Autoware 実環境での読み込みテスト~~ | ✅ map loaders 読込は検証済み（README の loader proof + AWSIM×Autoware E2E 自動運転まで dogfood 済み、§6） |


### PR DESCRIPTION
## Summary
Runs and reports the benchmark that was the last open D1 item: the 8-vs-16 head-to-head that decides whether `deterministic_loop_scheduling` (#208, opt-in) becomes the default. **It does not — the flag stays default off**, and this is a docs-only closeout (no behavior change).

## Bench
3 runs × {off/16 control, on/16, on/8} on the GLIM MID-360 bag (277 s), reproducing the 2026-05-24 sweep's tuned effective config exactly (`min_votes=6 / min_inliers=3`, from the archived `graph_params.effective.yaml`), APE vs the GLIM cross-validation reference, all 18 effective configs audited for the flag/max_pairs values.

| arm | cand APE m ± σ | Δ APE m ± σ | tri cand/run | base accepted loops/run |
|---|---|---|---|---|
| off/16 (control) | 4.343 ± 0.066 | +0.096 ± 0.481 | 2,2,2 | 2,2,2 |
| on/16 | 4.402 ± 0.259 | +0.187 ± 0.511 | 6,7,6 | 1,1,1 |
| on/8 | 5.318 ± 1.154 | +0.698 ± 2.139 | 4,0,1 | 2,4,0 |
| off/8 (2026-05-24) | 4.643 ± 0.254 | +0.768 ± 0.167 | — | — |

- **APE-safe at 16** (difference 0.06 m, small vs the 0.40 m noise envelope) but **no reproducibility win**: candidate σ grows 0.066 → 0.259; the catch-up scheduler is mechanically correct (triangle candidate queries 2 → 6–7/run = full submap coverage) yet baseline distance-loop acceptance drops 2 → 1/run and two on/8 executions attempted zero loops. Deterministic scheduling ≠ deterministic outcomes.
- **The May mp8 low-variance systematic regression does not survive the flag** (+0.768 ± 0.167 → +0.698 ± 2.139, one run beating its own baseline) — consistent with scheduling being a major contributor to the May U-shape, though not proof of root cause. Either way mp8 turns erratic, so `max_pairs: 16` stays.

Raw data: `output/d1_sched_bench_20260611/` (gitignored; `aggregate.py --verdict` reproduces the tables).

## Changes
- `docs/research/triangle-stack-2026-05-summary.md`: new head-to-head section + header/closing updated — no remaining triangle-stack work item.
- `docs/roadmap/v0.4.md`: D1 'Remaining' → resolved; sequencing row → done.
- `plan.md`: §1.2 live status and action row 0d → closed.

## Test plan
- Docs-only. `test_docs_entrypoints.py` + `test_triangle_descriptor_yaml_defaults.py`: 34 passed.