### PR TITLE
refactor(slam): extract loop-closure verification decisions into loop_verifier.hpp

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -200,6 +200,13 @@ if(BUILD_TESTING)
     target_include_directories(test_gnss_alignment PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_loop_verifier
+    test/test_loop_verifier.cpp
+  )
+  if(TARGET test_loop_verifier)
+    target_include_directories(test_loop_verifier PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  endif()
+  ament_add_gtest(
     test_pose_graph_optimization
     test/test_pose_graph_optimization.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/loop_verifier.hpp
+++ b/graph_based_slam/include/graph_based_slam/loop_verifier.hpp
@@ -1,0 +1,298 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__LOOP_VERIFIER_HPP_
+#define GRAPH_BASED_SLAM__LOOP_VERIFIER_HPP_
+
+// Pure decision logic for the per-candidate verification stage of
+// searchLoopForLatest: the registration initial guess, the correction
+// magnitudes, the acceptance gates and the best-candidate selection.
+// The heavy I/O (submap aggregation, voxel filtering, NDT/GICP, 3D-BBS)
+// stays in the ROS component; everything that decides what those results
+// mean lives here so the offline BackendCore can reuse it unchanged
+// (docs/roadmap/v0.6.md, Phase 2).
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Geometry>  // NOLINT(build/include_order)
+
+namespace graphslam
+{
+namespace loop_verifier
+{
+
+struct LoopCandidate
+{
+  enum class Source
+  {
+    DISTANCE,
+    SCAN_CONTEXT,
+    BEV_DESCRIPTOR,
+    SOLID_DESCRIPTOR,
+    TRIANGLE_DESCRIPTOR
+  };
+
+  int index {-1};
+  double selection_metric {std::numeric_limits<double>::max()};
+  Source source {Source::DISTANCE};
+  double yaw_rad {0.0};
+  // Recovered SE(3) from the descriptor that proposed this candidate
+  // (currently only triangle). Identity unless populated. Used as the NDT
+  // initial guess instead of the pose-derived guess when source matches.
+  Eigen::Matrix4f relative_transform {Eigen::Matrix4f::Identity()};
+  bool has_relative_transform {false};
+};
+
+struct LoopCandidateResult
+{
+  bool valid {false};
+  int index {-1};
+  double selection_metric {std::numeric_limits<double>::max()};
+  double fitness_score {std::numeric_limits<double>::max()};
+  double travel_distance {0.0};
+  double euclidean_distance {0.0};
+  double translation_delta_m {0.0};
+  double rotation_delta_deg {0.0};
+  LoopCandidate::Source source {LoopCandidate::Source::DISTANCE};
+  bool used_3d_bbs {false};
+  double three_d_bbs_score_percentage {0.0};
+  double three_d_bbs_elapsed_msec {0.0};
+  Eigen::Matrix4f final_transformation {Eigen::Matrix4f::Identity()};
+};
+
+inline const char * sourceName(LoopCandidate::Source source)
+{
+  switch (source) {
+    case LoopCandidate::Source::SCAN_CONTEXT:
+      return "scan_context";
+    case LoopCandidate::Source::BEV_DESCRIPTOR:
+      return "bev_descriptor";
+    case LoopCandidate::Source::SOLID_DESCRIPTOR:
+      return "solid_descriptor";
+    case LoopCandidate::Source::TRIANGLE_DESCRIPTOR:
+      return "triangle_descriptor";
+    case LoopCandidate::Source::DISTANCE:
+    default:
+      return "distance";
+  }
+}
+
+struct RegistrationDelta
+{
+  double translation_m {0.0};
+  double rotation_deg {0.0};
+};
+
+// Magnitude of the correction a converged registration applied on top of
+// the stored poses. The rotation angle comes from the trace identity with
+// the cosine clamped so float round-off near identity cannot produce NaN.
+inline RegistrationDelta computeRegistrationDelta(const Eigen::Matrix4f & final_transformation)
+{
+  RegistrationDelta delta;
+  const Eigen::Vector3f translation = final_transformation.block<3, 1>(0, 3);
+  delta.translation_m = translation.cast<double>().norm();
+  const Eigen::Matrix3f rotation = final_transformation.block<3, 3>(0, 0);
+  const double trace = static_cast<double>(rotation.trace());
+  const double cos_theta = std::max(-1.0, std::min(1.0, 0.5 * (trace - 1.0)));
+  delta.rotation_deg = std::acos(cos_theta) * 180.0 / M_PI;
+  return delta;
+}
+
+// The initial guess maps latest-submap world points into the candidate's
+// neighborhood: candidate * latest^-1, optionally refined by a descriptor
+// yaw hint. A triangle-recovered SE(3) maps latest-submap-local points to
+// candidate-submap-local points, so it is chained in between the two poses
+// to recover the world-frame guess.
+inline Eigen::Matrix4f computeInitialGuess(
+  const Eigen::Affine3d & candidate_affine,
+  const Eigen::Affine3d & latest_affine,
+  const LoopCandidate & candidate)
+{
+  if (
+    candidate.source == LoopCandidate::Source::TRIANGLE_DESCRIPTOR &&
+    candidate.has_relative_transform)
+  {
+    return (candidate_affine.matrix() *
+           candidate.relative_transform.cast<double>() *
+           latest_affine.inverse().matrix()).cast<float>();
+  }
+  if (std::abs(candidate.yaw_rad) > 1e-6) {
+    Eigen::Affine3d yaw_correction = Eigen::Affine3d::Identity();
+    yaw_correction.rotate(Eigen::AngleAxisd(candidate.yaw_rad, Eigen::Vector3d::UnitZ()));
+    return (candidate_affine.matrix() * yaw_correction.matrix() *
+           latest_affine.inverse().matrix()).cast<float>();
+  }
+  return (candidate_affine.matrix() * latest_affine.inverse().matrix()).cast<float>();
+}
+
+// DISTANCE candidates historically align without a guess (their stored
+// poses are already close); every descriptor-sourced candidate, and any
+// candidate re-localized by 3D-BBS, supplies one.
+inline bool shouldUseInitialGuess(LoopCandidate::Source source, bool used_3d_bbs)
+{
+  return source != LoopCandidate::Source::DISTANCE || used_3d_bbs;
+}
+
+struct GateConfig
+{
+  double generic_score_threshold {0.0};
+  // ScanContext candidates may use their own fitness threshold; a value
+  // <= 0 falls back to the generic one.
+  double scan_context_score_threshold {0.0};
+  double max_translation_m {0.0};
+  double max_rotation_deg {0.0};
+  // Descriptor-sourced candidates (TRIANGLE / SCAN_CONTEXT / BEV / SOLID)
+  // already passed a place-recognition gate, so they can accept a larger
+  // correction when the operator opts in (> 0). DISTANCE candidates (close
+  // in stored pose) always keep the strict generic cap.
+  double max_translation_descriptor_m {0.0};
+  double max_rotation_descriptor_deg {0.0};
+};
+
+enum class GateRejection
+{
+  NONE,
+  FITNESS,
+  TRANSLATION,
+  ROTATION
+};
+
+struct GateResult
+{
+  GateRejection rejection {GateRejection::NONE};
+  // Effective thresholds after the per-source fallbacks, for operator logs.
+  double score_threshold {0.0};
+  double translation_cap_m {0.0};
+  double rotation_cap_deg {0.0};
+};
+
+// Acceptance gates in their historical order: fitness (>= rejects, so a
+// score exactly at the threshold is rejected), then the translation and
+// rotation caps (> rejects, so a correction exactly at the cap passes).
+inline GateResult evaluateGates(
+  LoopCandidate::Source source,
+  double fitness_score,
+  const RegistrationDelta & delta,
+  const GateConfig & config)
+{
+  GateResult result;
+  result.score_threshold =
+    (source == LoopCandidate::Source::SCAN_CONTEXT &&
+    config.scan_context_score_threshold > 0.0) ?
+    config.scan_context_score_threshold : config.generic_score_threshold;
+  const bool is_descriptor_source = source != LoopCandidate::Source::DISTANCE;
+  result.translation_cap_m =
+    (is_descriptor_source && config.max_translation_descriptor_m > 0.0) ?
+    config.max_translation_descriptor_m : config.max_translation_m;
+  result.rotation_cap_deg =
+    (is_descriptor_source && config.max_rotation_descriptor_deg > 0.0) ?
+    config.max_rotation_descriptor_deg : config.max_rotation_deg;
+
+  if (fitness_score >= result.score_threshold) {
+    result.rejection = GateRejection::FITNESS;
+    return result;
+  }
+  if (delta.translation_m > result.translation_cap_m) {
+    result.rejection = GateRejection::TRANSLATION;
+    return result;
+  }
+  if (delta.rotation_deg > result.rotation_cap_deg) {
+    result.rejection = GateRejection::ROTATION;
+    return result;
+  }
+  return result;
+}
+
+// The historical three-track selection. Every converged registration feeds
+// considerConverged (diagnostics: best_attempt survives even when all gates
+// reject); gate-passing results (valid must already be set) feed
+// considerValid, which also tracks the best ScanContext-sourced result so
+// the operator can prefer it. Ties keep the first arrival (strict <), which
+// together with the deterministic candidate order keeps selection
+// deterministic.
+struct SelectionState
+{
+  LoopCandidateResult best_attempt;
+  LoopCandidateResult best_valid;
+  LoopCandidateResult best_scan_context;
+
+  void considerConverged(const LoopCandidateResult & result)
+  {
+    if (best_attempt.index < 0 || result.fitness_score < best_attempt.fitness_score) {
+      best_attempt = result;
+    }
+  }
+
+  void considerValid(const LoopCandidateResult & result)
+  {
+    if (!best_valid.valid || result.fitness_score < best_valid.fitness_score) {
+      best_valid = result;
+    }
+    if (
+      result.source == LoopCandidate::Source::SCAN_CONTEXT &&
+      (!best_scan_context.valid ||
+      result.fitness_score < best_scan_context.fitness_score))
+    {
+      best_scan_context = result;
+    }
+  }
+
+  // A valid ScanContext result overrides the global best when preferred,
+  // even when its fitness is worse. Returns a result with valid == false
+  // when no candidate passed the gates.
+  LoopCandidateResult select(bool prefer_scan_context) const
+  {
+    if (prefer_scan_context && best_scan_context.valid) {
+      return best_scan_context;
+    }
+    return best_valid;
+  }
+};
+
+// The accepted loop edge stores candidate -> latest expressed in the
+// candidate frame: from^-1 * (final_transformation * latest), exactly as
+// the optimizer consumed it historically.
+inline Eigen::Isometry3d composeLoopRelativePose(
+  const Eigen::Affine3d & candidate_affine,
+  const Eigen::Affine3d & latest_affine,
+  const Eigen::Matrix4f & final_transformation)
+{
+  Eigen::Isometry3d from = Eigen::Isometry3d(candidate_affine.matrix());
+  Eigen::Isometry3d to = Eigen::Isometry3d(
+    final_transformation.cast<double>() * latest_affine.matrix());
+  return Eigen::Isometry3d(from.inverse() * to);
+}
+
+}  // namespace loop_verifier
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__LOOP_VERIFIER_HPP_

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -41,6 +41,7 @@
 #include "graph_based_slam/bev_mutual_visibility.hpp"
 #include "graph_based_slam/dynamic_object_filter.hpp"
 #include "graph_based_slam/gnss_alignment.hpp"
+#include "graph_based_slam/loop_verifier.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
 #include "graph_based_slam/submap_creation.hpp"
 #include "g2o/core/robust_kernel_impl.h"
@@ -1281,60 +1282,16 @@ bool GraphBasedSlamComponent::upsertLoopEdge(const LoopEdge & loop_edge)
 }
 namespace
 {
-struct LoopCandidate
-{
-  enum class Source
-  {
-    DISTANCE,
-    SCAN_CONTEXT,
-    BEV_DESCRIPTOR,
-    SOLID_DESCRIPTOR,
-    TRIANGLE_DESCRIPTOR
-  };
-
-  int index {-1};
-  double selection_metric {std::numeric_limits<double>::max()};
-  Source source {Source::DISTANCE};
-  double yaw_rad {0.0};
-  // Recovered SE(3) from the descriptor that proposed this candidate
-  // (currently only triangle). Identity unless populated. Used as the NDT
-  // initial guess instead of the pose-derived guess when source matches.
-  Eigen::Matrix4f relative_transform {Eigen::Matrix4f::Identity()};
-  bool has_relative_transform {false};
-};
-
-struct LoopCandidateResult
-{
-  bool valid {false};
-  int index {-1};
-  double selection_metric {std::numeric_limits<double>::max()};
-  double fitness_score {std::numeric_limits<double>::max()};
-  double travel_distance {0.0};
-  double euclidean_distance {0.0};
-  double translation_delta_m {0.0};
-  double rotation_delta_deg {0.0};
-  LoopCandidate::Source source {LoopCandidate::Source::DISTANCE};
-  bool used_3d_bbs {false};
-  double three_d_bbs_score_percentage {0.0};
-  double three_d_bbs_elapsed_msec {0.0};
-  Eigen::Matrix4f final_transformation {Eigen::Matrix4f::Identity()};
-};
+// The candidate/result types and every verification decision (initial
+// guess, gates, best-candidate selection) live in loop_verifier.hpp so the
+// offline BackendCore can reuse them; this file only does the I/O around
+// them (cloud aggregation, registration, logging).
+using LoopCandidate = loop_verifier::LoopCandidate;
+using LoopCandidateResult = loop_verifier::LoopCandidateResult;
 
 const char * candidate_source_name(LoopCandidate::Source source)
 {
-  switch (source) {
-    case LoopCandidate::Source::SCAN_CONTEXT:
-      return "scan_context";
-    case LoopCandidate::Source::BEV_DESCRIPTOR:
-      return "bev_descriptor";
-    case LoopCandidate::Source::SOLID_DESCRIPTOR:
-      return "solid_descriptor";
-    case LoopCandidate::Source::TRIANGLE_DESCRIPTOR:
-      return "triangle_descriptor";
-    case LoopCandidate::Source::DISTANCE:
-    default:
-      return "distance";
-  }
+  return loop_verifier::sourceName(source);
 }
 }  // namespace
 
@@ -2272,9 +2229,15 @@ void GraphBasedSlamComponent::searchLoopForLatest(
     return;
   }
 
-  LoopCandidateResult best_candidate;
-  LoopCandidateResult best_scan_context_candidate;
-  LoopCandidateResult best_attempt;
+  loop_verifier::GateConfig gate_config;
+  gate_config.generic_score_threshold = threshold_loop_closure_score_;
+  gate_config.scan_context_score_threshold = scan_context_loop_closure_score_threshold_;
+  gate_config.max_translation_m = loop_max_translation_delta_;
+  gate_config.max_rotation_deg = loop_max_rotation_delta_deg_;
+  gate_config.max_translation_descriptor_m = loop_max_translation_delta_descriptor_;
+  gate_config.max_rotation_descriptor_deg = loop_max_rotation_delta_deg_descriptor_;
+
+  loop_verifier::SelectionState selection;
   bool attempted_registration = false;
 
   for (const auto & candidate : candidates) {
@@ -2339,25 +2302,7 @@ void GraphBasedSlamComponent::searchLoopForLatest(
     double three_d_bbs_score_percentage = 0.0;
     double three_d_bbs_elapsed_msec = 0.0;
     Eigen::Matrix4f initial_guess =
-      (candidate_affine.matrix() * latest_affine.inverse().matrix()).cast<float>();
-    if (
-      candidate.source == LoopCandidate::Source::TRIANGLE_DESCRIPTOR &&
-      candidate.has_relative_transform)
-    {
-      // Triangle proposes a SE(3) that maps latest-submap-local points to
-      // chosen-submap-local points. NDT works in world frame, so chain in
-      // the two submap poses to recover the source -> target world guess.
-      initial_guess =
-        (candidate_affine.matrix() *
-        candidate.relative_transform.cast<double>() *
-        latest_affine.inverse().matrix()).cast<float>();
-    } else if (std::abs(candidate.yaw_rad) > 1e-6) {
-      Eigen::Affine3d yaw_correction = Eigen::Affine3d::Identity();
-      yaw_correction.rotate(Eigen::AngleAxisd(candidate.yaw_rad, Eigen::Vector3d::UnitZ()));
-      initial_guess =
-        (candidate_affine.matrix() * yaw_correction.matrix() * latest_affine.inverse().matrix()).
-        cast<float>();
-    }
+      loop_verifier::computeInitialGuess(candidate_affine, latest_affine, candidate);
     if (candidate.source == LoopCandidate::Source::SCAN_CONTEXT) {
       registration_->setInputSource(filtered_source_sc);
       registration_->setInputTarget(filtered_clouds_sc_ptr);
@@ -2419,7 +2364,7 @@ void GraphBasedSlamComponent::searchLoopForLatest(
         }
       }
     }
-    if (candidate.source != LoopCandidate::Source::DISTANCE || used_3d_bbs) {
+    if (loop_verifier::shouldUseInitialGuess(candidate.source, used_3d_bbs)) {
       registration_->align(*output_cloud_ptr, initial_guess);
     } else {
       registration_->align(*output_cloud_ptr);
@@ -2438,12 +2383,8 @@ void GraphBasedSlamComponent::searchLoopForLatest(
 
     const double fitness_score = registration_->getFitnessScore();
     const Eigen::Matrix4f final_transformation = registration_->getFinalTransformation();
-    const Eigen::Vector3f translation = final_transformation.block<3, 1>(0, 3);
-    const double translation_delta_m = translation.cast<double>().norm();
-    const Eigen::Matrix3f rotation = final_transformation.block<3, 3>(0, 0);
-    const double trace = static_cast<double>(rotation.trace());
-    const double cos_theta = std::max(-1.0, std::min(1.0, 0.5 * (trace - 1.0)));
-    const double rotation_delta_deg = std::acos(cos_theta) * 180.0 / M_PI;
+    const loop_verifier::RegistrationDelta registration_delta =
+      loop_verifier::computeRegistrationDelta(final_transformation);
 
     LoopCandidateResult candidate_result;
     candidate_result.index = candidate.index;
@@ -2455,100 +2396,78 @@ void GraphBasedSlamComponent::searchLoopForLatest(
       candidate_submap.pose.position.y,
       candidate_submap.pose.position.z);
     candidate_result.euclidean_distance = (latest_submap_pos - candidate_submap_pos).norm();
-    candidate_result.translation_delta_m = translation_delta_m;
-    candidate_result.rotation_delta_deg = rotation_delta_deg;
+    candidate_result.translation_delta_m = registration_delta.translation_m;
+    candidate_result.rotation_delta_deg = registration_delta.rotation_deg;
     candidate_result.source = candidate.source;
     candidate_result.used_3d_bbs = used_3d_bbs;
     candidate_result.three_d_bbs_score_percentage = three_d_bbs_score_percentage;
     candidate_result.three_d_bbs_elapsed_msec = three_d_bbs_elapsed_msec;
     candidate_result.final_transformation = final_transformation;
 
-    if (best_attempt.index < 0 || fitness_score < best_attempt.fitness_score) {
-      best_attempt = candidate_result;
-    }
+    selection.considerConverged(candidate_result);
 
-    const double loop_score_threshold =
-      (candidate.source == LoopCandidate::Source::SCAN_CONTEXT &&
-      scan_context_loop_closure_score_threshold_ > 0.0) ?
-      scan_context_loop_closure_score_threshold_ : threshold_loop_closure_score_;
-
-    if (fitness_score >= loop_score_threshold) {
+    const loop_verifier::GateResult gate = loop_verifier::evaluateGates(
+      candidate.source, fitness_score, registration_delta, gate_config);
+    if (gate.rejection != loop_verifier::GateRejection::NONE) {
       if (debug_flag_) {
-        RCLCPP_INFO(
-          get_logger(),
-          "Rejected loop candidate %d -> %d because fitness %.6f exceeds threshold %.6f",
-          candidate.index,
-          latest_idx,
-          fitness_score,
-          loop_score_threshold);
-      }
-      continue;
-    }
-    // Descriptor-sourced candidates (TRIANGLE / SCAN_CONTEXT / BEV / SOLID)
-    // already passed a place-recognition gate, so they can accept a larger
-    // NDT correction when the operator opts in. DISTANCE candidates (close
-    // in stored pose) keep the strict generic cap.
-    const bool is_descriptor_source =
-      candidate.source != LoopCandidate::Source::DISTANCE;
-    const double effective_translation_cap =
-      (is_descriptor_source && loop_max_translation_delta_descriptor_ > 0.0) ?
-      loop_max_translation_delta_descriptor_ : loop_max_translation_delta_;
-    const double effective_rotation_cap_deg =
-      (is_descriptor_source && loop_max_rotation_delta_deg_descriptor_ > 0.0) ?
-      loop_max_rotation_delta_deg_descriptor_ : loop_max_rotation_delta_deg_;
-    if (translation_delta_m > effective_translation_cap) {
-      if (debug_flag_) {
-        RCLCPP_INFO(
-          get_logger(),
-          "Rejected loop candidate %d -> %d because translation correction %.3f m exceeds %.3f m",
-          candidate.index,
-          latest_idx,
-          translation_delta_m,
-          effective_translation_cap);
-      }
-      continue;
-    }
-    if (rotation_delta_deg > effective_rotation_cap_deg) {
-      if (debug_flag_) {
-        RCLCPP_INFO(
-          get_logger(),
-          "Rejected loop candidate %d -> %d because rotation correction %.3f deg exceeds %.3f deg",
-          candidate.index,
-          latest_idx,
-          rotation_delta_deg,
-          effective_rotation_cap_deg);
+        switch (gate.rejection) {
+          case loop_verifier::GateRejection::FITNESS:
+            RCLCPP_INFO(
+              get_logger(),
+              "Rejected loop candidate %d -> %d because fitness %.6f exceeds threshold %.6f",
+              candidate.index,
+              latest_idx,
+              fitness_score,
+              gate.score_threshold);
+            break;
+          case loop_verifier::GateRejection::TRANSLATION:
+            RCLCPP_INFO(
+              get_logger(),
+              "Rejected loop candidate %d -> %d because translation correction %.3f m "
+              "exceeds %.3f m",
+              candidate.index,
+              latest_idx,
+              registration_delta.translation_m,
+              gate.translation_cap_m);
+            break;
+          case loop_verifier::GateRejection::ROTATION:
+            RCLCPP_INFO(
+              get_logger(),
+              "Rejected loop candidate %d -> %d because rotation correction %.3f deg "
+              "exceeds %.3f deg",
+              candidate.index,
+              latest_idx,
+              registration_delta.rotation_deg,
+              gate.rotation_cap_deg);
+            break;
+          default:
+            break;
+        }
       }
       continue;
     }
 
     candidate_result.valid = true;
-    if (!best_candidate.valid || fitness_score < best_candidate.fitness_score) {
-      best_candidate = candidate_result;
-    }
-    if (
-      candidate.source == LoopCandidate::Source::SCAN_CONTEXT &&
-      (!best_scan_context_candidate.valid ||
-      fitness_score < best_scan_context_candidate.fitness_score))
-    {
-      best_scan_context_candidate = candidate_result;
-    }
+    selection.considerValid(candidate_result);
   }
 
-  if (prefer_scan_context_candidates_ && best_scan_context_candidate.valid) {
+  if (prefer_scan_context_candidates_ && selection.best_scan_context.valid) {
     if (
-      !best_candidate.valid ||
-      best_candidate.index != best_scan_context_candidate.index ||
-      best_candidate.source != LoopCandidate::Source::SCAN_CONTEXT)
+      !selection.best_valid.valid ||
+      selection.best_valid.index != selection.best_scan_context.index ||
+      selection.best_valid.source != LoopCandidate::Source::SCAN_CONTEXT)
     {
       std::cout << "Preferring valid ScanContext candidate id:" <<
-        best_scan_context_candidate.index << " over best candidate id:" <<
-        (best_candidate.valid ? std::to_string(best_candidate.index) : std::string("none"))
+        selection.best_scan_context.index << " over best candidate id:" <<
+        (selection.best_valid.valid ?
+      std::to_string(selection.best_valid.index) : std::string("none"))
                 << std::endl;
     }
-    best_candidate = best_scan_context_candidate;
   }
+  const LoopCandidateResult best_candidate = selection.select(prefer_scan_context_candidates_);
 
   if (!best_candidate.valid) {
+    const LoopCandidateResult & best_attempt = selection.best_attempt;
     if (best_attempt.index >= 0) {
       std::cout << "best_loop_candidate id:" << best_attempt.index
                 << " source:" << candidate_source_name(best_attempt.source)
@@ -2576,11 +2495,8 @@ void GraphBasedSlamComponent::searchLoopForLatest(
 
   LoopEdge loop_edge;
   loop_edge.pair_id = std::pair<int, int>(best_candidate.index, latest_idx);
-  Eigen::Isometry3d from = Eigen::Isometry3d(submap_affine.matrix());
-  Eigen::Isometry3d to = Eigen::Isometry3d(
-    best_candidate.final_transformation.cast<double>() * init_affine.matrix());
-
-  loop_edge.relative_pose = Eigen::Isometry3d(from.inverse() * to);
+  loop_edge.relative_pose = loop_verifier::composeLoopRelativePose(
+    submap_affine, init_affine, best_candidate.final_transformation);
   loop_edge.fitness_score = best_candidate.fitness_score;
   const bool graph_changed = upsertLoopEdge(loop_edge);
 

--- a/graph_based_slam/test/test_loop_verifier.cpp
+++ b/graph_based_slam/test/test_loop_verifier.cpp
@@ -1,0 +1,373 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Characterization tests for the loop-closure verification decision logic
+// extracted from searchLoopForLatest. These pin the historical semantics
+// (threshold fallbacks, >= vs > boundaries, first-wins ties, ScanContext
+// preference) so the extraction and the later BackendCore reuse cannot
+// silently change behavior.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Geometry>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/loop_verifier.hpp"
+
+namespace graphslam
+{
+namespace
+{
+
+using loop_verifier::GateConfig;
+using loop_verifier::GateRejection;
+using loop_verifier::LoopCandidate;
+using loop_verifier::LoopCandidateResult;
+using loop_verifier::RegistrationDelta;
+using loop_verifier::SelectionState;
+
+using Source = LoopCandidate::Source;
+
+Eigen::Affine3d makePose(double x, double y, double z, double yaw_rad)
+{
+  Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+  pose.translate(Eigen::Vector3d(x, y, z));
+  pose.rotate(Eigen::AngleAxisd(yaw_rad, Eigen::Vector3d::UnitZ()));
+  return pose;
+}
+
+LoopCandidateResult makeResult(int index, double fitness, Source source)
+{
+  LoopCandidateResult result;
+  result.index = index;
+  result.fitness_score = fitness;
+  result.source = source;
+  result.valid = true;
+  return result;
+}
+
+GateConfig makeGateConfig()
+{
+  GateConfig config;
+  config.generic_score_threshold = 1.0;
+  config.scan_context_score_threshold = 0.0;
+  config.max_translation_m = 5.0;
+  config.max_rotation_deg = 30.0;
+  config.max_translation_descriptor_m = 0.0;
+  config.max_rotation_descriptor_deg = 0.0;
+  return config;
+}
+
+TEST(LoopVerifierDelta, RecoversKnownRotationAndTranslation)
+{
+  const double yaw = 30.0 * M_PI / 180.0;
+  Eigen::Matrix4f transform = Eigen::Matrix4f::Identity();
+  transform.block<3, 3>(0, 0) =
+    Eigen::AngleAxisf(static_cast<float>(yaw), Eigen::Vector3f::UnitZ()).toRotationMatrix();
+  transform.block<3, 1>(0, 3) = Eigen::Vector3f(1.0F, 2.0F, 2.0F);
+
+  const auto delta = loop_verifier::computeRegistrationDelta(transform);
+  EXPECT_NEAR(delta.translation_m, 3.0, 1e-6);
+  EXPECT_NEAR(delta.rotation_deg, 30.0, 1e-4);
+}
+
+TEST(LoopVerifierDelta, IdentityIsZeroAndTraceIsClamped)
+{
+  const auto delta = loop_verifier::computeRegistrationDelta(Eigen::Matrix4f::Identity());
+  EXPECT_DOUBLE_EQ(delta.translation_m, 0.0);
+  // Float round-off can push the trace of a near-identity rotation above
+  // 3.0; the clamp keeps acos finite instead of NaN.
+  EXPECT_FALSE(std::isnan(delta.rotation_deg));
+  EXPECT_DOUBLE_EQ(delta.rotation_deg, 0.0);
+
+  Eigen::Matrix4f half_turn = Eigen::Matrix4f::Identity();
+  half_turn.block<3, 3>(0, 0) =
+    Eigen::AngleAxisf(static_cast<float>(M_PI), Eigen::Vector3f::UnitZ()).toRotationMatrix();
+  EXPECT_NEAR(loop_verifier::computeRegistrationDelta(half_turn).rotation_deg, 180.0, 1e-3);
+}
+
+TEST(LoopVerifierGuess, DefaultIsCandidateTimesLatestInverse)
+{
+  const auto candidate_pose = makePose(10.0, -4.0, 1.0, 0.8);
+  const auto latest_pose = makePose(-2.0, 7.0, 0.5, -1.2);
+  LoopCandidate candidate;
+  candidate.source = Source::DISTANCE;
+
+  const Eigen::Matrix4f guess =
+    loop_verifier::computeInitialGuess(candidate_pose, latest_pose, candidate);
+  const Eigen::Matrix4f expected =
+    (candidate_pose.matrix() * latest_pose.inverse().matrix()).cast<float>();
+  EXPECT_TRUE(guess.isApprox(expected));
+}
+
+TEST(LoopVerifierGuess, YawHintInsertsAYawCorrection)
+{
+  const auto candidate_pose = makePose(3.0, 2.0, 0.0, 0.1);
+  const auto latest_pose = makePose(1.0, 1.0, 0.0, 0.0);
+  LoopCandidate candidate;
+  candidate.source = Source::SCAN_CONTEXT;
+  candidate.yaw_rad = 0.3;
+
+  const Eigen::Matrix4f guess =
+    loop_verifier::computeInitialGuess(candidate_pose, latest_pose, candidate);
+  Eigen::Affine3d yaw_correction = Eigen::Affine3d::Identity();
+  yaw_correction.rotate(Eigen::AngleAxisd(0.3, Eigen::Vector3d::UnitZ()));
+  const Eigen::Matrix4f expected =
+    (candidate_pose.matrix() * yaw_correction.matrix() *
+    latest_pose.inverse().matrix()).cast<float>();
+  EXPECT_TRUE(guess.isApprox(expected));
+
+  // A yaw at or below the 1e-6 dead band falls back to the default guess.
+  candidate.yaw_rad = 1e-7;
+  const Eigen::Matrix4f tiny_yaw_guess =
+    loop_verifier::computeInitialGuess(candidate_pose, latest_pose, candidate);
+  const Eigen::Matrix4f default_guess =
+    (candidate_pose.matrix() * latest_pose.inverse().matrix()).cast<float>();
+  EXPECT_TRUE(tiny_yaw_guess.isApprox(default_guess));
+}
+
+TEST(LoopVerifierGuess, TriangleRelativeTransformIsChainedBetweenThePoses)
+{
+  const auto candidate_pose = makePose(5.0, 0.0, 0.0, 0.4);
+  const auto latest_pose = makePose(0.0, 5.0, 0.0, -0.4);
+  LoopCandidate candidate;
+  candidate.source = Source::TRIANGLE_DESCRIPTOR;
+  candidate.has_relative_transform = true;
+  Eigen::Matrix4f relative = Eigen::Matrix4f::Identity();
+  relative.block<3, 1>(0, 3) = Eigen::Vector3f(0.5F, -0.25F, 0.0F);
+  candidate.relative_transform = relative;
+  candidate.yaw_rad = 1.0;  // must be ignored when the SE(3) is present
+
+  const Eigen::Matrix4f guess =
+    loop_verifier::computeInitialGuess(candidate_pose, latest_pose, candidate);
+  const Eigen::Matrix4f expected =
+    (candidate_pose.matrix() * relative.cast<double>() *
+    latest_pose.inverse().matrix()).cast<float>();
+  EXPECT_TRUE(guess.isApprox(expected));
+}
+
+TEST(LoopVerifierGuess, RelativeTransformOnNonTriangleSourceIsIgnored)
+{
+  const auto candidate_pose = makePose(5.0, 0.0, 0.0, 0.4);
+  const auto latest_pose = makePose(0.0, 5.0, 0.0, -0.4);
+  LoopCandidate candidate;
+  candidate.source = Source::BEV_DESCRIPTOR;
+  candidate.has_relative_transform = true;
+  Eigen::Matrix4f relative = Eigen::Matrix4f::Identity();
+  relative.block<3, 1>(0, 3) = Eigen::Vector3f(9.0F, 9.0F, 9.0F);
+  candidate.relative_transform = relative;
+
+  const Eigen::Matrix4f guess =
+    loop_verifier::computeInitialGuess(candidate_pose, latest_pose, candidate);
+  const Eigen::Matrix4f expected =
+    (candidate_pose.matrix() * latest_pose.inverse().matrix()).cast<float>();
+  EXPECT_TRUE(guess.isApprox(expected));
+}
+
+TEST(LoopVerifierGuess, OnlyDistanceWithout3dBbsAlignsWithoutAGuess)
+{
+  EXPECT_FALSE(loop_verifier::shouldUseInitialGuess(Source::DISTANCE, false));
+  EXPECT_TRUE(loop_verifier::shouldUseInitialGuess(Source::DISTANCE, true));
+  EXPECT_TRUE(loop_verifier::shouldUseInitialGuess(Source::SCAN_CONTEXT, false));
+  EXPECT_TRUE(loop_verifier::shouldUseInitialGuess(Source::TRIANGLE_DESCRIPTOR, false));
+}
+
+TEST(LoopVerifierGates, FitnessExactlyAtThresholdIsRejected)
+{
+  const auto config = makeGateConfig();
+  RegistrationDelta delta;
+  const auto at_threshold = loop_verifier::evaluateGates(
+    Source::DISTANCE, 1.0, delta, config);
+  EXPECT_EQ(at_threshold.rejection, GateRejection::FITNESS);
+  EXPECT_DOUBLE_EQ(at_threshold.score_threshold, 1.0);
+
+  const auto below = loop_verifier::evaluateGates(
+    Source::DISTANCE, 0.999, delta, config);
+  EXPECT_EQ(below.rejection, GateRejection::NONE);
+}
+
+TEST(LoopVerifierGates, ScanContextThresholdAppliesOnlyWhenPositive)
+{
+  auto config = makeGateConfig();
+  config.scan_context_score_threshold = 0.5;
+  RegistrationDelta delta;
+
+  const auto sc = loop_verifier::evaluateGates(Source::SCAN_CONTEXT, 0.7, delta, config);
+  EXPECT_EQ(sc.rejection, GateRejection::FITNESS);
+  EXPECT_DOUBLE_EQ(sc.score_threshold, 0.5);
+
+  // Other sources keep the generic threshold even when the SC one is set.
+  const auto bev = loop_verifier::evaluateGates(Source::BEV_DESCRIPTOR, 0.7, delta, config);
+  EXPECT_EQ(bev.rejection, GateRejection::NONE);
+
+  // A non-positive SC threshold falls back to the generic one.
+  config.scan_context_score_threshold = 0.0;
+  const auto fallback = loop_verifier::evaluateGates(Source::SCAN_CONTEXT, 0.7, delta, config);
+  EXPECT_EQ(fallback.rejection, GateRejection::NONE);
+  EXPECT_DOUBLE_EQ(fallback.score_threshold, 1.0);
+}
+
+TEST(LoopVerifierGates, DescriptorCapsApplyOnlyToDescriptorSourcesAndWhenPositive)
+{
+  auto config = makeGateConfig();
+  config.max_translation_descriptor_m = 10.0;
+  config.max_rotation_descriptor_deg = 60.0;
+  RegistrationDelta delta;
+  delta.translation_m = 7.0;
+  delta.rotation_deg = 45.0;
+
+  // Descriptor source: the relaxed caps accept the larger correction.
+  const auto sc = loop_verifier::evaluateGates(Source::SCAN_CONTEXT, 0.1, delta, config);
+  EXPECT_EQ(sc.rejection, GateRejection::NONE);
+  EXPECT_DOUBLE_EQ(sc.translation_cap_m, 10.0);
+  EXPECT_DOUBLE_EQ(sc.rotation_cap_deg, 60.0);
+
+  // DISTANCE always keeps the strict generic caps.
+  const auto distance = loop_verifier::evaluateGates(Source::DISTANCE, 0.1, delta, config);
+  EXPECT_EQ(distance.rejection, GateRejection::TRANSLATION);
+  EXPECT_DOUBLE_EQ(distance.translation_cap_m, 5.0);
+
+  // Non-positive descriptor caps fall back to the generic ones.
+  config.max_translation_descriptor_m = 0.0;
+  config.max_rotation_descriptor_deg = 0.0;
+  const auto fallback = loop_verifier::evaluateGates(Source::SCAN_CONTEXT, 0.1, delta, config);
+  EXPECT_EQ(fallback.rejection, GateRejection::TRANSLATION);
+  EXPECT_DOUBLE_EQ(fallback.translation_cap_m, 5.0);
+}
+
+TEST(LoopVerifierGates, GateOrderIsFitnessThenTranslationThenRotation)
+{
+  const auto config = makeGateConfig();
+  RegistrationDelta delta;
+  delta.translation_m = 100.0;
+  delta.rotation_deg = 100.0;
+
+  const auto all_fail = loop_verifier::evaluateGates(Source::DISTANCE, 2.0, delta, config);
+  EXPECT_EQ(all_fail.rejection, GateRejection::FITNESS);
+
+  const auto trans_rot_fail = loop_verifier::evaluateGates(Source::DISTANCE, 0.1, delta, config);
+  EXPECT_EQ(trans_rot_fail.rejection, GateRejection::TRANSLATION);
+
+  delta.translation_m = 1.0;
+  const auto rot_fail = loop_verifier::evaluateGates(Source::DISTANCE, 0.1, delta, config);
+  EXPECT_EQ(rot_fail.rejection, GateRejection::ROTATION);
+}
+
+TEST(LoopVerifierGates, CorrectionExactlyAtTheCapPasses)
+{
+  const auto config = makeGateConfig();
+  RegistrationDelta delta;
+  delta.translation_m = 5.0;
+  delta.rotation_deg = 30.0;
+  const auto result = loop_verifier::evaluateGates(Source::DISTANCE, 0.1, delta, config);
+  EXPECT_EQ(result.rejection, GateRejection::NONE);
+}
+
+TEST(LoopVerifierSelection, FirstArrivalWinsOnEqualFitness)
+{
+  SelectionState selection;
+  selection.considerValid(makeResult(3, 0.5, Source::DISTANCE));
+  selection.considerValid(makeResult(7, 0.5, Source::DISTANCE));
+  const auto best = selection.select(false);
+  ASSERT_TRUE(best.valid);
+  EXPECT_EQ(best.index, 3);
+}
+
+TEST(LoopVerifierSelection, BestAttemptTracksGateRejectedCandidatesToo)
+{
+  SelectionState selection;
+  // A converged registration whose gates rejected it: only considerConverged.
+  auto rejected = makeResult(2, 0.05, Source::DISTANCE);
+  rejected.valid = false;
+  selection.considerConverged(rejected);
+
+  auto accepted = makeResult(9, 0.4, Source::DISTANCE);
+  selection.considerConverged(accepted);
+  selection.considerValid(accepted);
+
+  EXPECT_EQ(selection.best_attempt.index, 2);
+  const auto best = selection.select(false);
+  ASSERT_TRUE(best.valid);
+  EXPECT_EQ(best.index, 9);
+}
+
+TEST(LoopVerifierSelection, ScanContextPreferenceOverridesBetterGenericFitness)
+{
+  SelectionState selection;
+  selection.considerValid(makeResult(4, 0.1, Source::DISTANCE));
+  selection.considerValid(makeResult(8, 0.6, Source::SCAN_CONTEXT));
+
+  const auto unpreferred = selection.select(false);
+  EXPECT_EQ(unpreferred.index, 4);
+
+  const auto preferred = selection.select(true);
+  EXPECT_EQ(preferred.index, 8);
+  EXPECT_EQ(preferred.source, Source::SCAN_CONTEXT);
+
+  // Preference without any valid ScanContext result is a no-op.
+  SelectionState no_sc;
+  no_sc.considerValid(makeResult(4, 0.1, Source::DISTANCE));
+  EXPECT_EQ(no_sc.select(true).index, 4);
+}
+
+TEST(LoopVerifierSelection, NoValidCandidateSelectsAnInvalidResult)
+{
+  SelectionState selection;
+  auto rejected = makeResult(2, 0.05, Source::DISTANCE);
+  rejected.valid = false;
+  selection.considerConverged(rejected);
+
+  const auto best = selection.select(true);
+  EXPECT_FALSE(best.valid);
+  EXPECT_EQ(best.index, -1);
+}
+
+TEST(LoopVerifierEdge, RelativePoseChainsCorrectionOntoTheLatestPose)
+{
+  const auto candidate_pose = makePose(10.0, 0.0, 0.0, 0.0);
+  const auto latest_pose = makePose(10.0, 2.0, 0.0, 0.0);
+
+  // Identity correction: the edge is exactly candidate^-1 * latest.
+  const auto identity_edge = loop_verifier::composeLoopRelativePose(
+    candidate_pose, latest_pose, Eigen::Matrix4f::Identity());
+  EXPECT_NEAR(identity_edge.translation().y(), 2.0, 1e-9);
+
+  // A correction that moves the latest submap onto the candidate closes
+  // the residual.
+  Eigen::Matrix4f correction = Eigen::Matrix4f::Identity();
+  correction(1, 3) = -2.0F;
+  const auto closed_edge = loop_verifier::composeLoopRelativePose(
+    candidate_pose, latest_pose, correction);
+  EXPECT_NEAR(closed_edge.translation().norm(), 0.0, 1e-6);
+}
+
+}  // namespace
+}  // namespace graphslam


### PR DESCRIPTION
## Summary

v0.6 Phase 1 の続き (docs/roadmap/v0.6.md)。`searchLoopForLatest` の per-candidate 検証ステージから純粋な決定ロジックを `loop_verifier.hpp` (15 個目のテスト済みヘッダ) に抽出する、挙動保存の機械的分割です。

- **移設**: `LoopCandidate` / `LoopCandidateResult` / `sourceName` (旧 .cpp 無名 namespace)
- **抽出した純関数**:
  - `computeInitialGuess` — triangle SE(3) 連鎖 / descriptor yaw ヒント / pose 由来の既定値
  - `computeRegistrationDelta` — 並進・回転補正量 (trace の cos クランプ込み)
  - `shouldUseInitialGuess` — DISTANCE のみ guess なし align という歴史的分岐
  - `evaluateGates` — fitness (ScanContext 別閾値 fallback) → 並進 cap → 回転 cap (descriptor 別 cap fallback)。実効閾値を `GateResult` で返すのでオペレータログはバイト同一
  - `SelectionState` — best_attempt / best_valid / best_scan_context の 3 トラック選択 + ScanContext 優先
  - `composeLoopRelativePose` — loop edge の相対ポーズ合成
- ROS component 側は I/O (submap 集約、voxel、registration、3D-BBS、ログ) だけに。重い I/O は Phase 2 で BackendCore がインターフェース越しに所有する予定

## Tests

characterization テスト 17 本が歴史的セマンティクスをピン留め:
- fitness は `>=` 棄却 (閾値ちょうどは reject)、cap は `>` 棄却 (cap ちょうどは pass)
- `<= 0` の SC 閾値 / descriptor cap は generic に fallback、DISTANCE は常に厳格 cap
- ゲート順序 fitness → translation → rotation
- 同 fitness は先着勝ち (strict `<`)、SC 優先は fitness 劣位でも上書き、有効 SC なしの優先は no-op
- 非 triangle ソースの `relative_transform` は無視、yaw の 1e-6 デッドバンド
- best_attempt はゲート棄却候補も追跡 (診断ログ用)

## Verification

```bash
colcon build --symlink-install --packages-select graph_based_slam --cmake-args -DCMAKE_BUILD_TYPE=Release
colcon test --packages-select graph_based_slam lidarslam_msgs scanmatcher lidarslam && colcon test-result
# => 1013 tests, 0 errors, 0 failures (987 -> 1013)
bash scripts/run_release_readiness_checks.sh
# => 全 profile PASS / TARGET_MET。mid360_gt_rtkslam_stadtgarten_seq2 raw 0.835 (v0.5 と完全一致 = 無回帰)
```

## Next

Phase 1 残り: candidate_aggregator (5 ソース合流部) と map_saver の抽出。揃い次第 Phase 2 (BackendCore + オフライン決定論ランナー、3-run ループエッジ集合完全一致ゲート) に入ります。