### PR TITLE
fix(slam): defined tie-breaks on every loop-candidate ranking (v0.6 Phase 1)

### DIFF
--- a/graph_based_slam/include/graph_based_slam/scan_context.hpp
+++ b/graph_based_slam/include/graph_based_slam/scan_context.hpp
@@ -297,7 +297,10 @@ public:
 
       std::sort(
         verified.begin(), verified.end(),
-        [](const Match & lhs, const Match & rhs) {return lhs.distance < rhs.distance;});
+        [](const Match & lhs, const Match & rhs) {
+          if (lhs.distance != rhs.distance) {return lhs.distance < rhs.distance;}
+          return lhs.submap_id < rhs.submap_id;
+        });
       for (const auto & candidate : verified) {
         if (candidate.distance >= threshold) {
           continue;

--- a/graph_based_slam/include/graph_based_slam/solid_descriptor.hpp
+++ b/graph_based_slam/include/graph_based_slam/solid_descriptor.hpp
@@ -269,8 +269,9 @@ public:
         scored_candidates.begin(),
         scored_candidates.begin() + k,
         scored_candidates.end(),
-        [](const auto & lhs, const auto & rhs) {
-          return lhs.first > rhs.first;
+        [this](const auto & lhs, const auto & rhs) {
+          if (lhs.first != rhs.first) {return lhs.first > rhs.first;}
+          return submap_ids[lhs.second] < submap_ids[rhs.second];
         });
 
       for (int idx = 0; idx < k; ++idx) {

--- a/graph_based_slam/include/graph_based_slam/submap_bev_descriptor.hpp
+++ b/graph_based_slam/include/graph_based_slam/submap_bev_descriptor.hpp
@@ -267,7 +267,10 @@ public:
 
       std::sort(
         verified.begin(), verified.end(),
-        [](const Match & lhs, const Match & rhs) {return lhs.distance < rhs.distance;});
+        [](const Match & lhs, const Match & rhs) {
+          if (lhs.distance != rhs.distance) {return lhs.distance < rhs.distance;}
+          return lhs.submap_id < rhs.submap_id;
+        });
       for (const auto & match : verified) {
         if (match.distance >= threshold) {
           continue;

--- a/graph_based_slam/include/graph_based_slam/triangle_descriptor.hpp
+++ b/graph_based_slam/include/graph_based_slam/triangle_descriptor.hpp
@@ -240,9 +240,16 @@ inline std::vector<Keypoint> extractKeypointsBEV(
     }
   }
 
+  // Salience ties resolve by position so the max_keypoints cutoff is a pure
+  // function of the keypoint set (v0.6 determinism contract).
   std::sort(
     candidates.begin(), candidates.end(),
-    [](const Keypoint & a, const Keypoint & b) {return a.salience > b.salience;});
+    [](const Keypoint & a, const Keypoint & b) {
+      if (a.salience != b.salience) {return a.salience > b.salience;}
+      if (a.position.x() != b.position.x()) {return a.position.x() < b.position.x();}
+      if (a.position.y() != b.position.y()) {return a.position.y() < b.position.y();}
+      return a.position.z() < b.position.z();
+    });
 
   const int keep = std::min<int>(cfg.max_keypoints, static_cast<int>(candidates.size()));
   result.assign(candidates.begin(), candidates.begin() + keep);

--- a/graph_based_slam/include/graph_based_slam/triangle_descriptor_database.hpp
+++ b/graph_based_slam/include/graph_based_slam/triangle_descriptor_database.hpp
@@ -287,9 +287,14 @@ inline std::vector<SubmapVote> accumulateVotes(
   for (const auto & kv : counts) {
     result.push_back({kv.first, kv.second});
   }
+  // Defined total order: vote ties resolve to the lower submap id instead of
+  // the unordered_map iteration order (v0.6 determinism contract).
   std::sort(
     result.begin(), result.end(),
-    [](const SubmapVote & a, const SubmapVote & b) {return a.votes > b.votes;});
+    [](const SubmapVote & a, const SubmapVote & b) {
+      if (a.votes != b.votes) {return a.votes > b.votes;}
+      return a.submap_id < b.submap_id;
+    });
   return result;
 }
 

--- a/graph_based_slam/test/test_scan_context.cpp
+++ b/graph_based_slam/test/test_scan_context.cpp
@@ -116,3 +116,23 @@ TEST(ScanContextDatabase, QueryTopMatchesWithYawReturnsShift)
   EXPECT_NEAR(matches[0].distance, 0.0, 1e-9);
   EXPECT_EQ(matches[0].yaw_shift, 7);
 }
+
+TEST(ScanContextDatabase, EqualDistanceTiesResolveToLowerSubmapId)
+{
+  // Two identical descriptors tie exactly; the defined order is by submap id,
+  // not insertion order (the higher id is inserted first on purpose).
+  graphslam::ScanContext::Database db;
+  db.add(20, makeDescriptor(0));
+  db.add(10, makeDescriptor(0));
+
+  const auto matches = db.queryTopMatchesWithYaw(
+    makeDescriptor(0),
+    /*num_matches=*/ 2,
+    /*num_candidates=*/ 2,
+    /*exclude_recent=*/ 0,
+    /*threshold=*/ 0.5);
+
+  ASSERT_EQ(matches.size(), 2u);
+  EXPECT_EQ(matches[0].submap_id, 10);
+  EXPECT_EQ(matches[1].submap_id, 20);
+}

--- a/graph_based_slam/test/test_solid_descriptor.cpp
+++ b/graph_based_slam/test/test_solid_descriptor.cpp
@@ -128,3 +128,25 @@ TEST(SolidDescriptor, DatabaseReturnsMatchingSubmapId)
   EXPECT_EQ(match.first, 7);
   EXPECT_GT(match.second, 0.5);
 }
+
+TEST(SolidDescriptor, EqualSimilarityTiesResolveToLowerSubmapId)
+{
+  // Identical descriptors tie exactly; the defined order is by submap id,
+  // not insertion order (the higher id is inserted first on purpose).
+  const auto descriptor =
+    graphslam::SolidDescriptor::computeDescriptor(makeForwardFacingCloud());
+  graphslam::SolidDescriptor::Database db;
+  db.add(20, descriptor);
+  db.add(10, descriptor);
+
+  const auto matches = db.queryTopMatchesWithYaw(
+    descriptor,
+    /*num_matches=*/ 2,
+    /*num_candidates=*/ 2,
+    /*exclude_recent=*/ 0,
+    /*min_similarity=*/ 0.0);
+
+  ASSERT_EQ(matches.size(), 2u);
+  EXPECT_EQ(matches[0].submap_id, 10);
+  EXPECT_EQ(matches[1].submap_id, 20);
+}

--- a/graph_based_slam/test/test_submap_bev_descriptor.cpp
+++ b/graph_based_slam/test/test_submap_bev_descriptor.cpp
@@ -146,3 +146,25 @@ TEST(SubmapBEVDescriptor, NextSubmapIndexTracksSequentialInsertion)
   db.add(1, graphslam::SubmapBEVDescriptor::computeDescriptor(makeDifferentCloud()));
   EXPECT_EQ(db.nextSubmapIndex(), 2);
 }
+
+TEST(SubmapBEVDescriptor, EqualDistanceTiesResolveToLowerSubmapId)
+{
+  // Identical descriptors tie exactly; the defined order is by submap id,
+  // not insertion order (the higher id is inserted first on purpose).
+  const auto descriptor =
+    graphslam::SubmapBEVDescriptor::computeDescriptor(makeAsymmetricCloud());
+  graphslam::SubmapBEVDescriptor::Database db;
+  db.add(20, descriptor);
+  db.add(10, descriptor);
+
+  const auto matches = db.queryTopMatchesWithYaw(
+    descriptor,
+    /*num_matches=*/ 2,
+    /*num_candidates=*/ 2,
+    /*exclude_recent=*/ 0,
+    /*threshold=*/ 0.5);
+
+  ASSERT_EQ(matches.size(), 2u);
+  EXPECT_EQ(matches[0].submap_id, 10);
+  EXPECT_EQ(matches[1].submap_id, 20);
+}

--- a/graph_based_slam/test/test_triangle_descriptor_database.cpp
+++ b/graph_based_slam/test/test_triangle_descriptor_database.cpp
@@ -746,3 +746,35 @@ TEST(TriangleDatabase, KeypointsAccessorReturnsStoredVector)
   const auto & missing = db.keypoints(7777);
   EXPECT_TRUE(missing.empty());
 }
+
+TEST(TriangleVotes, VoteTiesResolveToLowerSubmapId)
+{
+  // Two submaps with identical keypoints/triangles collect identical votes;
+  // the defined order is by submap id, independent of unordered_map iteration
+  // and of insertion order (the higher id is inserted first on purpose).
+  HashConfig cfg;
+  cfg.edge_bin_m = 1.0f;
+  VoteConfig vote_cfg;
+
+  std::vector<Keypoint> kps;
+  auto push = [&kps](float x, float y) {
+      Keypoint k;
+      k.position = Eigen::Vector3f(x, y, 0.0f);
+      k.salience = 1.0f;
+      kps.push_back(k);
+    };
+  push(0.0f, 0.0f);
+  push(6.0f, 0.0f);
+  push(3.0f, 4.0f);
+  TriangleDescriptor t = makeTriangle(kps, 0, 1, 2);
+
+  TriangleDatabase db;
+  db.addSubmap(20, kps, {t}, cfg);
+  db.addSubmap(10, kps, {t}, cfg);
+
+  const auto votes = accumulateVotes(db, kps, {t}, cfg, vote_cfg);
+  ASSERT_EQ(votes.size(), 2u);
+  EXPECT_EQ(votes[0].votes, votes[1].votes);
+  EXPECT_EQ(votes[0].submap_id, 10);
+  EXPECT_EQ(votes[1].submap_id, 20);
+}


### PR DESCRIPTION
## Summary
Second Phase 1 PR of the v0.6 deterministic refactor: every loop-candidate / vote ranking now has a **defined total order** (score first, then submap id; position-lexicographic for keypoints), making each ranked result a pure function of the candidate set.

Audit found five score-only comparators with unspecified tie order:
| site | before | after |
|---|---|---|
| triangle `accumulateVotes` | unordered_map iteration → sort on votes alone (worst case) | (votes ↓, submap_id ↑) |
| scan context `queryTopMatchesWithYaw` | distance only | (distance ↑, submap_id ↑) |
| BEV `queryTopMatchesWithYaw` | distance only | (distance ↑, submap_id ↑) |
| SOLiD `partial_sort` | similarity only | (similarity ↓, **submap_id** ↑) |
| triangle keypoint selection (feeds the `max_keypoints` cutoff) | salience only | (salience ↓, position lex ↑) |

Audit byproducts: **no RNG exists anywhere in the loop-closure path** (the triangle 'RANSAC' enumerates pairs in fixed order) — the roadmap's 'seed the RANSAC' item is moot; the distance-candidate ranking already tie-breaks by index via `pair<double,int>` ordering.

## Why this matters even though libstdc++ replays identically
Same-binary replay was accidentally deterministic; the orders were unspecified by contract — fragile across platforms/stdlibs (the buildfarm builds both Humble and Jazzy) and unstable under single-element upstream perturbations, which currently cascade arbitrarily through ties. The Phase 2 hard gate (identical loop-edge sets) needs specified orders, not accidental ones.

## Tests
Four new tie tests insert **identical descriptors with the higher submap id first** and assert the lower id wins (proving the order is not insertion order). One of them immediately caught the SOLiD comparator tie-breaking on descriptor index instead of submap id — fixed to submap id for a uniform spec.

Behavior on real data unchanged: exact float-score ties are measure-zero outside synthetic inputs, and all descriptor sources are opt-in (default off) on every preset. Package tests: 957, 0 failures (lint clean).