### PR TITLE
refactor(slam): extract distance/ScanContext candidate generation into candidate_aggregator.hpp

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -200,6 +200,13 @@ if(BUILD_TESTING)
     target_include_directories(test_gnss_alignment PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_candidate_aggregator
+    test/test_candidate_aggregator.cpp
+  )
+  if(TARGET test_candidate_aggregator)
+    target_include_directories(test_candidate_aggregator PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  endif()
+  ament_add_gtest(
     test_loop_verifier
     test/test_loop_verifier.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/candidate_aggregator.hpp
+++ b/graph_based_slam/include/graph_based_slam/candidate_aggregator.hpp
@@ -1,0 +1,256 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__CANDIDATE_AGGREGATOR_HPP_
+#define GRAPH_BASED_SLAM__CANDIDATE_AGGREGATOR_HPP_
+
+// Pure candidate-generation logic for searchLoopForLatest: one collector
+// per loop-candidate source feeding a shared upsert, with operator log
+// lines returned as data so the ROS shell can emit them byte-identically.
+// Inputs are plain pose/travel-distance arrays plus the (already pure,
+// individually tested) descriptor databases; nothing here may touch ROS,
+// the clock or global state so the offline BackendCore can replay it
+// deterministically (docs/roadmap/v0.6.md, Phase 2).
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/loop_verifier.hpp"
+#include "graph_based_slam/scan_context.hpp"
+
+namespace graphslam
+{
+namespace candidate_aggregator
+{
+
+struct LogLine
+{
+  // Emit through the rclcpp logger (historically RCLCPP_INFO) instead of
+  // std::cout. Debug-gated lines are simply not generated when
+  // Config::debug is false, exactly like the historical call sites.
+  bool via_logger {false};
+  std::string text;
+};
+
+struct Config
+{
+  bool debug {false};
+  int max_loop_candidate_count {0};
+  // Minimum travelled distance between the latest submap and a candidate;
+  // anything closer along the trajectory is still "the same place".
+  double distance_loop_closure {0.0};
+  // Maximum euclidean distance for the distance source.
+  double range_of_searching_loop_closure {0.0};
+  double scan_context_threshold {0.0};
+};
+
+// The shared candidate upsert (historically the add_candidate lambda):
+// one entry per (index, source); repeats keep the smallest selection
+// metric but always adopt the latest yaw hint / relative transform.
+inline void upsertCandidate(
+  std::vector<loop_verifier::LoopCandidate> & candidates,
+  int index,
+  double selection_metric,
+  loop_verifier::LoopCandidate::Source source,
+  double yaw_rad = 0.0,
+  const Eigen::Matrix4f * relative_transform = nullptr)
+{
+  if (index < 0) {
+    return;
+  }
+  for (auto & candidate : candidates) {
+    if (candidate.index != index || candidate.source != source) {
+      continue;
+    }
+    candidate.selection_metric = std::min(candidate.selection_metric, selection_metric);
+    candidate.yaw_rad = yaw_rad;
+    if (relative_transform != nullptr) {
+      candidate.relative_transform = *relative_transform;
+      candidate.has_relative_transform = true;
+    }
+    return;
+  }
+
+  loop_verifier::LoopCandidate candidate;
+  candidate.index = index;
+  candidate.selection_metric = selection_metric;
+  candidate.source = source;
+  candidate.yaw_rad = yaw_rad;
+  if (relative_transform != nullptr) {
+    candidate.relative_transform = *relative_transform;
+    candidate.has_relative_transform = true;
+  }
+  candidates.push_back(candidate);
+}
+
+// Every submap that already left the trajectory exclusion window and lies
+// within search range, as (euclidean distance, submap index) pairs sorted
+// ascending — the pair ordering tie-breaks equal distances on the lower
+// index, which keeps downstream consumers deterministic.
+inline std::vector<std::pair<double, int>> collectDistanceCandidates(
+  const std::vector<Eigen::Vector3d> & submap_positions,
+  const std::vector<double> & submap_travel_distances,
+  int latest_idx,
+  const Config & config)
+{
+  std::vector<std::pair<double, int>> distance_candidates;
+  distance_candidates.reserve(submap_positions.size());
+  const Eigen::Vector3d latest_submap_pos = submap_positions[latest_idx];
+  const double latest_moving_distance = submap_travel_distances[latest_idx];
+  for (int i = 0; i < latest_idx; i++) {
+    const double dist = (latest_submap_pos - submap_positions[i]).norm();
+    if (latest_moving_distance - submap_travel_distances[i] <= config.distance_loop_closure) {
+      continue;
+    }
+    if (dist >= config.range_of_searching_loop_closure) {
+      continue;
+    }
+    distance_candidates.emplace_back(dist, i);
+  }
+  std::sort(distance_candidates.begin(), distance_candidates.end());
+  return distance_candidates;
+}
+
+// The non-reranked tail of the distance source: the nearest
+// max_loop_candidate_count candidates become DISTANCE candidates
+// (historically the else branch taken when the BEV reranker is off).
+inline void appendTopDistanceCandidates(
+  const std::vector<std::pair<double, int>> & distance_candidates,
+  const Config & config,
+  std::vector<loop_verifier::LoopCandidate> & candidates)
+{
+  const int num_distance_candidates =
+    std::min(config.max_loop_candidate_count, static_cast<int>(distance_candidates.size()));
+  for (int i = 0; i < num_distance_candidates; i++) {
+    upsertCandidate(
+      candidates,
+      distance_candidates[i].second,
+      distance_candidates[i].first,
+      loop_verifier::LoopCandidate::Source::DISTANCE);
+  }
+}
+
+// ScanContext source: the first top-K match (matches arrive sorted by
+// descriptor distance, ties on the lower submap id) that survives the
+// travel-distance gate becomes the single SC candidate, with the sector
+// shift converted to a [-pi, pi] yaw hint. The query is the database's
+// most recent descriptor, which the caller keeps aligned with latest_idx.
+inline void collectScanContextCandidate(
+  const ScanContext::Database & scan_context_db,
+  const std::vector<double> & submap_travel_distances,
+  int latest_idx,
+  const Config & config,
+  std::vector<loop_verifier::LoopCandidate> & candidates,
+  std::vector<LogLine> & logs)
+{
+  if (scan_context_db.size() <= ScanContext::EXCLUDE_RECENT) {
+    return;
+  }
+  const double latest_moving_distance = submap_travel_distances[latest_idx];
+  const auto sc_matches = scan_context_db.queryTopMatchesWithYaw(
+    scan_context_db.descriptors.back(),
+    config.max_loop_candidate_count,
+    ScanContext::NUM_CANDIDATES,
+    ScanContext::EXCLUDE_RECENT,
+    config.scan_context_threshold);
+
+  if (!sc_matches.empty()) {
+    bool added_scan_context_candidate = false;
+    for (const auto & sc_match : sc_matches) {
+      const int sc_idx = sc_match.submap_id;
+      const double sc_dist = sc_match.distance;
+      if (sc_idx < 0 || sc_idx >= latest_idx) {
+        continue;
+      }
+      const double sc_travel_distance =
+        latest_moving_distance - submap_travel_distances[sc_idx];
+      if (sc_travel_distance <= config.distance_loop_closure) {
+        if (config.debug) {
+          char buffer[256];
+          std::snprintf(
+            buffer, sizeof(buffer),
+            "Skip ScanContext candidate %d because travel distance %.3f m is below %.3f m",
+            sc_idx,
+            sc_travel_distance,
+            config.distance_loop_closure);
+          logs.push_back(LogLine{true, std::string(buffer)});
+        }
+        continue;
+      }
+      double sc_yaw_rad =
+        -static_cast<double>(sc_match.yaw_shift) * 2.0 * M_PI / ScanContext::NUM_SECTORS;
+      while (sc_yaw_rad > M_PI) {
+        sc_yaw_rad -= 2.0 * M_PI;
+      }
+      while (sc_yaw_rad < -M_PI) {
+        sc_yaw_rad += 2.0 * M_PI;
+      }
+      upsertCandidate(
+        candidates,
+        sc_idx,
+        sc_dist,
+        loop_verifier::LoopCandidate::Source::SCAN_CONTEXT,
+        sc_yaw_rad);
+      std::ostringstream oss;
+      oss << "ScanContext loop candidate: id=" << sc_idx
+          << " sc_dist=" << sc_dist
+          << " yaw_deg=" << sc_yaw_rad * 180.0 / M_PI;
+      logs.push_back(LogLine{false, oss.str()});
+      added_scan_context_candidate = true;
+      break;
+    }
+    if (!added_scan_context_candidate && config.debug) {
+      logs.push_back(
+        LogLine{false, "ScanContext matches exist but none satisfied travel-distance gating"});
+    }
+  } else if (config.debug) {
+    const auto best = scan_context_db.query(
+      scan_context_db.descriptors.back(),
+      ScanContext::NUM_CANDIDATES,
+      ScanContext::EXCLUDE_RECENT,
+      std::numeric_limits<double>::max());
+    std::ostringstream oss;
+    oss << "ScanContext no match: best_sc_dist=" << best.second
+        << " threshold=" << config.scan_context_threshold;
+    logs.push_back(LogLine{false, oss.str()});
+  }
+}
+
+}  // namespace candidate_aggregator
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__CANDIDATE_AGGREGATOR_HPP_

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -39,6 +39,7 @@
 
 #include "graph_based_slam/adjacent_edge_auto_scale.hpp"
 #include "graph_based_slam/bev_mutual_visibility.hpp"
+#include "graph_based_slam/candidate_aggregator.hpp"
 #include "graph_based_slam/dynamic_object_filter.hpp"
 #include "graph_based_slam/gnss_alignment.hpp"
 #include "graph_based_slam/loop_verifier.hpp"
@@ -1542,32 +1543,8 @@ void GraphBasedSlamComponent::searchLoopForLatest(
     double yaw_rad = 0.0,
     const Eigen::Matrix4f * relative_transform = nullptr)
     {
-      if (index < 0) {
-        return;
-      }
-      for (auto & candidate : candidates) {
-        if (candidate.index != index || candidate.source != source) {
-          continue;
-        }
-        candidate.selection_metric = std::min(candidate.selection_metric, selection_metric);
-        candidate.yaw_rad = yaw_rad;
-        if (relative_transform != nullptr) {
-          candidate.relative_transform = *relative_transform;
-          candidate.has_relative_transform = true;
-        }
-        return;
-      }
-
-      LoopCandidate candidate;
-      candidate.index = index;
-      candidate.selection_metric = selection_metric;
-      candidate.source = source;
-      candidate.yaw_rad = yaw_rad;
-      if (relative_transform != nullptr) {
-        candidate.relative_transform = *relative_transform;
-        candidate.has_relative_transform = true;
-      }
-      candidates.push_back(candidate);
+      candidate_aggregator::upsertCandidate(
+        candidates, index, selection_metric, source, yaw_rad, relative_transform);
     };
 
   struct DescriptorRerankHint
@@ -1576,82 +1553,45 @@ void GraphBasedSlamComponent::searchLoopForLatest(
     double yaw_rad = 0.0;
   };
 
-  std::vector<std::pair<double, int>> distance_candidates;
-  distance_candidates.reserve(num_submaps);
-  for (int i = 0; i < latest_idx; i++) {
+  candidate_aggregator::Config aggregator_config;
+  aggregator_config.debug = debug_flag_;
+  aggregator_config.max_loop_candidate_count = max_loop_candidate_count_;
+  aggregator_config.distance_loop_closure = distance_loop_closure_;
+  aggregator_config.range_of_searching_loop_closure = range_of_searching_loop_closure_;
+  aggregator_config.scan_context_threshold = scan_context_threshold_;
+
+  std::vector<Eigen::Vector3d> submap_positions;
+  std::vector<double> submap_travel_distances;
+  submap_positions.reserve(latest_idx + 1);
+  submap_travel_distances.reserve(latest_idx + 1);
+  for (int i = 0; i <= latest_idx; i++) {
     const auto & submap = map_array_msg.submaps[i];
-    const Eigen::Vector3d submap_pos{
+    submap_positions.emplace_back(
       submap.pose.position.x,
       submap.pose.position.y,
-      submap.pose.position.z};
-    const double dist = (latest_submap_pos - submap_pos).norm();
-    if (latest_moving_distance - submap.distance <= distance_loop_closure_) {
-      continue;
-    }
-    if (dist >= range_of_searching_loop_closure_) {
-      continue;
-    }
-    distance_candidates.emplace_back(dist, i);
+      submap.pose.position.z);
+    submap_travel_distances.push_back(submap.distance);
   }
-  std::sort(distance_candidates.begin(), distance_candidates.end());
 
-  if (use_scan_context_ && scan_context_db_.size() > ScanContext::EXCLUDE_RECENT) {
-    const auto sc_matches = scan_context_db_.queryTopMatchesWithYaw(
-      scan_context_db_.descriptors.back(),
-      max_loop_candidate_count_,
-      ScanContext::NUM_CANDIDATES,
-      ScanContext::EXCLUDE_RECENT,
-      scan_context_threshold_);
+  std::vector<std::pair<double, int>> distance_candidates =
+    candidate_aggregator::collectDistanceCandidates(
+      submap_positions, submap_travel_distances, latest_idx, aggregator_config);
 
-    if (!sc_matches.empty()) {
-      bool added_scan_context_candidate = false;
-      for (const auto & sc_match : sc_matches) {
-        const int sc_idx = sc_match.submap_id;
-        const double sc_dist = sc_match.distance;
-        if (sc_idx < 0 || sc_idx >= latest_idx) {
-          continue;
-        }
-        const double sc_travel_distance =
-          latest_moving_distance - map_array_msg.submaps[sc_idx].distance;
-        if (sc_travel_distance <= distance_loop_closure_) {
-          if (debug_flag_) {
-            RCLCPP_INFO(
-              get_logger(),
-              "Skip ScanContext candidate %d because travel distance %.3f m is below %.3f m",
-              sc_idx,
-              sc_travel_distance,
-              distance_loop_closure_);
-          }
-          continue;
-        }
-        double sc_yaw_rad =
-          -static_cast<double>(sc_match.yaw_shift) * 2.0 * M_PI / ScanContext::NUM_SECTORS;
-        while (sc_yaw_rad > M_PI) {
-          sc_yaw_rad -= 2.0 * M_PI;
-        }
-        while (sc_yaw_rad < -M_PI) {
-          sc_yaw_rad += 2.0 * M_PI;
-        }
-        add_candidate(sc_idx, sc_dist, LoopCandidate::Source::SCAN_CONTEXT, sc_yaw_rad);
-        std::cout << "ScanContext loop candidate: id=" << sc_idx
-                  << " sc_dist=" << sc_dist
-                  << " yaw_deg=" << sc_yaw_rad * 180.0 / M_PI << std::endl;
-        added_scan_context_candidate = true;
-        break;
+  if (use_scan_context_) {
+    std::vector<candidate_aggregator::LogLine> aggregator_logs;
+    candidate_aggregator::collectScanContextCandidate(
+      scan_context_db_,
+      submap_travel_distances,
+      latest_idx,
+      aggregator_config,
+      candidates,
+      aggregator_logs);
+    for (const auto & line : aggregator_logs) {
+      if (line.via_logger) {
+        RCLCPP_INFO(get_logger(), "%s", line.text.c_str());
+      } else {
+        std::cout << line.text << std::endl;
       }
-      if (!added_scan_context_candidate && debug_flag_) {
-        std::cout << "ScanContext matches exist but none satisfied travel-distance gating"
-                  << std::endl;
-      }
-    } else if (debug_flag_) {
-      auto [sc_idx, sc_dist] = scan_context_db_.query(
-        scan_context_db_.descriptors.back(),
-        ScanContext::NUM_CANDIDATES,
-        ScanContext::EXCLUDE_RECENT,
-        std::numeric_limits<double>::max());
-      static_cast<void>(sc_idx);
-      std::cout << "ScanContext no match: best_sc_dist=" << sc_dist
-                << " threshold=" << scan_context_threshold_ << std::endl;
     }
   }
 
@@ -1898,14 +1838,8 @@ void GraphBasedSlamComponent::searchLoopForLatest(
       }
     }
   } else {
-    const int num_distance_candidates =
-      std::min(max_loop_candidate_count_, static_cast<int>(distance_candidates.size()));
-    for (int i = 0; i < num_distance_candidates; i++) {
-      add_candidate(
-        distance_candidates[i].second,
-        distance_candidates[i].first,
-        LoopCandidate::Source::DISTANCE);
-    }
+    candidate_aggregator::appendTopDistanceCandidates(
+      distance_candidates, aggregator_config, candidates);
   }
   if (
     use_solid_descriptor_ &&

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -1575,7 +1575,7 @@ void GraphBasedSlamComponent::searchLoopForLatest(
 
   std::vector<std::pair<double, int>> distance_candidates =
     candidate_aggregator::collectDistanceCandidates(
-      submap_positions, submap_travel_distances, latest_idx, aggregator_config);
+    submap_positions, submap_travel_distances, latest_idx, aggregator_config);
 
   if (use_scan_context_) {
     std::vector<candidate_aggregator::LogLine> aggregator_logs;

--- a/graph_based_slam/test/test_candidate_aggregator.cpp
+++ b/graph_based_slam/test/test_candidate_aggregator.cpp
@@ -1,0 +1,313 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Characterization tests for the candidate-generation logic extracted from
+// searchLoopForLatest (distance + ScanContext sources and the shared
+// upsert). These pin the historical semantics: gate boundaries, the
+// first-surviving-match rule, yaw normalization, and the exact operator
+// log lines.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/candidate_aggregator.hpp"
+
+namespace graphslam
+{
+namespace
+{
+
+using candidate_aggregator::Config;
+using candidate_aggregator::LogLine;
+using loop_verifier::LoopCandidate;
+
+using Source = LoopCandidate::Source;
+
+Config makeConfig()
+{
+  Config config;
+  config.debug = false;
+  config.max_loop_candidate_count = 3;
+  config.distance_loop_closure = 5.0;
+  config.range_of_searching_loop_closure = 10.0;
+  config.scan_context_threshold = 0.5;
+  return config;
+}
+
+// A descriptor whose ring key is invariant to the sector offset, so two
+// offsets of the same pattern are KNN neighbors with a pure yaw shift.
+ScanContext::Descriptor makePatternDescriptor(int sector_offset)
+{
+  ScanContext::Descriptor desc =
+    ScanContext::Descriptor::Zero(ScanContext::NUM_RINGS, ScanContext::NUM_SECTORS);
+  desc(2, sector_offset % ScanContext::NUM_SECTORS) = 1.0;
+  desc(5, (sector_offset + 3) % ScanContext::NUM_SECTORS) = 2.0;
+  return desc;
+}
+
+// A filler descriptor far from the pattern in both ring key and cosine
+// distance, so it never enters the match list.
+ScanContext::Descriptor makeFillerDescriptor(int seed)
+{
+  ScanContext::Descriptor desc =
+    ScanContext::Descriptor::Zero(ScanContext::NUM_RINGS, ScanContext::NUM_SECTORS);
+  desc(8, seed % ScanContext::NUM_SECTORS) = 9.0;
+  desc(12, (seed + 17) % ScanContext::NUM_SECTORS) = 4.0;
+  return desc;
+}
+
+TEST(CandidateAggregatorUpsert, KeepsMinimumMetricAndAdoptsLatestHints)
+{
+  std::vector<LoopCandidate> candidates;
+  candidate_aggregator::upsertCandidate(candidates, 4, 2.0, Source::DISTANCE, 0.1);
+  ASSERT_EQ(candidates.size(), 1U);
+  EXPECT_DOUBLE_EQ(candidates[0].selection_metric, 2.0);
+
+  // A worse metric does not raise the stored one, but the yaw hint is
+  // always the latest.
+  candidate_aggregator::upsertCandidate(candidates, 4, 3.0, Source::DISTANCE, 0.2);
+  ASSERT_EQ(candidates.size(), 1U);
+  EXPECT_DOUBLE_EQ(candidates[0].selection_metric, 2.0);
+  EXPECT_DOUBLE_EQ(candidates[0].yaw_rad, 0.2);
+
+  // A relative transform is adopted on update.
+  Eigen::Matrix4f relative = Eigen::Matrix4f::Identity();
+  relative(0, 3) = 1.5F;
+  candidate_aggregator::upsertCandidate(candidates, 4, 1.0, Source::DISTANCE, 0.3, &relative);
+  ASSERT_EQ(candidates.size(), 1U);
+  EXPECT_DOUBLE_EQ(candidates[0].selection_metric, 1.0);
+  EXPECT_TRUE(candidates[0].has_relative_transform);
+  EXPECT_FLOAT_EQ(candidates[0].relative_transform(0, 3), 1.5F);
+
+  // Negative indices are dropped.
+  candidate_aggregator::upsertCandidate(candidates, -1, 0.0, Source::DISTANCE);
+  EXPECT_EQ(candidates.size(), 1U);
+}
+
+TEST(CandidateAggregatorUpsert, SameIndexDifferentSourcesStaySeparate)
+{
+  std::vector<LoopCandidate> candidates;
+  candidate_aggregator::upsertCandidate(candidates, 4, 2.0, Source::DISTANCE);
+  candidate_aggregator::upsertCandidate(candidates, 4, 0.3, Source::SCAN_CONTEXT);
+  ASSERT_EQ(candidates.size(), 2U);
+  EXPECT_EQ(candidates[0].source, Source::DISTANCE);
+  EXPECT_EQ(candidates[1].source, Source::SCAN_CONTEXT);
+  EXPECT_DOUBLE_EQ(candidates[0].selection_metric, 2.0);
+  EXPECT_DOUBLE_EQ(candidates[1].selection_metric, 0.3);
+}
+
+TEST(CandidateAggregatorDistance, GatesByTravelDistanceAndRange)
+{
+  const auto config = makeConfig();
+  // latest at index 4, position origin, travelled 100 m.
+  std::vector<Eigen::Vector3d> positions = {
+    {3.0, 0.0, 0.0},   // in range, travelled long ago -> candidate
+    {3.0, 0.0, 0.0},   // in range but only 3 m of travel separation -> gated
+    {15.0, 0.0, 0.0},  // out of range -> gated
+    {1.0, 0.0, 0.0},   // in range -> candidate
+    {0.0, 0.0, 0.0},
+  };
+  std::vector<double> travels = {50.0, 97.0, 50.0, 80.0, 100.0};
+
+  const auto distance_candidates =
+    candidate_aggregator::collectDistanceCandidates(positions, travels, 4, config);
+  ASSERT_EQ(distance_candidates.size(), 2U);
+  // Sorted by distance ascending.
+  EXPECT_EQ(distance_candidates[0].second, 3);
+  EXPECT_DOUBLE_EQ(distance_candidates[0].first, 1.0);
+  EXPECT_EQ(distance_candidates[1].second, 0);
+  EXPECT_DOUBLE_EQ(distance_candidates[1].first, 3.0);
+}
+
+TEST(CandidateAggregatorDistance, EqualDistancesTieBreakOnLowerIndex)
+{
+  const auto config = makeConfig();
+  std::vector<Eigen::Vector3d> positions = {
+    {2.0, 0.0, 0.0},
+    {-2.0, 0.0, 0.0},
+    {0.0, 0.0, 0.0},
+  };
+  std::vector<double> travels = {0.0, 10.0, 100.0};
+
+  const auto distance_candidates =
+    candidate_aggregator::collectDistanceCandidates(positions, travels, 2, config);
+  ASSERT_EQ(distance_candidates.size(), 2U);
+  EXPECT_EQ(distance_candidates[0].second, 0);
+  EXPECT_EQ(distance_candidates[1].second, 1);
+}
+
+TEST(CandidateAggregatorDistance, AppendTopCandidatesCapsAtMaxCount)
+{
+  auto config = makeConfig();
+  config.max_loop_candidate_count = 2;
+  const std::vector<std::pair<double, int>> distance_candidates = {
+    {1.0, 7}, {2.0, 3}, {3.0, 9},
+  };
+  std::vector<LoopCandidate> candidates;
+  candidate_aggregator::appendTopDistanceCandidates(distance_candidates, config, candidates);
+  ASSERT_EQ(candidates.size(), 2U);
+  EXPECT_EQ(candidates[0].index, 7);
+  EXPECT_DOUBLE_EQ(candidates[0].selection_metric, 1.0);
+  EXPECT_EQ(candidates[0].source, Source::DISTANCE);
+  EXPECT_EQ(candidates[1].index, 3);
+}
+
+class CandidateAggregatorScanContext : public ::testing::Test
+{
+protected:
+  // A database whose searchable head (EXCLUDE_RECENT excluded) holds the
+  // pattern at ids 0 and 1, query (= back()) holds the same pattern. The
+  // latest submap is id 51 with 100 m travelled.
+  void buildDatabase(int id0_offset, int id1_offset)
+  {
+    db_.add(0, makePatternDescriptor(id0_offset));
+    db_.add(1, makePatternDescriptor(id1_offset));
+    for (int id = 2; id < 51; ++id) {
+      db_.add(id, makeFillerDescriptor(id));
+    }
+    db_.add(51, makePatternDescriptor(0));
+    travels_.assign(52, 0.0);
+    travels_[51] = 100.0;
+  }
+
+  ScanContext::Database db_;
+  std::vector<double> travels_;
+  std::vector<LoopCandidate> candidates_;
+  std::vector<LogLine> logs_;
+};
+
+TEST_F(CandidateAggregatorScanContext, FirstSurvivingMatchWinsAndGatedMatchLogsWhenDebug)
+{
+  buildDatabase(0, 0);
+  // id 0 ties with id 1 at descriptor distance 0; the (distance, id) order
+  // puts id 0 first, but its travel separation of 3 m gates it out.
+  travels_[0] = 97.0;
+  auto config = makeConfig();
+  config.debug = true;
+
+  candidate_aggregator::collectScanContextCandidate(
+    db_, travels_, 51, config, candidates_, logs_);
+
+  ASSERT_EQ(candidates_.size(), 1U);
+  EXPECT_EQ(candidates_[0].index, 1);
+  EXPECT_EQ(candidates_[0].source, Source::SCAN_CONTEXT);
+  EXPECT_NEAR(candidates_[0].selection_metric, 0.0, 1e-9);
+
+  ASSERT_EQ(logs_.size(), 2U);
+  EXPECT_TRUE(logs_[0].via_logger);
+  EXPECT_EQ(
+    logs_[0].text,
+    "Skip ScanContext candidate 0 because travel distance 3.000 m is below 5.000 m");
+  EXPECT_FALSE(logs_[1].via_logger);
+  EXPECT_EQ(logs_[1].text.rfind("ScanContext loop candidate: id=1", 0), 0U);
+}
+
+TEST_F(CandidateAggregatorScanContext, GatedSkipIsSilentWithoutDebug)
+{
+  buildDatabase(0, 0);
+  travels_[0] = 97.0;
+  const auto config = makeConfig();
+
+  candidate_aggregator::collectScanContextCandidate(
+    db_, travels_, 51, config, candidates_, logs_);
+
+  ASSERT_EQ(candidates_.size(), 1U);
+  EXPECT_EQ(candidates_[0].index, 1);
+  // Only the unconditional acceptance line remains.
+  ASSERT_EQ(logs_.size(), 1U);
+  EXPECT_FALSE(logs_[0].via_logger);
+}
+
+TEST_F(CandidateAggregatorScanContext, SectorShiftBecomesNormalizedYawHint)
+{
+  // Candidate pattern shifted by 45 sectors: the raw hint of
+  // -45 * 6 deg = -270 deg must normalize to +90 deg.
+  buildDatabase(45, 45);
+  const auto config = makeConfig();
+
+  candidate_aggregator::collectScanContextCandidate(
+    db_, travels_, 51, config, candidates_, logs_);
+
+  ASSERT_EQ(candidates_.size(), 1U);
+  EXPECT_EQ(candidates_[0].index, 0);
+  EXPECT_NEAR(candidates_[0].yaw_rad, M_PI / 2.0, 1e-9);
+  EXPECT_GE(candidates_[0].yaw_rad, -M_PI);
+  EXPECT_LE(candidates_[0].yaw_rad, M_PI);
+}
+
+TEST_F(CandidateAggregatorScanContext, NoMatchEmitsDiagnosticOnlyWhenDebug)
+{
+  // No pattern in the searchable head: every candidate is a filler beyond
+  // the threshold, so the match list is empty.
+  db_.add(0, makeFillerDescriptor(100));
+  db_.add(1, makeFillerDescriptor(101));
+  for (int id = 2; id < 51; ++id) {
+    db_.add(id, makeFillerDescriptor(id));
+  }
+  db_.add(51, makePatternDescriptor(0));
+  travels_.assign(52, 0.0);
+  travels_[51] = 100.0;
+
+  auto config = makeConfig();
+  candidate_aggregator::collectScanContextCandidate(
+    db_, travels_, 51, config, candidates_, logs_);
+  EXPECT_TRUE(candidates_.empty());
+  EXPECT_TRUE(logs_.empty());
+
+  config.debug = true;
+  candidate_aggregator::collectScanContextCandidate(
+    db_, travels_, 51, config, candidates_, logs_);
+  EXPECT_TRUE(candidates_.empty());
+  ASSERT_EQ(logs_.size(), 1U);
+  EXPECT_FALSE(logs_[0].via_logger);
+  EXPECT_EQ(logs_[0].text.rfind("ScanContext no match: best_sc_dist=", 0), 0U);
+}
+
+TEST_F(CandidateAggregatorScanContext, DatabaseWithinExcludeRecentWindowIsSkipped)
+{
+  for (int id = 0; id < ScanContext::EXCLUDE_RECENT; ++id) {
+    db_.add(id, makePatternDescriptor(0));
+  }
+  travels_.assign(ScanContext::EXCLUDE_RECENT, 0.0);
+  auto config = makeConfig();
+  config.debug = true;
+
+  candidate_aggregator::collectScanContextCandidate(
+    db_, travels_, ScanContext::EXCLUDE_RECENT - 1, config, candidates_, logs_);
+  EXPECT_TRUE(candidates_.empty());
+  EXPECT_TRUE(logs_.empty());
+}
+
+}  // namespace
+}  // namespace graphslam


### PR DESCRIPTION
## Summary

v0.6 Phase 1 の続き (docs/roadmap/v0.6.md)。`searchLoopForLatest` の候補生成ステージをソース別に分解する第 1 弾として、**共有 upsert + distance ソース + ScanContext ソース**を `candidate_aggregator.hpp` (16 個目のテスト済みヘッダ) に純関数抽出します。挙動保存の機械的分割です。

- `upsertCandidate` — 旧 `add_candidate` lambda。(index, source) ごとに 1 エントリ、再訪時は最小 metric 維持 + 最新 yaw/SE(3) ヒント採用
- `collectDistanceCandidates` — travel 除外 (`<=`) / range (`>=`) ゲート + (距離, index) pair ソート (同距離は低 index 勝ち)
- `appendTopDistanceCandidates` — BEV rerank off 時の素の top-N 追加
- `collectScanContextCandidate` — 先頭生存マッチ規則 (travel ゲートで落ちたら次へ、採用は 1 件で break)、sector shift → ±π 正規化 yaw ヒント
- **ログは `LogLine` データとして返却**: debug フラグを純 config に含めたので、debug 時のみ実行される副計算 (no-match 時の診断クエリ) まで正確に再現。shell は via_logger で RCLCPP_INFO / std::cout に振り分けるだけで出力はバイト同一
- BEV / SOLiD / triangle ブロックは次の PR で同パターンに移行 (今回は薄くなった lambda 経由で同じ upsert を使用)

## Tests

characterization テスト 9 本:
- upsert: 最小 metric 維持 + ヒント上書き、同 index 別ソースは別エントリ、負 index 棄却
- distance: travel/range ゲート境界、同距離 tie-break (低 index)、top-N cap
- ScanContext: ゲートで落ちた先頭マッチのスキップ + 次マッチ採用 (debug ログ文字列も完全一致で assert)、±180° での yaw wrap (+90° 復元)、no-match 診断は debug 時のみ、DB が EXCLUDE_RECENT 以下なら無動作

## Verification

```bash
colcon build --symlink-install --packages-select graph_based_slam --cmake-args -DCMAKE_BUILD_TYPE=Release
colcon test --packages-select graph_based_slam lidarslam_msgs scanmatcher lidarslam && colcon test-result
# => 1032 tests, 0 errors, 0 failures (1013 -> 1032)
bash scripts/run_release_readiness_checks.sh
# => 全 profile PASS / TARGET_MET。mid360_gt_rtkslam_stadtgarten_seq2 raw 0.835 (3 回連続完全一致 = 無回帰)
```

## Next

candidate_aggregator 第 2 弾: BEV / SOLiD rerank ブロック (sequence metric + pose consistency)、第 3 弾: triangle ブロック。その後 map_saver を抽出して Phase 2 (BackendCore + オフライン決定論ランナー) へ。