### PR TITLE
docs(research): first real-data validation of the GNSS constraint

### DIFF
--- a/docs/research/gnss-constraint-first-validation.md
+++ b/docs/research/gnss-constraint-first-validation.md
@@ -1,0 +1,79 @@
+# GNSS constraint — first real-data validation (2026-06-12)
+
+The GNSS pose-graph constraint and the `LocalCartesian` projector output had
+been documented as untested ⚠️ since they landed. #242 fixed the constraint's
+information-matrix block order (it had never pulled translation), which made a
+real validation meaningful for the first time. Substrate: RTK-SLAM
+`stadtgarten_seq2` (outdoor park, `/gnss/fix` NavSatFix at ~136 Hz, RTK-grade,
+total-station GT available), the v0.5 outdoor preset, A/B with
+`use_gnss: false/true`. Raw artifacts: `output/gnss_ab/`.
+
+## Validated ✅
+
+1. **The fixed constraint works mechanically on real data**: with the stamp
+   skew override (below), the final pose adjustment reports
+   `Added 163 GNSS position constraint edges (163 RTK-like by covariance)` —
+   origin initialization (3-sample + 20 m consistency), geodetic→ENU
+   conversion, covariance weighting and RTK classification all behave.
+2. **`LocalCartesian` projector output, first ever**:
+   `map_projector_info.yaml` came out as `LocalCartesian` + `WGS84` with
+   `map_origin` lat 48.7819948 / lon 9.1729486 — the actual Stuttgart
+   Stadtgarten. The `Local`-fallback path (GNSS off) is unchanged.
+3. **No-regression sanity**: the GNSS-off arm reproduces the v0.5 result
+   exactly (raw 0.835 m RMSE, 19/19 checkpoints, median 0.327) — also strong
+   end-to-end evidence that the Phase 1 changes (#238–#242) did not move the
+   benchmark path. GNSS-on raw is identical (GNSS only affects the graph), as
+   it must be.
+
+## The remaining gap ❌ — no odom→ENU yaw alignment
+
+The GNSS-on corrected trajectory diverges from GNSS-off by a pattern that is
+zero at the fixed vertex and grows linearly with distance from it:
+
+| pose index | 0 | 10 | 50 | 270 |
+|---|---|---|---|---|
+| on/off displacement [m] | 0.00 | 24.1 | 94.1 | 337.1 |
+
+That is a pure **frame-rotation mismatch**: the odometry frame's x axis is
+the robot's initial heading, the ENU anchors' x axis is east, and nothing in
+the pipeline estimates the yaw between them. With vertex 0 fixed (position
+*and* orientation), the optimizer cannot rotate the graph into the ENU frame,
+so 163 strong anchors shear the map instead of georeferencing it. The effect
+was unobservable before #242 because the anchors never pulled translation at
+all.
+
+**Conclusion: `use_gnss: true` remains unusable for accuracy on real data
+until a yaw alignment lands.** Design sketch for the follow-up:
+
+- estimate the odom→ENU yaw online once the GNSS track baseline exceeds a
+  few meters (2-D least squares between odometry positions at fix stamps and
+  the ENU track), then
+- either rotate the ENU anchors into the odometry frame (map stays in the
+  odometry frame; record the yaw in the projector metadata), or release the
+  vertex-0 gauge under GNSS so the graph itself rotates into ENU (map becomes
+  truly georeferenced; matches what `LocalCartesian` consumers expect).
+  The second is the production-correct target; it needs a minimum-anchor
+  guard before un-fixing the gauge.
+
+## Replay pitfalls worth keeping (cost a run each)
+
+- The RKO-LIO offline node reads the bag internally — `/gnss/fix` never
+  enters the ROS graph. Replay it alongside
+  (`ros2 bag play <bag> --topics /gnss/fix --rate 5`); matching is by message
+  stamp so the rate is free.
+- `gnss_header_stamp_max_skew_sec` (default 30 s) re-stamps fixes with the
+  receive time when the header is "too old" — on a recorded bag that is
+  *every* fix, silently producing 0 edges. Override it to a huge value for
+  replays (the experiment used 1e12).
+- A benchmark `--output-dir` whose basename is `on`/`off` becomes a boolean
+  `run_name` parameter via YAML and aborts RKO-LIO; name arms `gnss_on`-style.
+- The corrected (submap-node) trajectory still cannot be scored against the
+  total-station checkpoints (dwell-gap pairing, the known v0.5 limitation), so
+  the corrected-level A/B metric stays blocked until denser export exists.
+
+## Reproduce
+
+```bash
+# off arm = v0.5 outdoor preset; on arm adds use_gnss + the skew override
+bash output/gnss_ab/run_ab.sh   # see the file for the exact invocations
+```

--- a/plan.md
+++ b/plan.md
@@ -269,8 +269,8 @@ indoor で 0.15–0.40m（真 GT, agreement でなく accuracy）。outdoor の�
 
 | 項目 | 状態 | 理由 |
 |------|------|------|
-| GNSS ポーズグラフ制約 | ⚠️ | 手元に有効な GNSS 付きデータセットがない（RTK-SLAM bag の `/gnss/fix` が流用候補、§8 #1） |
-| `map_projector_info.yaml`（LocalCartesian） | ⚠️ | GNSS 未動作のため地理座標版は未検証（`local` 版は検証済み） |
+| GNSS ポーズグラフ制約 | 🟡 部分実証 | 2026-06-12 RTK-SLAM stadtgarten_seq2 で初検証: #242 修正後にエッジ 163 本形成・RTK 判定・ENU 変換まで動作 ✅。ただし **odom→ENU の初期 yaw 整合が未実装**でアンカーがマップを剪断（pose0 で 0m → 遠方 337m の回転不整合パターン）→ 精度用途はまだ不可。詳細: `docs/research/gnss-constraint-first-validation.md` |
+| ~~`map_projector_info.yaml`（LocalCartesian）~~ | ✅ | 同検証で初実証: LocalCartesian + WGS84 + 実origin（Stadtgarten 48.78199/9.17295）が出力された |
 | ~~Autoware 実環境読み込み~~ | ✅ | map loaders 読込 + AWSIM×Autoware E2E 自動運転まで dogfood 済み |
 
 ### Autoware ユーザーへのバリュー
@@ -329,7 +329,7 @@ indoor で 0.15–0.40m（真 GT, agreement でなく accuracy）。outdoor の�
 | 0f | **v0.6 決定論 core/shell リファクタリング** | スコープ確定（2026-06-11、backend + scanmatcher）。Phase 0 変動帰属測定 → Phase 1 競合除去+分割 → Phase 2 BackendCore+オフライン決定論ランナー（ループエッジ集合 3-run 完全一致がハードゲート）→ Phase 3 default 切替 → Phase 4 scanmatcher。テスト 4 層（characterization / unit / 決定論契約 / リプレイ回帰）を各フェーズのゲートに。詳細 [`docs/roadmap/v0.6.md`](docs/roadmap/v0.6.md) |
 | 0d | ~~D1 8-vs-16 再現性ベンチ~~ | ✅ 2026-06-11 実施（GLIM MID-360 bag、3 run × {off/16, on/16, on/8}）。on/16 は APE 実質無回帰（差 0.06m ≪ noise 0.40m）だが分散縮小なし（σ 0.066→0.259）、on/8 arm の 2 実行で loop 試行ゼロ。mp8 の系統的 regression 署名は消滅し乱高下に置換（スケジューリング主要因子と整合、根本原因の証明ではない）。**default off 維持で D1 完全クローズ**（§1.2、research summary） |
 | 0e | **発信（P2-8）** | ghcr ワンコマンド + lanelet2 完全バンドル + 実 GT 数値が揃い、発信material は完成状態。ROS Discourse / Reddit / X はユーザー本人が実施。事前に B2 social preview 設定（Web UI 1 分） |
-| 1 | **GNSS 付きデータセットで GNSS 制約テスト** | Autoware の地理座標系マッピング機能が未検証。RTK-SLAM bag は `/gnss/fix` を持つので流用候補 |
+| 1 | **GNSS odom→ENU yaw 整合の実装** | 初検証（2026-06-12）で制約形成 ✅・LocalCartesian projector ✅ まで実証済み。残るは yaw 整合（ENU トラックとの 2D 最小二乗 → アンカー回転 or vertex-0 gauge 解放）。これが入ると GNSS georeferencing が実用になる。`docs/research/gnss-constraint-first-validation.md` |
 | 2 | ~~Autoware 実環境での読み込みテスト~~ | ✅ map loaders 読込は検証済み（README の loader proof + AWSIM×Autoware E2E 自動運転まで dogfood 済み、§6） |
 | 3a | ~~MID-360 robot toolkit chain (操作員 pipeline)~~ | ✅ PR #168-#177 で 10 PR inside-out で landing 完了 (§10) |
 | 3b | **実機 Jetson + MID-360 robot での dogfood 実走** | chain (§10) を組んだものの実機 bag での E2E 検証はまだ。dogfood-vs-bench の cloud distribution 不一致も併せて調査 |


### PR DESCRIPTION
## Summary
First real-data exercise of the GNSS pose-graph constraint and the `LocalCartesian` projector — both documented as untested ⚠️ since they landed, and meaningful to test for the first time now that #242 makes the anchors actually pull translation. Substrate: RTK-SLAM `stadtgarten_seq2` (`/gnss/fix` RTK-grade NavSatFix), v0.5 outdoor preset, A/B off/on.

**Validated ✅**
- 163 GNSS edges form on real data (origin init 3-sample+consistency, geodetic→ENU, covariance weighting; all 163 classified RTK-like).
- `map_projector_info.yaml` = **LocalCartesian + WGS84 + the actual Stuttgart Stadtgarten origin** (48.7819948, 9.1729486) — first-ever validation of that output.
- GNSS-off arm reproduces the v0.5 raw result exactly (0.835 m, 19/19 checkpoints) — strong no-regression evidence for the whole Phase 1 series (#238–#242) on the real pipeline.

**Remaining gap ❌ (precisely characterized)**
No odom→ENU yaw alignment exists: with vertex 0 fixed, the anchors shear the map instead of georeferencing it — on/off corrected displacement is 0.00 m at the fixed vertex growing to 337 m with distance (pure frame-rotation signature). `use_gnss` stays unusable for accuracy until a yaw alignment lands; design sketch in the note (rotate anchors into the odom frame, or release the vertex-0 gauge under a minimum-anchor guard — the production-correct target).

Also records three replay pitfalls that each cost a run (offline node never publishes `/gnss/fix`; the 30 s header-stamp skew guard silently kills every fix on recorded bags; `on`/`off` output-dir basenames become boolean `run_name` params).

## Test plan
Docs-only. Raw artifacts under `output/gnss_ab/` (gitignored).