### PR TITLE
refactor(slam): extract the map-save decision logic into map_saver.hpp

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -215,6 +215,13 @@ if(BUILD_TESTING)
     target_include_directories(test_loop_verifier PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_map_saver
+    test/test_map_saver.cpp
+  )
+  if(TARGET test_map_saver)
+    target_include_directories(test_map_saver PRIVATE include)
+  endif()
+  ament_add_gtest(
     test_pose_graph_optimization
     test/test_pose_graph_optimization.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/map_saver.hpp
+++ b/graph_based_slam/include/graph_based_slam/map_saver.hpp
@@ -1,0 +1,181 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__MAP_SAVER_HPP_
+#define GRAPH_BASED_SLAM__MAP_SAVER_HPP_
+
+// Pure decision logic for the map-save path: grid bounds, the
+// point-to-cell assignment, the Autoware metadata / projector-info YAML
+// content and the operator log lines. The PCD file I/O, the directory
+// management and the PCL downsampling stay in the ROS component; every
+// byte that ends up in a YAML file or on stdout is produced here so the
+// offline BackendCore can reuse it unchanged (docs/roadmap/v0.6.md,
+// Phase 2).
+
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <utility>
+
+namespace graphslam
+{
+namespace map_saver
+{
+
+struct GridConfig
+{
+  double grid_size_x{20.0};
+  double grid_size_y{20.0};
+};
+
+struct GridBounds
+{
+  double x_min{0.0};
+  double y_min{0.0};
+  int nx{1};
+  int ny{1};
+};
+
+// Grid-aligned bounding box of the map. nx/ny keep the historical
+// at-least-one-cell clamp.
+inline GridBounds computeGridBounds(
+  double min_x, double min_y, double max_x, double max_y, const GridConfig & config)
+{
+  GridBounds bounds;
+  bounds.x_min = std::floor(min_x / config.grid_size_x) * config.grid_size_x;
+  bounds.y_min = std::floor(min_y / config.grid_size_y) * config.grid_size_y;
+  const double x_max = std::ceil(max_x / config.grid_size_x) * config.grid_size_x;
+  const double y_max = std::ceil(max_y / config.grid_size_y) * config.grid_size_y;
+  bounds.nx = static_cast<int>((x_max - bounds.x_min) / config.grid_size_x);
+  bounds.ny = static_cast<int>((y_max - bounds.y_min) / config.grid_size_y);
+  if (bounds.nx <= 0) {bounds.nx = 1;}
+  if (bounds.ny <= 0) {bounds.ny = 1;}
+  return bounds;
+}
+
+inline std::pair<int, int> cellIndexFor(
+  double x, double y, const GridBounds & bounds, const GridConfig & config)
+{
+  return std::make_pair(
+    static_cast<int>(std::floor((x - bounds.x_min) / config.grid_size_x)),
+    static_cast<int>(std::floor((y - bounds.y_min) / config.grid_size_y)));
+}
+
+struct CellFile
+{
+  std::string filename;
+  int label_x{0};
+  int label_y{0};
+};
+
+// Filename and metadata label for one grid cell; the labels are the
+// truncated lower-left corner coordinates Autoware's
+// pointcloud_map_loader expects.
+inline CellFile makeCellFile(
+  const std::pair<int, int> & key, const GridBounds & bounds, const GridConfig & config)
+{
+  const double cell_x = bounds.x_min + key.first * config.grid_size_x;
+  const double cell_y = bounds.y_min + key.second * config.grid_size_y;
+  CellFile cell;
+  cell.label_x = static_cast<int>(cell_x);
+  cell.label_y = static_cast<int>(cell_y);
+  std::ostringstream name;
+  name << cell.label_x << "_" << cell.label_y << ".pcd";
+  cell.filename = name.str();
+  return cell;
+}
+
+inline std::string metadataHeader(const GridConfig & config)
+{
+  std::ostringstream out;
+  out << std::fixed;
+  out << "x_resolution: " << std::setprecision(1) << config.grid_size_x << "\n";
+  out << "y_resolution: " << std::setprecision(1) << config.grid_size_y << "\n";
+  return out.str();
+}
+
+inline std::string metadataEntry(const CellFile & cell)
+{
+  std::ostringstream out;
+  out << cell.filename << ": [" << cell.label_x << ", " << cell.label_y << "]" << "\n";
+  return out.str();
+}
+
+inline std::string projectorInfoYaml(bool gnss_origin_set, double origin_lat, double origin_lon)
+{
+  std::ostringstream out;
+  out << std::fixed << std::setprecision(10);
+  if (gnss_origin_set) {
+    out << "projector_type: LocalCartesian" << "\n";
+    out << "vertical_datum: WGS84" << "\n";
+    out << "map_origin:" << "\n";
+    out << "  latitude: " << origin_lat << "\n";
+    out << "  longitude: " << origin_lon << "\n";
+  } else {
+    out << "projector_type: Local" << "\n";
+  }
+  return out.str();
+}
+
+inline std::string projectorInfoLogLine(bool gnss_origin_set, const std::string & proj_file)
+{
+  std::ostringstream out;
+  out << "Saved Autoware map projector info ("
+      << (gnss_origin_set ? "LocalCartesian" : "Local") << "): " << proj_file;
+  return out.str();
+}
+
+inline std::string downsampleLogLine(
+  std::size_t input_points, std::size_t output_points, double leaf_size)
+{
+  std::ostringstream out;
+  out << "Map points: " << input_points << " -> " << output_points
+      << " (leaf=" << leaf_size << "m)";
+  return out.str();
+}
+
+inline std::string savedMapLogLine(
+  int saved_cells, const GridConfig & config, const std::string & out_dir)
+{
+  std::ostringstream out;
+  out << "Saved grid-divided map: " << saved_cells << " cells ("
+      << config.grid_size_x << "x" << config.grid_size_y << "m) to " << out_dir;
+  return out.str();
+}
+
+inline std::string submapCachePath(const std::string & cache_dir, int idx)
+{
+  return cache_dir + "/submap_" + std::to_string(idx) + ".pcd";
+}
+
+}  // namespace map_saver
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__MAP_SAVER_HPP_

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -34,7 +34,6 @@
 #include <cmath>
 #include <filesystem>
 #include <fstream>
-#include <iomanip>
 #include <unordered_map>
 
 #include "graph_based_slam/adjacent_edge_auto_scale.hpp"
@@ -43,6 +42,7 @@
 #include "graph_based_slam/dynamic_object_filter.hpp"
 #include "graph_based_slam/gnss_alignment.hpp"
 #include "graph_based_slam/loop_verifier.hpp"
+#include "graph_based_slam/map_saver.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
 #include "graph_based_slam/submap_creation.hpp"
 #include "g2o/core/robust_kernel_impl.h"
@@ -2639,14 +2639,14 @@ void GraphBasedSlamComponent::saveSubmapToPCD(
   int idx,
   const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud)
 {
-  std::string path = pcd_cache_dir_ + "/submap_" + std::to_string(idx) + ".pcd";
+  std::string path = map_saver::submapCachePath(pcd_cache_dir_, idx);
   pcl::io::savePCDFileBinaryCompressed(path, *cloud);
 }
 
 pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::loadSubmapFromPCD(int idx)
 {
   auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
-  std::string path = pcd_cache_dir_ + "/submap_" + std::to_string(idx) + ".pcd";
+  std::string path = map_saver::submapCachePath(pcd_cache_dir_, idx);
   if (pcl::io::loadPCDFile(path, *cloud) == -1) {
     RCLCPP_WARN(get_logger(), "Failed to load PCD: %s", path.c_str());
   }
@@ -2679,30 +2679,24 @@ void GraphBasedSlamComponent::saveGridDividedMap(
   vg.setLeafSize(map_leaf_size_, map_leaf_size_, map_leaf_size_);
   vg.filter(*downsampled);
 
-  std::cout << "Map points: " << map->size() << " -> " << downsampled->size()
-            << " (leaf=" << map_leaf_size_ << "m)" << std::endl;
+  std::cout << map_saver::downsampleLogLine(map->size(), downsampled->size(), map_leaf_size_)
+            << std::endl;
 
-  // Compute bounding box
+  // Compute bounding box and grid-aligned bounds (semantics pinned by
+  // test_map_saver.cpp)
   pcl::PointXYZI min_pt, max_pt;
   pcl::getMinMax3D(*downsampled, min_pt, max_pt);
 
-  // Compute grid bounds (align to grid)
-  double x_min = std::floor(min_pt.x / map_grid_size_x_) * map_grid_size_x_;
-  double y_min = std::floor(min_pt.y / map_grid_size_y_) * map_grid_size_y_;
-  double x_max = std::ceil(max_pt.x / map_grid_size_x_) * map_grid_size_x_;
-  double y_max = std::ceil(max_pt.y / map_grid_size_y_) * map_grid_size_y_;
-
-  int nx = static_cast<int>((x_max - x_min) / map_grid_size_x_);
-  int ny = static_cast<int>((y_max - y_min) / map_grid_size_y_);
-  if (nx <= 0) {nx = 1;}
-  if (ny <= 0) {ny = 1;}
+  map_saver::GridConfig grid_config;
+  grid_config.grid_size_x = map_grid_size_x_;
+  grid_config.grid_size_y = map_grid_size_y_;
+  const map_saver::GridBounds grid_bounds =
+    map_saver::computeGridBounds(min_pt.x, min_pt.y, max_pt.x, max_pt.y, grid_config);
 
   // Assign points to grid cells
   std::map<std::pair<int, int>, pcl::PointCloud<pcl::PointXYZI>::Ptr> grid_cells;
   for (const auto & pt : downsampled->points) {
-    int gx = static_cast<int>(std::floor((pt.x - x_min) / map_grid_size_x_));
-    int gy = static_cast<int>(std::floor((pt.y - y_min) / map_grid_size_y_));
-    auto key = std::make_pair(gx, gy);
+    auto key = map_saver::cellIndexFor(pt.x, pt.y, grid_bounds, grid_config);
     if (grid_cells.find(key) == grid_cells.end()) {
       grid_cells[key] = pcl::PointCloud<pcl::PointXYZI>::Ptr(
         new pcl::PointCloud<pcl::PointXYZI>);
@@ -2710,31 +2704,17 @@ void GraphBasedSlamComponent::saveGridDividedMap(
     grid_cells[key]->push_back(pt);
   }
 
-  // Save each grid cell as PCD and build metadata
-  // Format: Autoware pointcloud_map_loader expects:
-  //   x_resolution: 20.0
-  //   y_resolution: 20.0
-  //   filename.pcd: [x, y]   (lower-left corner of grid cell)
+  // Save each grid cell as PCD and build the Autoware pointcloud_map_loader
+  // metadata (content produced in map_saver.hpp)
   std::ofstream meta(out_dir + "/pointcloud_map_metadata.yaml");
-  meta << std::fixed;
-  meta << "x_resolution: " << std::setprecision(1) << map_grid_size_x_ << std::endl;
-  meta << "y_resolution: " << std::setprecision(1) << map_grid_size_y_ << std::endl;
+  meta << map_saver::metadataHeader(grid_config);
 
   int saved = 0;
   for (auto & [key, cloud] : grid_cells) {
     if (cloud->empty()) {continue;}
-    double cell_x = x_min + key.first * map_grid_size_x_;
-    double cell_y = y_min + key.second * map_grid_size_y_;
-
-    std::ostringstream filename;
-    filename << static_cast<int>(cell_x) << "_"
-             << static_cast<int>(cell_y) << ".pcd";
-    std::string filepath = out_dir + "/" + filename.str();
-    pcl::io::savePCDFileBinaryCompressed(filepath, *cloud);
-
-    meta << filename.str() << ": ["
-         << static_cast<int>(cell_x) << ", "
-         << static_cast<int>(cell_y) << "]" << std::endl;
+    const map_saver::CellFile cell = map_saver::makeCellFile(key, grid_bounds, grid_config);
+    pcl::io::savePCDFileBinaryCompressed(out_dir + "/" + cell.filename, *cloud);
+    meta << map_saver::metadataEntry(cell);
     saved++;
   }
 
@@ -2743,28 +2723,15 @@ void GraphBasedSlamComponent::saveGridDividedMap(
   // Also save the full map as a single PCD for convenience
   pcl::io::savePCDFileBinaryCompressed(map_save_dir_ + "/map.pcd", *downsampled);
 
-  std::cout << "Saved grid-divided map: " << saved << " cells ("
-            << map_grid_size_x_ << "x" << map_grid_size_y_ << "m) to " << out_dir
-            << std::endl;
+  std::cout << map_saver::savedMapLogLine(saved, grid_config, out_dir) << std::endl;
   std::cout << "Total points: " << downsampled->size() << std::endl;
   std::cout << "Metadata: " << out_dir << "/pointcloud_map_metadata.yaml" << std::endl;
 
   // Always emit map_projector_info.yaml so Autoware can load pointcloud-only maps.
   std::string proj_file = map_save_dir_ + "/map_projector_info.yaml";
   std::ofstream proj(proj_file);
-  proj << std::fixed << std::setprecision(10);
-  if (gnss_origin_set_) {
-    proj << "projector_type: LocalCartesian" << std::endl;
-    proj << "vertical_datum: WGS84" << std::endl;
-    proj << "map_origin:" << std::endl;
-    proj << "  latitude: " << gnss_origin_lat_ << std::endl;
-    proj << "  longitude: " << gnss_origin_lon_ << std::endl;
-    std::cout << "Saved Autoware map projector info (LocalCartesian): " << proj_file
-              << std::endl;
-  } else {
-    proj << "projector_type: Local" << std::endl;
-    std::cout << "Saved Autoware map projector info (Local): " << proj_file << std::endl;
-  }
+  proj << map_saver::projectorInfoYaml(gnss_origin_set_, gnss_origin_lat_, gnss_origin_lon_);
+  std::cout << map_saver::projectorInfoLogLine(gnss_origin_set_, proj_file) << std::endl;
   proj.close();
 }
 }  // namespace graphslam

--- a/graph_based_slam/test/test_map_saver.cpp
+++ b/graph_based_slam/test/test_map_saver.cpp
@@ -1,0 +1,196 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Characterization tests for the map-save decision logic extracted from
+// saveGridDividedMap / saveSubmapToPCD. These pin the historical grid
+// alignment, the truncated-corner cell filenames and the exact YAML /
+// stdout formatting (fixed precision 1 metadata, fixed precision 10
+// projector origin, default-float log lines) so the extraction and the
+// later BackendCore reuse cannot silently change the Autoware map
+// bundle.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <utility>
+
+#include "graph_based_slam/map_saver.hpp"
+
+namespace graphslam
+{
+namespace
+{
+
+using map_saver::CellFile;
+using map_saver::GridBounds;
+using map_saver::GridConfig;
+
+GridConfig makeConfig(double grid_x = 20.0, double grid_y = 20.0)
+{
+  GridConfig config;
+  config.grid_size_x = grid_x;
+  config.grid_size_y = grid_y;
+  return config;
+}
+
+TEST(MapSaverGridBounds, AlignsToGridAndCountsCells)
+{
+  const GridBounds bounds = map_saver::computeGridBounds(5.0, 7.0, 25.0, 33.0, makeConfig());
+  EXPECT_DOUBLE_EQ(bounds.x_min, 0.0);
+  EXPECT_DOUBLE_EQ(bounds.y_min, 0.0);
+  EXPECT_EQ(bounds.nx, 2);
+  EXPECT_EQ(bounds.ny, 2);
+}
+
+TEST(MapSaverGridBounds, NegativeCoordinatesFloorAwayFromZero)
+{
+  const GridBounds bounds = map_saver::computeGridBounds(-5.0, -25.0, 15.0, -1.0, makeConfig());
+  EXPECT_DOUBLE_EQ(bounds.x_min, -20.0);
+  EXPECT_DOUBLE_EQ(bounds.y_min, -40.0);
+  EXPECT_EQ(bounds.nx, 2);
+  EXPECT_EQ(bounds.ny, 2);
+}
+
+TEST(MapSaverGridBounds, DegenerateExtentClampsToOneCell)
+{
+  const GridBounds bounds = map_saver::computeGridBounds(0.0, 0.0, 0.0, 0.0, makeConfig());
+  EXPECT_EQ(bounds.nx, 1);
+  EXPECT_EQ(bounds.ny, 1);
+}
+
+TEST(MapSaverCellIndex, BoundaryPointBelongsToTheUpperCell)
+{
+  const GridConfig config = makeConfig();
+  GridBounds bounds;
+  bounds.x_min = 0.0;
+  bounds.y_min = 0.0;
+  EXPECT_EQ(map_saver::cellIndexFor(0.0, 0.0, bounds, config), std::make_pair(0, 0));
+  EXPECT_EQ(map_saver::cellIndexFor(19.999, 19.999, bounds, config), std::make_pair(0, 0));
+  EXPECT_EQ(map_saver::cellIndexFor(20.0, 20.0, bounds, config), std::make_pair(1, 1));
+}
+
+TEST(MapSaverCellIndex, RoundTripsThroughTheCellCorner)
+{
+  const GridConfig config = makeConfig();
+  const GridBounds bounds = map_saver::computeGridBounds(-5.0, -25.0, 15.0, -1.0, config);
+  const std::pair<int, int> key = map_saver::cellIndexFor(-3.5, -21.0, bounds, config);
+  const CellFile cell = map_saver::makeCellFile(key, bounds, config);
+  EXPECT_LE(cell.label_x, -3.5);
+  EXPECT_GT(cell.label_x + config.grid_size_x, -3.5);
+  EXPECT_LE(cell.label_y, -21.0);
+  EXPECT_GT(cell.label_y + config.grid_size_y, -21.0);
+}
+
+TEST(MapSaverCellFile, NameIsTruncatedCornerPair)
+{
+  const GridConfig config = makeConfig();
+  GridBounds bounds;
+  bounds.x_min = -20.0;
+  bounds.y_min = -40.0;
+  const CellFile origin_cell = map_saver::makeCellFile(std::make_pair(0, 0), bounds, config);
+  EXPECT_EQ(origin_cell.filename, "-20_-40.pcd");
+  EXPECT_EQ(origin_cell.label_x, -20);
+  EXPECT_EQ(origin_cell.label_y, -40);
+  const CellFile shifted_cell = map_saver::makeCellFile(std::make_pair(1, 2), bounds, config);
+  EXPECT_EQ(shifted_cell.filename, "0_0.pcd");
+}
+
+TEST(MapSaverMetadata, HeaderUsesFixedPrecisionOne)
+{
+  EXPECT_EQ(
+    map_saver::metadataHeader(makeConfig()),
+    "x_resolution: 20.0\ny_resolution: 20.0\n");
+  EXPECT_EQ(
+    map_saver::metadataHeader(makeConfig(12.5, 7.25)),
+    "x_resolution: 12.5\ny_resolution: 7.2\n");
+}
+
+TEST(MapSaverMetadata, EntryListsFilenameAndCorner)
+{
+  CellFile cell;
+  cell.filename = "0_20.pcd";
+  cell.label_x = 0;
+  cell.label_y = 20;
+  EXPECT_EQ(map_saver::metadataEntry(cell), "0_20.pcd: [0, 20]\n");
+}
+
+TEST(MapSaverProjectorInfo, LocalCartesianWritesOriginAtPrecisionTen)
+{
+  EXPECT_EQ(
+    map_saver::projectorInfoYaml(true, 35.5, 139.75),
+    "projector_type: LocalCartesian\n"
+    "vertical_datum: WGS84\n"
+    "map_origin:\n"
+    "  latitude: 35.5000000000\n"
+    "  longitude: 139.7500000000\n");
+}
+
+TEST(MapSaverProjectorInfo, LocalOmitsOrigin)
+{
+  EXPECT_EQ(map_saver::projectorInfoYaml(false, 35.5, 139.75), "projector_type: Local\n");
+}
+
+TEST(MapSaverProjectorInfo, LogLineNamesTheProjectorType)
+{
+  EXPECT_EQ(
+    map_saver::projectorInfoLogLine(true, "/tmp/map_projector_info.yaml"),
+    "Saved Autoware map projector info (LocalCartesian): /tmp/map_projector_info.yaml");
+  EXPECT_EQ(
+    map_saver::projectorInfoLogLine(false, "/tmp/map_projector_info.yaml"),
+    "Saved Autoware map projector info (Local): /tmp/map_projector_info.yaml");
+}
+
+TEST(MapSaverLogLines, DownsampleUsesDefaultFloatFormatting)
+{
+  EXPECT_EQ(
+    map_saver::downsampleLogLine(1000, 200, 0.2),
+    "Map points: 1000 -> 200 (leaf=0.2m)");
+  EXPECT_EQ(
+    map_saver::downsampleLogLine(50, 50, 1.0),
+    "Map points: 50 -> 50 (leaf=1m)");
+}
+
+TEST(MapSaverLogLines, SavedMapUsesDefaultFloatFormatting)
+{
+  EXPECT_EQ(
+    map_saver::savedMapLogLine(5, makeConfig(), "/tmp/out/pointcloud_map"),
+    "Saved grid-divided map: 5 cells (20x20m) to /tmp/out/pointcloud_map");
+  EXPECT_EQ(
+    map_saver::savedMapLogLine(1, makeConfig(12.5, 12.5), "/tmp/out/pointcloud_map"),
+    "Saved grid-divided map: 1 cells (12.5x12.5m) to /tmp/out/pointcloud_map");
+}
+
+TEST(MapSaverSubmapCache, PathAppendsIndexedFilename)
+{
+  EXPECT_EQ(map_saver::submapCachePath("/cache", 0), "/cache/submap_0.pcd");
+  EXPECT_EQ(map_saver::submapCachePath("/cache", 42), "/cache/submap_42.pcd");
+}
+
+}  // namespace
+}  // namespace graphslam


### PR DESCRIPTION
## 概要

v0.6 決定論リファクタ Phase 1 の最終スライス。`saveGridDividedMap` / `saveSubmapToPCD` の決定ロジックを純関数ヘッダ `map_saver.hpp`（17 個目のテスト済みヘッダ）に抽出する。

- グリッド境界計算（floor/ceil 整列 + 最低 1 セルのクランプ）、点→セル割当、セルファイル名（切り捨て左下角）
- Autoware pointcloud_map_loader metadata YAML（fixed precision 1）と map_projector_info.yaml（fixed precision 10）の内容生成
- オペレータ向け stdout 行（default-float フォーマット）と submap キャッシュパス
- コンポーネント側に残るのは PCD ファイル I/O・ディレクトリ管理・VoxelGrid ダウンサンプルのみ

これで searchLoopForLatest（#245-#248）に続き、マップ保存経路も BackendCore（Phase 2）からバイト同一の Autoware マップバンドルを出力できる。

## テスト

- 特性テスト 14 本追加（`test_map_saver.cpp`）: 負座標の floor 整列、境界点のセル帰属、YAML/ログの正確なフォーマットを固定
- `colcon test`（lidarslam_msgs / scanmatcher / graph_based_slam / lidarslam）: **1066 tests, 0 failures**
- lint 8 本（uncrustify / cpplint / copyright / cppcheck / flake8 / pep257 / xmllint / lint_cmake）全パス
- `run_release_readiness_checks.sh`: 全プロファイル PASS/TARGET_MET、`mid360_gt_rtkslam_stadtgarten_seq2` score_raw = **0.835**（抽出 PR 系列で 6 回連続ビット一致 = 挙動保存）

## 再現コマンド

```bash
colcon build --symlink-install --packages-select graph_based_slam --cmake-args -DCMAKE_BUILD_TYPE=Release
colcon test --packages-select lidarslam_msgs scanmatcher graph_based_slam lidarslam
bash scripts/run_release_readiness_checks.sh
```