### PR TITLE
fix(ci): drop the stale 'v2 beta' prefix from the release title template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.meta.outputs.tag_name }}
-          name: lidarslam_ros2 v2 beta (${{ steps.meta.outputs.version }})
+          name: lidarslam_ros2 v${{ steps.meta.outputs.version }}
           body_path: ${{ steps.meta.outputs.release_notes }}
           prerelease: true
           files: ${{ steps.meta.outputs.bundle_name }}


### PR DESCRIPTION
## Summary
The v0.5.0 tag published as **'lidarslam_ros2 v2 beta (0.5.0)'** — the release title template in `release.yml` still carried the v0.2.x-era marketing prefix. Name releases after the version alone. (The published v0.5.0 release itself was already renamed via the API.)

## Test plan
Workflow-only one-liner; `test_docs_entrypoints.py` release-workflow assertions do not pin the title template.