### PR TITLE
feat(bench): v0.6 Phase 0 — determinism attribution harness, registration gtest, findings

### DIFF
--- a/docs/research/determinism-variance-attribution.md
+++ b/docs/research/determinism-variance-attribution.md
@@ -1,0 +1,88 @@
+# Determinism variance attribution (v0.6 Phase 0, 2026-06-11)
+
+Phase 0 of the deterministic core/shell refactor
+([`../roadmap/v0.6.md`](../roadmap/v0.6.md)): before touching the
+architecture, measure **which layer owns the run-to-run variance** that the
+D1 closeout exposed. Substrate: the GLIM MID-360 demo bag (277 s), the same
+one the D1 bench used.
+
+## Method
+
+Three measurements, each isolating one layer:
+
+1. **End-to-end** (frontend + transport + backend): the D1 bench arms
+   (`output/d1_sched_bench_20260611/`, 3 runs each).
+2. **Backend + transport, byte-identical input**: record the backend's exact
+   input topics (`/rko_lio/odometry` + `/rko_lio/frame`) during one benchmark
+   run, then replay that bag into `graph_based_slam` alone, 3 times
+   (`scripts/run_backend_replay_variance.sh`; raw data
+   `output/backend_replay_mid360_p0/`).
+3. **Registration floor**: `test_registration_determinism.cpp` — pclomp NDT
+   on a fixed synthetic scene, 5 repeats per thread count and a
+   cross-thread-count comparison.
+
+## Results
+
+| Layer | APE behaviour | Loop-edge behaviour |
+|---|---|---|
+| End-to-end (D1 armA, off/16) | baseline APE 3.83–4.83 (σ 0.52); candidate σ 0.066–0.481 | accepted count stable (2) per run |
+| Backend + transport (fixed input, 3 runs) | 5.748 / 5.792 / 5.849 (**σ 0.050**) | **a different edge every run**: 1↔577, 6↔583, 14↔582 (edge sets never identical) |
+| Registration (NDT micro-bench) | — | bitwise repeatable at any fixed thread count (max dev = 0 for threads 1/2/4); threads 1 vs ≥2 differ by a *fixed, deterministic* 0.028° rotation, 0 m translation |
+
+(The replay APE level ~5.8 m differs from the in-benchmark level ~3.8–4.3 m
+because replay timing/pacing differs from the live pipeline and typically
+accepts one loop instead of two; the harness measures replay-vs-replay
+variance, not replay-vs-benchmark equality.)
+
+## Attribution
+
+1. **The frontend owns most of the APE variance.** With the input stream
+   frozen, backend APE σ collapses from ~0.5 to 0.050 — an order of
+   magnitude. RKO-LIO's own run-to-run variation (out of scope for v0.6;
+   Thirdparty) plus live transport dominate the end-to-end number.
+2. **The backend owns the loop-edge nondeterminism, and it is purely a
+   scheduling/interleaving artifact.** Same bytes in, three different loop
+   closures out (geometrically the same revisit, entered at a different
+   submap index each run, hence the small APE spread). This is exactly the
+   class of nondeterminism the Phase 2 event-driven core eliminates: process
+   submaps in arrival order, query each one exactly once, and the chosen
+   edge becomes a function of the input sequence.
+3. **Registration will not betray the determinism contract.** ndt_omp NDT is
+   bitwise repeatable at a fixed thread count — even multithreaded — and the
+   thread-count-dependent difference is itself deterministic and tiny
+   (0.028° on the synthetic scene). The Phase 2 core does **not** need to pin
+   `ndt_num_threads: 1`; it needs to pin the *value* (a config already does)
+   and the candidate evaluation order. Caveat: one synthetic scene; the
+   identity-at-fixed-threads result should be re-checked on real submap
+   pairs once the offline runner exists (cheap to add there).
+
+## Phase 1/2 design consequences
+
+- The hard Phase 2 gate (identical loop-edge sets across runs of the offline
+  runner) is **achievable**: the only remaining nondeterminism sources at
+  fixed input are the timer/arrival interleaving (removed by event-driven
+  scheduling), the unprotected shared state (removed in Phase 1), and
+  candidate-order/tie-break ambiguity (defined in Phase 1).
+- Two backend warts found while building the harness, queued for Phase 1:
+  - `doPoseAdjustment` writes `pose_graph.g2o` to the node's **CWD**
+    (`graph_based_slam_component.cpp:2761`) regardless of any save-path
+    parameter — the harness works around it with a per-run working
+    directory.
+  - The g2o file does not distinguish loop edges from the
+    `num_adjacent_pose_cnstraints` adjacency fan-out (edges up to |i−j| ≤ 4
+    at the default 5); consumers must window on |i−j| (the harness uses
+    `--adjacent-window`, default 5). The offline runner should emit loop
+    edges explicitly instead.
+
+## Reproduce
+
+```bash
+# layer 2 (backend + transport)
+bash scripts/run_backend_replay_variance.sh --mode record --output-dir output/backend_replay_mid360
+bash scripts/run_backend_replay_variance.sh --mode replay --output-dir output/backend_replay_mid360 --runs 3
+cat output/backend_replay_mid360/backend_replay_summary.md
+
+# layer 3 (registration floor) — report lines grep "[determinism]"
+colcon test --packages-select graph_based_slam \
+  --ctest-args -R test_registration_determinism
+```

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -185,6 +185,17 @@ if(BUILD_TESTING)
     target_link_libraries(test_triangle_descriptor_database ${PCL_LIBRARIES})
   endif()
   ament_add_gtest(
+    test_registration_determinism
+    test/test_registration_determinism.cpp
+  )
+  if(TARGET test_registration_determinism)
+    target_include_directories(
+      test_registration_determinism PRIVATE ${EIGEN3_INCLUDE_DIR} ${PCL_INCLUDE_DIRS}
+    )
+    ament_target_dependencies(test_registration_determinism ndt_omp_ros2)
+    target_link_libraries(test_registration_determinism ${PCL_LIBRARIES})
+  endif()
+  ament_add_gtest(
     test_dynamic_object_filter
     test/test_dynamic_object_filter.cpp
   )

--- a/graph_based_slam/test/test_registration_determinism.cpp
+++ b/graph_based_slam/test/test_registration_determinism.cpp
@@ -84,8 +84,9 @@ CloudT::Ptr makeStructuredCloud()
   for (float z = 0.0F; z <= 3.0F; z += 0.1F) {
     for (float a = 0.0F; a < 6.28F; a += 0.5F) {
       cloud->push_back(
-        pcl::PointXYZ(3.0F + 0.3F * std::cos(a) + jitter(rng),
-                      4.0F + 0.3F * std::sin(a) + jitter(rng), z + jitter(rng)));
+        pcl::PointXYZ(
+          3.0F + 0.3F * std::cos(a) + jitter(rng),
+          4.0F + 0.3F * std::sin(a) + jitter(rng), z + jitter(rng)));
     }
   }
   return cloud;

--- a/graph_based_slam/test/test_registration_determinism.cpp
+++ b/graph_based_slam/test/test_registration_determinism.cpp
@@ -1,0 +1,216 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Phase 0 determinism characterization for pclomp NDT registration
+// (docs/roadmap/v0.6.md). Single-threaded alignment must be bitwise
+// repeatable; multi-threaded repeatability and cross-thread-count
+// consistency are measured and reported (grep "[determinism]" in the
+// ctest log), not demanded.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Geometry>  // NOLINT(build/include_order)
+#include <pcl/point_cloud.h>  // NOLINT(build/include_order)
+#include <pcl/point_types.h>  // NOLINT(build/include_order)
+#include <pclomp/ndt_omp.h>  // NOLINT(build/include_order)
+// ndt_omp_ros2 installs no compiled library; template definitions come from
+// the impl headers, the same way graph_based_slam_component.h consumes them.
+#include <pclomp/ndt_omp_impl.hpp>
+#include <pclomp/voxel_grid_covariance_omp_impl.hpp>
+
+namespace
+{
+
+using CloudT = pcl::PointCloud<pcl::PointXYZ>;
+
+CloudT::Ptr makeStructuredCloud()
+{
+  auto cloud = CloudT::Ptr(new CloudT());
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<float> jitter(-0.02F, 0.02F);
+
+  // Ground plane 20 x 20 m at z = 0.
+  for (float x = -10.0F; x <= 10.0F; x += 0.4F) {
+    for (float y = -10.0F; y <= 10.0F; y += 0.4F) {
+      cloud->push_back(pcl::PointXYZ(x + jitter(rng), y + jitter(rng), jitter(rng)));
+    }
+  }
+  // Wall at x = 10, 3 m tall.
+  for (float y = -10.0F; y <= 10.0F; y += 0.3F) {
+    for (float z = 0.0F; z <= 3.0F; z += 0.3F) {
+      cloud->push_back(pcl::PointXYZ(10.0F + jitter(rng), y + jitter(rng), z + jitter(rng)));
+    }
+  }
+  // Wall at y = -10, 3 m tall.
+  for (float x = -10.0F; x <= 10.0F; x += 0.3F) {
+    for (float z = 0.0F; z <= 3.0F; z += 0.3F) {
+      cloud->push_back(pcl::PointXYZ(x + jitter(rng), -10.0F + jitter(rng), z + jitter(rng)));
+    }
+  }
+  // A free-standing pillar for asymmetry.
+  for (float z = 0.0F; z <= 3.0F; z += 0.1F) {
+    for (float a = 0.0F; a < 6.28F; a += 0.5F) {
+      cloud->push_back(
+        pcl::PointXYZ(3.0F + 0.3F * std::cos(a) + jitter(rng),
+                      4.0F + 0.3F * std::sin(a) + jitter(rng), z + jitter(rng)));
+    }
+  }
+  return cloud;
+}
+
+Eigen::Matrix4f knownTransform()
+{
+  Eigen::Affine3f t = Eigen::Translation3f(0.4F, 0.2F, 0.05F) *
+    Eigen::AngleAxisf(8.0F * static_cast<float>(M_PI) / 180.0F, Eigen::Vector3f::UnitZ());
+  return t.matrix();
+}
+
+CloudT::Ptr makeTargetCloud(const CloudT::Ptr & source)
+{
+  auto target = CloudT::Ptr(new CloudT());
+  const Eigen::Matrix4f t = knownTransform();
+  target->reserve(source->size());
+  for (const auto & p : *source) {
+    const Eigen::Vector4f v = t * Eigen::Vector4f(p.x, p.y, p.z, 1.0F);
+    target->push_back(pcl::PointXYZ(v.x(), v.y(), v.z()));
+  }
+  return target;
+}
+
+struct AlignResult
+{
+  Eigen::Matrix4f matrix;
+  double fitness;
+  bool converged;
+};
+
+AlignResult runAlign(int num_threads)
+{
+  // Fresh inputs and a fresh NDT object every call: no shared mutable state.
+  const CloudT::Ptr source = makeStructuredCloud();
+  const CloudT::Ptr target = makeTargetCloud(source);
+
+  pclomp::NormalDistributionsTransform<pcl::PointXYZ, pcl::PointXYZ> ndt;
+  ndt.setNumThreads(num_threads);
+  ndt.setNeighborhoodSearchMethod(pclomp::DIRECT7);
+  ndt.setResolution(2.0F);
+  ndt.setMaximumIterations(35);
+  ndt.setTransformationEpsilon(0.01);
+  ndt.setInputSource(source);
+  ndt.setInputTarget(target);
+
+  CloudT aligned;
+  ndt.align(aligned, Eigen::Matrix4f::Identity());
+
+  return AlignResult{ndt.getFinalTransformation(), ndt.getFitnessScore(), ndt.hasConverged()};
+}
+
+bool bitwiseEqual(const Eigen::Matrix4f & a, const Eigen::Matrix4f & b)
+{
+  return std::memcmp(a.data(), b.data(), sizeof(float) * 16) == 0;
+}
+
+float maxAbsDeviation(const Eigen::Matrix4f & a, const Eigen::Matrix4f & b)
+{
+  return (a - b).cwiseAbs().maxCoeff();
+}
+
+float translationDelta(const Eigen::Matrix4f & a, const Eigen::Matrix4f & b)
+{
+  return (a.block<3, 1>(0, 3) - b.block<3, 1>(0, 3)).norm();
+}
+
+float rotationDeltaDeg(const Eigen::Matrix4f & a, const Eigen::Matrix4f & b)
+{
+  const Eigen::Matrix3f r = a.block<3, 3>(0, 0).transpose() * b.block<3, 3>(0, 0);
+  const float c = std::min(1.0F, std::max(-1.0F, (r.trace() - 1.0F) / 2.0F));
+  return std::acos(c) * 180.0F / static_cast<float>(M_PI);
+}
+
+TEST(RegistrationDeterminism, SingleThreadIsBitwiseRepeatable)
+{
+  const AlignResult first = runAlign(1);
+  ASSERT_TRUE(first.converged);
+
+  for (int i = 1; i < 5; ++i) {
+    const AlignResult next = runAlign(1);
+    ASSERT_TRUE(next.converged);
+    EXPECT_TRUE(bitwiseEqual(first.matrix, next.matrix))
+      << "single-thread NDT diverged on repeat " << i
+      << " max_dev=" << maxAbsDeviation(first.matrix, next.matrix);
+    EXPECT_EQ(first.fitness, next.fitness) << "fitness diverged on repeat " << i;
+  }
+}
+
+TEST(RegistrationDeterminism, MultiThreadRepeatabilityReport)
+{
+  for (int threads : {2, 4}) {
+    const AlignResult first = runAlign(threads);
+    ASSERT_TRUE(first.converged);
+
+    float max_matrix_dev = 0.0F;
+    double max_fitness_dev = 0.0;
+    for (int i = 1; i < 5; ++i) {
+      const AlignResult next = runAlign(threads);
+      ASSERT_TRUE(next.converged);
+      max_matrix_dev = std::max(max_matrix_dev, maxAbsDeviation(first.matrix, next.matrix));
+      max_fitness_dev = std::max(max_fitness_dev, std::abs(first.fitness - next.fitness));
+      // Characterization, not a contract: only a loose sanity bound.
+      EXPECT_LT(translationDelta(first.matrix, next.matrix), 1e-3F);
+    }
+    std::cout << "[determinism] threads=" << threads << " max_matrix_dev=" << max_matrix_dev
+              << " max_fitness_dev=" << max_fitness_dev << std::endl;
+  }
+}
+
+TEST(RegistrationDeterminism, CrossThreadCountConsistencyReport)
+{
+  const AlignResult base = runAlign(1);
+  ASSERT_TRUE(base.converged);
+
+  for (int threads : {2, 4}) {
+    const AlignResult other = runAlign(threads);
+    ASSERT_TRUE(other.converged);
+    const float trans_delta = translationDelta(base.matrix, other.matrix);
+    const float rot_delta = rotationDeltaDeg(base.matrix, other.matrix);
+    std::cout << "[determinism] threads_1_vs_" << threads << " trans_delta_m=" << trans_delta
+              << " rot_delta_deg=" << rot_delta << std::endl;
+    EXPECT_LT(trans_delta, 5e-3F);
+    EXPECT_LT(rot_delta, 0.1F);
+  }
+}
+
+}  // namespace

--- a/scripts/aggregate_backend_replay.py
+++ b/scripts/aggregate_backend_replay.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Aggregate backend replay variance runs into a small markdown report."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+RMSE_RE = re.compile(
+    r'^\s*rmse:\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)'
+)
+
+
+@dataclass
+class RunSummary:
+    name: str
+    rmse: Optional[float]
+    edges: set[tuple[int, int]]
+    edge_hash: str
+    log_loop_edges: Optional[int]
+
+
+def run_sort_key(path: Path) -> tuple[int, str]:
+    match = re.search(r'(\d+)$', path.name)
+    if match:
+        return int(match.group(1)), path.name
+    return sys.maxsize, path.name
+
+
+def read_rmse(path: Path) -> Optional[float]:
+    if not path.exists():
+        return None
+
+    for line in path.read_text(errors='replace').splitlines():
+        match = RMSE_RE.match(line)
+        if match:
+            return float(match.group(1))
+
+    return None
+
+
+def read_edges(path: Path) -> set[tuple[int, int]]:
+    edges: set[tuple[int, int]] = set()
+    if not path.exists():
+        return edges
+
+    for line in path.read_text(errors='replace').splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+
+        try:
+            i = int(parts[0])
+            j = int(parts[1])
+        except ValueError:
+            continue
+
+        edges.add((min(i, j), max(i, j)))
+
+    return edges
+
+
+def edge_set_hash(edges: set[tuple[int, int]]) -> str:
+    payload = '\n'.join(f'{i} {j}' for i, j in sorted(edges))
+    return hashlib.sha256(payload.encode('utf-8')).hexdigest()[:12]
+
+
+def count_backend_loop_lines(path: Path) -> Optional[int]:
+    if not path.exists():
+        return None
+
+    return sum(
+        1 for line in path.read_text(errors='replace').splitlines()
+        if 'Loop edge' in line
+    )
+
+
+def collect_runs(bench_dir: Path) -> list[RunSummary]:
+    summaries: list[RunSummary] = []
+
+    for run_dir in sorted(bench_dir.glob('replay_run*'), key=run_sort_key):
+        if not run_dir.is_dir():
+            continue
+
+        edges = read_edges(run_dir / 'loop_edges.txt')
+        summaries.append(
+            RunSummary(
+                name=run_dir.name,
+                rmse=read_rmse(run_dir / 'ape.txt'),
+                edges=edges,
+                edge_hash=edge_set_hash(edges),
+                log_loop_edges=count_backend_loop_lines(run_dir / 'backend.log'),
+            )
+        )
+
+    return summaries
+
+
+def format_rmse(value: Optional[float]) -> str:
+    if value is None:
+        return 'NA'
+    return f'{value:.9g}'
+
+
+def format_sigma(values: list[float]) -> str:
+    if not values:
+        return 'nan'
+    if len(values) == 1:
+        return '0'
+    return f'{statistics.stdev(values):.9g}'
+
+
+def format_pair_list(edges: set[tuple[int, int]]) -> str:
+    if not edges:
+        return '(none)'
+    return ', '.join(f'{i} {j}' for i, j in sorted(edges))
+
+
+def print_report(summaries: list[RunSummary]) -> None:
+    print('| run | ape_rmse | n_loop_edges | edge_set_hash |')
+    print('| --- | ---: | ---: | --- |')
+
+    for summary in summaries:
+        print(
+            f'| {summary.name} | {format_rmse(summary.rmse)} | '
+            f'{len(summary.edges)} | `{summary.edge_hash}` |'
+        )
+
+    rmse_values = [summary.rmse for summary in summaries if summary.rmse is not None]
+    print()
+    print(f'ape_sigma: {format_sigma(rmse_values)}')
+
+    if not summaries:
+        print('edge_sets_identical: true')
+        return
+
+    base_edges = summaries[0].edges
+    identical = all(summary.edges == base_edges for summary in summaries[1:])
+    print(f'edge_sets_identical: {str(identical).lower()}')
+
+    if identical:
+        return
+
+    print()
+    print('symmetric_differences_vs_run1:')
+    for summary in summaries[1:]:
+        diff = base_edges ^ summary.edges
+        print(f'- {summary.name}: {format_pair_list(diff)}')
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Aggregate backend replay variance outputs.'
+    )
+    parser.add_argument(
+        '--bench-dir',
+        required=True,
+        type=Path,
+        help='Directory containing replay_run*/ subdirectories.',
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    summaries = collect_runs(args.bench_dir)
+    print_report(summaries)
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # Reporting tool: never fail the sweep.
+        print(f'aggregate_backend_replay.py: ERROR: {exc}', file=sys.stderr)
+        raise SystemExit(0)

--- a/scripts/run_backend_replay_variance.sh
+++ b/scripts/run_backend_replay_variance.sh
@@ -1,0 +1,523 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WS_ROOT="${REPO_ROOT}"
+if [[ ! -f "${WS_ROOT}/install/setup.bash" && -f "${REPO_ROOT}/../install/setup.bash" ]]; then
+  WS_ROOT="$(cd "${REPO_ROOT}/.." && pwd)"
+fi
+
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+MODE=""
+OUTPUT_DIR="${REPO_ROOT}/output/backend_replay_${TIMESTAMP}"
+OUTPUT_DIR_GIVEN=false
+INPUT_BAG=""
+RUNS=3
+PLAY_RATE="1.0"
+DRAIN_SECS="10"
+LIDARSLAM_PARAM="lidarslam/param/lidarslam_mid360_rko_graph.yaml"
+LIDARSLAM_PARAM_GIVEN=false
+REFERENCE_TUM="output/glim_mid360_reference.tum"
+SOURCE_BAG=""
+
+RECORDER_PID=""
+LOGGER_PID=""
+BACKEND_PID=""
+BACKEND_PGID=""
+
+usage() {
+  cat <<'EOF'
+Usage: run_backend_replay_variance.sh --mode record|replay [options]
+
+Measures backend + ROS transport replay variance from byte-identical RKO-LIO output topics.
+
+Options:
+  --mode record|replay
+      record: run the MID-360 cross-validation benchmark once and record backend inputs
+      replay: replay a recorded backend input bag into graph_based_slam only
+
+  --output-dir DIR
+      Output directory.
+      Default in record mode: output/backend_replay_<timestamp>
+      Required explicitly in replay mode so the recorded bag can be reused.
+
+  --input-bag DIR
+      Replay input bag directory.
+      Replay default: $OUTPUT_DIR/backend_input
+
+  --runs N
+      Replay run count. Default: 3
+
+  --rate FLOAT
+      ros2 bag play rate for replay mode. Default: 1.0
+
+  --drain-secs SECS
+      Seconds to wait after bag playback before /map_save. Default: 10
+
+  --lidarslam-param FILE
+      graph_based_slam parameter file.
+      Default: lidarslam/param/lidarslam_mid360_rko_graph.yaml
+      In record mode this is forwarded to the source benchmark only when given.
+
+  --reference-tum FILE
+      Reference trajectory for APE post-processing.
+      Default: output/glim_mid360_reference.tum
+
+  --bag FILE
+      Source bag forwarded to run_rko_lio_mid360_crossval_benchmark.sh in record mode.
+
+  --help
+      Show this help.
+
+Replay mode keeps the current ROS_DOMAIN_ID environment. No other ROS nodes should be
+running in the same domain while this harness is recording or replaying.
+EOF
+}
+
+resolve_repo_path() {
+  local path="$1"
+  if [[ "${path}" = /* ]]; then
+    printf '%s\n' "${path}"
+  else
+    printf '%s\n' "${REPO_ROOT}/${path}"
+  fi
+}
+
+source_ros() {
+  set +u
+  if [[ -f "${WS_ROOT}/install/setup.bash" ]]; then
+    # shellcheck source=/dev/null
+    source "${WS_ROOT}/install/setup.bash"
+  elif [[ -n "${ROS_DISTRO:-}" && -f "/opt/ros/${ROS_DISTRO}/setup.bash" ]]; then
+    # shellcheck source=/dev/null
+    source "/opt/ros/${ROS_DISTRO}/setup.bash"
+  fi
+  set -u
+}
+
+wait_for_pid_exit() {
+  local pid="$1"
+  local timeout_secs="$2"
+  local deadline=$((SECONDS + timeout_secs))
+
+  while kill -0 "${pid}" 2>/dev/null; do
+    if (( SECONDS >= deadline )); then
+      return 1
+    fi
+    sleep 1
+  done
+  return 0
+}
+
+wait_for_pgid_exit() {
+  local pgid="$1"
+  local timeout_secs="$2"
+  local deadline=$((SECONDS + timeout_secs))
+
+  while kill -0 -- "-${pgid}" 2>/dev/null; do
+    if (( SECONDS >= deadline )); then
+      return 1
+    fi
+    sleep 1
+  done
+  return 0
+}
+
+stop_pid_with_guard() {
+  local pid="$1"
+  local label="$2"
+
+  if [[ -z "${pid}" ]]; then
+    return 0
+  fi
+
+  if kill -0 "${pid}" 2>/dev/null; then
+    echo "Stopping ${label} pid=${pid}"
+    kill -INT "${pid}" 2>/dev/null || true
+    if ! wait_for_pid_exit "${pid}" 10; then
+      echo "WARN: ${label} did not exit after SIGINT; sending SIGKILL"
+      kill -KILL "${pid}" 2>/dev/null || true
+    fi
+  fi
+
+  wait "${pid}" 2>/dev/null || true
+}
+
+stop_backend_group() {
+  if [[ -z "${BACKEND_PGID}" ]]; then
+    return 0
+  fi
+
+  if kill -0 -- "-${BACKEND_PGID}" 2>/dev/null; then
+    echo "Stopping backend process group pgid=${BACKEND_PGID}"
+    kill -INT -- "-${BACKEND_PGID}" 2>/dev/null || true
+    if ! wait_for_pgid_exit "${BACKEND_PGID}" 10; then
+      echo "WARN: backend process group did not exit after SIGINT; sending SIGKILL"
+      kill -KILL -- "-${BACKEND_PGID}" 2>/dev/null || true
+    fi
+  fi
+
+  if [[ -n "${BACKEND_PID}" ]]; then
+    wait "${BACKEND_PID}" 2>/dev/null || true
+  fi
+
+  BACKEND_PID=""
+  BACKEND_PGID=""
+}
+
+cleanup() {
+  set +e
+  stop_pid_with_guard "${RECORDER_PID}" "rosbag recorder"
+  RECORDER_PID=""
+
+  stop_pid_with_guard "${LOGGER_PID}" "path logger"
+  LOGGER_PID=""
+
+  stop_backend_group
+}
+trap cleanup EXIT INT TERM
+
+topic_count_from_info() {
+  local topic="$1"
+  local info_file="$2"
+
+  awk -v topic="${topic}" '
+    function emit_count(line) {
+      if (match(line, /(Count|message_count):[[:space:]]*[0-9]+/)) {
+        value = substr(line, RSTART, RLENGTH)
+        gsub(/[^0-9]/, "", value)
+        print value
+        exit
+      }
+    }
+
+    {
+      if (index($0, "Topic: " topic) > 0) {
+        in_topic = 1
+        emit_count($0)
+        next
+      }
+
+      if ($0 ~ /^[[:space:]]*Topic:/) {
+        in_topic = 0
+      }
+
+      if ($0 ~ /^[[:space:]]*name:[[:space:]]*/) {
+        name = $0
+        sub(/^[[:space:]]*name:[[:space:]]*/, "", name)
+        in_topic = (name == topic)
+      }
+
+      if (in_topic) {
+        emit_count($0)
+      }
+    }
+  ' "${info_file}"
+}
+
+record_mode() {
+  mkdir -p "${OUTPUT_DIR}"
+  export ROS_LOG_DIR="${OUTPUT_DIR}/ros_logs_record"
+  mkdir -p "${ROS_LOG_DIR}"
+
+  local record_log="${OUTPUT_DIR}/backend_input_record.log"
+  local bag_dir="${OUTPUT_DIR}/backend_input"
+  local benchmark_status=0
+
+  echo "Recording backend inputs to ${bag_dir}"
+  ros2 bag record -o "${bag_dir}" /rko_lio/odometry /rko_lio/frame \
+    > "${record_log}" 2>&1 &
+  RECORDER_PID=$!
+
+  sleep 2
+
+  local benchmark_cmd=(
+    bash "${SCRIPT_DIR}/run_rko_lio_mid360_crossval_benchmark.sh"
+    --output-dir "${OUTPUT_DIR}/source_run"
+  )
+
+  if [[ -n "${SOURCE_BAG}" ]]; then
+    benchmark_cmd+=(--bag "${SOURCE_BAG}")
+  fi
+
+  if [[ "${LIDARSLAM_PARAM_GIVEN}" == true ]]; then
+    benchmark_cmd+=(--lidarslam-param "${LIDARSLAM_PARAM}")
+  fi
+
+  echo "Running source benchmark"
+  set +e
+  "${benchmark_cmd[@]}"
+  benchmark_status=$?
+  set -e
+
+  stop_pid_with_guard "${RECORDER_PID}" "rosbag recorder"
+  RECORDER_PID=""
+
+  local info_file="${OUTPUT_DIR}/backend_input_info.txt"
+  echo "Inspecting recorded bag"
+  ros2 bag info "${bag_dir}" | tee "${info_file}"
+
+  local odom_count
+  local frame_count
+  odom_count="$(topic_count_from_info /rko_lio/odometry "${info_file}")"
+  frame_count="$(topic_count_from_info /rko_lio/frame "${info_file}")"
+  odom_count="${odom_count:-0}"
+  frame_count="${frame_count:-0}"
+
+  echo "Recorded /rko_lio/odometry messages: ${odom_count}"
+  echo "Recorded /rko_lio/frame messages: ${frame_count}"
+
+  if (( odom_count <= 0 || frame_count <= 0 )); then
+    echo "ERROR: recorded bag is missing required backend input messages" >&2
+    exit 1
+  fi
+
+  if (( benchmark_status != 0 )); then
+    echo "ERROR: source benchmark failed with status ${benchmark_status}" >&2
+    exit "${benchmark_status}"
+  fi
+
+  echo "Record complete: ${OUTPUT_DIR}"
+}
+
+extract_loop_edges() {
+  local g2o_file="$1"
+  local out_file="$2"
+
+  if [[ ! -s "${g2o_file}" ]]; then
+    : > "${out_file}"
+    echo "WARN: pose graph missing or empty: ${g2o_file}" >&2
+    return 1
+  fi
+
+  awk '
+    $1 == "EDGE_SE3:QUAT" {
+      i = $2
+      j = $3
+      d = i - j
+      if (d < 0) {
+        d = -d
+      }
+      if (d > 1) {
+        if (i <= j) {
+          print i, j
+        } else {
+          print j, i
+        }
+      }
+    }
+  ' "${g2o_file}" | sort -n -k1,1 -k2,2 -u > "${out_file}"
+}
+
+call_map_save() {
+  local run_dir="$1"
+  local log_file="${run_dir}/map_save.log"
+
+  if timeout 15 ros2 service call /map_save std_srvs/srv/Empty "{}" \
+    > "${log_file}" 2>&1; then
+    return 0
+  fi
+
+  echo "WARN: /map_save failed once; retrying" | tee -a "${log_file}" >&2
+  sleep 2
+
+  timeout 15 ros2 service call /map_save std_srvs/srv/Empty "{}" \
+    >> "${log_file}" 2>&1
+}
+
+run_one_replay() {
+  local idx="$1"
+  local run_dir="${OUTPUT_DIR}/replay_run${idx}"
+  local failed=0
+
+  mkdir -p "${run_dir}"
+  export ROS_LOG_DIR="${run_dir}/ros_logs"
+  mkdir -p "${ROS_LOG_DIR}"
+
+  echo "Replay run ${idx}: ${run_dir}"
+
+  setsid ros2 run graph_based_slam graph_based_slam_node --ros-args \
+    --params-file "${LIDARSLAM_PARAM}" \
+    -r odom_input:=/rko_lio/odometry \
+    -r cloud_input:=/rko_lio/frame \
+    -p use_odom_input:=true \
+    -p use_sim_time:=true \
+    -p map_save_dir:="${run_dir}" \
+    -p save_map_path:="${run_dir}/map.pcd" \
+    -p save_pose_graph_path:="${run_dir}/pose_graph.g2o" \
+    > "${run_dir}/backend.log" 2>&1 &
+  BACKEND_PID=$!
+  BACKEND_PGID="${BACKEND_PID}"
+
+  python3 "${SCRIPT_DIR}/path_to_tum.py" \
+    --topic /modified_path \
+    --output "${run_dir}/traj_corrected.tum" \
+    --use-sim-time true \
+    > "${run_dir}/path_logger.log" 2>&1 &
+  LOGGER_PID=$!
+
+  sleep 5
+
+  if ! kill -0 "${BACKEND_PID}" 2>/dev/null; then
+    echo "WARN: backend exited before playback in run ${idx}" >&2
+    failed=1
+  fi
+
+  if ! ros2 bag play "${INPUT_BAG}" --clock 100 --rate "${PLAY_RATE}" \
+    > "${run_dir}/bag_play.log" 2>&1; then
+    echo "WARN: ros2 bag play failed in run ${idx}" >&2
+    failed=1
+  fi
+
+  sleep "${DRAIN_SECS}"
+
+  if ! call_map_save "${run_dir}"; then
+    echo "WARN: /map_save failed twice in run ${idx}; continuing" >&2
+  fi
+
+  sleep 3
+
+  stop_pid_with_guard "${LOGGER_PID}" "path logger"
+  LOGGER_PID=""
+
+  stop_backend_group
+
+  if ! python3 "${SCRIPT_DIR}/ape_from_tum.py" \
+    --ref "${REFERENCE_TUM}" \
+    --est "${run_dir}/traj_corrected.tum" \
+    --out "${run_dir}/ape.txt" \
+    > "${run_dir}/ape_postprocess.log" 2>&1; then
+    echo "WARN: APE post-processing failed in run ${idx}; continuing" >&2
+  fi
+
+  if ! extract_loop_edges "${run_dir}/pose_graph.g2o" "${run_dir}/loop_edges.txt"; then
+    failed=1
+  fi
+
+  if (( failed == 0 )); then
+    echo "PASS" > "${run_dir}/status.txt"
+  else
+    echo "FAIL" > "${run_dir}/status.txt"
+  fi
+
+  return "${failed}"
+}
+
+replay_mode() {
+  if [[ "${OUTPUT_DIR_GIVEN}" != true ]]; then
+    echo "ERROR: --output-dir is required in replay mode" >&2
+    exit 2
+  fi
+
+  mkdir -p "${OUTPUT_DIR}"
+
+  if [[ -z "${INPUT_BAG}" ]]; then
+    INPUT_BAG="${OUTPUT_DIR}/backend_input"
+  fi
+
+  if [[ ! -d "${INPUT_BAG}" ]]; then
+    echo "ERROR: input bag directory does not exist: ${INPUT_BAG}" >&2
+    exit 2
+  fi
+
+  local failures=0
+  local idx
+  for idx in $(seq 1 "${RUNS}"); do
+    set +e
+    run_one_replay "${idx}"
+    local status=$?
+    set -e
+
+    if (( status != 0 )); then
+      failures=$((failures + 1))
+      echo "WARN: replay run ${idx} recorded FAIL"
+    fi
+  done
+
+  local summary_file="${OUTPUT_DIR}/backend_replay_summary.md"
+  python3 "${SCRIPT_DIR}/aggregate_backend_replay.py" \
+    --bench-dir "${OUTPUT_DIR}" | tee "${summary_file}"
+
+  echo "Summary written to ${summary_file}"
+
+  if (( failures > 0 )); then
+    echo "WARN: ${failures} replay run(s) recorded FAIL; see per-run status.txt files" >&2
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$(resolve_repo_path "$2")"
+      OUTPUT_DIR_GIVEN=true
+      shift 2
+      ;;
+    --input-bag)
+      INPUT_BAG="$(resolve_repo_path "$2")"
+      shift 2
+      ;;
+    --runs)
+      RUNS="$2"
+      shift 2
+      ;;
+    --rate)
+      PLAY_RATE="$2"
+      shift 2
+      ;;
+    --drain-secs)
+      DRAIN_SECS="$2"
+      shift 2
+      ;;
+    --lidarslam-param)
+      LIDARSLAM_PARAM="$(resolve_repo_path "$2")"
+      LIDARSLAM_PARAM_GIVEN=true
+      shift 2
+      ;;
+    --reference-tum)
+      REFERENCE_TUM="$(resolve_repo_path "$2")"
+      shift 2
+      ;;
+    --bag)
+      SOURCE_BAG="$(resolve_repo_path "$2")"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${MODE}" ]]; then
+  echo "ERROR: --mode is required" >&2
+  usage >&2
+  exit 2
+fi
+
+LIDARSLAM_PARAM="$(resolve_repo_path "${LIDARSLAM_PARAM}")"
+REFERENCE_TUM="$(resolve_repo_path "${REFERENCE_TUM}")"
+
+source_ros
+
+case "${MODE}" in
+  record)
+    record_mode
+    ;;
+  replay)
+    replay_mode
+    ;;
+  *)
+    echo "ERROR: --mode must be record or replay" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/run_backend_replay_variance.sh
+++ b/scripts/run_backend_replay_variance.sh
@@ -127,6 +127,7 @@ wait_for_pgid_exit() {
 stop_pid_with_guard() {
   local pid="$1"
   local label="$2"
+  local grace_secs="${3:-10}"
 
   if [[ -z "${pid}" ]]; then
     return 0
@@ -135,7 +136,7 @@ stop_pid_with_guard() {
   if kill -0 "${pid}" 2>/dev/null; then
     echo "Stopping ${label} pid=${pid}"
     kill -INT "${pid}" 2>/dev/null || true
-    if ! wait_for_pid_exit "${pid}" 10; then
+    if ! wait_for_pid_exit "${pid}" "${grace_secs}"; then
       echo "WARN: ${label} did not exit after SIGINT; sending SIGKILL"
       kill -KILL "${pid}" 2>/dev/null || true
     fi
@@ -251,8 +252,15 @@ record_mode() {
   benchmark_status=$?
   set -e
 
-  stop_pid_with_guard "${RECORDER_PID}" "rosbag recorder"
+  # A pointcloud-heavy mcap can take well over 10 s to flush on SIGINT;
+  # killing the recorder early loses metadata.yaml.
+  stop_pid_with_guard "${RECORDER_PID}" "rosbag recorder" 60
   RECORDER_PID=""
+
+  if [[ ! -f "${bag_dir}/metadata.yaml" ]]; then
+    echo "WARN: recorder left no metadata.yaml; reindexing ${bag_dir}" >&2
+    ros2 bag reindex "${bag_dir}" -s mcap
+  fi
 
   local info_file="${OUTPUT_DIR}/backend_input_info.txt"
   echo "Inspecting recorded bag"

--- a/scripts/run_backend_replay_variance.sh
+++ b/scripts/run_backend_replay_variance.sh
@@ -16,6 +16,7 @@ INPUT_BAG=""
 RUNS=3
 PLAY_RATE="1.0"
 DRAIN_SECS="10"
+ADJACENT_WINDOW=5
 LIDARSLAM_PARAM="lidarslam/param/lidarslam_mid360_rko_graph.yaml"
 LIDARSLAM_PARAM_GIVEN=false
 REFERENCE_TUM="output/glim_mid360_reference.tum"
@@ -54,6 +55,10 @@ Options:
 
   --drain-secs SECS
       Seconds to wait after bag playback before /map_save. Default: 10
+
+  --adjacent-window N
+      g2o edges with |i-j| <= N are treated as odometry adjacency constraints,
+      not loop closures (match num_adjacent_pose_cnstraints). Default: 5
 
   --lidarslam-param FILE
       graph_based_slam parameter file.
@@ -299,7 +304,9 @@ extract_loop_edges() {
     return 1
   fi
 
-  awk '
+  # Edges within num_adjacent_pose_cnstraints (default 5) of each other are
+  # odometry adjacency constraints, not loop closures.
+  awk -v window="${ADJACENT_WINDOW}" '
     $1 == "EDGE_SE3:QUAT" {
       i = $2
       j = $3
@@ -307,7 +314,7 @@ extract_loop_edges() {
       if (d < 0) {
         d = -d
       }
-      if (d > 1) {
+      if (d > window) {
         if (i <= j) {
           print i, j
         } else {
@@ -345,16 +352,19 @@ run_one_replay() {
 
   echo "Replay run ${idx}: ${run_dir}"
 
-  setsid ros2 run graph_based_slam graph_based_slam_node --ros-args \
-    --params-file "${LIDARSLAM_PARAM}" \
-    -r odom_input:=/rko_lio/odometry \
-    -r cloud_input:=/rko_lio/frame \
-    -p use_odom_input:=true \
-    -p use_sim_time:=true \
-    -p map_save_dir:="${run_dir}" \
-    -p save_map_path:="${run_dir}/map.pcd" \
-    -p save_pose_graph_path:="${run_dir}/pose_graph.g2o" \
-    > "${run_dir}/backend.log" 2>&1 &
+  # The backend writes pose_graph.g2o into its CWD (hardcoded relative path
+  # in doPoseAdjustment), so give every run its own working directory.
+  (
+    cd "${run_dir}" && exec setsid ros2 run graph_based_slam graph_based_slam_node --ros-args \
+      --params-file "${LIDARSLAM_PARAM}" \
+      -r odom_input:=/rko_lio/odometry \
+      -r cloud_input:=/rko_lio/frame \
+      -p use_odom_input:=true \
+      -p use_sim_time:=true \
+      -p map_save_dir:="${run_dir}" \
+      -p save_map_path:="${run_dir}/map.pcd" \
+      -p save_pose_graph_path:="${run_dir}/pose_graph.g2o"
+  ) > "${run_dir}/backend.log" 2>&1 &
   BACKEND_PID=$!
   BACKEND_PGID="${BACKEND_PID}"
 
@@ -479,6 +489,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --drain-secs)
       DRAIN_SECS="$2"
+      shift 2
+      ;;
+    --adjacent-window)
+      ADJACENT_WINDOW="$2"
       shift 2
       ;;
     --lidarslam-param)


### PR DESCRIPTION
## Summary
Phase 0 of the v0.6 deterministic core/shell refactor (docs/roadmap/v0.6.md): measure which layer owns the run-to-run variance before touching the architecture. Ships the tooling **and** the measured attribution.

### Tooling
- `scripts/run_backend_replay_variance.sh` + `scripts/aggregate_backend_replay.py`: record the backend's exact input topics (`/rko_lio/odometry` + `/rko_lio/frame`) during one benchmark run, replay the byte-identical stream into `graph_based_slam` alone N times, report per-run APE, the loop-edge set extracted from `pose_graph.g2o` (windowed by `--adjacent-window` to exclude the adjacency fan-out), `ape_sigma` and `edge_sets_identical`.
- `graph_based_slam/test/test_registration_determinism.cpp`: the first determinism-contract-layer test — single-threaded pclomp NDT must be **bitwise** repeatable (hard assert); multi-thread repeatability and cross-thread-count deltas are reported as grep-able `[determinism]` lines.

### Findings (docs/research/determinism-variance-attribution.md)
| layer | result |
|---|---|
| end-to-end | baseline APE σ ~0.5 — **frontend owns most APE variance** |
| backend+transport, input frozen | APE σ collapses to **0.050**, but **a different loop edge every run** (1↔577 / 6↔583 / 14↔582) — pure scheduling/interleaving artifact |
| registration (NDT) | **bitwise repeatable at every fixed thread count** (even multithreaded); fixed 0.028° delta between threads=1 and ≥2 |

Consequences: the Phase 2 hard gate (identical loop-edge sets) is achievable, determinism mode does **not** need `ndt_num_threads: 1`, and two Phase 1 warts are documented (`pose_graph.g2o` written to the node CWD at `graph_based_slam_component.cpp:2761`; loop edges indistinguishable from adjacency edges in the g2o without windowing).

### Found-and-fixed while building
- recorder SIGKILLed mid-flush lost `metadata.yaml` (60 s grace + auto-reindex)
- per-run backend CWD so g2o artifacts don't overwrite each other
- `|i-j| > 1` misclassified `num_adjacent_pose_cnstraints` fan-out as loops

## Test plan
- Full local CI: 937 tests, 0 failures (includes the new gtest + cpplint/uncrustify clean).
- Harness exercised end-to-end twice on the GLIM MID-360 bag (record + replay ×3); raw artifacts under `output/backend_replay_mid360_p0/`.
- No behavior change to any shipped node; tooling + test + docs only.