### PR TITLE
docs(roadmap): v0.6 — deterministic core / ROS shell refactor (backend + scanmatcher)

### DIFF
--- a/docs/roadmap/v0.6.md
+++ b/docs/roadmap/v0.6.md
@@ -1,0 +1,168 @@
+# lidarslam-ros2 v0.6 roadmap — deterministic core / ROS shell refactor
+
+> Status: **drafted 2026-06-11, scope locked (backend + scanmatcher)**.
+> Successor to v0.5 (real MID-360 ground truth, done). The driving evidence is
+> the v0.4 D1 closeout: the 8-vs-16 head-to-head (2026-06-11,
+> `docs/research/triangle-stack-2026-05-summary.md`) showed that making the
+> loop-query *schedule* deterministic does not make *outcomes* deterministic —
+> the coupling of results to wall-clock interleaving is architectural, not a
+> scheduling bug. v0.6 changes the architecture.
+
+## 0. Why this exists
+
+Same bag, same config, three runs — and the backend produces different loop
+sets and APE every time (candidate σ up to 1.15 m on the MID-360 substrate;
+two runs in the D1 bench attempted **zero** loops). The release gates absorb
+this as threshold slack and occasional flakiness. The structural causes are
+known and file:line-pinned:
+
+| Cause | Evidence |
+|---|---|
+| Wall-clock-timer-driven loop search: DB state, poses and accepted edges at query time all depend on when the tick fires | `graph_based_slam_component.cpp:1129-1132` + D1 bench (deterministic catch-up alone made variance *worse*, σ 0.066 → 0.259) |
+| Data races (bugs regardless of determinism): 4 descriptor databases and the `latest_odom_`/`latest_cloud_` pair are unprotected | `:256-368`, `:3207-3284` |
+| Input stream itself unstable: `map_array` subscription is QoS KeepLast(**1**) — messages can drop under load, changing the submap sequence per run | `:1114-1116` |
+| Undefined ordering in the candidate merge: 5 sources into one vector, `unordered_map` iteration order, no tie-breaks on equal fitness | `:1548-1583`, `:1847-1886`, `:2249-2577` |
+| Suspected numeric nondeterminism in multithreaded registration (ndt_omp OpenMP reduction order) | unmeasured — Phase 0 |
+| A 3421-line god object makes all of the above hard to fix safely | `graph_based_slam_component.cpp` (3421), `scanmatcher_component.cpp` (2140) |
+
+The asset side: 11 pure logic headers with unit tests already exist (scan
+context, BEV, SOLiD, triangle ×2, dynamic-object filter, GNSS weighting,
+adjacent-edge auto-scale, BEV mutual visibility, loop-edge robustifier,
+3D-BBS verifier) — the extract-to-tested-header pattern is proven in this
+codebase. The release gates (NTU ≤ 1.00 m, RTK-SLAM indoor 0.30/0.55 m
+blocking) and the D1 bench harness are the safety net for every phase.
+
+## 1. Target architecture
+
+**Functional core / imperative shell.**
+
+```
+[ROS shell]   subscribers → ordered event stream → single processing thread
+                                   │
+[Backend core: a ROS-free, clock-free, single-threaded library]
+   SubmapStore · DescriptorIndexes · LoopEdgeSet · PoseGraph
+   addSubmap(submap) → loop search for that submap → verify → (maybe) optimize
+   Contract: same ordered input sequence + same config
+             ⇒ identical loop-edge set and optimized poses
+```
+
+- **Event-driven, not wall-clock**: loop search runs once per submap arrival,
+  in arrival order. The timer survives only as online-mode pacing in the
+  shell. `deterministic_loop_scheduling` is *subsumed* — querying every
+  submap exactly once, in order, becomes the only semantics — and the flag is
+  retired in Phase 3.
+- **Offline deterministic runner**: bag reader → core, bypassing pub/sub
+  entirely. Bag order is a total order, so "same bag ⇒ same map" becomes a
+  testable contract. Benchmarks and release gates migrate here, which
+  removes gate flakiness at the root.
+- Online mode keeps working as today; arrival order is inherently
+  nondeterministic live, and that becomes explicitly the shell's concern.
+- The same pattern then applies to `scanmatcher_component.cpp` (Phase 4):
+  odometry core (registration + map update, already partially extracted as
+  `voxel_hash_map.hpp` / `lidar_undistortion.hpp`) vs ROS shell.
+
+## 2. Testing strategy (first-class requirement)
+
+Tests are not an afterthought of this refactor; they are how every phase is
+gated. Four layers:
+
+1. **Characterization tests before extraction.** Before a unit moves out of
+   the component, record its current input→output behaviour on synthetic
+   fixtures and pin it with a test, so the extraction PR can prove
+   "no behavior change" rather than assert it.
+2. **Unit tests for every extracted module** (the existing header-pattern
+   discipline, continued): `submap_store`, `candidate_aggregator` (merge
+   order + tie-breaks!), `loop_verifier` (caps, fitness gates),
+   `pose_graph_builder` (vertex/edge assembly incl. IMU/GNSS branches),
+   `map_saver`, and in Phase 4 the scanmatcher odometry core. Target: the
+   component shells contain no logic worth unit-testing.
+3. **Determinism contract tests.** The core's promise becomes a pytest: feed
+   a synthetic ordered submap stream twice, assert the loop-edge sets and
+   optimized poses are *identical* (not "close"). A second test feeds the
+   same stream with perturbed arrival timing through the shell's queue and
+   asserts the core still sees the same ordered sequence.
+4. **Replay/regression harness in CI.** The Phase 0 backend-replay harness
+   (recorded input stream → N backend runs → loop-edge-set comparison) joins
+   the benchmark suite; the offline runner's 3-run identity check becomes a
+   release-gate item next to the APE thresholds.
+
+Every phase's PRs run: full local CI (929+ tests, growing), the release
+gates, and the variance harness (no-worsening rule until Phase 2, identity
+rule after).
+
+## 3. Phases and gates
+
+### Phase 0 — variance attribution (measure before touching)
+- Backend replay harness: record the exact input stream (`map_array`, or
+  odom+cloud for `use_odom_input`) once; replay into the backend N times →
+  separate frontend variance vs transport variance vs backend variance.
+  (Even the no-triangle baselines spread 3.83–4.83 m APE; nobody currently
+  knows which layer owns that.)
+- Registration determinism micro-bench: same cloud pair × N registrations ×
+  ndt_omp thread counts → does multithreading change results?
+- Define the determinism metrics: loop-edge-set equality, APE σ, pose diff.
+- **Gate**: a written attribution table in `docs/research/`.
+
+### Phase 1 — race removal + mechanical decomposition (4–6 narrow PRs)
+- Bug-class fixes: mutex/snapshot the descriptor DBs; synchronize the
+  odom/cloud pair (message_filters); revisit the KeepLast(1) QoS.
+- Determinism groundwork: stable candidate sort key
+  `(score, submap_id, source_rank)`, defined tie-breaks, seeded RANSAC.
+- Extract modules listed in §2 layer 2 with characterization + unit tests.
+- **Gate**: component < ~1200 lines; every extracted unit tested; release
+  gates and variance harness unchanged-or-better per PR.
+
+### Phase 2 — core/shell split + event-driven scheduling (the architecture change)
+- `BackendCore` library; ROS component becomes an adapter with a single
+  serialized processing queue.
+- New offline runner (`graph_slam_offline_runner`); benchmark scripts
+  migrate to it.
+- Legacy wall-clock path stays behind a flag, **default on** (no default
+  behavior change yet — repo discipline).
+- **Gate (hard)**: offline runner produces an *identical* loop-edge set
+  across 3 runs on the MID-360 and NTU substrates; live mode within noise of
+  legacy on the release gates.
+
+### Phase 3 — default flip + cleanup
+- Flip the default to event-driven on release-gate evidence; retire
+  `deterministic_loop_scheduling` (subsumed); remove the legacy timer path
+  one release later.
+- Docs: comparison.md caveats shrink; README gains an honest
+  "deterministic offline mapping" claim (also publicity material).
+
+### Phase 4 — scanmatcher core/shell
+- Same pattern on `scanmatcher_component.cpp` (2140 lines): extract the
+  odometry core (registration, map update, keyframe logic) behind the same
+  determinism contract; the existing `voxel_hash_map.hpp` /
+  `lidar_undistortion.hpp` headers are the seed.
+- **Gate**: scanmatcher-frontend release profiles unchanged; new unit tests
+  for the extracted core; offline runner supports the scanmatcher frontend
+  path end-to-end deterministically.
+
+## 4. Risks
+
+- **Behavior drift during extraction** → characterization tests + replay
+  byte-comparison of loop-edge logs per PR, not just APE thresholds.
+- **ndt_omp OpenMP nondeterminism survives** → Phase 0 measures it; the
+  fallback decision is "determinism mode pins registration threads to 1" vs
+  "accept ε-variance and make selection robust via tie-breaks" — decided on
+  data, not taste.
+- **RKO-LIO (Thirdparty) nondeterminism** → out of scope to fix; Phase 0
+  quantifies it and the docs state the end-to-end determinism boundary
+  honestly (the deterministic contract starts at the backend's input
+  stream; Phase 4 extends it to the scanmatcher frontend path).
+- **Long-running track vs release cadence** → every phase lands behind
+  default-off flags or as pure decomposition; the public default only moves
+  in Phase 3 with gate evidence.
+
+## 5. Out of scope
+
+RKO-LIO internals (Thirdparty submodule); new SLAM features; place
+recognition algorithm changes (D-track is closed); rosdistro release work
+(tracked separately in `docs/rosdistro-release.md`).
+
+---
+
+(Related: `docs/research/triangle-stack-2026-05-summary.md` — the D1
+head-to-head that motivated this; `docs/roadmap/v0.5.md`;
+`output/d1_sched_bench_20260611/` raw data.)

--- a/plan.md
+++ b/plan.md
@@ -21,10 +21,15 @@ total-station GT 化（§11）— 4/4 sequence 計測済み、indoor 2 profile �
 バージョン 0.5.0 整列 + rosdistro (bloom) バイナリリリース prep。README の見せ物は
 実カメラ色のマップフライスルー GIF（§12、PR #229/#230/#231）。
 
-次の主要アクション: bloom リリース実行（ndt_omp_ros2 fork 先行、
-`docs/rosdistro-release.md` のランブック、maintainer の GitHub 操作）と
+次の主要アクション: **v0.6 決定論 core/shell リファクタリング**
+（[`docs/roadmap/v0.6.md`](docs/roadmap/v0.6.md)、スコープ確定: backend +
+scanmatcher、テスト充実を一級要件化）、bloom リリース実行（ndt_omp_ros2 fork
+先行、`docs/rosdistro-release.md` のランブック、maintainer の GitHub 操作）、
 発信（P2-8、ユーザー本人）。D1 8-vs-16 ベンチは 2026-06-11 実施済み —
 `deterministic_loop_scheduling` は default off 維持で D1 完全クローズ（§1.2）。
+D1 の負の結果が v0.6 の直接の動機: スケジュールの決定論化ではアウトカムは
+決定論にならない = 問題はアーキテクチャ（wall-clock 結合 + データ競合 +
+順序未定義マージ）。
 
 ---
 
@@ -320,7 +325,8 @@ indoor で 0.15–0.40m（真 GT, agreement でなく accuracy）。outdoor の�
 |---|--------|------|
 | 0a | ~~v0.5 outdoor config 調整 → stadtgarten 再 run~~ | ✅ 2026-06-11 解決。`double_downsample: false` で 3.903→0.835m、outdoor preset 化（§11.8 A） |
 | 0b | ~~v0.5 indoor pair を blocking 昇格 + mid360_vs_glim 降格~~ | ✅ PR #228。4/4 seq 計測、indoor blocking、glim は report-only canary（§11.8 C） |
-| 0c | **bloom リリース実行（P2-7 後半）** | repo 側 prep 完了（0.5.0 整列 + ランブック `docs/rosdistro-release.md`）。残り = ndt_omp_ros2 fork の package.xml 整備 → 先行 bloom → 本体 bloom → ros/rosdistro PR（maintainer の GitHub 操作が必要、§13） |
+| 0c | **bloom リリース実行（P2-7 後半）** | repo 側 prep 完了（0.5.0 整列 + ランブック `docs/rosdistro-release.md`）。残り = ndt_omp_ros2 fork PR #11 マージ（整備 PR 作成済み）→ 先行 bloom → 本体 bloom → ros/rosdistro PR（maintainer の GitHub 操作が必要、§13） |
+| 0f | **v0.6 決定論 core/shell リファクタリング** | スコープ確定（2026-06-11、backend + scanmatcher）。Phase 0 変動帰属測定 → Phase 1 競合除去+分割 → Phase 2 BackendCore+オフライン決定論ランナー（ループエッジ集合 3-run 完全一致がハードゲート）→ Phase 3 default 切替 → Phase 4 scanmatcher。テスト 4 層（characterization / unit / 決定論契約 / リプレイ回帰）を各フェーズのゲートに。詳細 [`docs/roadmap/v0.6.md`](docs/roadmap/v0.6.md) |
 | 0d | ~~D1 8-vs-16 再現性ベンチ~~ | ✅ 2026-06-11 実施（GLIM MID-360 bag、3 run × {off/16, on/16, on/8}）。on/16 は APE 実質無回帰（差 0.06m ≪ noise 0.40m）だが分散縮小なし（σ 0.066→0.259）、on/8 arm の 2 実行で loop 試行ゼロ。mp8 の系統的 regression 署名は消滅し乱高下に置換（スケジューリング主要因子と整合、根本原因の証明ではない）。**default off 維持で D1 完全クローズ**（§1.2、research summary） |
 | 0e | **発信（P2-8）** | ghcr ワンコマンド + lanelet2 完全バンドル + 実 GT 数値が揃い、発信material は完成状態。ROS Discourse / Reddit / X はユーザー本人が実施。事前に B2 social preview 設定（Web UI 1 分） |
 | 1 | **GNSS 付きデータセットで GNSS 制約テスト** | Autoware の地理座標系マッピング機能が未検証。RTK-SLAM bag は `/gnss/fix` を持つので流用候補 |


### PR DESCRIPTION
## Summary
Locks the v0.6 plan: refactor `graph_based_slam` (3421 lines) and `scanmatcher` (2140 lines) around a **ROS-free, clock-free, single-threaded core** with an ordered-event determinism contract (same ordered input + same config ⇒ identical loop-edge set and poses), plus an **offline deterministic runner** that the benchmarks and release gates migrate to.

Motivation is the D1 closeout (#235): making the loop-query *schedule* deterministic did not make *outcomes* deterministic — the wall-clock coupling, data races (4 unprotected descriptor DBs, unprotected odom/cloud buffers, KeepLast(1) map_array QoS) and undefined candidate-merge ordering are architectural.

## Plan shape
- **Phase 0** measure: backend replay harness for variance attribution (frontend vs transport vs backend), registration determinism micro-bench (ndt_omp threads).
- **Phase 1** fix races + decompose into tested modules (the existing 11-header extract-and-test pattern, continued).
- **Phase 2** BackendCore + event-driven scheduling + offline runner. Hard gate: identical loop-edge sets across 3 runs. Legacy wall-clock path stays default-on.
- **Phase 3** default flip on gate evidence; `deterministic_loop_scheduling` retired (subsumed).
- **Phase 4** same pattern for scanmatcher.

**Testing is a first-class requirement**: characterization tests before extraction, unit tests per module, determinism contract tests, replay/regression harness in CI — every phase is gated by them plus the existing release gates.

## Test plan
- Docs-only. `test_docs_entrypoints.py` 6 passed; `mkdocs build --strict` passes.