### PR TITLE
fix(slam): put IMU/GNSS edge information on the correct EdgeSE3 blocks

### DIFF
--- a/graph_based_slam/include/graph_based_slam/pose_graph_optimization.hpp
+++ b/graph_based_slam/include/graph_based_slam/pose_graph_optimization.hpp
@@ -203,16 +203,13 @@ inline OptimizationResult optimizePoseGraph(
     edge_se3->setMeasurement(imu_constraint.measurement);
 
     Eigen::Matrix<double, 6, 6> imu_info = Eigen::Matrix<double, 6, 6>::Zero();
-    // KNOWN MISPLACEMENT, preserved bit-for-bit by this extraction:
     // g2o EdgeSE3 error order is (x, y, z, qx, qy, qz) — translation first
-    // (toVectorMQT, isometry3d_mappings.h) — so these weights land on the
-    // TRANSLATION block and the rotation block stays zero; as built, this
-    // edge never constrained rotation. Characterized in
-    // test_pose_graph_optimization.cpp; the behavioural fix is a separate
-    // follow-up PR.
-    imu_info(0, 0) = imu_cfg.info_roll_pitch;
-    imu_info(1, 1) = imu_cfg.info_roll_pitch;
-    imu_info(2, 2) = imu_cfg.info_yaw;
+    // (toVectorMQT, isometry3d_mappings.h). Rotation weights go on the
+    // rotation block (3..5); translation stays zero on purpose (no trust in
+    // IMU double integration).
+    imu_info(3, 3) = imu_cfg.info_roll_pitch;  // qx ~ roll
+    imu_info(4, 4) = imu_cfg.info_roll_pitch;  // qy ~ pitch
+    imu_info(5, 5) = imu_cfg.info_yaw;         // qz ~ yaw
     edge_se3->setInformation(imu_info);
 
     edge_se3->vertices()[0] = optimizer.vertex(imu_constraint.from);
@@ -253,14 +250,12 @@ inline OptimizationResult optimizePoseGraph(
     g2o::EdgeSE3 * edge = new g2o::EdgeSE3();
     edge->setMeasurement(Eigen::Isometry3d::Identity());
     Eigen::Matrix<double, 6, 6> gnss_info = Eigen::Matrix<double, 6, 6>::Zero();
-    // KNOWN MISPLACEMENT, preserved bit-for-bit by this extraction: with the
-    // g2o (x, y, z, qx, qy, qz) error order these weights land on the
-    // ROTATION block, so as built the GNSS anchor never pulled translation
-    // (consistent with the feature being documented as untested). See
-    // test_pose_graph_optimization.cpp; fix in a follow-up PR.
-    gnss_info(3, 3) = gnss_constraint.info_diag.x();
-    gnss_info(4, 4) = gnss_constraint.info_diag.y();
-    gnss_info(5, 5) = gnss_constraint.info_diag.z();
+    // g2o EdgeSE3 error order is (x, y, z, qx, qy, qz) — translation first —
+    // so the position weights go on the translation block (0..2); rotation
+    // stays unconstrained (GNSS carries no orientation).
+    gnss_info(0, 0) = gnss_constraint.info_diag.x();
+    gnss_info(1, 1) = gnss_constraint.info_diag.y();
+    gnss_info(2, 2) = gnss_constraint.info_diag.z();
     edge->setInformation(gnss_info);
     edge->vertices()[0] = gnss_vertex;
     edge->vertices()[1] = optimizer.vertex(gnss_constraint.submap_index);

--- a/graph_based_slam/test/test_pose_graph_optimization.cpp
+++ b/graph_based_slam/test/test_pose_graph_optimization.cpp
@@ -148,15 +148,11 @@ TEST(PoseGraphOptimization, SameInputsGiveBitwiseIdenticalPoses)
   }
 }
 
-TEST(PoseGraphOptimization, GnssAnchorAsBuiltDoesNotPullTranslation)
+TEST(PoseGraphOptimization, GnssAnchorPullsVertexTowardAnchor)
 {
-  // CHARACTERIZATION OF A KNOWN MISPLACEMENT (preserved by the extraction):
-  // the GNSS edge writes its weights into indices (3,3)..(5,5), which in
-  // g2o's EdgeSE3 error order (x, y, z, qx, qy, qz) is the ROTATION block.
-  // As built, the anchor exerts no translation pull at all — consistent
-  // with the GNSS constraint having always been documented as untested.
-  // The behavioural fix (moving the weights to the translation block) is a
-  // separate follow-up PR, which must flip this test to EXPECT_LT.
+  // The intended GNSS semantics, enabled by the block-order fix: position
+  // weights sit on the translation block of g2o's (x, y, z, qx, qy, qz)
+  // error, so a strong anchor reduces the anchored vertex position error.
   const auto submaps = makeDriftedChain();
   GnssConstraint gnss;
   gnss.submap_index = 10;
@@ -173,9 +169,8 @@ TEST(PoseGraphOptimization, GnssAnchorAsBuiltDoesNotPullTranslation)
   const double err_without =
     (without.poses[10].translation() - gnss.position).norm();
   const double err_with = (with.poses[10].translation() - gnss.position).norm();
-  EXPECT_NEAR(err_with, err_without, 1e-9)
-    << "as built, the GNSS anchor must not change translation; if this fails "
-    << "because err_with shrank, the block-order fix landed — update this test";
+  EXPECT_LT(err_with, err_without * 0.5)
+    << "a strong GNSS anchor must substantially reduce the anchored vertex error";
 }
 
 TEST(PoseGraphOptimization, Chi2CollectionModesPopulateExpectedVectors)
@@ -203,14 +198,11 @@ TEST(PoseGraphOptimization, Chi2CollectionModesPopulateExpectedVectors)
   EXPECT_EQ(split.adjacent_trans_chi2.size(), split.adjacent_rot_chi2.size());
 }
 
-TEST(PoseGraphOptimization, ImuRotationConstraintAsBuiltDoesNotRotate)
+TEST(PoseGraphOptimization, ImuRotationConstraintInfluencesOrientation)
 {
-  // CHARACTERIZATION OF A KNOWN MISPLACEMENT (preserved by the extraction):
-  // the IMU edge writes roll/pitch/yaw weights into indices (0,0)..(2,2),
-  // which in g2o's EdgeSE3 error order (x, y, z, qx, qy, qz) is the
-  // TRANSLATION block; the rotation block stays zero, so as built the "IMU
-  // rotation constraint" never constrained rotation. The behavioural fix is
-  // a separate follow-up PR, which must flip this test to EXPECT_GT.
+  // The intended IMU semantics, enabled by the block-order fix: rotation
+  // weights sit on the rotation block of g2o's (x, y, z, qx, qy, qz) error,
+  // so a dominant IMU yaw measurement rotates the relative orientation.
   std::vector<SubmapNode> submaps(2);
   submaps[0].pose = Eigen::Isometry3d::Identity();
   submaps[1].pose = Eigen::Isometry3d::Identity();
@@ -236,9 +228,8 @@ TEST(PoseGraphOptimization, ImuRotationConstraintAsBuiltDoesNotRotate)
 
   const Eigen::AngleAxisd delta(
     result.poses[0].linear().transpose() * result.poses[1].linear());
-  EXPECT_LT(delta.angle() * 180.0 / M_PI, 1e-6)
-    << "as built, the IMU edge must not rotate anything; if this fails "
-    << "because rotation appeared, the block-order fix landed — update this test";
+  EXPECT_GT(delta.angle() * 180.0 / M_PI, 5.0)
+    << "a dominant IMU yaw constraint must rotate the relative orientation";
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
The behavioural follow-up to #241. g2o `EdgeSE3`'s error order is **(x, y, z, qx, qy, qz)** — translation first — but both opt-in constraint edges had their information blocks swapped (exposed by #241's characterization tests):

| edge | intended | as built (until now) | fixed |
|---|---|---|---|
| IMU 'rotation' constraint | constrain roll/pitch/yaw | weighted **translation**, never constrained rotation | weights on the rotation block (3..5) |
| GNSS 'position' anchor | pull position | weighted **rotation**, never pulled translation | weights on the translation block (0..2) |

The GNSS finding explains why georeferencing has been documented as untested ⚠️ since it landed — it could not have worked. For opted-in users this is the first time the GNSS anchor actually anchors.

## Tests
The two characterization tests flip to the intended semantics exactly as their embedded instructions said:
- `GnssAnchorPullsVertexTowardAnchor`: a strong anchor must **halve** the anchored vertex position error.
- `ImuRotationConstraintInfluencesOrientation`: a dominant IMU yaw measurement must rotate the relative orientation by **>5°**.

Package tests: 972, 0 failures (lint clean).

## Blast radius
`use_gnss` / `use_imu_preintegration` are default-false on every preset; the release gates do not exercise them. Follow-up candidate (separate task): first real-data GNSS validation on the RTK-SLAM bag's `/gnss/fix`, which would also exercise the never-tested LocalCartesian projector output.