### PR TITLE
refactor(slam): extract the BEV/SOLiD rerank blocks into candidate_aggregator.hpp

### DIFF
--- a/graph_based_slam/include/graph_based_slam/candidate_aggregator.hpp
+++ b/graph_based_slam/include/graph_based_slam/candidate_aggregator.hpp
@@ -44,13 +44,18 @@
 #include <limits>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Geometry>  // NOLINT(build/include_order)
 
+#include "graph_based_slam/bev_mutual_visibility.hpp"
 #include "graph_based_slam/loop_verifier.hpp"
 #include "graph_based_slam/scan_context.hpp"
+#include "graph_based_slam/solid_descriptor.hpp"
+#include "graph_based_slam/submap_bev_descriptor.hpp"
 
 namespace graphslam
 {
@@ -76,6 +81,23 @@ struct Config
   // Maximum euclidean distance for the distance source.
   double range_of_searching_loop_closure {0.0};
   double scan_context_threshold {0.0};
+
+  bool bev_use_mutual_visibility {false};
+  double bev_mutual_visibility_min_overlap_ratio {0.0};
+  double bev_mutual_visibility_occupancy_eps {0.0};
+  int bev_descriptor_yaw_bins {0};
+  double bev_descriptor_max_euclidean_distance_m {0.0};
+  double bev_descriptor_threshold {0.0};
+  int bev_descriptor_sequence_window {0};
+  double bev_descriptor_sequence_threshold {0.0};
+  double bev_descriptor_pose_consistency_threshold_m {0.0};
+  double bev_descriptor_rerank_weight_m {0.0};
+
+  double solid_descriptor_max_euclidean_distance_m {0.0};
+  double solid_descriptor_min_similarity {0.0};
+  int solid_descriptor_sequence_window {0};
+  double solid_descriptor_sequence_min_similarity {0.0};
+  double solid_descriptor_pose_consistency_threshold_m {0.0};
 };
 
 // The shared candidate upsert (historically the add_candidate lambda):
@@ -246,6 +268,473 @@ inline void collectScanContextCandidate(
     std::ostringstream oss;
     oss << "ScanContext no match: best_sc_dist=" << best.second
         << " threshold=" << config.scan_context_threshold;
+    logs.push_back(LogLine{false, oss.str()});
+  }
+}
+
+// BEV reranker for the distance source: descriptor hints gathered over the
+// nearest 4x candidates (euclidean / descriptor / sequence /
+// pose-consistency gated, best score per submap) shift the distance
+// ordering by rerank_weight * (hint - threshold), then the top
+// max_loop_candidate_count entries become DISTANCE candidates carrying the
+// hint's yaw. The stable sort tie-breaks on the original distance, keeping
+// the result deterministic. Call before the SOLiD collector: it reorders
+// distance_candidates in place exactly like the historical block did.
+inline void rerankDistanceCandidatesWithBev(
+  const SubmapBEVDescriptor::Database & bev_db,
+  const std::vector<Eigen::Affine3d> & submap_poses,
+  int latest_idx,
+  const Config & config,
+  std::vector<std::pair<double, int>> & distance_candidates,
+  std::vector<loop_verifier::LoopCandidate> & candidates,
+  std::vector<LogLine> & logs)
+{
+  struct DescriptorRerankHint
+  {
+    double score = std::numeric_limits<double>::max();
+    double yaw_rad = 0.0;
+  };
+
+  const Eigen::Affine3d & latest_affine = submap_poses[latest_idx];
+  const Eigen::Vector3d latest_submap_pos = latest_affine.translation();
+
+  std::unordered_map<int, DescriptorRerankHint> bev_rerank_hints;
+  const int bev_rerank_candidates = std::min(
+    std::max(config.max_loop_candidate_count * 4, config.max_loop_candidate_count),
+    static_cast<int>(distance_candidates.size()));
+  bool added_bev_candidate = false;
+  double best_bev_dist = std::numeric_limits<double>::max();
+  int best_bev_idx = -1;
+  for (int i = 0; i < bev_rerank_candidates; ++i) {
+    const int bev_idx = distance_candidates[i].second;
+    if (bev_idx < 0 || bev_idx >= latest_idx || bev_idx >= bev_db.size()) {
+      continue;
+    }
+    const double bev_euclidean_distance =
+      (latest_submap_pos - submap_poses[bev_idx].translation()).norm();
+    if (
+      config.bev_descriptor_max_euclidean_distance_m > 0.0 &&
+      bev_euclidean_distance > config.bev_descriptor_max_euclidean_distance_m)
+    {
+      if (config.debug) {
+        char buffer[256];
+        std::snprintf(
+          buffer, sizeof(buffer),
+          "Skip BEV candidate %d because euclidean distance %.3f m exceeds %.3f m",
+          bev_idx,
+          bev_euclidean_distance,
+          config.bev_descriptor_max_euclidean_distance_m);
+        logs.push_back(LogLine{true, std::string(buffer)});
+      }
+      continue;
+    }
+
+    SubmapBEVDescriptor::Match bev_match;
+    if (config.bev_use_mutual_visibility) {
+      graphslam::bev::MutualVisibilityConfig mv_cfg;
+      mv_cfg.min_overlap_ratio = config.bev_mutual_visibility_min_overlap_ratio;
+      mv_cfg.occupancy_eps =
+        static_cast<float>(config.bev_mutual_visibility_occupancy_eps);
+      const auto fov = graphslam::bev::mutualVisibilityWithYawSearch(
+        bev_db.descriptors.back(),
+        bev_db.descriptors[bev_idx],
+        bev_idx,
+        config.bev_descriptor_yaw_bins,
+        mv_cfg);
+      bev_match.submap_id = fov.submap_id;
+      bev_match.distance = fov.valid ? fov.distance : 1.0;
+      bev_match.yaw_bin = fov.yaw_bin;
+      bev_match.yaw_rad = fov.yaw_rad;
+    } else {
+      bev_match = SubmapBEVDescriptor::distanceWithAlignment(
+        bev_db.descriptors.back(),
+        bev_db.descriptors[bev_idx],
+        bev_idx,
+        config.bev_descriptor_yaw_bins);
+    }
+    if (bev_match.distance < best_bev_dist) {
+      best_bev_dist = bev_match.distance;
+      best_bev_idx = bev_idx;
+    }
+    if (bev_match.distance >= config.bev_descriptor_threshold) {
+      if (config.debug) {
+        char buffer[256];
+        std::snprintf(
+          buffer, sizeof(buffer),
+          "Skip BEV candidate %d because descriptor distance %.3f exceeds %.3f",
+          bev_idx,
+          bev_match.distance,
+          config.bev_descriptor_threshold);
+        logs.push_back(LogLine{true, std::string(buffer)});
+      }
+      continue;
+    }
+
+    double bev_yaw_rad = bev_match.yaw_rad;
+    while (bev_yaw_rad > M_PI) {
+      bev_yaw_rad -= 2.0 * M_PI;
+    }
+    while (bev_yaw_rad < -M_PI) {
+      bev_yaw_rad += 2.0 * M_PI;
+    }
+    double bev_sequence_metric = bev_match.distance;
+    if (config.bev_descriptor_sequence_window > 0) {
+      double bev_sequence_distance_sum = bev_match.distance;
+      int bev_sequence_count = 1;
+      for (int offset = 1; offset <= config.bev_descriptor_sequence_window; ++offset) {
+        const int query_idx = latest_idx - offset;
+        const int candidate_sequence_idx = bev_idx - offset;
+        if (
+          query_idx < 0 || candidate_sequence_idx < 0 ||
+          query_idx >= bev_db.size() ||
+          candidate_sequence_idx >= bev_db.size())
+        {
+          break;
+        }
+        const auto rotated_candidate_descriptor = SubmapBEVDescriptor::rotateDescriptor(
+          bev_db.descriptors[candidate_sequence_idx],
+          bev_yaw_rad);
+        double sequence_distance;
+        if (config.bev_use_mutual_visibility) {
+          graphslam::bev::MutualVisibilityConfig mv_cfg;
+          mv_cfg.min_overlap_ratio = config.bev_mutual_visibility_min_overlap_ratio;
+          mv_cfg.occupancy_eps =
+            static_cast<float>(config.bev_mutual_visibility_occupancy_eps);
+          const auto fov = graphslam::bev::mutualVisibilityDistance(
+            bev_db.descriptors[query_idx],
+            rotated_candidate_descriptor,
+            mv_cfg);
+          sequence_distance = fov.valid ? fov.distance : 1.0;
+        } else {
+          sequence_distance = SubmapBEVDescriptor::descriptorDistance(
+            bev_db.descriptors[query_idx],
+            rotated_candidate_descriptor);
+        }
+        bev_sequence_distance_sum += sequence_distance;
+        ++bev_sequence_count;
+      }
+      bev_sequence_metric = bev_sequence_distance_sum / static_cast<double>(bev_sequence_count);
+    }
+    if (bev_sequence_metric >= config.bev_descriptor_sequence_threshold) {
+      if (config.debug) {
+        char buffer[256];
+        std::snprintf(
+          buffer, sizeof(buffer),
+          "Skip BEV candidate %d because sequence metric %.3f exceeds %.3f",
+          bev_idx,
+          bev_sequence_metric,
+          config.bev_descriptor_sequence_threshold);
+        logs.push_back(LogLine{true, std::string(buffer)});
+      }
+      continue;
+    }
+    double bev_pose_consistency_metric = -1.0;
+    if (
+      config.bev_descriptor_pose_consistency_threshold_m > 0.0 &&
+      config.bev_descriptor_sequence_window > 0)
+    {
+      const Eigen::Affine3d & bev_candidate_affine = submap_poses[bev_idx];
+      const Eigen::AngleAxisd yaw_correction(bev_yaw_rad, Eigen::Vector3d::UnitZ());
+      double bev_pose_consistency_sum = 0.0;
+      int bev_pose_consistency_count = 0;
+      for (int offset = 1; offset <= config.bev_descriptor_sequence_window; ++offset) {
+        const int query_idx = latest_idx - offset;
+        const int candidate_sequence_idx = bev_idx - offset;
+        if (query_idx < 0 || candidate_sequence_idx < 0) {
+          break;
+        }
+
+        const Eigen::Affine3d & query_prev_affine = submap_poses[query_idx];
+        const Eigen::Affine3d & candidate_prev_affine = submap_poses[candidate_sequence_idx];
+
+        const Eigen::Vector3d query_delta =
+          (latest_affine.inverse() * query_prev_affine).translation();
+        const Eigen::Vector3d candidate_delta =
+          yaw_correction * (bev_candidate_affine.inverse() * candidate_prev_affine).translation();
+        bev_pose_consistency_sum +=
+          (query_delta.head<2>() - candidate_delta.head<2>()).norm();
+        ++bev_pose_consistency_count;
+      }
+      if (bev_pose_consistency_count > 0) {
+        bev_pose_consistency_metric =
+          bev_pose_consistency_sum / static_cast<double>(bev_pose_consistency_count);
+        if (bev_pose_consistency_metric >= config.bev_descriptor_pose_consistency_threshold_m) {
+          if (config.debug) {
+            char buffer[256];
+            std::snprintf(
+              buffer, sizeof(buffer),
+              "Skip BEV candidate %d because pose consistency %.3f m exceeds %.3f m",
+              bev_idx,
+              bev_pose_consistency_metric,
+              config.bev_descriptor_pose_consistency_threshold_m);
+            logs.push_back(LogLine{true, std::string(buffer)});
+          }
+          continue;
+        }
+      }
+    }
+    auto & bev_hint = bev_rerank_hints[bev_idx];
+    if (bev_sequence_metric < bev_hint.score) {
+      bev_hint.score = bev_sequence_metric;
+      bev_hint.yaw_rad = bev_yaw_rad;
+    }
+    std::ostringstream oss;
+    oss << "BEV rerank hint: id=" << bev_idx
+        << " bev_dist=" << bev_match.distance
+        << " seq_dist=" << bev_sequence_metric
+        << " pose_seq_m=" << bev_pose_consistency_metric
+        << " yaw_deg=" << bev_yaw_rad * 180.0 / M_PI;
+    logs.push_back(LogLine{false, oss.str()});
+    added_bev_candidate = true;
+  }
+  if (!added_bev_candidate && config.debug) {
+    std::ostringstream oss;
+    oss << "BEV rerank no candidate: best_idx=" << best_bev_idx
+        << " best_bev_dist=" << best_bev_dist
+        << " threshold=" << config.bev_descriptor_threshold;
+    logs.push_back(LogLine{false, oss.str()});
+  }
+
+  auto bev_adjusted_distance =
+    [&config, &bev_rerank_hints](const std::pair<double, int> & candidate) {
+      const auto bev_hint = bev_rerank_hints.find(candidate.second);
+      if (bev_hint == bev_rerank_hints.end()) {
+        return candidate.first;
+      }
+      return candidate.first +
+             config.bev_descriptor_rerank_weight_m *
+             (bev_hint->second.score - config.bev_descriptor_threshold);
+    };
+
+  std::stable_sort(
+    distance_candidates.begin(),
+    distance_candidates.end(),
+    [&bev_adjusted_distance](const auto & lhs, const auto & rhs) {
+      const double lhs_adjusted = bev_adjusted_distance(lhs);
+      const double rhs_adjusted = bev_adjusted_distance(rhs);
+      if (lhs_adjusted != rhs_adjusted) {
+        return lhs_adjusted < rhs_adjusted;
+      }
+      return lhs.first < rhs.first;
+    });
+
+  const int num_distance_candidates =
+    std::min(config.max_loop_candidate_count, static_cast<int>(distance_candidates.size()));
+  for (int i = 0; i < num_distance_candidates; ++i) {
+    const int candidate_idx = distance_candidates[i].second;
+    const auto bev_hint = bev_rerank_hints.find(candidate_idx);
+    const double adjusted_distance = bev_adjusted_distance(distance_candidates[i]);
+    if (bev_hint != bev_rerank_hints.end()) {
+      upsertCandidate(
+        candidates,
+        candidate_idx,
+        adjusted_distance,
+        loop_verifier::LoopCandidate::Source::DISTANCE,
+        bev_hint->second.yaw_rad);
+      std::ostringstream oss;
+      oss << "Distance candidate reranked by BEV: id=" << candidate_idx
+          << " dist_m=" << distance_candidates[i].first
+          << " bev_score=" << bev_hint->second.score
+          << " adjusted_dist_m=" << adjusted_distance
+          << " yaw_deg=" << bev_hint->second.yaw_rad * 180.0 / M_PI;
+      logs.push_back(LogLine{false, oss.str()});
+    } else {
+      upsertCandidate(
+        candidates,
+        candidate_idx,
+        adjusted_distance,
+        loop_verifier::LoopCandidate::Source::DISTANCE);
+    }
+  }
+}
+
+// SOLiD source: rescore the nearest 4x distance candidates by descriptor
+// similarity (euclidean / similarity / sequence / pose-consistency gated)
+// and add each survivor as a SOLID_DESCRIPTOR candidate whose selection
+// metric is 1 - sequence similarity. Reads distance_candidates after any
+// BEV reordering, exactly like the historical block did.
+inline void collectSolidCandidates(
+  const SolidDescriptor::Database & solid_db,
+  const std::vector<Eigen::Affine3d> & submap_poses,
+  const std::vector<std::pair<double, int>> & distance_candidates,
+  int latest_idx,
+  const Config & config,
+  std::vector<loop_verifier::LoopCandidate> & candidates,
+  std::vector<LogLine> & logs)
+{
+  if (solid_db.size() <= SolidDescriptor::DEFAULT_EXCLUDE_RECENT) {
+    return;
+  }
+  const Eigen::Affine3d & latest_affine = submap_poses[latest_idx];
+  const Eigen::Vector3d latest_submap_pos = latest_affine.translation();
+
+  const int solid_rerank_candidates = std::min(
+    std::max(config.max_loop_candidate_count * 4, config.max_loop_candidate_count),
+    static_cast<int>(distance_candidates.size()));
+  bool added_solid_candidate = false;
+  double best_solid_similarity = -1.0;
+  int best_solid_idx = -1;
+  for (int i = 0; i < solid_rerank_candidates; ++i) {
+    const int solid_idx = distance_candidates[i].second;
+    if (solid_idx < 0 || solid_idx >= latest_idx || solid_idx >= solid_db.size()) {
+      continue;
+    }
+    const double solid_euclidean_distance =
+      (latest_submap_pos - submap_poses[solid_idx].translation()).norm();
+    if (
+      config.solid_descriptor_max_euclidean_distance_m > 0.0 &&
+      solid_euclidean_distance > config.solid_descriptor_max_euclidean_distance_m)
+    {
+      if (config.debug) {
+        char buffer[256];
+        std::snprintf(
+          buffer, sizeof(buffer),
+          "Skip SOLiD candidate %d because euclidean distance %.3f m exceeds %.3f m",
+          solid_idx,
+          solid_euclidean_distance,
+          config.solid_descriptor_max_euclidean_distance_m);
+        logs.push_back(LogLine{true, std::string(buffer)});
+      }
+      continue;
+    }
+
+    const double solid_similarity = SolidDescriptor::loopSimilarity(
+      solid_db.descriptors.back(),
+      solid_db.descriptors[solid_idx]);
+    if (solid_similarity > best_solid_similarity) {
+      best_solid_similarity = solid_similarity;
+      best_solid_idx = solid_idx;
+    }
+    if (solid_similarity < config.solid_descriptor_min_similarity) {
+      if (config.debug) {
+        char buffer[256];
+        std::snprintf(
+          buffer, sizeof(buffer),
+          "Skip SOLiD candidate %d because similarity %.3f is below %.3f",
+          solid_idx,
+          solid_similarity,
+          config.solid_descriptor_min_similarity);
+        logs.push_back(LogLine{true, std::string(buffer)});
+      }
+      continue;
+    }
+
+    double solid_yaw_rad = SolidDescriptor::poseYawRad(
+      solid_db.descriptors.back(),
+      solid_db.descriptors[solid_idx]);
+    while (solid_yaw_rad > M_PI) {
+      solid_yaw_rad -= 2.0 * M_PI;
+    }
+    while (solid_yaw_rad < -M_PI) {
+      solid_yaw_rad += 2.0 * M_PI;
+    }
+
+    double solid_sequence_similarity = solid_similarity;
+    if (config.solid_descriptor_sequence_window > 0) {
+      double solid_sequence_similarity_sum = solid_similarity;
+      int solid_sequence_count = 1;
+      for (int offset = 1; offset <= config.solid_descriptor_sequence_window; ++offset) {
+        const int query_idx = latest_idx - offset;
+        const int candidate_sequence_idx = solid_idx - offset;
+        if (
+          query_idx < 0 || candidate_sequence_idx < 0 ||
+          query_idx >= solid_db.size() ||
+          candidate_sequence_idx >= solid_db.size())
+        {
+          break;
+        }
+        solid_sequence_similarity_sum += SolidDescriptor::loopSimilarity(
+          solid_db.descriptors[query_idx],
+          solid_db.descriptors[candidate_sequence_idx]);
+        ++solid_sequence_count;
+      }
+      solid_sequence_similarity =
+        solid_sequence_similarity_sum / static_cast<double>(solid_sequence_count);
+    }
+    if (solid_sequence_similarity < config.solid_descriptor_sequence_min_similarity) {
+      if (config.debug) {
+        char buffer[256];
+        std::snprintf(
+          buffer, sizeof(buffer),
+          "Skip SOLiD candidate %d because sequence similarity %.3f is below %.3f",
+          solid_idx,
+          solid_sequence_similarity,
+          config.solid_descriptor_sequence_min_similarity);
+        logs.push_back(LogLine{true, std::string(buffer)});
+      }
+      continue;
+    }
+
+    double solid_pose_consistency_metric = -1.0;
+    if (
+      config.solid_descriptor_pose_consistency_threshold_m > 0.0 &&
+      config.solid_descriptor_sequence_window > 0)
+    {
+      const Eigen::Affine3d & solid_candidate_affine = submap_poses[solid_idx];
+      const Eigen::AngleAxisd yaw_correction(solid_yaw_rad, Eigen::Vector3d::UnitZ());
+      double solid_pose_consistency_sum = 0.0;
+      int solid_pose_consistency_count = 0;
+      for (int offset = 1; offset <= config.solid_descriptor_sequence_window; ++offset) {
+        const int query_idx = latest_idx - offset;
+        const int candidate_sequence_idx = solid_idx - offset;
+        if (query_idx < 0 || candidate_sequence_idx < 0) {
+          break;
+        }
+
+        const Eigen::Affine3d & query_prev_affine = submap_poses[query_idx];
+        const Eigen::Affine3d & candidate_prev_affine = submap_poses[candidate_sequence_idx];
+
+        const Eigen::Vector3d query_delta =
+          (latest_affine.inverse() * query_prev_affine).translation();
+        const Eigen::Vector3d candidate_delta =
+          yaw_correction *
+          (solid_candidate_affine.inverse() * candidate_prev_affine).translation();
+        solid_pose_consistency_sum +=
+          (query_delta.head<2>() - candidate_delta.head<2>()).norm();
+        ++solid_pose_consistency_count;
+      }
+      if (solid_pose_consistency_count > 0) {
+        solid_pose_consistency_metric =
+          solid_pose_consistency_sum / static_cast<double>(solid_pose_consistency_count);
+        if (
+          solid_pose_consistency_metric >=
+          config.solid_descriptor_pose_consistency_threshold_m)
+        {
+          if (config.debug) {
+            char buffer[256];
+            std::snprintf(
+              buffer, sizeof(buffer),
+              "Skip SOLiD candidate %d because pose consistency %.3f m exceeds %.3f m",
+              solid_idx,
+              solid_pose_consistency_metric,
+              config.solid_descriptor_pose_consistency_threshold_m);
+            logs.push_back(LogLine{true, std::string(buffer)});
+          }
+          continue;
+        }
+      }
+    }
+
+    upsertCandidate(
+      candidates,
+      solid_idx,
+      1.0 - solid_sequence_similarity,
+      loop_verifier::LoopCandidate::Source::SOLID_DESCRIPTOR,
+      solid_yaw_rad);
+    std::ostringstream oss;
+    oss << "SOLiD rerank candidate: id=" << solid_idx
+        << " solid_sim=" << solid_similarity
+        << " seq_sim=" << solid_sequence_similarity
+        << " pose_seq_m=" << solid_pose_consistency_metric
+        << " yaw_deg=" << solid_yaw_rad * 180.0 / M_PI;
+    logs.push_back(LogLine{false, oss.str()});
+    added_solid_candidate = true;
+  }
+  if (!added_solid_candidate && config.debug) {
+    std::ostringstream oss;
+    oss << "SOLiD rerank no candidate: best_idx=" << best_solid_idx
+        << " best_similarity=" << best_solid_similarity
+        << " threshold=" << config.solid_descriptor_min_similarity;
     logs.push_back(LogLine{false, oss.str()});
   }
 }

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -1547,23 +1547,51 @@ void GraphBasedSlamComponent::searchLoopForLatest(
         candidates, index, selection_metric, source, yaw_rad, relative_transform);
     };
 
-  struct DescriptorRerankHint
-  {
-    double score = std::numeric_limits<double>::max();
-    double yaw_rad = 0.0;
-  };
-
   candidate_aggregator::Config aggregator_config;
   aggregator_config.debug = debug_flag_;
   aggregator_config.max_loop_candidate_count = max_loop_candidate_count_;
   aggregator_config.distance_loop_closure = distance_loop_closure_;
   aggregator_config.range_of_searching_loop_closure = range_of_searching_loop_closure_;
   aggregator_config.scan_context_threshold = scan_context_threshold_;
+  aggregator_config.bev_use_mutual_visibility = bev_use_mutual_visibility_;
+  aggregator_config.bev_mutual_visibility_min_overlap_ratio =
+    bev_mutual_visibility_min_overlap_ratio_;
+  aggregator_config.bev_mutual_visibility_occupancy_eps = bev_mutual_visibility_occupancy_eps_;
+  aggregator_config.bev_descriptor_yaw_bins = bev_descriptor_yaw_bins_;
+  aggregator_config.bev_descriptor_max_euclidean_distance_m =
+    bev_descriptor_max_euclidean_distance_m_;
+  aggregator_config.bev_descriptor_threshold = bev_descriptor_threshold_;
+  aggregator_config.bev_descriptor_sequence_window = bev_descriptor_sequence_window_;
+  aggregator_config.bev_descriptor_sequence_threshold = bev_descriptor_sequence_threshold_;
+  aggregator_config.bev_descriptor_pose_consistency_threshold_m =
+    bev_descriptor_pose_consistency_threshold_m_;
+  aggregator_config.bev_descriptor_rerank_weight_m = bev_descriptor_rerank_weight_m_;
+  aggregator_config.solid_descriptor_max_euclidean_distance_m =
+    solid_descriptor_max_euclidean_distance_m_;
+  aggregator_config.solid_descriptor_min_similarity = solid_descriptor_min_similarity_;
+  aggregator_config.solid_descriptor_sequence_window = solid_descriptor_sequence_window_;
+  aggregator_config.solid_descriptor_sequence_min_similarity =
+    solid_descriptor_sequence_min_similarity_;
+  aggregator_config.solid_descriptor_pose_consistency_threshold_m =
+    solid_descriptor_pose_consistency_threshold_m_;
+
+  auto emit_aggregator_logs =
+    [this](const std::vector<candidate_aggregator::LogLine> & logs) {
+      for (const auto & line : logs) {
+        if (line.via_logger) {
+          RCLCPP_INFO(get_logger(), "%s", line.text.c_str());
+        } else {
+          std::cout << line.text << std::endl;
+        }
+      }
+    };
 
   std::vector<Eigen::Vector3d> submap_positions;
   std::vector<double> submap_travel_distances;
+  std::vector<Eigen::Affine3d> submap_affines;
   submap_positions.reserve(latest_idx + 1);
   submap_travel_distances.reserve(latest_idx + 1);
+  submap_affines.reserve(latest_idx + 1);
   for (int i = 0; i <= latest_idx; i++) {
     const auto & submap = map_array_msg.submaps[i];
     submap_positions.emplace_back(
@@ -1571,6 +1599,9 @@ void GraphBasedSlamComponent::searchLoopForLatest(
       submap.pose.position.y,
       submap.pose.position.z);
     submap_travel_distances.push_back(submap.distance);
+    Eigen::Affine3d submap_affine;
+    tf2::fromMsg(submap.pose, submap_affine);
+    submap_affines.push_back(submap_affine);
   }
 
   std::vector<std::pair<double, int>> distance_candidates =
@@ -1586,428 +1617,37 @@ void GraphBasedSlamComponent::searchLoopForLatest(
       aggregator_config,
       candidates,
       aggregator_logs);
-    for (const auto & line : aggregator_logs) {
-      if (line.via_logger) {
-        RCLCPP_INFO(get_logger(), "%s", line.text.c_str());
-      } else {
-        std::cout << line.text << std::endl;
-      }
-    }
+    emit_aggregator_logs(aggregator_logs);
   }
 
   if (use_bev_descriptor_ &&
     bev_descriptor_db_.size() > SubmapBEVDescriptor::DEFAULT_EXCLUDE_RECENT)
   {
-    std::unordered_map<int, DescriptorRerankHint> bev_rerank_hints;
-    const int bev_rerank_candidates = std::min(
-      std::max(max_loop_candidate_count_ * 4, max_loop_candidate_count_),
-      static_cast<int>(distance_candidates.size()));
-    bool added_bev_candidate = false;
-    double best_bev_dist = std::numeric_limits<double>::max();
-    int best_bev_idx = -1;
-    for (int i = 0; i < bev_rerank_candidates; ++i) {
-      const int bev_idx = distance_candidates[i].second;
-      if (bev_idx < 0 || bev_idx >= latest_idx || bev_idx >= bev_descriptor_db_.size()) {
-        continue;
-      }
-      const auto & bev_submap = map_array_msg.submaps[bev_idx];
-      const Eigen::Vector3d bev_submap_pos(
-        bev_submap.pose.position.x,
-        bev_submap.pose.position.y,
-        bev_submap.pose.position.z);
-      const double bev_euclidean_distance = (latest_submap_pos - bev_submap_pos).norm();
-      if (
-        bev_descriptor_max_euclidean_distance_m_ > 0.0 &&
-        bev_euclidean_distance > bev_descriptor_max_euclidean_distance_m_)
-      {
-        if (debug_flag_) {
-          RCLCPP_INFO(
-            get_logger(),
-            "Skip BEV candidate %d because euclidean distance %.3f m exceeds %.3f m",
-            bev_idx,
-            bev_euclidean_distance,
-            bev_descriptor_max_euclidean_distance_m_);
-        }
-        continue;
-      }
-
-      SubmapBEVDescriptor::Match bev_match;
-      if (bev_use_mutual_visibility_) {
-        graphslam::bev::MutualVisibilityConfig mv_cfg;
-        mv_cfg.min_overlap_ratio = bev_mutual_visibility_min_overlap_ratio_;
-        mv_cfg.occupancy_eps =
-          static_cast<float>(bev_mutual_visibility_occupancy_eps_);
-        const auto fov = graphslam::bev::mutualVisibilityWithYawSearch(
-          bev_descriptor_db_.descriptors.back(),
-          bev_descriptor_db_.descriptors[bev_idx],
-          bev_idx,
-          bev_descriptor_yaw_bins_,
-          mv_cfg);
-        bev_match.submap_id = fov.submap_id;
-        bev_match.distance = fov.valid ? fov.distance : 1.0;
-        bev_match.yaw_bin = fov.yaw_bin;
-        bev_match.yaw_rad = fov.yaw_rad;
-      } else {
-        bev_match = SubmapBEVDescriptor::distanceWithAlignment(
-          bev_descriptor_db_.descriptors.back(),
-          bev_descriptor_db_.descriptors[bev_idx],
-          bev_idx,
-          bev_descriptor_yaw_bins_);
-      }
-      if (bev_match.distance < best_bev_dist) {
-        best_bev_dist = bev_match.distance;
-        best_bev_idx = bev_idx;
-      }
-      if (bev_match.distance >= bev_descriptor_threshold_) {
-        if (debug_flag_) {
-          RCLCPP_INFO(
-            get_logger(),
-            "Skip BEV candidate %d because descriptor distance %.3f exceeds %.3f",
-            bev_idx,
-            bev_match.distance,
-            bev_descriptor_threshold_);
-        }
-        continue;
-      }
-
-      double bev_yaw_rad = bev_match.yaw_rad;
-      while (bev_yaw_rad > M_PI) {
-        bev_yaw_rad -= 2.0 * M_PI;
-      }
-      while (bev_yaw_rad < -M_PI) {
-        bev_yaw_rad += 2.0 * M_PI;
-      }
-      double bev_sequence_metric = bev_match.distance;
-      if (bev_descriptor_sequence_window_ > 0) {
-        double bev_sequence_distance_sum = bev_match.distance;
-        int bev_sequence_count = 1;
-        for (int offset = 1; offset <= bev_descriptor_sequence_window_; ++offset) {
-          const int query_idx = latest_idx - offset;
-          const int candidate_sequence_idx = bev_idx - offset;
-          if (
-            query_idx < 0 || candidate_sequence_idx < 0 ||
-            query_idx >= bev_descriptor_db_.size() ||
-            candidate_sequence_idx >= bev_descriptor_db_.size())
-          {
-            break;
-          }
-          const auto rotated_candidate_descriptor = SubmapBEVDescriptor::rotateDescriptor(
-            bev_descriptor_db_.descriptors[candidate_sequence_idx],
-            bev_yaw_rad);
-          double sequence_distance;
-          if (bev_use_mutual_visibility_) {
-            graphslam::bev::MutualVisibilityConfig mv_cfg;
-            mv_cfg.min_overlap_ratio = bev_mutual_visibility_min_overlap_ratio_;
-            mv_cfg.occupancy_eps =
-              static_cast<float>(bev_mutual_visibility_occupancy_eps_);
-            const auto fov = graphslam::bev::mutualVisibilityDistance(
-              bev_descriptor_db_.descriptors[query_idx],
-              rotated_candidate_descriptor,
-              mv_cfg);
-            sequence_distance = fov.valid ? fov.distance : 1.0;
-          } else {
-            sequence_distance = SubmapBEVDescriptor::descriptorDistance(
-              bev_descriptor_db_.descriptors[query_idx],
-              rotated_candidate_descriptor);
-          }
-          bev_sequence_distance_sum += sequence_distance;
-          ++bev_sequence_count;
-        }
-        bev_sequence_metric = bev_sequence_distance_sum / static_cast<double>(bev_sequence_count);
-      }
-      if (bev_sequence_metric >= bev_descriptor_sequence_threshold_) {
-        if (debug_flag_) {
-          RCLCPP_INFO(
-            get_logger(),
-            "Skip BEV candidate %d because sequence metric %.3f exceeds %.3f",
-            bev_idx,
-            bev_sequence_metric,
-            bev_descriptor_sequence_threshold_);
-        }
-        continue;
-      }
-      double bev_pose_consistency_metric = -1.0;
-      if (
-        bev_descriptor_pose_consistency_threshold_m_ > 0.0 &&
-        bev_descriptor_sequence_window_ > 0)
-      {
-        Eigen::Affine3d bev_candidate_affine;
-        tf2::fromMsg(map_array_msg.submaps[bev_idx].pose, bev_candidate_affine);
-        const Eigen::AngleAxisd yaw_correction(bev_yaw_rad, Eigen::Vector3d::UnitZ());
-        double bev_pose_consistency_sum = 0.0;
-        int bev_pose_consistency_count = 0;
-        for (int offset = 1; offset <= bev_descriptor_sequence_window_; ++offset) {
-          const int query_idx = latest_idx - offset;
-          const int candidate_sequence_idx = bev_idx - offset;
-          if (query_idx < 0 || candidate_sequence_idx < 0) {
-            break;
-          }
-
-          Eigen::Affine3d query_prev_affine;
-          Eigen::Affine3d candidate_prev_affine;
-          tf2::fromMsg(map_array_msg.submaps[query_idx].pose, query_prev_affine);
-          tf2::fromMsg(map_array_msg.submaps[candidate_sequence_idx].pose, candidate_prev_affine);
-
-          const Eigen::Vector3d query_delta =
-            (latest_affine.inverse() * query_prev_affine).translation();
-          const Eigen::Vector3d candidate_delta =
-            yaw_correction * (bev_candidate_affine.inverse() * candidate_prev_affine).translation();
-          bev_pose_consistency_sum +=
-            (query_delta.head<2>() - candidate_delta.head<2>()).norm();
-          ++bev_pose_consistency_count;
-        }
-        if (bev_pose_consistency_count > 0) {
-          bev_pose_consistency_metric =
-            bev_pose_consistency_sum / static_cast<double>(bev_pose_consistency_count);
-          if (bev_pose_consistency_metric >= bev_descriptor_pose_consistency_threshold_m_) {
-            if (debug_flag_) {
-              RCLCPP_INFO(
-                get_logger(),
-                "Skip BEV candidate %d because pose consistency %.3f m exceeds %.3f m",
-                bev_idx,
-                bev_pose_consistency_metric,
-                bev_descriptor_pose_consistency_threshold_m_);
-            }
-            continue;
-          }
-        }
-      }
-      auto & bev_hint = bev_rerank_hints[bev_idx];
-      if (bev_sequence_metric < bev_hint.score) {
-        bev_hint.score = bev_sequence_metric;
-        bev_hint.yaw_rad = bev_yaw_rad;
-      }
-      std::cout << "BEV rerank hint: id=" << bev_idx
-                << " bev_dist=" << bev_match.distance
-                << " seq_dist=" << bev_sequence_metric
-                << " pose_seq_m=" << bev_pose_consistency_metric
-                << " yaw_deg=" << bev_yaw_rad * 180.0 / M_PI << std::endl;
-      added_bev_candidate = true;
-    }
-    if (!added_bev_candidate && debug_flag_) {
-      std::cout << "BEV rerank no candidate: best_idx=" << best_bev_idx
-                << " best_bev_dist=" << best_bev_dist
-                << " threshold=" << bev_descriptor_threshold_ << std::endl;
-    }
-
-    auto bev_adjusted_distance =
-      [this, &bev_rerank_hints](const std::pair<double, int> & candidate) {
-        const auto bev_hint = bev_rerank_hints.find(candidate.second);
-        if (bev_hint == bev_rerank_hints.end()) {
-          return candidate.first;
-        }
-        return candidate.first +
-               bev_descriptor_rerank_weight_m_ *
-               (bev_hint->second.score - bev_descriptor_threshold_);
-      };
-
-    std::stable_sort(
-      distance_candidates.begin(),
-      distance_candidates.end(),
-      [&bev_adjusted_distance](const auto & lhs, const auto & rhs) {
-        const double lhs_adjusted = bev_adjusted_distance(lhs);
-        const double rhs_adjusted = bev_adjusted_distance(rhs);
-        if (lhs_adjusted != rhs_adjusted) {
-          return lhs_adjusted < rhs_adjusted;
-        }
-        return lhs.first < rhs.first;
-      });
-
-    const int num_distance_candidates =
-      std::min(max_loop_candidate_count_, static_cast<int>(distance_candidates.size()));
-    for (int i = 0; i < num_distance_candidates; ++i) {
-      const int candidate_idx = distance_candidates[i].second;
-      const auto bev_hint = bev_rerank_hints.find(candidate_idx);
-      const double adjusted_distance = bev_adjusted_distance(distance_candidates[i]);
-      if (bev_hint != bev_rerank_hints.end()) {
-        add_candidate(
-          candidate_idx,
-          adjusted_distance,
-          LoopCandidate::Source::DISTANCE,
-          bev_hint->second.yaw_rad);
-        std::cout << "Distance candidate reranked by BEV: id=" << candidate_idx
-                  << " dist_m=" << distance_candidates[i].first
-                  << " bev_score=" << bev_hint->second.score
-                  << " adjusted_dist_m=" << adjusted_distance
-                  << " yaw_deg=" << bev_hint->second.yaw_rad * 180.0 / M_PI << std::endl;
-      } else {
-        add_candidate(
-          candidate_idx,
-          adjusted_distance,
-          LoopCandidate::Source::DISTANCE);
-      }
-    }
+    std::vector<candidate_aggregator::LogLine> aggregator_logs;
+    candidate_aggregator::rerankDistanceCandidatesWithBev(
+      bev_descriptor_db_,
+      submap_affines,
+      latest_idx,
+      aggregator_config,
+      distance_candidates,
+      candidates,
+      aggregator_logs);
+    emit_aggregator_logs(aggregator_logs);
   } else {
     candidate_aggregator::appendTopDistanceCandidates(
       distance_candidates, aggregator_config, candidates);
   }
-  if (
-    use_solid_descriptor_ &&
-    solid_descriptor_db_.size() > SolidDescriptor::DEFAULT_EXCLUDE_RECENT)
-  {
-    const int solid_rerank_candidates = std::min(
-      std::max(max_loop_candidate_count_ * 4, max_loop_candidate_count_),
-      static_cast<int>(distance_candidates.size()));
-    bool added_solid_candidate = false;
-    double best_solid_similarity = -1.0;
-    int best_solid_idx = -1;
-    for (int i = 0; i < solid_rerank_candidates; ++i) {
-      const int solid_idx = distance_candidates[i].second;
-      if (solid_idx < 0 || solid_idx >= latest_idx || solid_idx >= solid_descriptor_db_.size()) {
-        continue;
-      }
-      const auto & solid_submap = map_array_msg.submaps[solid_idx];
-      const Eigen::Vector3d solid_submap_pos(
-        solid_submap.pose.position.x,
-        solid_submap.pose.position.y,
-        solid_submap.pose.position.z);
-      const double solid_euclidean_distance = (latest_submap_pos - solid_submap_pos).norm();
-      if (
-        solid_descriptor_max_euclidean_distance_m_ > 0.0 &&
-        solid_euclidean_distance > solid_descriptor_max_euclidean_distance_m_)
-      {
-        if (debug_flag_) {
-          RCLCPP_INFO(
-            get_logger(),
-            "Skip SOLiD candidate %d because euclidean distance %.3f m exceeds %.3f m",
-            solid_idx,
-            solid_euclidean_distance,
-            solid_descriptor_max_euclidean_distance_m_);
-        }
-        continue;
-      }
-
-      const double solid_similarity = SolidDescriptor::loopSimilarity(
-        solid_descriptor_db_.descriptors.back(),
-        solid_descriptor_db_.descriptors[solid_idx]);
-      if (solid_similarity > best_solid_similarity) {
-        best_solid_similarity = solid_similarity;
-        best_solid_idx = solid_idx;
-      }
-      if (solid_similarity < solid_descriptor_min_similarity_) {
-        if (debug_flag_) {
-          RCLCPP_INFO(
-            get_logger(),
-            "Skip SOLiD candidate %d because similarity %.3f is below %.3f",
-            solid_idx,
-            solid_similarity,
-            solid_descriptor_min_similarity_);
-        }
-        continue;
-      }
-
-      double solid_yaw_rad = SolidDescriptor::poseYawRad(
-        solid_descriptor_db_.descriptors.back(),
-        solid_descriptor_db_.descriptors[solid_idx]);
-      while (solid_yaw_rad > M_PI) {
-        solid_yaw_rad -= 2.0 * M_PI;
-      }
-      while (solid_yaw_rad < -M_PI) {
-        solid_yaw_rad += 2.0 * M_PI;
-      }
-
-      double solid_sequence_similarity = solid_similarity;
-      if (solid_descriptor_sequence_window_ > 0) {
-        double solid_sequence_similarity_sum = solid_similarity;
-        int solid_sequence_count = 1;
-        for (int offset = 1; offset <= solid_descriptor_sequence_window_; ++offset) {
-          const int query_idx = latest_idx - offset;
-          const int candidate_sequence_idx = solid_idx - offset;
-          if (
-            query_idx < 0 || candidate_sequence_idx < 0 ||
-            query_idx >= solid_descriptor_db_.size() ||
-            candidate_sequence_idx >= solid_descriptor_db_.size())
-          {
-            break;
-          }
-          solid_sequence_similarity_sum += SolidDescriptor::loopSimilarity(
-            solid_descriptor_db_.descriptors[query_idx],
-            solid_descriptor_db_.descriptors[candidate_sequence_idx]);
-          ++solid_sequence_count;
-        }
-        solid_sequence_similarity =
-          solid_sequence_similarity_sum / static_cast<double>(solid_sequence_count);
-      }
-      if (solid_sequence_similarity < solid_descriptor_sequence_min_similarity_) {
-        if (debug_flag_) {
-          RCLCPP_INFO(
-            get_logger(),
-            "Skip SOLiD candidate %d because sequence similarity %.3f is below %.3f",
-            solid_idx,
-            solid_sequence_similarity,
-            solid_descriptor_sequence_min_similarity_);
-        }
-        continue;
-      }
-
-      double solid_pose_consistency_metric = -1.0;
-      if (
-        solid_descriptor_pose_consistency_threshold_m_ > 0.0 &&
-        solid_descriptor_sequence_window_ > 0)
-      {
-        Eigen::Affine3d solid_candidate_affine;
-        tf2::fromMsg(map_array_msg.submaps[solid_idx].pose, solid_candidate_affine);
-        const Eigen::AngleAxisd yaw_correction(solid_yaw_rad, Eigen::Vector3d::UnitZ());
-        double solid_pose_consistency_sum = 0.0;
-        int solid_pose_consistency_count = 0;
-        for (int offset = 1; offset <= solid_descriptor_sequence_window_; ++offset) {
-          const int query_idx = latest_idx - offset;
-          const int candidate_sequence_idx = solid_idx - offset;
-          if (query_idx < 0 || candidate_sequence_idx < 0) {
-            break;
-          }
-
-          Eigen::Affine3d query_prev_affine;
-          Eigen::Affine3d candidate_prev_affine;
-          tf2::fromMsg(map_array_msg.submaps[query_idx].pose, query_prev_affine);
-          tf2::fromMsg(map_array_msg.submaps[candidate_sequence_idx].pose, candidate_prev_affine);
-
-          const Eigen::Vector3d query_delta =
-            (latest_affine.inverse() * query_prev_affine).translation();
-          const Eigen::Vector3d candidate_delta =
-            yaw_correction *
-            (solid_candidate_affine.inverse() * candidate_prev_affine).translation();
-          solid_pose_consistency_sum +=
-            (query_delta.head<2>() - candidate_delta.head<2>()).norm();
-          ++solid_pose_consistency_count;
-        }
-        if (solid_pose_consistency_count > 0) {
-          solid_pose_consistency_metric =
-            solid_pose_consistency_sum / static_cast<double>(solid_pose_consistency_count);
-          if (
-            solid_pose_consistency_metric >=
-            solid_descriptor_pose_consistency_threshold_m_)
-          {
-            if (debug_flag_) {
-              RCLCPP_INFO(
-                get_logger(),
-                "Skip SOLiD candidate %d because pose consistency %.3f m exceeds %.3f m",
-                solid_idx,
-                solid_pose_consistency_metric,
-                solid_descriptor_pose_consistency_threshold_m_);
-            }
-            continue;
-          }
-        }
-      }
-
-      add_candidate(
-        solid_idx,
-        1.0 - solid_sequence_similarity,
-        LoopCandidate::Source::SOLID_DESCRIPTOR,
-        solid_yaw_rad);
-      std::cout << "SOLiD rerank candidate: id=" << solid_idx
-                << " solid_sim=" << solid_similarity
-                << " seq_sim=" << solid_sequence_similarity
-                << " pose_seq_m=" << solid_pose_consistency_metric
-                << " yaw_deg=" << solid_yaw_rad * 180.0 / M_PI << std::endl;
-      added_solid_candidate = true;
-    }
-    if (!added_solid_candidate && debug_flag_) {
-      std::cout << "SOLiD rerank no candidate: best_idx=" << best_solid_idx
-                << " best_similarity=" << best_solid_similarity
-                << " threshold=" << solid_descriptor_min_similarity_ << std::endl;
-    }
+  if (use_solid_descriptor_) {
+    std::vector<candidate_aggregator::LogLine> aggregator_logs;
+    candidate_aggregator::collectSolidCandidates(
+      solid_descriptor_db_,
+      submap_affines,
+      distance_candidates,
+      latest_idx,
+      aggregator_config,
+      candidates,
+      aggregator_logs);
+    emit_aggregator_logs(aggregator_logs);
   }
 
   if (

--- a/graph_based_slam/test/test_candidate_aggregator.cpp
+++ b/graph_based_slam/test/test_candidate_aggregator.cpp
@@ -40,6 +40,7 @@
 #include <vector>
 
 #include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Geometry>  // NOLINT(build/include_order)
 
 #include "graph_based_slam/candidate_aggregator.hpp"
 
@@ -305,6 +306,255 @@ TEST_F(CandidateAggregatorScanContext, DatabaseWithinExcludeRecentWindowIsSkippe
 
   candidate_aggregator::collectScanContextCandidate(
     db_, travels_, ScanContext::EXCLUDE_RECENT - 1, config, candidates_, logs_);
+  EXPECT_TRUE(candidates_.empty());
+  EXPECT_TRUE(logs_.empty());
+}
+
+Eigen::Affine3d makeTestPose(double x, double y)
+{
+  Eigen::Affine3d pose = Eigen::Affine3d::Identity();
+  pose.translate(Eigen::Vector3d(x, y, 0.0));
+  return pose;
+}
+
+// A BEV descriptor whose flattened cosine distance is 0 against the same
+// spike cell and 1 against a different one.
+SubmapBEVDescriptor::Descriptor makeBevDescriptor(int spike_cell)
+{
+  SubmapBEVDescriptor::Descriptor desc;
+  desc.occupancy = Eigen::MatrixXf::Zero(4, 4);
+  desc.density = Eigen::MatrixXf::Zero(4, 4);
+  desc.max_height = Eigen::MatrixXf::Zero(4, 4);
+  desc.occupancy(spike_cell / 4, spike_cell % 4) = 1.0F;
+  desc.coarse_key = Eigen::VectorXf::Zero(1);
+  return desc;
+}
+
+Config makeBevConfig()
+{
+  Config config;
+  config.max_loop_candidate_count = 2;
+  config.bev_descriptor_yaw_bins = 1;  // evaluate yaw 0 only: distances stay exact
+  config.bev_descriptor_threshold = 0.5;
+  config.bev_descriptor_sequence_threshold = 0.5;
+  config.bev_descriptor_rerank_weight_m = 100.0;
+  return config;
+}
+
+TEST(CandidateAggregatorBev, MatchingDescriptorBoostsFartherCandidateAheadOfNearer)
+{
+  // Submap 0 (5 m away) matches the latest descriptor, submap 1 (3 m away)
+  // does not: the hint shifts 0 ahead of 1 in the reranked order and both
+  // end up as DISTANCE candidates, the boosted one carrying the hint yaw.
+  SubmapBEVDescriptor::Database db;
+  db.add(0, makeBevDescriptor(0));
+  db.add(1, makeBevDescriptor(5));
+  db.add(2, makeBevDescriptor(0));
+  const std::vector<Eigen::Affine3d> poses = {
+    makeTestPose(5.0, 0.0), makeTestPose(3.0, 0.0), makeTestPose(0.0, 0.0)};
+  std::vector<std::pair<double, int>> distance_candidates = {{3.0, 1}, {5.0, 0}};
+  std::vector<LoopCandidate> candidates;
+  std::vector<LogLine> logs;
+
+  candidate_aggregator::rerankDistanceCandidatesWithBev(
+    db, poses, 2, makeBevConfig(), distance_candidates, candidates, logs);
+
+  ASSERT_EQ(distance_candidates.size(), 2U);
+  EXPECT_EQ(distance_candidates[0].second, 0);
+  EXPECT_EQ(distance_candidates[1].second, 1);
+
+  ASSERT_EQ(candidates.size(), 2U);
+  EXPECT_EQ(candidates[0].index, 0);
+  EXPECT_EQ(candidates[0].source, Source::DISTANCE);
+  // adjusted = 5.0 + 100 * (0 - 0.5)
+  EXPECT_NEAR(candidates[0].selection_metric, -45.0, 1e-9);
+  EXPECT_EQ(candidates[1].index, 1);
+  EXPECT_DOUBLE_EQ(candidates[1].selection_metric, 3.0);
+
+  ASSERT_EQ(logs.size(), 2U);
+  EXPECT_EQ(logs[0].text.rfind("BEV rerank hint: id=0", 0), 0U);
+  EXPECT_EQ(logs[1].text.rfind("Distance candidate reranked by BEV: id=0", 0), 0U);
+}
+
+TEST(CandidateAggregatorBev, EuclideanGateSkipsAndReportsNoCandidateWhenDebug)
+{
+  SubmapBEVDescriptor::Database db;
+  db.add(0, makeBevDescriptor(0));
+  db.add(1, makeBevDescriptor(0));
+  const std::vector<Eigen::Affine3d> poses = {
+    makeTestPose(5.0, 0.0), makeTestPose(0.0, 0.0)};
+  std::vector<std::pair<double, int>> distance_candidates = {{5.0, 0}};
+  std::vector<LoopCandidate> candidates;
+  std::vector<LogLine> logs;
+  auto config = makeBevConfig();
+  config.debug = true;
+  config.bev_descriptor_max_euclidean_distance_m = 4.0;
+
+  candidate_aggregator::rerankDistanceCandidatesWithBev(
+    db, poses, 1, config, distance_candidates, candidates, logs);
+
+  // No hint: the candidate still appears via the plain top-N add.
+  ASSERT_EQ(candidates.size(), 1U);
+  EXPECT_DOUBLE_EQ(candidates[0].selection_metric, 5.0);
+  EXPECT_DOUBLE_EQ(candidates[0].yaw_rad, 0.0);
+
+  ASSERT_EQ(logs.size(), 2U);
+  EXPECT_TRUE(logs[0].via_logger);
+  EXPECT_EQ(
+    logs[0].text,
+    "Skip BEV candidate 0 because euclidean distance 5.000 m exceeds 4.000 m");
+  EXPECT_FALSE(logs[1].via_logger);
+  EXPECT_EQ(logs[1].text.rfind("BEV rerank no candidate: best_idx=-1", 0), 0U);
+}
+
+TEST(CandidateAggregatorBev, SequenceWindowAveragesAndGatesAtThreshold)
+{
+  // Candidate 2 matches at the head (distance 0) but its window-1
+  // predecessor mismatches (distance 1): the averaged metric 0.5 hits the
+  // >= 0.5 gate exactly and the hint is rejected.
+  SubmapBEVDescriptor::Database db;
+  db.add(0, makeBevDescriptor(0));
+  db.add(1, makeBevDescriptor(5));
+  db.add(2, makeBevDescriptor(0));
+  db.add(3, makeBevDescriptor(0));
+  const std::vector<Eigen::Affine3d> poses = {
+    makeTestPose(9.0, 0.0), makeTestPose(10.0, 0.0),
+    makeTestPose(10.0, 1.0), makeTestPose(0.0, 0.0)};
+  std::vector<std::pair<double, int>> distance_candidates = {{10.0, 2}};
+  std::vector<LoopCandidate> candidates;
+  std::vector<LogLine> logs;
+  auto config = makeBevConfig();
+  config.debug = true;
+  config.bev_descriptor_sequence_window = 1;
+
+  candidate_aggregator::rerankDistanceCandidatesWithBev(
+    db, poses, 3, config, distance_candidates, candidates, logs);
+
+  ASSERT_GE(logs.size(), 1U);
+  EXPECT_EQ(
+    logs[0].text,
+    "Skip BEV candidate 2 because sequence metric 0.500 exceeds 0.500");
+}
+
+TEST(CandidateAggregatorBev, PoseConsistencyGateComparesTrajectoryDeltas)
+{
+  // Descriptors match through the window, but the relative motion to the
+  // window-1 predecessor differs between the query and candidate tracks,
+  // so the pose-consistency gate rejects the hint.
+  SubmapBEVDescriptor::Database db;
+  for (int i = 0; i < 4; ++i) {
+    db.add(i, makeBevDescriptor(0));
+  }
+  const std::vector<Eigen::Affine3d> poses = {
+    makeTestPose(9.0, 0.0), makeTestPose(9.0, 0.0),
+    makeTestPose(10.0, 0.0), makeTestPose(0.0, 0.0)};
+  std::vector<std::pair<double, int>> distance_candidates = {{10.0, 2}};
+  std::vector<LoopCandidate> candidates;
+  std::vector<LogLine> logs;
+  auto config = makeBevConfig();
+  config.debug = true;
+  config.bev_descriptor_sequence_window = 1;
+  config.bev_descriptor_pose_consistency_threshold_m = 1.0;
+
+  candidate_aggregator::rerankDistanceCandidatesWithBev(
+    db, poses, 3, config, distance_candidates, candidates, logs);
+
+  // query delta (latest -> poses[2]) is (10, 0); candidate delta
+  // (candidate 2 -> poses[1]) is (-1, 0): 2-D mismatch 11 m >= 1 m.
+  ASSERT_GE(logs.size(), 1U);
+  EXPECT_EQ(
+    logs[0].text,
+    "Skip BEV candidate 2 because pose consistency 11.000 m exceeds 1.000 m");
+}
+
+SolidDescriptor::Descriptor makeSolidDescriptor(double range0, double range1)
+{
+  SolidDescriptor::Descriptor desc;
+  desc.range = Eigen::VectorXd::Zero(4);
+  desc.range(0) = range0;
+  desc.range(1) = range1;
+  desc.angle = Eigen::VectorXd::Zero(4);
+  desc.angle(0) = 1.0;
+  desc.solid = Eigen::VectorXd::Zero(8);
+  return desc;
+}
+
+class CandidateAggregatorSolid : public ::testing::Test
+{
+protected:
+  // 52 entries: ids 0 and 1 hold the given patterns, fillers are
+  // orthogonal to the query, the query (id 51) is (1, 0).
+  void buildDatabase(double id0_range0, double id0_range1)
+  {
+    db_.add(0, makeSolidDescriptor(id0_range0, id0_range1));
+    db_.add(1, makeSolidDescriptor(0.0, 1.0));
+    for (int id = 2; id < 51; ++id) {
+      db_.add(id, makeSolidDescriptor(0.0, 1.0));
+    }
+    db_.add(51, makeSolidDescriptor(1.0, 0.0));
+    poses_.assign(52, Eigen::Affine3d::Identity());
+  }
+
+  SolidDescriptor::Database db_;
+  std::vector<Eigen::Affine3d> poses_;
+  std::vector<LoopCandidate> candidates_;
+  std::vector<LogLine> logs_;
+};
+
+TEST_F(CandidateAggregatorSolid, HighSimilarityCandidateIsAddedWithSequenceMetric)
+{
+  buildDatabase(1.0, 0.0);  // identical to the query: similarity 1
+  auto config = makeConfig();
+  config.solid_descriptor_min_similarity = 0.7;
+  const std::vector<std::pair<double, int>> distance_candidates = {{1.0, 0}};
+
+  candidate_aggregator::collectSolidCandidates(
+    db_, poses_, distance_candidates, 51, config, candidates_, logs_);
+
+  ASSERT_EQ(candidates_.size(), 1U);
+  EXPECT_EQ(candidates_[0].index, 0);
+  EXPECT_EQ(candidates_[0].source, Source::SOLID_DESCRIPTOR);
+  // selection metric is 1 - sequence similarity (window 0 -> plain
+  // similarity 1).
+  EXPECT_NEAR(candidates_[0].selection_metric, 0.0, 1e-12);
+  ASSERT_EQ(logs_.size(), 1U);
+  EXPECT_EQ(logs_[0].text.rfind("SOLiD rerank candidate: id=0", 0), 0U);
+}
+
+TEST_F(CandidateAggregatorSolid, LowSimilarityIsGatedAndReportedWhenDebug)
+{
+  buildDatabase(0.0, 1.0);  // orthogonal to the query: similarity 0
+  auto config = makeConfig();
+  config.debug = true;
+  config.solid_descriptor_min_similarity = 0.7;
+  const std::vector<std::pair<double, int>> distance_candidates = {{1.0, 0}};
+
+  candidate_aggregator::collectSolidCandidates(
+    db_, poses_, distance_candidates, 51, config, candidates_, logs_);
+
+  EXPECT_TRUE(candidates_.empty());
+  ASSERT_EQ(logs_.size(), 2U);
+  EXPECT_TRUE(logs_[0].via_logger);
+  EXPECT_EQ(
+    logs_[0].text,
+    "Skip SOLiD candidate 0 because similarity 0.000 is below 0.700");
+  EXPECT_FALSE(logs_[1].via_logger);
+  EXPECT_EQ(logs_[1].text.rfind("SOLiD rerank no candidate: best_idx=0", 0), 0U);
+}
+
+TEST_F(CandidateAggregatorSolid, DatabaseWithinExcludeRecentWindowIsSkipped)
+{
+  for (int id = 0; id < SolidDescriptor::DEFAULT_EXCLUDE_RECENT; ++id) {
+    db_.add(id, makeSolidDescriptor(1.0, 0.0));
+  }
+  poses_.assign(SolidDescriptor::DEFAULT_EXCLUDE_RECENT, Eigen::Affine3d::Identity());
+  auto config = makeConfig();
+  config.debug = true;
+  const std::vector<std::pair<double, int>> distance_candidates = {{1.0, 0}};
+
+  candidate_aggregator::collectSolidCandidates(
+    db_, poses_, distance_candidates,
+    SolidDescriptor::DEFAULT_EXCLUDE_RECENT - 1, config, candidates_, logs_);
   EXPECT_TRUE(candidates_.empty());
   EXPECT_TRUE(logs_.empty());
 }


### PR DESCRIPTION
## Summary

candidate_aggregator 第 2 弾 (v0.6 Phase 1, #246 の続き)。`searchLoopForLatest` に残っていた BEV / SOLiD rerank ブロック (~390 行) を逐語移植で純関数化します。挙動保存の機械的分割です。

- `rerankDistanceCandidatesWithBev` — hint 収集 (euclidean / descriptor / sequence / pose-consistency の 4 段ゲート) → `weight * (hint - threshold)` の rerank 重み付き stable_sort (元距離 tie-break) → hint yaw 付き top-N DISTANCE 追加。mutual visibility 経路も config 経由でそのまま
- `collectSolidCandidates` — 同型のゲート連鎖、selection metric は `1 - sequence similarity`。**BEV が並べ替えた後の distance_candidates を読む歴史的順序を維持** (shell の呼び出し順で保証)
- component は submap poses を `Eigen::Affine3d` 配列へ 1 回前変換 (従来の遅延 tf2::fromMsg と同値・同演算)、LogLine 出力は共有 lambda に集約。skip 診断・rerank 行・debug 限定の no-candidate サマリまでバイト同一
- `searchLoopForLatest` 残りは triangle ブロックのみ (第 3 弾)。component は 3279 → 2888 行

## Tests

characterization 7 本追加 (計 16 本):
- rerank boost: マッチした遠方候補が近傍候補を adjusted distance で追い越す (期待値 -45.0 まで assert)、reorder 後の distance_candidates 順序、hint yaw 伝播
- euclidean ゲート: skip ログ文字列完全一致 + no-candidate サマリ (debug 時のみ)
- sequence window: 平均値が閾値ちょうど (0.500) で `>=` 棄却される境界
- pose consistency: 軌跡デルタ不整合 11m の棄却とログ
- SOLiD: 高類似度受理 (metric 0)、類似度ゲート + no-candidate サマリ、EXCLUDE_RECENT ガード

## Verification

```bash
colcon test --packages-select graph_based_slam lidarslam_msgs scanmatcher lidarslam && colcon test-result
# => 1039 tests, 0 errors, 0 failures (1032 -> 1039)
bash scripts/run_release_readiness_checks.sh
# => 全 profile PASS / TARGET_MET。stadtgarten_seq2 raw 0.835 (4 回連続完全一致 = 無回帰)
```

## Next

第 3 弾: triangle ブロックの抽出で candidate_aggregator 完成 → map_saver → Phase 2 (BackendCore + オフライン決定論ランナー)。