### PR TITLE
refactor(slam): extract the pose-graph optimization as a pure function (v0.6 Phase 1)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -193,6 +193,22 @@ if(BUILD_TESTING)
     target_include_directories(test_submap_creation PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_pose_graph_optimization
+    test/test_pose_graph_optimization.cpp
+  )
+  if(TARGET test_pose_graph_optimization)
+    target_include_directories(
+      test_pose_graph_optimization PRIVATE include ${EIGEN3_INCLUDE_DIR}
+    )
+    target_link_libraries(
+      test_pose_graph_optimization
+      g2o::core
+      g2o::types_slam3d
+      g2o::solver_eigen
+      g2o::stuff
+    )
+  endif()
+  ament_add_gtest(
     test_registration_determinism
     test/test_registration_determinism.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -399,6 +399,7 @@ private:
 
     // Autoware-compatible grid-divided PCD map output
     std::string map_save_dir_ {"."};
+    std::string save_pose_graph_path_ {"pose_graph.g2o"};
     double map_grid_size_x_ {20.0};
     double map_grid_size_y_ {20.0};
     double map_leaf_size_ {0.2};

--- a/graph_based_slam/include/graph_based_slam/pose_graph_optimization.hpp
+++ b/graph_based_slam/include/graph_based_slam/pose_graph_optimization.hpp
@@ -1,0 +1,319 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__POSE_GRAPH_OPTIMIZATION_HPP_
+#define GRAPH_BASED_SLAM__POSE_GRAPH_OPTIMIZATION_HPP_
+
+// The g2o pose-graph assembly + optimization extracted from
+// doPoseAdjustment() as a pure function of plain data (v0.6 Phase 1;
+// this becomes the Phase 2 BackendCore optimize step). The construction
+// order mirrors the historical code exactly — vertex i, then its adjacent
+// edges, then IMU edges, loop edges, GNSS anchors — so optimization
+// results match the pre-extraction behaviour bit for bit.
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Geometry>  // NOLINT(build/include_order)
+
+#include "g2o/core/block_solver.h"
+#include "g2o/core/optimization_algorithm_levenberg.h"
+#include "g2o/core/robust_kernel_impl.h"
+#include "g2o/core/sparse_optimizer.h"
+#include "g2o/solvers/eigen/linear_solver_eigen.h"
+#include "g2o/types/slam3d/edge_se3.h"
+#include "g2o/types/slam3d/vertex_se3.h"
+#ifndef GRAPH_BASED_SLAM_WITH_G2O
+#define GRAPH_BASED_SLAM_WITH_G2O 1
+#endif
+#include "graph_based_slam/loop_edge_robustifier.hpp"
+
+namespace graphslam
+{
+namespace pose_graph
+{
+
+struct SubmapNode
+{
+  Eigen::Isometry3d pose {Eigen::Isometry3d::Identity()};
+};
+
+struct LoopConstraint
+{
+  int from {0};
+  int to {0};
+  Eigen::Isometry3d relative_pose {Eigen::Isometry3d::Identity()};
+  double fitness_score {0.0};
+};
+
+// Pre-built relative measurement between submap `from` and `to` whose
+// rotation comes from IMU integration (the caller owns the IMU buffer).
+struct ImuRotationConstraint
+{
+  int from {0};
+  int to {0};
+  Eigen::Isometry3d measurement {Eigen::Isometry3d::Identity()};
+};
+
+// Pre-matched GNSS anchor for one submap (the caller owns the GNSS buffer
+// and the nearest-measurement matching).
+struct GnssConstraint
+{
+  int submap_index {0};
+  Eigen::Vector3d position {Eigen::Vector3d::Zero()};
+  Eigen::Vector3d info_diag {Eigen::Vector3d::Zero()};
+};
+
+struct AdjacentEdgeConfig
+{
+  int num_adjacent_pose_constraints {5};
+  bool split_trans_rot {false};
+  double info_weight {1000.0};
+  double info_weight_trans {1000.0};
+  double info_weight_rot {1000.0};
+};
+
+struct LoopEdgeConfig
+{
+  double info_weight {100.0};
+  std::string robust_kernel_type {"NONE"};
+  double robust_kernel_delta {1.0};
+};
+
+struct ImuEdgeConfig
+{
+  double info_roll_pitch {100.0};
+  double info_yaw {10.0};
+};
+
+struct OptimizationResult
+{
+  std::vector<Eigen::Isometry3d> poses;
+  // Post-optimization adjacent-edge chi2 contributions, for the caller's
+  // NIS auto-scale update (finite values only, in edge construction order).
+  std::vector<double> adjacent_chi2;
+  std::vector<double> adjacent_trans_chi2;
+  std::vector<double> adjacent_rot_chi2;
+};
+
+// What to collect for the caller's NIS auto-scale update; NONE skips the
+// post-optimization error recomputation entirely (matching the historical
+// cost when auto-scale is off).
+enum class Chi2Collection
+{
+  NONE,
+  UNIFIED,
+  SPLIT,
+};
+
+inline OptimizationResult optimizePoseGraph(
+  const std::vector<SubmapNode> & submaps,
+  const std::vector<LoopConstraint> & loop_constraints,
+  const std::vector<ImuRotationConstraint> & imu_constraints,
+  const std::vector<GnssConstraint> & gnss_constraints,
+  const AdjacentEdgeConfig & adjacent_cfg,
+  const LoopEdgeConfig & loop_cfg,
+  const ImuEdgeConfig & imu_cfg,
+  Chi2Collection chi2_collection,
+  int iterations = 10,
+  const std::string & save_path = std::string())
+{
+  g2o::SparseOptimizer optimizer;
+  optimizer.setVerbose(false);
+  std::unique_ptr<g2o::BlockSolver_6_3::LinearSolverType> linear_solver =
+    std::make_unique<g2o::LinearSolverEigen<g2o::BlockSolver_6_3::PoseMatrixType>>();
+  g2o::OptimizationAlgorithmLevenberg * solver = new g2o::OptimizationAlgorithmLevenberg(
+    std::make_unique<g2o::BlockSolver_6_3>(std::move(linear_solver)));
+  optimizer.setAlgorithm(solver);
+
+  const int submaps_size = static_cast<int>(submaps.size());
+  std::vector<g2o::EdgeSE3 *> adjacent_edges;
+  for (int i = 0; i < submaps_size; i++) {
+    const Eigen::Isometry3d & pose = submaps[i].pose;
+
+    g2o::VertexSE3 * vertex_se3 = new g2o::VertexSE3();
+    vertex_se3->setId(i);
+    vertex_se3->setEstimate(pose);
+    if (i == 0) {vertex_se3->setFixed(true);}
+    optimizer.addVertex(vertex_se3);
+
+    if (i > 0) {
+      const int start_idx = std::max(0, i - adjacent_cfg.num_adjacent_pose_constraints);
+      for (int pre_idx = start_idx; pre_idx < i; pre_idx++) {
+        const Eigen::Isometry3d & pre_pose = submaps[pre_idx].pose;
+        Eigen::Isometry3d relative_pose = pre_pose.inverse() * pose;
+
+        const int separation = i - pre_idx;
+        const double sep_d = static_cast<double>(separation);
+        Eigen::Matrix<double, 6, 6> info_mat = Eigen::Matrix<double, 6, 6>::Zero();
+        if (adjacent_cfg.split_trans_rot) {
+          const double w_trans = adjacent_cfg.info_weight_trans / sep_d;
+          const double w_rot = adjacent_cfg.info_weight_rot / sep_d;
+          info_mat.topLeftCorner<3, 3>().diagonal().setConstant(w_trans);
+          info_mat.bottomRightCorner<3, 3>().diagonal().setConstant(w_rot);
+        } else {
+          const double edge_weight = adjacent_cfg.info_weight / sep_d;
+          info_mat = Eigen::Matrix<double, 6, 6>::Identity() * edge_weight;
+        }
+        g2o::EdgeSE3 * edge_se3 = new g2o::EdgeSE3();
+        edge_se3->setMeasurement(relative_pose);
+        edge_se3->setInformation(info_mat);
+        edge_se3->vertices()[0] = optimizer.vertex(pre_idx);
+        edge_se3->vertices()[1] = optimizer.vertex(i);
+        optimizer.addEdge(edge_se3);
+        adjacent_edges.push_back(edge_se3);
+      }
+    }
+  }
+
+  /* IMU rotation constraint edges */
+  for (const auto & imu_constraint : imu_constraints) {
+    g2o::EdgeSE3 * edge_se3 = new g2o::EdgeSE3();
+    edge_se3->setMeasurement(imu_constraint.measurement);
+
+    Eigen::Matrix<double, 6, 6> imu_info = Eigen::Matrix<double, 6, 6>::Zero();
+    // KNOWN MISPLACEMENT, preserved bit-for-bit by this extraction:
+    // g2o EdgeSE3 error order is (x, y, z, qx, qy, qz) — translation first
+    // (toVectorMQT, isometry3d_mappings.h) — so these weights land on the
+    // TRANSLATION block and the rotation block stays zero; as built, this
+    // edge never constrained rotation. Characterized in
+    // test_pose_graph_optimization.cpp; the behavioural fix is a separate
+    // follow-up PR.
+    imu_info(0, 0) = imu_cfg.info_roll_pitch;
+    imu_info(1, 1) = imu_cfg.info_roll_pitch;
+    imu_info(2, 2) = imu_cfg.info_yaw;
+    edge_se3->setInformation(imu_info);
+
+    edge_se3->vertices()[0] = optimizer.vertex(imu_constraint.from);
+    edge_se3->vertices()[1] = optimizer.vertex(imu_constraint.to);
+    optimizer.addEdge(edge_se3);
+  }
+
+  /* loop edges */
+  const auto loop_kernel_type =
+    graphslam::robust::parseLoopEdgeKernelType(loop_cfg.robust_kernel_type);
+  for (const auto & loop_constraint : loop_constraints) {
+    g2o::EdgeSE3 * edge_se3 = new g2o::EdgeSE3();
+    edge_se3->setMeasurement(loop_constraint.relative_pose);
+    const double fitness = std::max(loop_constraint.fitness_score, 1e-3);
+    Eigen::Matrix<double, 6, 6> loop_info_mat =
+      Eigen::Matrix<double, 6, 6>::Identity() * (loop_cfg.info_weight / fitness);
+    edge_se3->setInformation(loop_info_mat);
+    edge_se3->setRobustKernel(
+      graphslam::robust::makeLoopEdgeKernel(
+        loop_kernel_type, loop_cfg.robust_kernel_delta));
+    edge_se3->vertices()[0] = optimizer.vertex(loop_constraint.from);
+    edge_se3->vertices()[1] = optimizer.vertex(loop_constraint.to);
+    optimizer.addEdge(edge_se3);
+  }
+
+  /* GNSS position anchors */
+  int gnss_edges_added = 0;
+  for (const auto & gnss_constraint : gnss_constraints) {
+    const int gnss_vertex_id = submaps_size + gnss_edges_added;
+    g2o::VertexSE3 * gnss_vertex = new g2o::VertexSE3();
+    gnss_vertex->setId(gnss_vertex_id);
+    Eigen::Isometry3d gnss_pose = Eigen::Isometry3d::Identity();
+    gnss_pose.translation() = gnss_constraint.position;
+    gnss_vertex->setEstimate(gnss_pose);
+    gnss_vertex->setFixed(true);
+    optimizer.addVertex(gnss_vertex);
+
+    g2o::EdgeSE3 * edge = new g2o::EdgeSE3();
+    edge->setMeasurement(Eigen::Isometry3d::Identity());
+    Eigen::Matrix<double, 6, 6> gnss_info = Eigen::Matrix<double, 6, 6>::Zero();
+    // KNOWN MISPLACEMENT, preserved bit-for-bit by this extraction: with the
+    // g2o (x, y, z, qx, qy, qz) error order these weights land on the
+    // ROTATION block, so as built the GNSS anchor never pulled translation
+    // (consistent with the feature being documented as untested). See
+    // test_pose_graph_optimization.cpp; fix in a follow-up PR.
+    gnss_info(3, 3) = gnss_constraint.info_diag.x();
+    gnss_info(4, 4) = gnss_constraint.info_diag.y();
+    gnss_info(5, 5) = gnss_constraint.info_diag.z();
+    edge->setInformation(gnss_info);
+    edge->vertices()[0] = gnss_vertex;
+    edge->vertices()[1] = optimizer.vertex(gnss_constraint.submap_index);
+    optimizer.addEdge(edge);
+    gnss_edges_added++;
+  }
+
+  optimizer.initializeOptimization();
+  optimizer.optimize(iterations);
+  if (!save_path.empty()) {
+    optimizer.save(save_path.c_str());
+  }
+
+  OptimizationResult result;
+  result.poses.reserve(submaps_size);
+  for (int i = 0; i < submaps_size; i++) {
+    g2o::VertexSE3 * vertex_se3 = static_cast<g2o::VertexSE3 *>(optimizer.vertex(i));
+    result.poses.push_back(vertex_se3->estimate());
+  }
+
+  if (chi2_collection == Chi2Collection::SPLIT) {
+    result.adjacent_trans_chi2.reserve(adjacent_edges.size());
+    result.adjacent_rot_chi2.reserve(adjacent_edges.size());
+    for (auto * e : adjacent_edges) {
+      e->computeError();
+      const auto err = e->error();
+      const Eigen::Matrix<double, 6, 6> info = e->information();
+      const double w_t = info(0, 0);
+      const double w_r = info(3, 3);
+      const double trans = w_t * err.template head<3>().squaredNorm();
+      const double rot = w_r * err.template tail<3>().squaredNorm();
+      if (std::isfinite(trans)) {
+        result.adjacent_trans_chi2.push_back(trans);
+      }
+      if (std::isfinite(rot)) {
+        result.adjacent_rot_chi2.push_back(rot);
+      }
+    }
+  } else if (chi2_collection == Chi2Collection::UNIFIED) {
+    result.adjacent_chi2.reserve(adjacent_edges.size());
+    for (auto * e : adjacent_edges) {
+      e->computeError();
+      const double v = e->chi2();
+      if (std::isfinite(v)) {
+        result.adjacent_chi2.push_back(v);
+      }
+    }
+  }
+
+  return result;
+}
+
+}  // namespace pose_graph
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__POSE_GRAPH_OPTIMIZATION_HPP_

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -40,6 +40,7 @@
 #include "graph_based_slam/adjacent_edge_auto_scale.hpp"
 #include "graph_based_slam/bev_mutual_visibility.hpp"
 #include "graph_based_slam/dynamic_object_filter.hpp"
+#include "graph_based_slam/pose_graph_optimization.hpp"
 #include "graph_based_slam/submap_creation.hpp"
 #include "g2o/core/robust_kernel_impl.h"
 #define GRAPH_BASED_SLAM_WITH_G2O 1
@@ -347,6 +348,11 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     dynamic_object_filter_max_range_from_sensor_m_);
   declare_parameter("map_save_dir", std::string("."));
   get_parameter("map_save_dir", map_save_dir_);
+  // The launch files have always passed this; until v0.6 Phase 1 it was
+  // silently ignored and the graph went to the CWD. The default keeps the
+  // historical CWD behaviour.
+  declare_parameter("save_pose_graph_path", std::string("pose_graph.g2o"));
+  get_parameter("save_pose_graph_path", save_pose_graph_path_);
   declare_parameter("map_grid_size_x", 20.0);
   get_parameter("map_grid_size_x", map_grid_size_x_);
   declare_parameter("map_grid_size_y", 20.0);
@@ -2599,64 +2605,24 @@ void GraphBasedSlamComponent::doPoseAdjustment(
   const LoopEdges & loop_edges,
   bool do_save_map)
 {
-  g2o::SparseOptimizer optimizer;
-  optimizer.setVerbose(false);
-  std::unique_ptr<g2o::BlockSolver_6_3::LinearSolverType> linear_solver =
-    std::make_unique<g2o::LinearSolverEigen<g2o::BlockSolver_6_3::PoseMatrixType>>();
-  g2o::OptimizationAlgorithmLevenberg * solver = new g2o::OptimizationAlgorithmLevenberg(
-    std::make_unique<g2o::BlockSolver_6_3>(std::move(linear_solver)));
-
-  optimizer.setAlgorithm(solver);
-
+  /* Plain-data inputs for the extracted pose-graph optimization
+     (graph_based_slam/pose_graph_optimization.hpp); the IMU/GNSS buffers
+     and their matching stay in the node, the g2o assembly does not. */
   int submaps_size = map_array_msg.submaps.size();
-  std::vector<g2o::EdgeSE3 *> adjacent_edges;
+  std::vector<pose_graph::SubmapNode> submap_nodes;
+  submap_nodes.reserve(submaps_size);
   for (int i = 0; i < submaps_size; i++) {
     Eigen::Affine3d affine;
     Eigen::fromMsg(map_array_msg.submaps[i].pose, affine);
-    Eigen::Isometry3d pose(affine.matrix());
-
-    g2o::VertexSE3 * vertex_se3 = new g2o::VertexSE3();
-    vertex_se3->setId(i);
-    vertex_se3->setEstimate(pose);
-    if (i == 0) {vertex_se3->setFixed(true);}
-    optimizer.addVertex(vertex_se3);
-
-    if (i > 0) {
-      const int start_idx = std::max(0, i - num_adjacent_pose_cnstraints_);
-      for (int pre_idx = start_idx; pre_idx < i; pre_idx++) {
-        Eigen::Affine3d pre_affine;
-        Eigen::fromMsg(map_array_msg.submaps[pre_idx].pose, pre_affine);
-        Eigen::Isometry3d pre_pose(pre_affine.matrix());
-        Eigen::Isometry3d relative_pose = pre_pose.inverse() * pose;
-
-        const int separation = i - pre_idx;
-        const double sep_d = static_cast<double>(separation);
-        Eigen::Matrix<double, 6, 6> info_mat = Eigen::Matrix<double, 6, 6>::Zero();
-        if (adjacent_edge_info_auto_scale_split_trans_rot_) {
-          // Block-diag with independent translation / rotation weights, each
-          // attenuated by edge separation just like the unified scalar path.
-          const double w_trans = adjacent_edge_info_weight_trans_ / sep_d;
-          const double w_rot = adjacent_edge_info_weight_rot_ / sep_d;
-          info_mat.topLeftCorner<3, 3>().diagonal().setConstant(w_trans);
-          info_mat.bottomRightCorner<3, 3>().diagonal().setConstant(w_rot);
-        } else {
-          const double edge_weight = adjacent_edge_info_weight_ / sep_d;
-          info_mat = Eigen::Matrix<double, 6, 6>::Identity() * edge_weight;
-        }
-        g2o::EdgeSE3 * edge_se3 = new g2o::EdgeSE3();
-        edge_se3->setMeasurement(relative_pose);
-        edge_se3->setInformation(info_mat);
-        edge_se3->vertices()[0] = optimizer.vertex(pre_idx);
-        edge_se3->vertices()[1] = optimizer.vertex(i);
-        optimizer.addEdge(edge_se3);
-        adjacent_edges.push_back(edge_se3);
-      }
-    }
+    pose_graph::SubmapNode node;
+    node.pose = Eigen::Isometry3d(affine.matrix());
+    submap_nodes.push_back(node);
   }
-  /* IMU rotation constraint edges */
+
+  /* IMU rotation constraints (pre-pass over the IMU buffer) */
+  std::vector<pose_graph::ImuRotationConstraint> imu_constraints;
   if (use_imu_preintegration_ && submaps_size > 1) {
     std::lock_guard<std::mutex> imu_lock(imu_mtx_);
-    int imu_edges_added = 0;
     for (int i = 1; i < submaps_size; i++) {
       double t0 = rclcpp::Time(map_array_msg.submaps[i - 1].header.stamp).seconds();
       double t1 = rclcpp::Time(map_array_msg.submaps[i].header.stamp).seconds();
@@ -2665,63 +2631,39 @@ void GraphBasedSlamComponent::doPoseAdjustment(
       Eigen::Quaterniond imu_delta_q = integrateImuRotation(t0, t1);
       if (imu_delta_q.isApprox(Eigen::Quaterniond::Identity(), 1e-8)) {continue;}
 
-      // Build relative pose measurement: translation from odometry, rotation from IMU
-      Eigen::Affine3d affine_prev, affine_curr;
-      Eigen::fromMsg(map_array_msg.submaps[i - 1].pose, affine_prev);
-      Eigen::fromMsg(map_array_msg.submaps[i].pose, affine_curr);
-      Eigen::Isometry3d odom_prev(affine_prev.matrix());
-      Eigen::Isometry3d odom_curr(affine_curr.matrix());
-      Eigen::Isometry3d odom_relative = odom_prev.inverse() * odom_curr;
-
-      // Replace rotation with IMU-integrated rotation
-      Eigen::Isometry3d imu_relative = Eigen::Isometry3d::Identity();
-      imu_relative.linear() = imu_delta_q.toRotationMatrix();
-      imu_relative.translation() = odom_relative.translation();
-
-      g2o::EdgeSE3 * edge_se3 = new g2o::EdgeSE3();
-      edge_se3->setMeasurement(imu_relative);
-
-      // Information matrix: high for roll/pitch rotation, moderate for yaw, zero for translation
-      Eigen::Matrix<double, 6, 6> imu_info = Eigen::Matrix<double, 6, 6>::Zero();
-      // g2o EdgeSE3 information: [rot(3) | trans(3)] order
-      imu_info(0, 0) = imu_rotation_info_roll_pitch_;  // roll
-      imu_info(1, 1) = imu_rotation_info_roll_pitch_;  // pitch
-      imu_info(2, 2) = imu_rotation_info_yaw_;         // yaw
-      // translation: zero weight (don't trust IMU double integration)
-      edge_se3->setInformation(imu_info);
-
-      edge_se3->vertices()[0] = optimizer.vertex(i - 1);
-      edge_se3->vertices()[1] = optimizer.vertex(i);
-      optimizer.addEdge(edge_se3);
-      imu_edges_added++;
+      // Relative measurement: translation from odometry, rotation from IMU
+      Eigen::Isometry3d odom_relative =
+        submap_nodes[i - 1].pose.inverse() * submap_nodes[i].pose;
+      pose_graph::ImuRotationConstraint imu_constraint;
+      imu_constraint.from = i - 1;
+      imu_constraint.to = i;
+      imu_constraint.measurement = Eigen::Isometry3d::Identity();
+      imu_constraint.measurement.linear() = imu_delta_q.toRotationMatrix();
+      imu_constraint.measurement.translation() = odom_relative.translation();
+      imu_constraints.push_back(imu_constraint);
     }
     if (debug_flag_) {
-      RCLCPP_INFO(get_logger(), "Added %d IMU rotation constraint edges", imu_edges_added);
+      RCLCPP_INFO(
+        get_logger(), "Added %zu IMU rotation constraint edges", imu_constraints.size());
     }
   }
 
-  /* loop edge */
-  const auto loop_kernel_type =
-    graphslam::robust::parseLoopEdgeKernelType(loop_edge_robust_kernel_type_);
+  /* loop edges -> plain constraints */
+  std::vector<pose_graph::LoopConstraint> loop_constraints;
+  loop_constraints.reserve(loop_edges.size());
   for (const auto & loop_edge : loop_edges) {
-    g2o::EdgeSE3 * edge_se3 = new g2o::EdgeSE3();
-    edge_se3->setMeasurement(loop_edge.relative_pose);
-    const double fitness = std::max(loop_edge.fitness_score, 1e-3);
-    Eigen::Matrix<double, 6, 6> loop_info_mat =
-      Eigen::Matrix<double, 6, 6>::Identity() * (loop_edge_info_weight_ / fitness);
-    edge_se3->setInformation(loop_info_mat);
-    edge_se3->setRobustKernel(
-      graphslam::robust::makeLoopEdgeKernel(
-        loop_kernel_type, loop_edge_robust_kernel_delta_));
-    edge_se3->vertices()[0] = optimizer.vertex(loop_edge.pair_id.first);
-    edge_se3->vertices()[1] = optimizer.vertex(loop_edge.pair_id.second);
-    optimizer.addEdge(edge_se3);
+    pose_graph::LoopConstraint loop_constraint;
+    loop_constraint.from = loop_edge.pair_id.first;
+    loop_constraint.to = loop_edge.pair_id.second;
+    loop_constraint.relative_pose = loop_edge.relative_pose;
+    loop_constraint.fitness_score = loop_edge.fitness_score;
+    loop_constraints.push_back(loop_constraint);
   }
 
-  /* GNSS position constraints */
+  /* GNSS anchors (pre-pass: nearest-measurement match over the buffer) */
+  std::vector<pose_graph::GnssConstraint> gnss_constraints;
   if (use_gnss_ && gnss_origin_set_) {
     std::lock_guard<std::mutex> gnss_lock(gnss_mtx_);
-    int gnss_edges_added = 0;
     int gnss_rtk_like_edges_added = 0;
 
     for (int i = 0; i < submaps_size; i++) {
@@ -2740,45 +2682,52 @@ void GraphBasedSlamComponent::doPoseAdjustment(
       }
       if (!found || best_dt > 1.0) {continue;}  // Skip if no GNSS within 1 second
 
-      // Create unary-like constraint: edge from vertex i to a fixed GNSS position
-      // Use EdgeSE3 with vertex 0 = fixed GNSS pose, vertex 1 = submap
-      int gnss_vertex_id = submaps_size + gnss_edges_added;
-      g2o::VertexSE3 * gnss_vertex = new g2o::VertexSE3();
-      gnss_vertex->setId(gnss_vertex_id);
-      Eigen::Isometry3d gnss_pose = Eigen::Isometry3d::Identity();
-      gnss_pose.translation() = Eigen::Vector3d(best_gnss.x, best_gnss.y, best_gnss.z);
-      gnss_vertex->setEstimate(gnss_pose);
-      gnss_vertex->setFixed(true);
-      optimizer.addVertex(gnss_vertex);
-
-      g2o::EdgeSE3 * edge = new g2o::EdgeSE3();
-      edge->setMeasurement(Eigen::Isometry3d::Identity());
-      Eigen::Matrix<double, 6, 6> gnss_info = Eigen::Matrix<double, 6, 6>::Zero();
-      gnss_info(3, 3) = best_gnss.info_x;
-      gnss_info(4, 4) = best_gnss.info_y;
-      gnss_info(5, 5) = best_gnss.info_z;
-      edge->setInformation(gnss_info);
-      edge->vertices()[0] = gnss_vertex;
-      edge->vertices()[1] = optimizer.vertex(i);
-      optimizer.addEdge(edge);
+      pose_graph::GnssConstraint gnss_constraint;
+      gnss_constraint.submap_index = i;
+      gnss_constraint.position = Eigen::Vector3d(best_gnss.x, best_gnss.y, best_gnss.z);
+      gnss_constraint.info_diag =
+        Eigen::Vector3d(best_gnss.info_x, best_gnss.info_y, best_gnss.info_z);
+      gnss_constraints.push_back(gnss_constraint);
       if (best_gnss.rtk_like) {
         gnss_rtk_like_edges_added++;
       }
-      gnss_edges_added++;
     }
     if (debug_flag_) {
       RCLCPP_INFO(
         get_logger(),
-        "Added %d GNSS position constraint edges (%d RTK-like by covariance)",
-        gnss_edges_added, gnss_rtk_like_edges_added);
+        "Added %zu GNSS position constraint edges (%d RTK-like by covariance)",
+        gnss_constraints.size(), gnss_rtk_like_edges_added);
     }
   }
 
-  optimizer.initializeOptimization();
-  optimizer.optimize(10);
-  optimizer.save("pose_graph.g2o");
+  pose_graph::AdjacentEdgeConfig adjacent_cfg;
+  adjacent_cfg.num_adjacent_pose_constraints = num_adjacent_pose_cnstraints_;
+  adjacent_cfg.split_trans_rot = adjacent_edge_info_auto_scale_split_trans_rot_;
+  adjacent_cfg.info_weight = adjacent_edge_info_weight_;
+  adjacent_cfg.info_weight_trans = adjacent_edge_info_weight_trans_;
+  adjacent_cfg.info_weight_rot = adjacent_edge_info_weight_rot_;
 
-  if (adjacent_edge_info_auto_scale_ && !adjacent_edges.empty()) {
+  pose_graph::LoopEdgeConfig loop_cfg;
+  loop_cfg.info_weight = loop_edge_info_weight_;
+  loop_cfg.robust_kernel_type = loop_edge_robust_kernel_type_;
+  loop_cfg.robust_kernel_delta = loop_edge_robust_kernel_delta_;
+
+  pose_graph::ImuEdgeConfig imu_cfg;
+  imu_cfg.info_roll_pitch = imu_rotation_info_roll_pitch_;
+  imu_cfg.info_yaw = imu_rotation_info_yaw_;
+
+  pose_graph::Chi2Collection chi2_collection = pose_graph::Chi2Collection::NONE;
+  if (adjacent_edge_info_auto_scale_) {
+    chi2_collection = adjacent_edge_info_auto_scale_split_trans_rot_ ?
+      pose_graph::Chi2Collection::SPLIT : pose_graph::Chi2Collection::UNIFIED;
+  }
+
+  const pose_graph::OptimizationResult opt_result = pose_graph::optimizePoseGraph(
+    submap_nodes, loop_constraints, imu_constraints, gnss_constraints,
+    adjacent_cfg, loop_cfg, imu_cfg, chi2_collection,
+    /*iterations=*/ 10, save_pose_graph_path_);
+
+  if (adjacent_edge_info_auto_scale_ && submaps_size > 1) {
     graphslam::detail::AutoScaleConfig cfg;
     cfg.ema_alpha = adjacent_edge_info_auto_scale_ema_alpha_;
     cfg.min_scale = adjacent_edge_info_auto_scale_min_;
@@ -2786,34 +2735,12 @@ void GraphBasedSlamComponent::doPoseAdjustment(
 
     if (adjacent_edge_info_auto_scale_split_trans_rot_) {
       // Level 2: split the post-opt residuals into translation / rotation
-      // blocks and rescale w_trans and w_rot independently. For diagonal
-      // block-diag Information matrices, trans_chi2 = w_trans *
-      // ||e.head<3>()||^2 and rot_chi2 = w_rot * ||e.tail<3>()||^2.
-      std::vector<double> trans_chi2_values;
-      std::vector<double> rot_chi2_values;
-      trans_chi2_values.reserve(adjacent_edges.size());
-      rot_chi2_values.reserve(adjacent_edges.size());
-      for (auto * e : adjacent_edges) {
-        e->computeError();
-        const auto err = e->error();
-        const Eigen::Matrix<double, 6, 6> info = e->information();
-        // For the block-diag construction above, the diagonals encode the
-        // per-block scale of I_3 already attenuated by separation, so
-        // multiplying ||delta||^2 by the leading diagonal of each block
-        // reproduces the standard chi^2 contribution of that block.
-        const double w_t = info(0, 0);
-        const double w_r = info(3, 3);
-        const double trans = w_t * err.template head<3>().squaredNorm();
-        const double rot = w_r * err.template tail<3>().squaredNorm();
-        if (std::isfinite(trans)) {
-          trans_chi2_values.push_back(trans);
-        }
-        if (std::isfinite(rot)) {
-          rot_chi2_values.push_back(rot);
-        }
-      }
-      const double median_chi2_trans = graphslam::detail::medianChi2(trans_chi2_values);
-      const double median_chi2_rot = graphslam::detail::medianChi2(rot_chi2_values);
+      // blocks and rescale w_trans and w_rot independently (the chi2
+      // vectors come back from optimizePoseGraph in edge order).
+      const double median_chi2_trans =
+        graphslam::detail::medianChi2(opt_result.adjacent_trans_chi2);
+      const double median_chi2_rot =
+        graphslam::detail::medianChi2(opt_result.adjacent_rot_chi2);
 
       cfg.target_nis = adjacent_edge_info_auto_scale_target_nis_trans_;
       const double prev_w_trans = adjacent_edge_info_weight_trans_;
@@ -2833,18 +2760,9 @@ void GraphBasedSlamComponent::doPoseAdjustment(
         prev_w_trans, adjacent_edge_info_weight_trans_,
         median_chi2_rot, adjacent_edge_info_auto_scale_target_nis_rot_,
         prev_w_rot, adjacent_edge_info_weight_rot_,
-        trans_chi2_values.size());
+        opt_result.adjacent_trans_chi2.size());
     } else {
-      std::vector<double> chi2_values;
-      chi2_values.reserve(adjacent_edges.size());
-      for (auto * e : adjacent_edges) {
-        e->computeError();
-        const double v = e->chi2();
-        if (std::isfinite(v)) {
-          chi2_values.push_back(v);
-        }
-      }
-      const double median_chi2 = graphslam::detail::medianChi2(chi2_values);
+      const double median_chi2 = graphslam::detail::medianChi2(opt_result.adjacent_chi2);
 
       cfg.target_nis = adjacent_edge_info_auto_scale_target_nis_;
       const double prev_weight = adjacent_edge_info_weight_;
@@ -2854,7 +2772,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
       RCLCPP_INFO(
         get_logger(),
         "[auto_scale] median_chi2=%.3f (n=%zu) target=%.3f weight=%.3f -> %.3f",
-        median_chi2, chi2_values.size(), cfg.target_nis, prev_weight,
+        median_chi2, opt_result.adjacent_chi2.size(), cfg.target_nis, prev_weight,
         adjacent_edge_info_weight_);
     }
   }
@@ -2871,8 +2789,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
     dynamic_filter_submaps.reserve(submaps_size);
   }
   for (int i = 0; i < submaps_size; i++) {
-    g2o::VertexSE3 * vertex_se3 = static_cast<g2o::VertexSE3 *>(optimizer.vertex(i));
-    Eigen::Affine3d se3 = vertex_se3->estimate();
+    Eigen::Affine3d se3(opt_result.poses[i].matrix());
     geometry_msgs::msg::Pose pose = tf2::toMsg(se3);
 
     /* map */

--- a/graph_based_slam/test/test_pose_graph_optimization.cpp
+++ b/graph_based_slam/test/test_pose_graph_optimization.cpp
@@ -102,7 +102,8 @@ TEST(PoseGraphOptimization, LoopClosurePullsDriftedEndpointHome)
   EXPECT_LT(drift_after, drift_before * 0.5)
     << "loop closure should pull the drifted endpoint toward node 0";
   // Vertex 0 is fixed.
-  EXPECT_LT((result.poses.front().translation() -
+  EXPECT_LT(
+    (result.poses.front().translation() -
     submaps.front().pose.translation()).norm(), 1e-12);
 }
 

--- a/graph_based_slam/test/test_pose_graph_optimization.cpp
+++ b/graph_based_slam/test/test_pose_graph_optimization.cpp
@@ -1,0 +1,244 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Characterization + determinism-contract tests for the pose-graph
+// optimization extracted from doPoseAdjustment() (v0.6 Phase 1).
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Geometry>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/pose_graph_optimization.hpp"
+
+namespace graphslam
+{
+namespace
+{
+
+using pose_graph::AdjacentEdgeConfig;
+using pose_graph::Chi2Collection;
+using pose_graph::GnssConstraint;
+using pose_graph::ImuEdgeConfig;
+using pose_graph::ImuRotationConstraint;
+using pose_graph::LoopConstraint;
+using pose_graph::LoopEdgeConfig;
+using pose_graph::SubmapNode;
+using pose_graph::optimizePoseGraph;
+
+// A straight 11-node chain along +x with 1 m spacing whose later nodes carry
+// an injected +y drift, plus the ground-truth loop measurement that says node
+// 10 should coincide with node 0.
+std::vector<SubmapNode> makeDriftedChain()
+{
+  std::vector<SubmapNode> submaps;
+  for (int i = 0; i <= 10; ++i) {
+    SubmapNode node;
+    const double x = (i <= 5) ? static_cast<double>(i) : static_cast<double>(10 - i);
+    const double drift = 0.06 * std::max(0, i - 5);
+    node.pose = Eigen::Isometry3d::Identity();
+    node.pose.translation() = Eigen::Vector3d(x, drift, 0.0);
+    submaps.push_back(node);
+  }
+  return submaps;
+}
+
+LoopConstraint makeClosingLoop()
+{
+  // Ground truth: node 10 sits exactly on node 0. A good registration
+  // fitness (0.1) gives the loop edge information weight 100 / 0.1 = 1000,
+  // on par with the adjacent odometry edges.
+  LoopConstraint loop;
+  loop.from = 0;
+  loop.to = 10;
+  loop.relative_pose = Eigen::Isometry3d::Identity();
+  loop.fitness_score = 0.1;
+  return loop;
+}
+
+TEST(PoseGraphOptimization, LoopClosurePullsDriftedEndpointHome)
+{
+  const auto submaps = makeDriftedChain();
+  const double drift_before =
+    (submaps.back().pose.translation() - submaps.front().pose.translation()).norm();
+  ASSERT_GT(drift_before, 0.25);
+
+  const auto result = optimizePoseGraph(
+    submaps, {makeClosingLoop()}, {}, {},
+    AdjacentEdgeConfig{}, LoopEdgeConfig{}, ImuEdgeConfig{}, Chi2Collection::NONE);
+
+  ASSERT_EQ(result.poses.size(), submaps.size());
+  const double drift_after =
+    (result.poses.back().translation() - result.poses.front().translation()).norm();
+  EXPECT_LT(drift_after, drift_before * 0.5)
+    << "loop closure should pull the drifted endpoint toward node 0";
+  // Vertex 0 is fixed.
+  EXPECT_LT((result.poses.front().translation() -
+    submaps.front().pose.translation()).norm(), 1e-12);
+}
+
+TEST(PoseGraphOptimization, NoConstraintsBeyondOdometryKeepsChainShape)
+{
+  const auto submaps = makeDriftedChain();
+  const auto result = optimizePoseGraph(
+    submaps, {}, {}, {},
+    AdjacentEdgeConfig{}, LoopEdgeConfig{}, ImuEdgeConfig{}, Chi2Collection::NONE);
+
+  ASSERT_EQ(result.poses.size(), submaps.size());
+  // Adjacent constraints reproduce the input relative poses exactly, so the
+  // optimum is the input chain itself.
+  for (size_t i = 0; i < submaps.size(); ++i) {
+    EXPECT_LT((result.poses[i].translation() - submaps[i].pose.translation()).norm(), 1e-6)
+      << "node " << i << " moved without any loop/IMU/GNSS constraint";
+  }
+}
+
+TEST(PoseGraphOptimization, SameInputsGiveBitwiseIdenticalPoses)
+{
+  // The Phase 2 determinism contract at the optimizer layer: identical
+  // inputs must give identical outputs, bit for bit.
+  const auto submaps = makeDriftedChain();
+  const auto a = optimizePoseGraph(
+    submaps, {makeClosingLoop()}, {}, {},
+    AdjacentEdgeConfig{}, LoopEdgeConfig{}, ImuEdgeConfig{}, Chi2Collection::UNIFIED);
+  const auto b = optimizePoseGraph(
+    submaps, {makeClosingLoop()}, {}, {},
+    AdjacentEdgeConfig{}, LoopEdgeConfig{}, ImuEdgeConfig{}, Chi2Collection::UNIFIED);
+
+  ASSERT_EQ(a.poses.size(), b.poses.size());
+  for (size_t i = 0; i < a.poses.size(); ++i) {
+    EXPECT_EQ(
+      0,
+      std::memcmp(a.poses[i].matrix().data(), b.poses[i].matrix().data(), sizeof(double) * 16))
+      << "pose " << i << " differs between identical runs";
+  }
+  ASSERT_EQ(a.adjacent_chi2.size(), b.adjacent_chi2.size());
+  for (size_t i = 0; i < a.adjacent_chi2.size(); ++i) {
+    EXPECT_EQ(a.adjacent_chi2[i], b.adjacent_chi2[i]);
+  }
+}
+
+TEST(PoseGraphOptimization, GnssAnchorAsBuiltDoesNotPullTranslation)
+{
+  // CHARACTERIZATION OF A KNOWN MISPLACEMENT (preserved by the extraction):
+  // the GNSS edge writes its weights into indices (3,3)..(5,5), which in
+  // g2o's EdgeSE3 error order (x, y, z, qx, qy, qz) is the ROTATION block.
+  // As built, the anchor exerts no translation pull at all — consistent
+  // with the GNSS constraint having always been documented as untested.
+  // The behavioural fix (moving the weights to the translation block) is a
+  // separate follow-up PR, which must flip this test to EXPECT_LT.
+  const auto submaps = makeDriftedChain();
+  GnssConstraint gnss;
+  gnss.submap_index = 10;
+  gnss.position = submaps.front().pose.translation();  // anchor at ground truth
+  gnss.info_diag = Eigen::Vector3d(1000.0, 1000.0, 1000.0);
+
+  const auto without = optimizePoseGraph(
+    submaps, {}, {}, {},
+    AdjacentEdgeConfig{}, LoopEdgeConfig{}, ImuEdgeConfig{}, Chi2Collection::NONE);
+  const auto with = optimizePoseGraph(
+    submaps, {}, {}, {gnss},
+    AdjacentEdgeConfig{}, LoopEdgeConfig{}, ImuEdgeConfig{}, Chi2Collection::NONE);
+
+  const double err_without =
+    (without.poses[10].translation() - gnss.position).norm();
+  const double err_with = (with.poses[10].translation() - gnss.position).norm();
+  EXPECT_NEAR(err_with, err_without, 1e-9)
+    << "as built, the GNSS anchor must not change translation; if this fails "
+    << "because err_with shrank, the block-order fix landed — update this test";
+}
+
+TEST(PoseGraphOptimization, Chi2CollectionModesPopulateExpectedVectors)
+{
+  const auto submaps = makeDriftedChain();
+  const auto none = optimizePoseGraph(
+    submaps, {makeClosingLoop()}, {}, {},
+    AdjacentEdgeConfig{}, LoopEdgeConfig{}, ImuEdgeConfig{}, Chi2Collection::NONE);
+  EXPECT_TRUE(none.adjacent_chi2.empty());
+  EXPECT_TRUE(none.adjacent_trans_chi2.empty());
+
+  const auto unified = optimizePoseGraph(
+    submaps, {makeClosingLoop()}, {}, {},
+    AdjacentEdgeConfig{}, LoopEdgeConfig{}, ImuEdgeConfig{}, Chi2Collection::UNIFIED);
+  EXPECT_FALSE(unified.adjacent_chi2.empty());
+  EXPECT_TRUE(unified.adjacent_trans_chi2.empty());
+
+  AdjacentEdgeConfig split_cfg;
+  split_cfg.split_trans_rot = true;
+  const auto split = optimizePoseGraph(
+    submaps, {makeClosingLoop()}, {}, {},
+    split_cfg, LoopEdgeConfig{}, ImuEdgeConfig{}, Chi2Collection::SPLIT);
+  EXPECT_TRUE(split.adjacent_chi2.empty());
+  EXPECT_FALSE(split.adjacent_trans_chi2.empty());
+  EXPECT_EQ(split.adjacent_trans_chi2.size(), split.adjacent_rot_chi2.size());
+}
+
+TEST(PoseGraphOptimization, ImuRotationConstraintAsBuiltDoesNotRotate)
+{
+  // CHARACTERIZATION OF A KNOWN MISPLACEMENT (preserved by the extraction):
+  // the IMU edge writes roll/pitch/yaw weights into indices (0,0)..(2,2),
+  // which in g2o's EdgeSE3 error order (x, y, z, qx, qy, qz) is the
+  // TRANSLATION block; the rotation block stays zero, so as built the "IMU
+  // rotation constraint" never constrained rotation. The behavioural fix is
+  // a separate follow-up PR, which must flip this test to EXPECT_GT.
+  std::vector<SubmapNode> submaps(2);
+  submaps[0].pose = Eigen::Isometry3d::Identity();
+  submaps[1].pose = Eigen::Isometry3d::Identity();
+  submaps[1].pose.translation() = Eigen::Vector3d(1.0, 0.0, 0.0);
+
+  ImuRotationConstraint imu;
+  imu.from = 0;
+  imu.to = 1;
+  imu.measurement = Eigen::Isometry3d::Identity();
+  imu.measurement.linear() =
+    Eigen::AngleAxisd(10.0 * M_PI / 180.0, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+  imu.measurement.translation() = Eigen::Vector3d(1.0, 0.0, 0.0);
+
+  ImuEdgeConfig imu_cfg;
+  imu_cfg.info_roll_pitch = 1e6;
+  imu_cfg.info_yaw = 1e6;
+
+  AdjacentEdgeConfig weak_odom;
+  weak_odom.info_weight = 1.0;
+
+  const auto result = optimizePoseGraph(
+    submaps, {}, {imu}, {}, weak_odom, LoopEdgeConfig{}, imu_cfg, Chi2Collection::NONE);
+
+  const Eigen::AngleAxisd delta(
+    result.poses[0].linear().transpose() * result.poses[1].linear());
+  EXPECT_LT(delta.angle() * 180.0 / M_PI, 1e-6)
+    << "as built, the IMU edge must not rotate anything; if this fails "
+    << "because rotation appeared, the block-order fix landed — update this test";
+}
+
+}  // namespace
+}  // namespace graphslam


### PR DESCRIPTION
## Summary
Third Phase 1 PR: `doPoseAdjustment`'s g2o assembly + optimization moves to **`pose_graph_optimization.hpp`** (13th tested pure header) as a pure function of plain data — vertices, adjacent edges (incl. split/unified auto-scale weighting), IMU edges, loop edges, GNSS anchors, optimize, chi2 export — mirroring the historical construction order exactly. The node keeps what is node-owned: IMU/GNSS buffers + matching become pre-passes producing plain constraint lists; the NIS auto-scale update consumes the returned chi2 vectors. **This function is the Phase 2 `BackendCore` optimize step.**

Also fixes the Phase 0 wart: `save_pose_graph_path` was passed by the launch files but never declared, so `pose_graph.g2o` always went to the node's CWD. It is now a real parameter (default keeps the historical CWD behaviour); verified landing in the run directory on a live run.

## Two latent bugs found by the new tests (preserved, NOT fixed here)
Writing the characterization tests exposed that g2o `EdgeSE3`'s error order is **(x, y, z, qx, qy, qz)** — translation first (`toVectorMQT`) — but:
- the **IMU 'rotation' edge** writes roll/pitch/yaw weights into indices (0,0)..(2,2) = the **translation** block → as built it has never constrained rotation;
- the **GNSS 'position' anchor** writes its weights into (3,3)..(5,5) = the **rotation** block → as built it has never pulled translation (consistent with the feature being documented as untested ⚠️ since day one).

This extraction PR preserves both **bit-for-bit** (repo discipline: no behaviour change in a refactor). The tests characterize the as-built behaviour and say exactly how to flip them when the behavioural fix lands as the follow-up PR. Both features are opt-in (default off) on every preset.

## Tests / evidence
- 6 new tests incl. the layer's determinism contract: **same inputs → bitwise identical poses**.
- Package tests: 972, 0 failures (lint clean).
- Equivalence run (MID-360 crossval): baseline 5.78 / 2 loops, candidate 4.39 / 1 loop — inside the recent observed band.