### PR TITLE
feat(slam): stamp-synchronize the odom+cloud input path (v0.6 Phase 1)

### DIFF
--- a/docs/research/determinism-variance-attribution.md
+++ b/docs/research/determinism-variance-attribution.md
@@ -74,6 +74,31 @@ variance, not replay-vs-benchmark equality.)
     `--adjacent-window`, default 5). The offline runner should emit loop
     edges explicitly instead.
 
+## Addendum: after the Phase 1 input-sync fix (same day)
+
+Re-running layer 2 with the stamp-synchronized odom+cloud path
+(message_filters ApproximateTime + deep queues) on the **same recorded
+input bag**:
+
+| metric | before | after |
+|---|---|---|
+| submaps per run | 603 / 598 / 599 | **639 / 640 / 639** |
+| APE σ | 0.050 | **0.032** |
+| loop-edge sets | differ per run | still differ per run |
+
+The old path was silently dropping ~6% of input frames (best-effort
+depth-5 cloud queue overflowing while `searchLoop` blocked the
+single-threaded executor) — the recovered frames are the 600 → 639 jump.
+Loop-edge selection still varies because it lives in the wall-clock loop
+scheduler, exactly as attributed above; that is Phase 2's target.
+
+An A/B on the live pipeline (3× new vs 3× old, shipped MID-360 preset,
+GLIM crossval): baseline APE 5.10 ± 1.16 (new) vs 3.96 ± 0.68 (old) —
+overlapping spreads, not distinguishable at n=3 on this deliberately
+noisy agreement substrate. The blocking GT gates score the dense raw
+odometry (frontend output) and are unaffected by backend input pairing
+by construction.
+
 ## Reproduce
 
 ```bash

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -37,6 +37,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_sensor_msgs REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(lidarslam_msgs REQUIRED)
+find_package(message_filters REQUIRED)
 find_package(ndt_omp_ros2 REQUIRED)
 find_package(PCL REQUIRED)
 find_package(g2o QUIET
@@ -183,6 +184,13 @@ if(BUILD_TESTING)
       test_triangle_descriptor_database PRIVATE include ${EIGEN3_INCLUDE_DIR}
     )
     target_link_libraries(test_triangle_descriptor_database ${PCL_LIBRARIES})
+  endif()
+  ament_add_gtest(
+    test_submap_creation
+    test/test_submap_creation.cpp
+  )
+  if(TARGET test_submap_creation)
+    target_include_directories(test_submap_creation PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
     test_registration_determinism
@@ -528,6 +536,7 @@ ament_target_dependencies(graph_based_slam_component
   nav_msgs
   std_srvs
   lidarslam_msgs
+  message_filters
   ndt_omp_ros2
 )
 

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -93,6 +93,9 @@ extern "C" {
 #include <geometry_msgs/msg/transform.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <lidarslam_msgs/msg/map_array.hpp>
+#include <message_filters/subscriber.h>  // NOLINT(build/include_order)
+#include <message_filters/sync_policies/approximate_time.h>  // NOLINT(build/include_order)
+#include <message_filters/synchronizer.h>  // NOLINT(build/include_order)
 #include <nav_msgs/msg/odometry.hpp>
 #include <nav_msgs/msg/path.hpp>
 #include <pclomp/gicp_omp_impl.hpp>
@@ -402,21 +405,29 @@ private:
     void saveGridDividedMap(
       const pcl::PointCloud < pcl::PointXYZI > ::Ptr & map);
 
-    // Direct odometry + cloud input mode (for LIO frontends)
+    // Direct odometry + cloud input mode (for LIO frontends). The two
+    // streams are stamp-synchronized (message_filters ApproximateTime) so
+    // the submap pose/cloud pairing no longer depends on executor timing
+    // (v0.6 Phase 1; see docs/research/determinism-variance-attribution.md).
     bool use_odom_input_ {false};
     double submap_distance_threshold_ {1.5};
-    rclcpp::Subscription < nav_msgs::msg::Odometry > ::SharedPtr odom_sub_;
-    rclcpp::Subscription < sensor_msgs::msg::PointCloud2 > ::SharedPtr cloud_sub_;
-    sensor_msgs::msg::PointCloud2::SharedPtr latest_cloud_;
+    int odom_cloud_sync_queue_size_ {100};
+    std::shared_ptr < message_filters::Subscriber < nav_msgs::msg::Odometry >> odom_sync_sub_;
+    std::shared_ptr < message_filters::Subscriber <
+    sensor_msgs::msg::PointCloud2 >> cloud_sync_sub_;
+    using OdomCloudSyncPolicy = message_filters::sync_policies::ApproximateTime <
+      nav_msgs::msg::Odometry, sensor_msgs::msg::PointCloud2 >;
+    std::shared_ptr < message_filters::Synchronizer < OdomCloudSyncPolicy >> odom_cloud_sync_;
     Eigen::Vector3d last_submap_position_ {0, 0, 0};
     bool last_submap_position_valid_ {false};
     double accumulated_distance_ {0.0};
-    void receiveOdometry(const nav_msgs::msg::Odometry & msg);
-    void receiveCloud(const sensor_msgs::msg::PointCloud2::SharedPtr msg);
-    void tryCreateSubmap();
-    nav_msgs::msg::Odometry latest_odom_;
-    bool latest_odom_valid_ {false};
-    rclcpp::Time latest_cloud_stamp_ {0, 0, RCL_ROS_TIME};
+    bool first_synced_input_logged_ {false};
+    void receiveSyncedOdomCloud(
+      const nav_msgs::msg::Odometry::ConstSharedPtr & odom_msg,
+      const sensor_msgs::msg::PointCloud2::ConstSharedPtr & cloud_msg);
+    void tryCreateSubmap(
+      const nav_msgs::msg::Odometry & odom_msg,
+      const sensor_msgs::msg::PointCloud2 & cloud_msg);
 
     // GNSS constraints for georeferenced mapping
     bool use_gnss_ {false};

--- a/graph_based_slam/include/graph_based_slam/submap_creation.hpp
+++ b/graph_based_slam/include/graph_based_slam/submap_creation.hpp
@@ -1,0 +1,81 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__SUBMAP_CREATION_HPP_
+#define GRAPH_BASED_SLAM__SUBMAP_CREATION_HPP_
+
+#include <Eigen/Core>
+
+namespace graphslam
+{
+namespace submap_creation
+{
+
+struct Decision
+{
+  // Append a new submap at this pose.
+  bool create {false};
+  // The pose moved implausibly far since the last submap and was rejected.
+  bool jump_rejected {false};
+  // Distance from the previous submap position (0 for the very first submap).
+  double distance {0.0};
+};
+
+// The submap spacing decision extracted verbatim from the odom-input path:
+// the first valid pose always creates a submap; afterwards a pose creates one
+// when it has moved at least `distance_threshold` since the previous submap,
+// unless the step exceeds `max_jump` (teleport guard), which rejects the pose
+// without consuming it as the new reference.
+inline Decision evaluate(
+  const Eigen::Vector3d & pos, bool last_position_valid,
+  const Eigen::Vector3d & last_position, double distance_threshold,
+  double max_jump = 100.0)
+{
+  Decision decision;
+  if (!last_position_valid) {
+    decision.create = true;
+    return decision;
+  }
+  const double dist = (pos - last_position).norm();
+  decision.distance = dist;
+  if (dist < distance_threshold) {
+    return decision;
+  }
+  if (dist > max_jump) {
+    decision.jump_rejected = true;
+    return decision;
+  }
+  decision.create = true;
+  return decision;
+}
+
+}  // namespace submap_creation
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__SUBMAP_CREATION_HPP_

--- a/graph_based_slam/package.xml
+++ b/graph_based_slam/package.xml
@@ -19,6 +19,7 @@
   <depend>tf2_eigen</depend>
   <depend>pcl_conversions</depend>
   <depend>lidarslam_msgs</depend>
+  <depend>message_filters</depend>
   <depend>ndt_omp_ros2</depend>
   <depend>libg2o</depend>
   <depend>libpcl-all-dev</depend>

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -40,6 +40,7 @@
 #include "graph_based_slam/adjacent_edge_auto_scale.hpp"
 #include "graph_based_slam/bev_mutual_visibility.hpp"
 #include "graph_based_slam/dynamic_object_filter.hpp"
+#include "graph_based_slam/submap_creation.hpp"
 #include "g2o/core/robust_kernel_impl.h"
 #define GRAPH_BASED_SLAM_WITH_G2O 1
 #include "graph_based_slam/loop_edge_robustifier.hpp"
@@ -1012,6 +1013,8 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("use_odom_input", use_odom_input_);
   declare_parameter("submap_distance_threshold", 1.5);
   get_parameter("submap_distance_threshold", submap_distance_threshold_);
+  declare_parameter("odom_cloud_sync_queue_size", 100);
+  get_parameter("odom_cloud_sync_queue_size", odom_cloud_sync_queue_size_);
   std::cout << "use_odom_input:" << std::boolalpha << use_odom_input_ << std::endl;
   if (use_odom_input_) {
     std::cout << "submap_distance_threshold[m]:" << submap_distance_threshold_ << std::endl;
@@ -1116,13 +1119,28 @@ void GraphBasedSlamComponent::initializePubSub()
     "map_array", rclcpp::QoS(rclcpp::KeepLast(1)).reliable(), map_array_callback);
 
   if (use_odom_input_) {
-    odom_sub_ = create_subscription<nav_msgs::msg::Odometry>(
-      "odom_input", 10,
-      std::bind(&GraphBasedSlamComponent::receiveOdometry, this, std::placeholders::_1));
-    cloud_sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
-      "cloud_input", rclcpp::SensorDataQoS(),
-      std::bind(&GraphBasedSlamComponent::receiveCloud, this, std::placeholders::_1));
-    RCLCPP_INFO(get_logger(), "Direct odom+cloud input mode enabled");
+    // Deep queues so a long loop-search callback cannot overflow the
+    // subscription histories and drop frames, plus stamp-based pairing so
+    // the submap pose/cloud match is a function of the data, not of the
+    // executor schedule. Reliability is kept as before (odom reliable,
+    // cloud sensor-data/best-effort) for publisher compatibility.
+    const size_t sync_depth = static_cast<size_t>(std::max(odom_cloud_sync_queue_size_, 1));
+    rmw_qos_profile_t odom_qos = rmw_qos_profile_default;
+    odom_qos.depth = sync_depth;
+    rmw_qos_profile_t cloud_qos = rmw_qos_profile_sensor_data;
+    cloud_qos.depth = sync_depth;
+    odom_sync_sub_ = std::make_shared<message_filters::Subscriber<nav_msgs::msg::Odometry>>(
+      this, "odom_input", odom_qos);
+    cloud_sync_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::PointCloud2>>(
+      this, "cloud_input", cloud_qos);
+    odom_cloud_sync_ = std::make_shared<message_filters::Synchronizer<OdomCloudSyncPolicy>>(
+      OdomCloudSyncPolicy(static_cast<uint32_t>(sync_depth)), *odom_sync_sub_, *cloud_sync_sub_);
+    odom_cloud_sync_->registerCallback(
+      std::bind(
+        &GraphBasedSlamComponent::receiveSyncedOdomCloud, this, std::placeholders::_1,
+        std::placeholders::_2));
+    RCLCPP_INFO(
+      get_logger(), "Direct odom+cloud input mode enabled (stamp-synced, queue %zu)", sync_depth);
   }
 
   std::chrono::milliseconds period(loop_detection_period_);
@@ -3204,63 +3222,55 @@ Eigen::Quaterniond GraphBasedSlamComponent::integrateImuRotation(double t0, doub
   return delta_q;
 }
 
-void GraphBasedSlamComponent::receiveCloud(const sensor_msgs::msg::PointCloud2::SharedPtr msg)
+void GraphBasedSlamComponent::receiveSyncedOdomCloud(
+  const nav_msgs::msg::Odometry::ConstSharedPtr & odom_msg,
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & cloud_msg)
 {
-  if (debug_flag_ && !latest_cloud_) {
-    RCLCPP_INFO(get_logger(), "First cloud received, %zu bytes", msg->data.size());
-  }
-  latest_cloud_ = msg;
-  latest_cloud_stamp_ = rclcpp::Time(msg->header.stamp);
-  // When cloud arrives, try to create submap with latest odom
-  tryCreateSubmap();
-}
-
-void GraphBasedSlamComponent::receiveOdometry(const nav_msgs::msg::Odometry & msg)
-{
-  // Buffer latest odom
-  Eigen::Vector3d pos(msg.pose.pose.position.x, msg.pose.pose.position.y, msg.pose.pose.position.z);
+  Eigen::Vector3d pos(
+    odom_msg->pose.pose.position.x, odom_msg->pose.pose.position.y,
+    odom_msg->pose.pose.position.z);
   if (!std::isfinite(pos.x()) || !std::isfinite(pos.y()) || !std::isfinite(pos.z())) {
     return;
   }
-  if (debug_flag_ && !latest_odom_valid_) {
-    RCLCPP_INFO(get_logger(), "First odom received: (%.2f, %.2f, %.2f)", pos.x(), pos.y(), pos.z());
+  if (debug_flag_ && !first_synced_input_logged_) {
+    first_synced_input_logged_ = true;
+    RCLCPP_INFO(
+      get_logger(), "First synced odom+cloud pair: (%.2f, %.2f, %.2f), %zu bytes", pos.x(),
+      pos.y(), pos.z(), cloud_msg->data.size());
   }
-  latest_odom_ = msg;
-  latest_odom_valid_ = true;
+  tryCreateSubmap(*odom_msg, *cloud_msg);
 }
 
-void GraphBasedSlamComponent::tryCreateSubmap()
+void GraphBasedSlamComponent::tryCreateSubmap(
+  const nav_msgs::msg::Odometry & odom_msg,
+  const sensor_msgs::msg::PointCloud2 & cloud_msg)
 {
-  if (!latest_odom_valid_ || !latest_cloud_) {return;}
-
   Eigen::Vector3d pos(
-    latest_odom_.pose.pose.position.x,
-    latest_odom_.pose.pose.position.y,
-    latest_odom_.pose.pose.position.z);
+    odom_msg.pose.pose.position.x,
+    odom_msg.pose.pose.position.y,
+    odom_msg.pose.pose.position.z);
 
-  // Check distance threshold
-  if (last_submap_position_valid_) {
-    double dist = (pos - last_submap_position_).norm();
-    if (dist < submap_distance_threshold_) {return;}
-    if (dist > 100.0) {return;}
-    accumulated_distance_ += dist;
-  }
+  // Check distance threshold (semantics pinned by test_submap_creation.cpp)
+  const submap_creation::Decision decision = submap_creation::evaluate(
+    pos, last_submap_position_valid_, last_submap_position_, submap_distance_threshold_);
+  if (!decision.create) {return;}
+  accumulated_distance_ += decision.distance;
   last_submap_position_ = pos;
   last_submap_position_valid_ = true;
 
   // Create SubMap (use "map" frame for SLAM output regardless of odom frame)
   lidarslam_msgs::msg::SubMap submap;
-  submap.header.stamp = latest_odom_.header.stamp;
+  submap.header.stamp = odom_msg.header.stamp;
   submap.header.frame_id = "map";
   submap.distance = accumulated_distance_;
-  submap.pose = latest_odom_.pose.pose;
-  submap.cloud = *latest_cloud_;
-  submap.cloud.header.frame_id = latest_odom_.child_frame_id;
+  submap.pose = odom_msg.pose.pose;
+  submap.cloud = cloud_msg;
+  submap.cloud.header.frame_id = odom_msg.child_frame_id;
 
   int n;
   {
     std::lock_guard<std::mutex> lock(mtx_);
-    map_array_msg_.header.stamp = latest_odom_.header.stamp;
+    map_array_msg_.header.stamp = odom_msg.header.stamp;
     map_array_msg_.header.frame_id = "map";
     map_array_msg_.submaps.push_back(submap);
     n = map_array_msg_.submaps.size();

--- a/graph_based_slam/test/test_submap_creation.cpp
+++ b/graph_based_slam/test/test_submap_creation.cpp
@@ -1,0 +1,109 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Characterization tests for the submap spacing decision (v0.6 Phase 1):
+// the semantics below are pinned to the historical odom-input behaviour in
+// tryCreateSubmap() before the extraction.
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Core>
+
+#include "graph_based_slam/submap_creation.hpp"
+
+namespace graphslam
+{
+namespace
+{
+
+TEST(SubmapCreation, FirstValidPoseAlwaysCreates)
+{
+  const auto d = submap_creation::evaluate(
+    Eigen::Vector3d(5.0, -2.0, 1.0), false, Eigen::Vector3d::Zero(), 1.5);
+  EXPECT_TRUE(d.create);
+  EXPECT_FALSE(d.jump_rejected);
+  EXPECT_DOUBLE_EQ(0.0, d.distance);
+}
+
+TEST(SubmapCreation, BelowThresholdDoesNotCreate)
+{
+  const auto d = submap_creation::evaluate(
+    Eigen::Vector3d(1.0, 0.0, 0.0), true, Eigen::Vector3d::Zero(), 1.5);
+  EXPECT_FALSE(d.create);
+  EXPECT_FALSE(d.jump_rejected);
+  EXPECT_DOUBLE_EQ(1.0, d.distance);
+}
+
+TEST(SubmapCreation, AtThresholdCreates)
+{
+  // Historical comparison is `dist < threshold` -> skip, so exactly the
+  // threshold distance creates a submap.
+  const auto d = submap_creation::evaluate(
+    Eigen::Vector3d(1.5, 0.0, 0.0), true, Eigen::Vector3d::Zero(), 1.5);
+  EXPECT_TRUE(d.create);
+  EXPECT_DOUBLE_EQ(1.5, d.distance);
+}
+
+TEST(SubmapCreation, JumpBeyondMaxIsRejectedNotCreated)
+{
+  const auto d = submap_creation::evaluate(
+    Eigen::Vector3d(150.0, 0.0, 0.0), true, Eigen::Vector3d::Zero(), 1.5);
+  EXPECT_FALSE(d.create);
+  EXPECT_TRUE(d.jump_rejected);
+  EXPECT_DOUBLE_EQ(150.0, d.distance);
+}
+
+TEST(SubmapCreation, ExactlyMaxJumpStillCreates)
+{
+  // Historical comparison is `dist > 100.0` -> reject, so exactly 100 m
+  // passes the guard.
+  const auto d = submap_creation::evaluate(
+    Eigen::Vector3d(100.0, 0.0, 0.0), true, Eigen::Vector3d::Zero(), 1.5);
+  EXPECT_TRUE(d.create);
+  EXPECT_FALSE(d.jump_rejected);
+}
+
+TEST(SubmapCreation, DistanceIsEuclidean3d)
+{
+  const auto d = submap_creation::evaluate(
+    Eigen::Vector3d(3.0, 4.0, 12.0), true, Eigen::Vector3d::Zero(), 1.5);
+  EXPECT_TRUE(d.create);
+  EXPECT_DOUBLE_EQ(13.0, d.distance);
+}
+
+TEST(SubmapCreation, CustomMaxJump)
+{
+  const auto d = submap_creation::evaluate(
+    Eigen::Vector3d(50.0, 0.0, 0.0), true, Eigen::Vector3d::Zero(), 1.5, 40.0);
+  EXPECT_FALSE(d.create);
+  EXPECT_TRUE(d.jump_rejected);
+}
+
+}  // namespace
+}  // namespace graphslam


### PR DESCRIPTION
## Summary
First Phase 1 PR of the v0.6 deterministic refactor (docs/roadmap/v0.6.md): make the odom-input submap stream a function of the data instead of the executor schedule.

**The bug**: odom-input mode paired each arriving cloud with whatever odometry happened to be newest, and subscribed clouds with SensorDataQoS (best_effort, **depth 5**). When the loop-search callback blocks the single-threaded executor, the queue overflows — the replay harness showed a byte-identical input bag producing 603/598/599 submaps across runs, i.e. **~6% of frames silently dropped**, nondeterministically.

**The fix**
- `message_filters` ApproximateTime pairing of `odom_input` + `cloud_input` (RKO-LIO stamps both identically per scan, so pairing becomes exact).
- Deep subscription queues (`odom_cloud_sync_queue_size`, default 100); reliability semantics unchanged for publisher compatibility.
- Submap spacing decision extracted to `submap_creation.hpp` (12th tested pure header) with characterization tests pinning the historical semantics (threshold boundary, 100 m teleport guard, first pose).

## Evidence (replay harness, same recorded input bag)
| metric | before | after |
|---|---|---|
| submaps per run | 603 / 598 / 599 | **639 / 640 / 639** |
| APE σ | 0.050 | **0.032** |
| loop-edge sets | differ per run | still differ (lives in the wall-clock loop scheduler — Phase 2's target, per the attribution note) |

Live-pipeline A/B (3× new vs 3× old, shipped MID-360 preset, GLIM crossval): baseline APE 5.10 ± 1.16 vs 3.96 ± 0.68 — overlapping spreads, not distinguishable at n=3 on this deliberately noisy report-only agreement substrate. The **blocking** GT gates score dense raw odometry (frontend output) and are unaffected by backend input pairing by construction. Full data appended to `docs/research/determinism-variance-attribution.md`.

## Test plan
- `test_submap_creation.cpp`: 7 characterization tests.
- Package tests: 953, 0 failures (lint clean incl. uncrustify/cpplint).
- Replay before/after + live A/B above.