### PR TITLE
feat(slam): GNSS yaw alignment — georeferenced maps via gauge release

### DIFF
--- a/docs/research/gnss-constraint-first-validation.md
+++ b/docs/research/gnss-constraint-first-validation.md
@@ -77,3 +77,23 @@ until a yaw alignment lands.** Design sketch for the follow-up:
 # off arm = v0.5 outdoor preset; on arm adds use_gnss + the skew override
 bash output/gnss_ab/run_ab.sh   # see the file for the exact invocations
 ```
+
+## Addendum: the yaw alignment landed (same day)
+
+With the planar odom→ENU alignment (closed-form 2-D Kabsch over the matched
+anchor pairs, `gnss_align_yaw`, min 10 anchors / 5 m baseline) and the
+vertex-0 gauge released when it succeeds:
+
+- the run estimates **yaw = −111.83°** (baseline 201.9 m, fit RMS 1.90 m) and
+  reports 165 anchors;
+- the corrected trajectory becomes a **rigid** −112.1° rotation of the
+  GNSS-off solution (independent best-fit), with post-alignment residuals of
+  mean 2.03 m / max 8.73 m — the anchors' actual drift corrections — instead
+  of the 180 m mean / 337 m max shear before;
+- raw stays 0.835 m, bit-for-bit.
+
+The map is georeferenced for the first time: poses live in the ENU frame of
+the `LocalCartesian` origin, which is what the projector metadata promises
+consumers. Quantifying the absolute-accuracy gain against the total-station
+checkpoints still needs the denser corrected export (the dwell-gap pairing
+limitation above).

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -193,6 +193,13 @@ if(BUILD_TESTING)
     target_include_directories(test_submap_creation PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_gnss_alignment
+    test/test_gnss_alignment.cpp
+  )
+  if(TARGET test_gnss_alignment)
+    target_include_directories(test_gnss_alignment PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  endif()
+  ament_add_gtest(
     test_pose_graph_optimization
     test/test_pose_graph_optimization.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/gnss_alignment.hpp
+++ b/graph_based_slam/include/graph_based_slam/gnss_alignment.hpp
@@ -1,0 +1,130 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__GNSS_ALIGNMENT_HPP_
+#define GRAPH_BASED_SLAM__GNSS_ALIGNMENT_HPP_
+
+// The odometry frame's x axis is the robot's initial heading; GNSS anchors
+// live in ENU where x is east. Estimate the planar rigid transform between
+// the two from matched (odometry position, ENU position) pairs so the pose
+// graph can be moved into the ENU frame before anchors are applied (see
+// docs/research/gnss-constraint-first-validation.md for what happens
+// without this: the anchors shear the map instead of georeferencing it).
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+
+namespace graphslam
+{
+namespace gnss_alignment
+{
+
+struct PlanarAlignment
+{
+  bool valid {false};
+  // T maps odometry-frame positions into the ENU frame:
+  // enu_xy = R(yaw_rad) * odom_xy + translation.
+  double yaw_rad {0.0};
+  Eigen::Vector2d translation {Eigen::Vector2d::Zero()};
+  // Diagnostics: the spread of the odometry-side track that supported the
+  // estimate, and the post-fit RMS residual.
+  double baseline_m {0.0};
+  double rms_residual_m {0.0};
+};
+
+// Closed-form 2-D rigid alignment (rotation + translation, no scale):
+// the Umeyama/Kabsch solution on the horizontal components. Requires at
+// least `min_pairs` matches whose odometry-side spread (max pairwise
+// distance from the centroid, doubled) reaches `min_baseline_m`; a short
+// baseline cannot observe yaw.
+inline PlanarAlignment estimatePlanarAlignment(
+  const std::vector<Eigen::Vector2d> & odom_xy,
+  const std::vector<Eigen::Vector2d> & enu_xy,
+  int min_pairs = 10,
+  double min_baseline_m = 5.0)
+{
+  PlanarAlignment result;
+  const int n = static_cast<int>(std::min(odom_xy.size(), enu_xy.size()));
+  if (n < std::max(min_pairs, 2)) {
+    return result;
+  }
+
+  Eigen::Vector2d odom_mean = Eigen::Vector2d::Zero();
+  Eigen::Vector2d enu_mean = Eigen::Vector2d::Zero();
+  for (int i = 0; i < n; ++i) {
+    odom_mean += odom_xy[i];
+    enu_mean += enu_xy[i];
+  }
+  odom_mean /= static_cast<double>(n);
+  enu_mean /= static_cast<double>(n);
+
+  double max_dev_sq = 0.0;
+  Eigen::Matrix2d cross = Eigen::Matrix2d::Zero();
+  for (int i = 0; i < n; ++i) {
+    const Eigen::Vector2d od = odom_xy[i] - odom_mean;
+    const Eigen::Vector2d ed = enu_xy[i] - enu_mean;
+    cross += ed * od.transpose();
+    max_dev_sq = std::max(max_dev_sq, od.squaredNorm());
+  }
+  result.baseline_m = 2.0 * std::sqrt(max_dev_sq);
+  if (result.baseline_m < min_baseline_m) {
+    return result;
+  }
+
+  // Planar Kabsch: yaw from the 2x2 cross-covariance.
+  const double s = cross(1, 0) - cross(0, 1);
+  const double c = cross(0, 0) + cross(1, 1);
+  if (s == 0.0 && c == 0.0) {
+    return result;
+  }
+  result.yaw_rad = std::atan2(s, c);
+
+  const double cy = std::cos(result.yaw_rad);
+  const double sy = std::sin(result.yaw_rad);
+  Eigen::Matrix2d rot;
+  rot << cy, -sy, sy, cy;
+  result.translation = enu_mean - rot * odom_mean;
+
+  double residual_sq_sum = 0.0;
+  for (int i = 0; i < n; ++i) {
+    const Eigen::Vector2d mapped = rot * odom_xy[i] + result.translation;
+    residual_sq_sum += (mapped - enu_xy[i]).squaredNorm();
+  }
+  result.rms_residual_m = std::sqrt(residual_sq_sum / static_cast<double>(n));
+  result.valid = true;
+  return result;
+}
+
+}  // namespace gnss_alignment
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__GNSS_ALIGNMENT_HPP_

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -432,6 +432,9 @@ private:
 
     // GNSS constraints for georeferenced mapping
     bool use_gnss_ {false};
+    bool gnss_align_yaw_ {true};
+    int gnss_yaw_alignment_min_anchors_ {10};
+    double gnss_yaw_alignment_min_baseline_m_ {5.0};
     std::string gnss_topic_ {"/gnss/fix"};
     double gnss_info_weight_ {1.0};
     bool gnss_use_covariance_weighting_ {true};

--- a/graph_based_slam/include/graph_based_slam/pose_graph_optimization.hpp
+++ b/graph_based_slam/include/graph_based_slam/pose_graph_optimization.hpp
@@ -146,6 +146,9 @@ inline OptimizationResult optimizePoseGraph(
   const LoopEdgeConfig & loop_cfg,
   const ImuEdgeConfig & imu_cfg,
   Chi2Collection chi2_collection,
+  // When GNSS anchors provide the gauge, release vertex 0 so the graph can
+  // settle into the anchor (ENU) frame; the historical default pins it.
+  bool fix_first_vertex = true,
   int iterations = 10,
   const std::string & save_path = std::string())
 {
@@ -165,7 +168,7 @@ inline OptimizationResult optimizePoseGraph(
     g2o::VertexSE3 * vertex_se3 = new g2o::VertexSE3();
     vertex_se3->setId(i);
     vertex_se3->setEstimate(pose);
-    if (i == 0) {vertex_se3->setFixed(true);}
+    if (i == 0 && fix_first_vertex) {vertex_se3->setFixed(true);}
     optimizer.addVertex(vertex_se3);
 
     if (i > 0) {

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -40,6 +40,7 @@
 #include "graph_based_slam/adjacent_edge_auto_scale.hpp"
 #include "graph_based_slam/bev_mutual_visibility.hpp"
 #include "graph_based_slam/dynamic_object_filter.hpp"
+#include "graph_based_slam/gnss_alignment.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
 #include "graph_based_slam/submap_creation.hpp"
 #include "g2o/core/robust_kernel_impl.h"
@@ -381,6 +382,12 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("gnss_non_rtk_weight_scale", gnss_non_rtk_weight_scale_);
   declare_parameter("gnss_header_stamp_max_skew_sec", 30.0);
   get_parameter("gnss_header_stamp_max_skew_sec", gnss_header_stamp_max_skew_sec_);
+  declare_parameter("gnss_align_yaw", true);
+  get_parameter("gnss_align_yaw", gnss_align_yaw_);
+  declare_parameter("gnss_yaw_alignment_min_anchors", 10);
+  get_parameter("gnss_yaw_alignment_min_anchors", gnss_yaw_alignment_min_anchors_);
+  declare_parameter("gnss_yaw_alignment_min_baseline_m", 5.0);
+  get_parameter("gnss_yaw_alignment_min_baseline_m", gnss_yaw_alignment_min_baseline_m_);
   declare_parameter("gnss_origin_min_samples", 3);
   get_parameter("gnss_origin_min_samples", gnss_origin_min_samples_);
   declare_parameter("gnss_origin_consistency_threshold_m", 20.0);
@@ -2700,6 +2707,48 @@ void GraphBasedSlamComponent::doPoseAdjustment(
     }
   }
 
+  // GNSS yaw alignment: the odometry frame's x axis is the initial heading,
+  // the anchors' x axis is east. Estimate the planar odom->ENU transform,
+  // move the whole graph into the ENU frame, and release the vertex-0 gauge
+  // so the anchors govern the global pose — without this the anchors shear
+  // the map (docs/research/gnss-constraint-first-validation.md).
+  bool fix_first_vertex = true;
+  if (gnss_align_yaw_ && !gnss_constraints.empty()) {
+    std::vector<Eigen::Vector2d> odom_xy;
+    std::vector<Eigen::Vector2d> enu_xy;
+    odom_xy.reserve(gnss_constraints.size());
+    enu_xy.reserve(gnss_constraints.size());
+    for (const auto & gnss_constraint : gnss_constraints) {
+      const Eigen::Vector3d p = submap_nodes[gnss_constraint.submap_index].pose.translation();
+      odom_xy.emplace_back(p.x(), p.y());
+      enu_xy.emplace_back(gnss_constraint.position.x(), gnss_constraint.position.y());
+    }
+    const auto alignment = gnss_alignment::estimatePlanarAlignment(
+      odom_xy, enu_xy, gnss_yaw_alignment_min_anchors_, gnss_yaw_alignment_min_baseline_m_);
+    if (alignment.valid) {
+      Eigen::Isometry3d enu_from_odom = Eigen::Isometry3d::Identity();
+      enu_from_odom.linear() =
+        Eigen::AngleAxisd(alignment.yaw_rad, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+      enu_from_odom.translation() =
+        Eigen::Vector3d(alignment.translation.x(), alignment.translation.y(), 0.0);
+      for (auto & node : submap_nodes) {
+        node.pose = enu_from_odom * node.pose;
+      }
+      fix_first_vertex = false;
+      RCLCPP_INFO(
+        get_logger(),
+        "GNSS yaw alignment applied: yaw=%.2f deg, baseline=%.1f m, rms=%.2f m; "
+        "vertex-0 gauge released, graph moves to the ENU frame",
+        alignment.yaw_rad * 180.0 / M_PI, alignment.baseline_m, alignment.rms_residual_m);
+    } else if (debug_flag_) {
+      RCLCPP_INFO(
+        get_logger(),
+        "GNSS yaw alignment not applied (pairs=%zu, baseline=%.1f m); keeping the "
+        "vertex-0 gauge",
+        odom_xy.size(), alignment.baseline_m);
+    }
+  }
+
   pose_graph::AdjacentEdgeConfig adjacent_cfg;
   adjacent_cfg.num_adjacent_pose_constraints = num_adjacent_pose_cnstraints_;
   adjacent_cfg.split_trans_rot = adjacent_edge_info_auto_scale_split_trans_rot_;
@@ -2725,7 +2774,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
   const pose_graph::OptimizationResult opt_result = pose_graph::optimizePoseGraph(
     submap_nodes, loop_constraints, imu_constraints, gnss_constraints,
     adjacent_cfg, loop_cfg, imu_cfg, chi2_collection,
-    /*iterations=*/ 10, save_pose_graph_path_);
+    fix_first_vertex, /*iterations=*/ 10, save_pose_graph_path_);
 
   if (adjacent_edge_info_auto_scale_ && submaps_size > 1) {
     graphslam::detail::AutoScaleConfig cfg;

--- a/graph_based_slam/test/test_gnss_alignment.cpp
+++ b/graph_based_slam/test/test_gnss_alignment.cpp
@@ -1,0 +1,140 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/gnss_alignment.hpp"
+
+namespace graphslam
+{
+namespace
+{
+
+using gnss_alignment::estimatePlanarAlignment;
+
+std::vector<Eigen::Vector2d> makeTrack()
+{
+  // An L-shaped 30 m track: enough baseline in both axes to observe yaw.
+  std::vector<Eigen::Vector2d> track;
+  for (int i = 0; i <= 15; ++i) {
+    track.emplace_back(static_cast<double>(i), 0.0);
+  }
+  for (int i = 1; i <= 15; ++i) {
+    track.emplace_back(15.0, static_cast<double>(i));
+  }
+  return track;
+}
+
+std::vector<Eigen::Vector2d> transformTrack(
+  const std::vector<Eigen::Vector2d> & track, double yaw_rad, const Eigen::Vector2d & t)
+{
+  const double c = std::cos(yaw_rad);
+  const double s = std::sin(yaw_rad);
+  Eigen::Matrix2d rot;
+  rot << c, -s, s, c;
+  std::vector<Eigen::Vector2d> out;
+  out.reserve(track.size());
+  for (const auto & p : track) {
+    out.push_back(rot * p + t);
+  }
+  return out;
+}
+
+TEST(GnssAlignment, RecoversKnownRotationAndTranslationExactly)
+{
+  const auto odom = makeTrack();
+  const double yaw = 137.0 * M_PI / 180.0;
+  const Eigen::Vector2d t(42.5, -17.25);
+  const auto enu = transformTrack(odom, yaw, t);
+
+  const auto a = estimatePlanarAlignment(odom, enu);
+  ASSERT_TRUE(a.valid);
+  EXPECT_NEAR(a.yaw_rad, yaw, 1e-12);
+  EXPECT_NEAR(a.translation.x(), t.x(), 1e-9);
+  EXPECT_NEAR(a.translation.y(), t.y(), 1e-9);
+  EXPECT_NEAR(a.rms_residual_m, 0.0, 1e-9);
+}
+
+TEST(GnssAlignment, RecoversNegativeYaw)
+{
+  const auto odom = makeTrack();
+  const double yaw = -92.0 * M_PI / 180.0;
+  const auto enu = transformTrack(odom, yaw, Eigen::Vector2d(3.0, 4.0));
+
+  const auto a = estimatePlanarAlignment(odom, enu);
+  ASSERT_TRUE(a.valid);
+  EXPECT_NEAR(a.yaw_rad, yaw, 1e-12);
+}
+
+TEST(GnssAlignment, RejectsTooFewPairs)
+{
+  std::vector<Eigen::Vector2d> odom = {{0.0, 0.0}, {10.0, 0.0}, {10.0, 10.0}};
+  const auto enu = transformTrack(odom, 0.5, Eigen::Vector2d(1.0, 1.0));
+  const auto a = estimatePlanarAlignment(odom, enu, /*min_pairs=*/ 10);
+  EXPECT_FALSE(a.valid);
+}
+
+TEST(GnssAlignment, RejectsShortBaseline)
+{
+  // 30 pairs but everything within ~1 m: yaw is unobservable.
+  std::vector<Eigen::Vector2d> odom;
+  for (int i = 0; i < 30; ++i) {
+    odom.emplace_back(0.01 * i, 0.005 * i);
+  }
+  const auto enu = transformTrack(odom, 1.0, Eigen::Vector2d(5.0, 5.0));
+  const auto a = estimatePlanarAlignment(odom, enu, 10, /*min_baseline_m=*/ 5.0);
+  EXPECT_FALSE(a.valid);
+  EXPECT_LT(a.baseline_m, 5.0);
+}
+
+TEST(GnssAlignment, NoisyTrackReportsResidualButStaysAccurate)
+{
+  const auto odom = makeTrack();
+  const double yaw = 0.7;
+  auto enu = transformTrack(odom, yaw, Eigen::Vector2d(-8.0, 2.0));
+  // Deterministic +/-5 cm zig-zag noise on the ENU side.
+  for (size_t i = 0; i < enu.size(); ++i) {
+    enu[i].x() += (i % 2 == 0) ? 0.05 : -0.05;
+    enu[i].y() += (i % 3 == 0) ? 0.05 : -0.05;
+  }
+
+  const auto a = estimatePlanarAlignment(odom, enu);
+  ASSERT_TRUE(a.valid);
+  EXPECT_NEAR(a.yaw_rad, yaw, 0.01);
+  EXPECT_GT(a.rms_residual_m, 0.01);
+  EXPECT_LT(a.rms_residual_m, 0.2);
+}
+
+}  // namespace
+}  // namespace graphslam

--- a/graph_based_slam/test/test_pose_graph_optimization.cpp
+++ b/graph_based_slam/test/test_pose_graph_optimization.cpp
@@ -173,6 +173,48 @@ TEST(PoseGraphOptimization, GnssAnchorPullsVertexTowardAnchor)
     << "a strong GNSS anchor must substantially reduce the anchored vertex error";
 }
 
+TEST(PoseGraphOptimization, FreeGaugeLetsAnchorsGovernTheGlobalPose)
+{
+  // A straight 11-node chain along +x, anchored by GNSS constraints that
+  // live in a frame translated by (100, 50): with the vertex-0 gauge
+  // released the whole graph must settle onto the anchors; with the gauge
+  // fixed it cannot.
+  std::vector<SubmapNode> submaps;
+  for (int i = 0; i <= 10; ++i) {
+    SubmapNode node;
+    node.pose = Eigen::Isometry3d::Identity();
+    node.pose.translation() = Eigen::Vector3d(static_cast<double>(i), 0.0, 0.0);
+    submaps.push_back(node);
+  }
+  std::vector<GnssConstraint> anchors;
+  for (int i = 0; i <= 10; i += 2) {
+    GnssConstraint g;
+    g.submap_index = i;
+    g.position = Eigen::Vector3d(static_cast<double>(i) + 100.0, 50.0, 0.0);
+    g.info_diag = Eigen::Vector3d(1000.0, 1000.0, 1000.0);
+    anchors.push_back(g);
+  }
+
+  const auto fixed_gauge = optimizePoseGraph(
+    submaps, {}, {}, anchors,
+    AdjacentEdgeConfig{}, LoopEdgeConfig{}, ImuEdgeConfig{}, Chi2Collection::NONE,
+    /*fix_first_vertex=*/ true);
+  const auto free_gauge = optimizePoseGraph(
+    submaps, {}, {}, anchors,
+    AdjacentEdgeConfig{}, LoopEdgeConfig{}, ImuEdgeConfig{}, Chi2Collection::NONE,
+    /*fix_first_vertex=*/ false, /*iterations=*/ 50);
+
+  const Eigen::Vector3d anchor0(100.0, 50.0, 0.0);
+  const double err_fixed = (fixed_gauge.poses[0].translation() - anchor0).norm();
+  const double err_free = (free_gauge.poses[0].translation() - anchor0).norm();
+  EXPECT_GT(err_fixed, 50.0) << "the pinned vertex cannot reach the anchor frame";
+  EXPECT_LT(err_free, 1.0) << "with the gauge released the graph must settle on the anchors";
+  // Chain shape is preserved while moving.
+  const double length_free =
+    (free_gauge.poses[10].translation() - free_gauge.poses[0].translation()).norm();
+  EXPECT_NEAR(length_free, 10.0, 0.5);
+}
+
 TEST(PoseGraphOptimization, Chi2CollectionModesPopulateExpectedVectors)
 {
   const auto submaps = makeDriftedChain();


### PR DESCRIPTION
## Summary
Closes the gap that #243's first validation characterized: the odometry frame's x axis is the robot's initial heading while GNSS anchors live in ENU, and with vertex 0 pinned the anchors **shear** the map (0 m at the pinned vertex growing to 337 m with distance) instead of georeferencing it.

- **`gnss_alignment.hpp`** (14th tested pure header): closed-form planar Kabsch between the matched (odometry, ENU) anchor pairs, guarded by `gnss_yaw_alignment_min_anchors` (10) and `gnss_yaw_alignment_min_baseline_m` (5.0) — a short baseline cannot observe yaw. Reports baseline + fit RMS.
- **`optimizePoseGraph` grows `fix_first_vertex`** (default true = historical behaviour). When the alignment succeeds, the component pre-rotates every submap pose into the ENU frame (relative constraints are invariant under the global transform) and **releases the vertex-0 gauge** so the anchors govern the global pose.
- `gnss_align_yaw` (default true) gates it; only ever active under the opt-in `use_gnss`. Default pipelines are untouched.

## Real-data validation (RTK-SLAM stadtgarten_seq2, appended to the research note)
- Estimated **yaw −111.83°** (baseline 201.9 m, fit RMS 1.90 m), 165 anchors.
- The corrected trajectory becomes a **rigid −112.1° rotation** of the GNSS-off solution (independent best-fit) with residuals mean 2.03 m / max 8.73 m — the anchors' actual drift corrections — replacing the **180 m mean / 337 m max shear** before.
- Raw stays 0.835 m bit-for-bit.
- **The map is georeferenced for the first time**: poses live in the ENU frame of the `LocalCartesian` origin, which is exactly what the projector metadata promises consumers.

## Tests
5 alignment unit tests (exact recovery at 1e-12, negative yaw, min-pairs / short-baseline rejection, noisy-track residual bounds) + a pose-graph gauge test (free gauge settles onto the anchors with chain shape preserved; pinned gauge cannot reach them). Package tests: **987, 0 failures** (lint clean).