### PR TITLE
refactor(slam): extract the triangle candidate block, completing candidate_aggregator

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -205,6 +205,7 @@ if(BUILD_TESTING)
   )
   if(TARGET test_candidate_aggregator)
     target_include_directories(test_candidate_aggregator PRIVATE include ${EIGEN3_INCLUDE_DIR})
+    target_link_libraries(test_candidate_aggregator ${PCL_LIBRARIES})
   endif()
   ament_add_gtest(
     test_loop_verifier

--- a/graph_based_slam/include/graph_based_slam/candidate_aggregator.hpp
+++ b/graph_based_slam/include/graph_based_slam/candidate_aggregator.hpp
@@ -41,6 +41,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <iomanip>
 #include <limits>
 #include <sstream>
 #include <string>
@@ -56,6 +57,7 @@
 #include "graph_based_slam/scan_context.hpp"
 #include "graph_based_slam/solid_descriptor.hpp"
 #include "graph_based_slam/submap_bev_descriptor.hpp"
+#include "graph_based_slam/triangle_descriptor_database.hpp"
 
 namespace graphslam
 {
@@ -98,6 +100,30 @@ struct Config
   int solid_descriptor_sequence_window {0};
   double solid_descriptor_sequence_min_similarity {0.0};
   double solid_descriptor_pose_consistency_threshold_m {0.0};
+
+  int triangle_descriptor_exclude_recent {0};
+  double triangle_descriptor_edge_bin_m {0.0};
+  double triangle_descriptor_quad_feature_bin_m {0.0};
+  double triangle_descriptor_inlier_translation_m {0.0};
+  double triangle_descriptor_inlier_rotation_deg {0.0};
+  int triangle_descriptor_min_inliers {0};
+  double triangle_descriptor_min_inlier_ratio {0.0};
+  int triangle_descriptor_max_pairs {0};
+  int triangle_descriptor_min_4th_point_agreements {0};
+  double triangle_descriptor_fourth_point_max_distance_m {0.0};
+  bool triangle_descriptor_refine_se3_with_all_inliers {false};
+  int triangle_descriptor_min_votes {0};
+  bool triangle_descriptor_skip_ransac {false};
+  bool triangle_verify_with_bev {false};
+  double triangle_verify_bev_max_distance {0.0};
+};
+
+// Per-submap triangle features, kept by the shell in submap order
+// (historically the component's private TrianglePerSubmap struct).
+struct TriangleSubmapFeatures
+{
+  std::vector<graphslam::triangle::Keypoint> keypoints;
+  std::vector<graphslam::triangle::TriangleDescriptor> triangles;
 };
 
 // The shared candidate upsert (historically the add_candidate lambda):
@@ -736,6 +762,186 @@ inline void collectSolidCandidates(
         << " best_similarity=" << best_solid_similarity
         << " threshold=" << config.solid_descriptor_min_similarity;
     logs.push_back(LogLine{false, oss.str()});
+  }
+}
+
+// Triangle source: vote across the whole database, take the first
+// non-recent top vote, then re-run RANSAC verification scoped to that
+// submap to recover the SE(3). Survivors of the travel-distance gate (and
+// the optional BEV cross-verification) become a TRIANGLE_DESCRIPTOR
+// candidate whose selection metric is 1 / (1 + inliers) and whose
+// relative transform seeds the registration initial guess.
+inline void collectTriangleCandidate(
+  const graphslam::triangle::TriangleDatabase & triangle_db,
+  const std::vector<TriangleSubmapFeatures> & triangle_per_submap,
+  const SubmapBEVDescriptor::Database & bev_db,
+  bool use_bev_descriptor,
+  const std::vector<double> & submap_travel_distances,
+  int latest_idx,
+  const Config & config,
+  std::vector<loop_verifier::LoopCandidate> & candidates,
+  std::vector<LogLine> & logs)
+{
+  if (
+    static_cast<int>(triangle_per_submap.size()) <= latest_idx ||
+    triangle_db.submapCount() <=
+    static_cast<std::size_t>(config.triangle_descriptor_exclude_recent))
+  {
+    return;
+  }
+  const auto & query_kps = triangle_per_submap[latest_idx].keypoints;
+  const auto & query_tris = triangle_per_submap[latest_idx].triangles;
+  if (query_tris.empty()) {
+    return;
+  }
+  const double latest_moving_distance = submap_travel_distances[latest_idx];
+  graphslam::triangle::HashConfig hash_cfg;
+  hash_cfg.edge_bin_m = static_cast<float>(config.triangle_descriptor_edge_bin_m);
+  hash_cfg.quad_feature_bin_m =
+    static_cast<float>(config.triangle_descriptor_quad_feature_bin_m);
+  graphslam::triangle::VoteConfig vote_cfg;
+  vote_cfg.exclude_submap_id = -1;
+  graphslam::triangle::VerificationConfig verify_cfg;
+  verify_cfg.inlier_translation_m =
+    static_cast<float>(config.triangle_descriptor_inlier_translation_m);
+  verify_cfg.inlier_rotation_deg =
+    static_cast<float>(config.triangle_descriptor_inlier_rotation_deg);
+  verify_cfg.min_inliers = config.triangle_descriptor_min_inliers;
+  verify_cfg.min_inlier_ratio =
+    static_cast<float>(config.triangle_descriptor_min_inlier_ratio);
+  verify_cfg.max_pairs = config.triangle_descriptor_max_pairs;
+  verify_cfg.min_4th_point_agreements =
+    config.triangle_descriptor_min_4th_point_agreements;
+  verify_cfg.fourth_point_max_distance_m =
+    static_cast<float>(config.triangle_descriptor_fourth_point_max_distance_m);
+  verify_cfg.refine_se3_with_all_inliers =
+    config.triangle_descriptor_refine_se3_with_all_inliers;
+
+  // Mask out the latest_idx and any recent submaps so we don't loop on
+  // ourselves. We do this by running the vote step first and dropping any
+  // candidate whose submap_id is too close to latest_idx.
+  const auto votes = graphslam::triangle::accumulateVotes(
+    triangle_db, query_kps, query_tris, hash_cfg, vote_cfg);
+  int chosen_submap_id = -1;
+  int chosen_votes = 0;
+  for (const auto & v : votes) {
+    if (v.submap_id < 0) {continue;}
+    if (latest_idx - v.submap_id < config.triangle_descriptor_exclude_recent) {continue;}
+    chosen_submap_id = v.submap_id;
+    chosen_votes = v.votes;
+    break;
+  }
+  if (
+    chosen_submap_id >= 0 &&
+    chosen_votes >= config.triangle_descriptor_min_votes &&
+    !config.triangle_descriptor_skip_ransac)
+  {
+    // Re-run verification scoped to the chosen submap to recover SE(3).
+    vote_cfg.exclude_submap_id = -1;
+    graphslam::triangle::TriangleDatabase scoped_db;
+    const auto db_kps_idx = static_cast<std::size_t>(chosen_submap_id);
+    if (db_kps_idx < triangle_per_submap.size()) {
+      scoped_db.addSubmap(
+        chosen_submap_id,
+        triangle_per_submap[db_kps_idx].keypoints,
+        triangle_per_submap[db_kps_idx].triangles,
+        hash_cfg);
+    }
+    const auto cand = graphslam::triangle::findLoopCandidate(
+      scoped_db, query_kps, query_tris, hash_cfg, vote_cfg, verify_cfg);
+    if (cand.accepted) {
+      const double travel_distance =
+        latest_moving_distance - submap_travel_distances[chosen_submap_id];
+      bool bev_cross_verify_ok = true;
+      double bev_cross_verify_distance = std::numeric_limits<double>::infinity();
+      if (
+        config.triangle_verify_with_bev &&
+        use_bev_descriptor &&
+        chosen_submap_id < bev_db.size() &&
+        !bev_db.descriptors.empty())
+      {
+        graphslam::bev::MutualVisibilityConfig mv_cfg;
+        mv_cfg.min_overlap_ratio = config.bev_mutual_visibility_min_overlap_ratio;
+        mv_cfg.occupancy_eps =
+          static_cast<float>(config.bev_mutual_visibility_occupancy_eps);
+        const auto fov = graphslam::bev::mutualVisibilityWithYawSearch(
+          bev_db.descriptors.back(),
+          bev_db.descriptors[chosen_submap_id],
+          chosen_submap_id,
+          config.bev_descriptor_yaw_bins,
+          mv_cfg);
+        bev_cross_verify_distance = fov.valid ?
+          fov.distance : std::numeric_limits<double>::infinity();
+        bev_cross_verify_ok =
+          fov.valid && fov.distance <= config.triangle_verify_bev_max_distance;
+      }
+      if (travel_distance > config.distance_loop_closure && bev_cross_verify_ok) {
+        const Eigen::Matrix3f R = cand.transform.block<3, 3>(0, 0);
+        const Eigen::Vector3f euler = R.eulerAngles(2, 1, 0);
+        double tri_yaw_rad = static_cast<double>(euler[0]);
+        while (tri_yaw_rad > M_PI) {tri_yaw_rad -= 2.0 * M_PI;}
+        while (tri_yaw_rad < -M_PI) {tri_yaw_rad += 2.0 * M_PI;}
+        const double tri_metric =
+          1.0 / (1.0 + static_cast<double>(cand.inliers));
+        upsertCandidate(
+          candidates,
+          chosen_submap_id,
+          tri_metric,
+          loop_verifier::LoopCandidate::Source::TRIANGLE_DESCRIPTOR,
+          tri_yaw_rad,
+          &cand.transform);
+        std::ostringstream oss;
+        oss << "Triangle loop candidate: id=" << chosen_submap_id
+            << " votes=" << chosen_votes
+            << " inliers=" << cand.inliers
+            << " eval_n=" << cand.eval_n
+            << " inlier_ratio="
+            << std::fixed << std::setprecision(3) << cand.inlier_ratio
+            << std::defaultfloat
+            << " yaw_deg=" << tri_yaw_rad * 180.0 / M_PI;
+        if (config.triangle_verify_with_bev) {
+          oss << " bev_xv_dist=" << bev_cross_verify_distance;
+        }
+        logs.push_back(LogLine{false, oss.str()});
+      } else if (!bev_cross_verify_ok && config.debug) {
+        char buffer[256];
+        std::snprintf(
+          buffer, sizeof(buffer),
+          "Skip Triangle candidate %d: BEV cross-verify distance %.3f > %.3f",
+          chosen_submap_id, bev_cross_verify_distance,
+          config.triangle_verify_bev_max_distance);
+        logs.push_back(LogLine{true, std::string(buffer)});
+      } else if (config.debug) {
+        char buffer[256];
+        std::snprintf(
+          buffer, sizeof(buffer),
+          "Skip Triangle candidate %d (travel %.3f m <= %.3f m)",
+          chosen_submap_id, travel_distance, config.distance_loop_closure);
+        logs.push_back(LogLine{true, std::string(buffer)});
+      }
+    } else if (config.debug) {
+      // Surface the ratio gate too: an inlier count that beats the
+      // absolute min can still fail when min_inlier_ratio is set and
+      // eval_n is high. Knowing the ratio is the only way operators
+      // can tune precision_floor without re-running.
+      char buffer[320];
+      std::snprintf(
+        buffer, sizeof(buffer),
+        "Triangle votes for %d (%d votes) rejected: inliers %d/%d "
+        "(ratio %.3f) below min_inliers=%d min_inlier_ratio=%.3f",
+        chosen_submap_id, chosen_votes, cand.inliers, cand.eval_n,
+        cand.inlier_ratio, config.triangle_descriptor_min_inliers,
+        config.triangle_descriptor_min_inlier_ratio);
+      logs.push_back(LogLine{true, std::string(buffer)});
+    }
+  } else if (config.debug && !votes.empty()) {
+    char buffer[256];
+    std::snprintf(
+      buffer, sizeof(buffer),
+      "Triangle top vote %d only %d votes (need %d) or excluded",
+      votes.front().submap_id, votes.front().votes,
+      config.triangle_descriptor_min_votes);
+    logs.push_back(LogLine{true, std::string(buffer)});
   }
 }
 

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -119,6 +119,7 @@ extern "C" {
 #include "g2o/types/slam3d/se3quat.h"
 #include "g2o/types/slam3d/vertex_pointxyz.h"
 #include "g2o/types/slam3d/vertex_se3.h"
+#include "graph_based_slam/candidate_aggregator.hpp"
 #include "graph_based_slam/gnss_weighting.hpp"
 #include "graph_based_slam/scan_context.hpp"
 #include "graph_based_slam/solid_descriptor.hpp"
@@ -355,11 +356,7 @@ private:
     bool triangle_verify_with_bev_ {false};
     double triangle_verify_bev_max_distance_ {0.30};
     graphslam::triangle::TriangleDatabase triangle_descriptor_db_;
-    struct TrianglePerSubmap
-    {
-      std::vector < graphslam::triangle::Keypoint > keypoints;
-      std::vector < graphslam::triangle::TriangleDescriptor > triangles;
-    };
+    using TrianglePerSubmap = candidate_aggregator::TriangleSubmapFeatures;
     std::vector < TrianglePerSubmap > triangle_descriptor_per_submap_;
     int triangle_descriptor_next_submap_idx_ {0};
     bool use_solid_descriptor_ {false};

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -1574,6 +1574,27 @@ void GraphBasedSlamComponent::searchLoopForLatest(
     solid_descriptor_sequence_min_similarity_;
   aggregator_config.solid_descriptor_pose_consistency_threshold_m =
     solid_descriptor_pose_consistency_threshold_m_;
+  aggregator_config.triangle_descriptor_exclude_recent = triangle_descriptor_exclude_recent_;
+  aggregator_config.triangle_descriptor_edge_bin_m = triangle_descriptor_edge_bin_m_;
+  aggregator_config.triangle_descriptor_quad_feature_bin_m =
+    triangle_descriptor_quad_feature_bin_m_;
+  aggregator_config.triangle_descriptor_inlier_translation_m =
+    triangle_descriptor_inlier_translation_m_;
+  aggregator_config.triangle_descriptor_inlier_rotation_deg =
+    triangle_descriptor_inlier_rotation_deg_;
+  aggregator_config.triangle_descriptor_min_inliers = triangle_descriptor_min_inliers_;
+  aggregator_config.triangle_descriptor_min_inlier_ratio = triangle_descriptor_min_inlier_ratio_;
+  aggregator_config.triangle_descriptor_max_pairs = triangle_descriptor_max_pairs_;
+  aggregator_config.triangle_descriptor_min_4th_point_agreements =
+    triangle_descriptor_min_4th_point_agreements_;
+  aggregator_config.triangle_descriptor_fourth_point_max_distance_m =
+    triangle_descriptor_fourth_point_max_distance_m_;
+  aggregator_config.triangle_descriptor_refine_se3_with_all_inliers =
+    triangle_descriptor_refine_se3_with_all_inliers_;
+  aggregator_config.triangle_descriptor_min_votes = triangle_descriptor_min_votes_;
+  aggregator_config.triangle_descriptor_skip_ransac = triangle_descriptor_skip_ransac_;
+  aggregator_config.triangle_verify_with_bev = triangle_verify_with_bev_;
+  aggregator_config.triangle_verify_bev_max_distance = triangle_verify_bev_max_distance_;
 
   auto emit_aggregator_logs =
     [this](const std::vector<candidate_aggregator::LogLine> & logs) {
@@ -1650,154 +1671,19 @@ void GraphBasedSlamComponent::searchLoopForLatest(
     emit_aggregator_logs(aggregator_logs);
   }
 
-  if (
-    use_triangle_descriptor_ &&
-    static_cast<int>(triangle_descriptor_per_submap_.size()) > latest_idx &&
-    triangle_descriptor_db_.submapCount() >
-    static_cast<std::size_t>(triangle_descriptor_exclude_recent_))
-  {
-    const auto & query_kps = triangle_descriptor_per_submap_[latest_idx].keypoints;
-    const auto & query_tris = triangle_descriptor_per_submap_[latest_idx].triangles;
-    if (!query_tris.empty()) {
-      graphslam::triangle::HashConfig hash_cfg;
-      hash_cfg.edge_bin_m = static_cast<float>(triangle_descriptor_edge_bin_m_);
-      hash_cfg.quad_feature_bin_m =
-        static_cast<float>(triangle_descriptor_quad_feature_bin_m_);
-      graphslam::triangle::VoteConfig vote_cfg;
-      vote_cfg.exclude_submap_id = -1;
-      graphslam::triangle::VerificationConfig verify_cfg;
-      verify_cfg.inlier_translation_m =
-        static_cast<float>(triangle_descriptor_inlier_translation_m_);
-      verify_cfg.inlier_rotation_deg =
-        static_cast<float>(triangle_descriptor_inlier_rotation_deg_);
-      verify_cfg.min_inliers = triangle_descriptor_min_inliers_;
-      verify_cfg.min_inlier_ratio =
-        static_cast<float>(triangle_descriptor_min_inlier_ratio_);
-      verify_cfg.max_pairs = triangle_descriptor_max_pairs_;
-      verify_cfg.min_4th_point_agreements =
-        triangle_descriptor_min_4th_point_agreements_;
-      verify_cfg.fourth_point_max_distance_m =
-        static_cast<float>(triangle_descriptor_fourth_point_max_distance_m_);
-      verify_cfg.refine_se3_with_all_inliers =
-        triangle_descriptor_refine_se3_with_all_inliers_;
-
-      // Mask out the latest_idx and any recent submaps so we don't loop on
-      // ourselves. We do this by running the vote step first and dropping any
-      // candidate whose submap_id is too close to latest_idx.
-      const auto votes = graphslam::triangle::accumulateVotes(
-        triangle_descriptor_db_, query_kps, query_tris, hash_cfg, vote_cfg);
-      int chosen_submap_id = -1;
-      int chosen_votes = 0;
-      for (const auto & v : votes) {
-        if (v.submap_id < 0) {continue;}
-        if (latest_idx - v.submap_id < triangle_descriptor_exclude_recent_) {continue;}
-        chosen_submap_id = v.submap_id;
-        chosen_votes = v.votes;
-        break;
-      }
-      if (
-        chosen_submap_id >= 0 &&
-        chosen_votes >= triangle_descriptor_min_votes_ &&
-        !triangle_descriptor_skip_ransac_)
-      {
-        // Re-run verification scoped to the chosen submap to recover SE(3).
-        vote_cfg.exclude_submap_id = -1;
-        graphslam::triangle::TriangleDatabase scoped_db;
-        const auto db_kps_idx = static_cast<std::size_t>(chosen_submap_id);
-        if (db_kps_idx < triangle_descriptor_per_submap_.size()) {
-          scoped_db.addSubmap(
-            chosen_submap_id,
-            triangle_descriptor_per_submap_[db_kps_idx].keypoints,
-            triangle_descriptor_per_submap_[db_kps_idx].triangles,
-            hash_cfg);
-        }
-        const auto cand = graphslam::triangle::findLoopCandidate(
-          scoped_db, query_kps, query_tris, hash_cfg, vote_cfg, verify_cfg);
-        if (cand.accepted) {
-          const double travel_distance =
-            latest_moving_distance - map_array_msg.submaps[chosen_submap_id].distance;
-          bool bev_cross_verify_ok = true;
-          double bev_cross_verify_distance = std::numeric_limits<double>::infinity();
-          if (
-            triangle_verify_with_bev_ &&
-            use_bev_descriptor_ &&
-            chosen_submap_id < bev_descriptor_db_.size() &&
-            !bev_descriptor_db_.descriptors.empty())
-          {
-            graphslam::bev::MutualVisibilityConfig mv_cfg;
-            mv_cfg.min_overlap_ratio = bev_mutual_visibility_min_overlap_ratio_;
-            mv_cfg.occupancy_eps =
-              static_cast<float>(bev_mutual_visibility_occupancy_eps_);
-            const auto fov = graphslam::bev::mutualVisibilityWithYawSearch(
-              bev_descriptor_db_.descriptors.back(),
-              bev_descriptor_db_.descriptors[chosen_submap_id],
-              chosen_submap_id,
-              bev_descriptor_yaw_bins_,
-              mv_cfg);
-            bev_cross_verify_distance = fov.valid ?
-              fov.distance : std::numeric_limits<double>::infinity();
-            bev_cross_verify_ok =
-              fov.valid && fov.distance <= triangle_verify_bev_max_distance_;
-          }
-          if (travel_distance > distance_loop_closure_ && bev_cross_verify_ok) {
-            const Eigen::Matrix3f R = cand.transform.block<3, 3>(0, 0);
-            const Eigen::Vector3f euler = R.eulerAngles(2, 1, 0);
-            double tri_yaw_rad = static_cast<double>(euler[0]);
-            while (tri_yaw_rad > M_PI) {tri_yaw_rad -= 2.0 * M_PI;}
-            while (tri_yaw_rad < -M_PI) {tri_yaw_rad += 2.0 * M_PI;}
-            const double tri_metric =
-              1.0 / (1.0 + static_cast<double>(cand.inliers));
-            add_candidate(
-              chosen_submap_id,
-              tri_metric,
-              LoopCandidate::Source::TRIANGLE_DESCRIPTOR,
-              tri_yaw_rad,
-              &cand.transform);
-            std::cout << "Triangle loop candidate: id=" << chosen_submap_id
-                      << " votes=" << chosen_votes
-                      << " inliers=" << cand.inliers
-                      << " eval_n=" << cand.eval_n
-                      << " inlier_ratio="
-                      << std::fixed << std::setprecision(3) << cand.inlier_ratio
-                      << std::defaultfloat
-                      << " yaw_deg=" << tri_yaw_rad * 180.0 / M_PI;
-            if (triangle_verify_with_bev_) {
-              std::cout << " bev_xv_dist=" << bev_cross_verify_distance;
-            }
-            std::cout << std::endl;
-          } else if (!bev_cross_verify_ok && debug_flag_) {
-            RCLCPP_INFO(
-              get_logger(),
-              "Skip Triangle candidate %d: BEV cross-verify distance %.3f > %.3f",
-              chosen_submap_id, bev_cross_verify_distance,
-              triangle_verify_bev_max_distance_);
-          } else if (debug_flag_) {
-            RCLCPP_INFO(
-              get_logger(),
-              "Skip Triangle candidate %d (travel %.3f m <= %.3f m)",
-              chosen_submap_id, travel_distance, distance_loop_closure_);
-          }
-        } else if (debug_flag_) {
-          // Surface the ratio gate too: an inlier count that beats the
-          // absolute min can still fail when min_inlier_ratio is set and
-          // eval_n is high. Knowing the ratio is the only way operators
-          // can tune precision_floor without re-running.
-          RCLCPP_INFO(
-            get_logger(),
-            "Triangle votes for %d (%d votes) rejected: inliers %d/%d "
-            "(ratio %.3f) below min_inliers=%d min_inlier_ratio=%.3f",
-            chosen_submap_id, chosen_votes, cand.inliers, cand.eval_n,
-            cand.inlier_ratio, triangle_descriptor_min_inliers_,
-            triangle_descriptor_min_inlier_ratio_);
-        }
-      } else if (debug_flag_ && !votes.empty()) {
-        RCLCPP_INFO(
-          get_logger(),
-          "Triangle top vote %d only %d votes (need %d) or excluded",
-          votes.front().submap_id, votes.front().votes,
-          triangle_descriptor_min_votes_);
-      }
-    }
+  if (use_triangle_descriptor_) {
+    std::vector<candidate_aggregator::LogLine> aggregator_logs;
+    candidate_aggregator::collectTriangleCandidate(
+      triangle_descriptor_db_,
+      triangle_descriptor_per_submap_,
+      bev_descriptor_db_,
+      use_bev_descriptor_,
+      submap_travel_distances,
+      latest_idx,
+      aggregator_config,
+      candidates,
+      aggregator_logs);
+    emit_aggregator_logs(aggregator_logs);
   }
   if (candidates.empty()) {
     return;

--- a/graph_based_slam/test/test_candidate_aggregator.cpp
+++ b/graph_based_slam/test/test_candidate_aggregator.cpp
@@ -559,5 +559,156 @@ TEST_F(CandidateAggregatorSolid, DatabaseWithinExcludeRecentWindowIsSkipped)
   EXPECT_TRUE(logs_.empty());
 }
 
+// A 4x4 grid plus an off-axis marker: distinct pairwise distances give
+// unambiguous triangles and a unique SE(3) (same shape as the
+// triangle-database tests). `spacing` changes the shape entirely, so two
+// different spacings never share hash votes.
+std::vector<graphslam::triangle::Keypoint> makeTriangleKeypoints(float spacing)
+{
+  std::vector<graphslam::triangle::Keypoint> kps;
+  for (int iy = 0; iy < 4; ++iy) {
+    for (int ix = 0; ix < 4; ++ix) {
+      graphslam::triangle::Keypoint k;
+      k.position = Eigen::Vector3f(
+        static_cast<float>(ix) * spacing,
+        static_cast<float>(iy) * spacing,
+        0.0F);
+      k.salience = 1.0F;
+      kps.push_back(k);
+    }
+  }
+  graphslam::triangle::Keypoint marker;
+  marker.position = Eigen::Vector3f(4.5F * spacing, 2.0F * spacing, 0.0F);
+  marker.salience = 1.0F;
+  kps.push_back(marker);
+  return kps;
+}
+
+class CandidateAggregatorTriangle : public ::testing::Test
+{
+protected:
+  using Features = candidate_aggregator::TriangleSubmapFeatures;
+
+  void SetUp() override
+  {
+    config_ = makeConfig();
+    config_.triangle_descriptor_exclude_recent = 1;
+    config_.triangle_descriptor_edge_bin_m = 0.2;
+    config_.triangle_descriptor_quad_feature_bin_m = 0.2;
+    config_.triangle_descriptor_inlier_translation_m = 0.3;
+    config_.triangle_descriptor_inlier_rotation_deg = 5.0;
+    config_.triangle_descriptor_min_inliers = 4;
+    config_.triangle_descriptor_max_pairs = 300;
+    config_.triangle_descriptor_fourth_point_max_distance_m = 1.0;
+    config_.triangle_descriptor_min_votes = 1;
+
+    hash_cfg_.edge_bin_m = 0.2F;
+    hash_cfg_.quad_feature_bin_m = 0.2F;
+
+    pattern_.keypoints = makeTriangleKeypoints(3.0F);
+    pattern_.triangles = graphslam::triangle::buildTriangles(
+      pattern_.keypoints, graphslam::triangle::TriangleBuildConfig{});
+    filler_.keypoints = makeTriangleKeypoints(2.3F);
+    filler_.triangles = graphslam::triangle::buildTriangles(
+      filler_.keypoints, graphslam::triangle::TriangleBuildConfig{});
+
+    travels_ = {0.0, 50.0, 100.0};
+  }
+
+  // db submaps 0 and 1, query = per_submap[2].
+  void buildDatabase(const Features & id0, const Features & id1, const Features & query)
+  {
+    per_submap_ = {id0, id1, query};
+    db_.addSubmap(0, id0.keypoints, id0.triangles, hash_cfg_);
+    db_.addSubmap(1, id1.keypoints, id1.triangles, hash_cfg_);
+  }
+
+  Config config_;
+  graphslam::triangle::HashConfig hash_cfg_;
+  Features pattern_;
+  Features filler_;
+  graphslam::triangle::TriangleDatabase db_;
+  std::vector<Features> per_submap_;
+  SubmapBEVDescriptor::Database bev_db_;
+  std::vector<double> travels_;
+  std::vector<LoopCandidate> candidates_;
+  std::vector<LogLine> logs_;
+};
+
+TEST_F(CandidateAggregatorTriangle, AcceptedCandidateCarriesRecoveredSe3)
+{
+  buildDatabase(pattern_, filler_, pattern_);
+
+  candidate_aggregator::collectTriangleCandidate(
+    db_, per_submap_, bev_db_, false, travels_, 2, config_, candidates_, logs_);
+
+  ASSERT_EQ(candidates_.size(), 1U);
+  EXPECT_EQ(candidates_[0].index, 0);
+  EXPECT_EQ(candidates_[0].source, Source::TRIANGLE_DESCRIPTOR);
+  ASSERT_TRUE(candidates_[0].has_relative_transform);
+  // Identical keypoint sets: the recovered SE(3) is the identity.
+  EXPECT_TRUE(candidates_[0].relative_transform.isApprox(Eigen::Matrix4f::Identity(), 1e-3F));
+  EXPECT_LT(candidates_[0].selection_metric, 1.0);
+  ASSERT_EQ(logs_.size(), 1U);
+  EXPECT_FALSE(logs_[0].via_logger);
+  EXPECT_EQ(logs_[0].text.rfind("Triangle loop candidate: id=0", 0), 0U);
+}
+
+TEST_F(CandidateAggregatorTriangle, TravelGateRejectsAndLogsWhenDebug)
+{
+  buildDatabase(pattern_, filler_, pattern_);
+  travels_[0] = 98.0;  // 2 m of travel separation <= 5 m gate
+  config_.debug = true;
+
+  candidate_aggregator::collectTriangleCandidate(
+    db_, per_submap_, bev_db_, false, travels_, 2, config_, candidates_, logs_);
+
+  EXPECT_TRUE(candidates_.empty());
+  ASSERT_EQ(logs_.size(), 1U);
+  EXPECT_TRUE(logs_[0].via_logger);
+  EXPECT_EQ(logs_[0].text, "Skip Triangle candidate 0 (travel 2.000 m <= 5.000 m)");
+}
+
+TEST_F(CandidateAggregatorTriangle, MinVotesGateReportsTopVoteWhenDebug)
+{
+  buildDatabase(pattern_, filler_, pattern_);
+  config_.triangle_descriptor_min_votes = 999999;
+  config_.debug = true;
+
+  candidate_aggregator::collectTriangleCandidate(
+    db_, per_submap_, bev_db_, false, travels_, 2, config_, candidates_, logs_);
+
+  EXPECT_TRUE(candidates_.empty());
+  ASSERT_EQ(logs_.size(), 1U);
+  EXPECT_TRUE(logs_[0].via_logger);
+  EXPECT_EQ(logs_[0].text.rfind("Triangle top vote 0 only ", 0), 0U);
+}
+
+TEST_F(CandidateAggregatorTriangle, ExcludeRecentMasksTheMatchingNeighbor)
+{
+  // The pattern sits at id 2, inside the widened exclusion window
+  // (latest 3 - id 2 < 2): its votes are masked and the non-matching
+  // fillers got none, so the debug diagnostic reports the excluded top
+  // vote and nothing is added.
+  Features filler2;
+  filler2.keypoints = makeTriangleKeypoints(1.7F);
+  filler2.triangles = graphslam::triangle::buildTriangles(
+    filler2.keypoints, graphslam::triangle::TriangleBuildConfig{});
+  per_submap_ = {filler_, filler2, pattern_, pattern_};
+  db_.addSubmap(0, filler_.keypoints, filler_.triangles, hash_cfg_);
+  db_.addSubmap(1, filler2.keypoints, filler2.triangles, hash_cfg_);
+  db_.addSubmap(2, pattern_.keypoints, pattern_.triangles, hash_cfg_);
+  travels_ = {0.0, 30.0, 60.0, 100.0};
+  config_.triangle_descriptor_exclude_recent = 2;
+  config_.debug = true;
+
+  candidate_aggregator::collectTriangleCandidate(
+    db_, per_submap_, bev_db_, false, travels_, 3, config_, candidates_, logs_);
+
+  EXPECT_TRUE(candidates_.empty());
+  ASSERT_EQ(logs_.size(), 1U);
+  EXPECT_EQ(logs_[0].text.rfind("Triangle top vote 2 only ", 0), 0U);
+}
+
 }  // namespace
 }  // namespace graphslam


### PR DESCRIPTION
## Summary

candidate_aggregator 第 3 弾 = 最終弾 (v0.6 Phase 1, #246 #247 の続き)。triangle ブロックを `collectTriangleCandidate` として逐語移植し、**5 候補ソース全部の純関数化が完了**します。`searchLoopForLatest` に残るのは cloud I/O + registration 実行 + ログ出力のみ (component は Phase 1 開始時 3421 行 → 2775 行)。

- `collectTriangleCandidate` — vote → exclude-recent マスク → chosen submap に scope した RANSAC 再検証 (SE(3) 復元) → travel / BEV cross-verify ゲート → `1/(1+inliers)` metric + SE(3) 持ち候補
- component の private `TrianglePerSubmap` 構造体はヘッダの `TriangleSubmapFeatures` の alias に (per-submap 特徴 vector がそのまま渡る)
- ログは LogLine 経由でバイト同一: 条件付き `bev_xv_dist` サフィックス、`std::fixed << setprecision(3)` の inlier_ratio 書式、debug 限定の ratio-gate 診断 ("inliers %d/%d (ratio %.3f) below ...") まで再現

## Tests

characterization 4 本追加 (aggregator 計 20 本):
- 同一 keypoint 集合で SE(3) 恒等復元 + relative_transform 伝播 + metric < 1
- travel ゲート: "Skip Triangle candidate 0 (travel 2.000 m <= 5.000 m)" 完全一致
- min-votes 診断: "Triangle top vote 0 only ..."
- exclude-recent マスク: 直近 submap の票が落ちて診断のみ残る (テスト中に submapCount ≤ exclude_recent の歴史的ガードも検証)

## Verification

```bash
colcon test --packages-select graph_based_slam lidarslam_msgs scanmatcher lidarslam && colcon test-result
# => 1043 tests, 0 errors, 0 failures (1039 -> 1043)
bash scripts/run_release_readiness_checks.sh
# => 全 profile PASS / TARGET_MET。stadtgarten_seq2 raw 0.835 (5 回連続完全一致 = 無回帰)
```

## Next

map_saver 抽出 → Phase 2: BackendCore 組み立て + オフライン決定論ランナー (ハードゲート = 3-run ループエッジ集合完全一致)。