### PR TITLE
refactor(slam): introduce BackendCore and move descriptor ingestion into it

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -222,6 +222,14 @@ if(BUILD_TESTING)
     target_include_directories(test_map_saver PRIVATE include)
   endif()
   ament_add_gtest(
+    test_backend_core
+    test/test_backend_core.cpp
+  )
+  if(TARGET test_backend_core)
+    target_include_directories(test_backend_core PRIVATE include ${EIGEN3_INCLUDE_DIR})
+    target_link_libraries(test_backend_core ${PCL_LIBRARIES})
+  endif()
+  ament_add_gtest(
     test_pose_graph_optimization
     test/test_pose_graph_optimization.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/backend_core.hpp
+++ b/graph_based_slam/include/graph_based_slam/backend_core.hpp
@@ -1,0 +1,216 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__BACKEND_CORE_HPP_
+#define GRAPH_BASED_SLAM__BACKEND_CORE_HPP_
+
+// The ROS-free, clock-free backend state (docs/roadmap/v0.6.md, Phase 2).
+// This first stage owns the four loop-closure descriptor databases and
+// their submap-ingestion logic; the search and optimization orchestration
+// migrate here in later stages. The contract this class builds toward:
+// the same ordered submap sequence plus the same config produce the same
+// state, independent of wall-clock timing. The shell supplies clouds via
+// a provider callback, so message-vs-PCD-cache stays its concern.
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <pcl/point_cloud.h>  // NOLINT(build/include_order)
+#include <pcl/point_types.h>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/candidate_aggregator.hpp"
+#include "graph_based_slam/scan_context.hpp"
+#include "graph_based_slam/solid_descriptor.hpp"
+#include "graph_based_slam/submap_bev_descriptor.hpp"
+#include "graph_based_slam/triangle_descriptor.hpp"
+#include "graph_based_slam/triangle_descriptor_database.hpp"
+
+namespace graphslam
+{
+namespace backend_core
+{
+
+struct DescriptorConfig
+{
+  bool use_scan_context{false};
+  bool use_bev_descriptor{false};
+  bool use_solid_descriptor{false};
+  bool use_triangle_descriptor{false};
+  double bev_descriptor_grid_size_m{80.0};
+  int bev_descriptor_grid_cells{40};
+  int bev_descriptor_yaw_bins{24};
+  std::string triangle_descriptor_keypoint_mode{"bev_max_height"};
+  double triangle_descriptor_grid_size_m{60.0};
+  int triangle_descriptor_grid_cells{100};
+  double triangle_descriptor_min_salience_m{0.8};
+  int triangle_descriptor_max_keypoints{40};
+  double triangle_descriptor_edge_voxel_size_m{0.4};
+  double triangle_descriptor_edge_neighbor_radius_m{1.0};
+  int triangle_descriptor_edge_min_neighbors{6};
+  double triangle_descriptor_edge_min_edgeness{0.5};
+  double triangle_descriptor_edge_nms_radius_m{2.0};
+  double triangle_descriptor_min_edge_m{2.0};
+  double triangle_descriptor_max_edge_m{50.0};
+  int triangle_descriptor_max_triangles{3000};
+  double triangle_descriptor_edge_bin_m{0.5};
+  double triangle_descriptor_quad_feature_bin_m{0.0};
+};
+
+// Backend-owned loop-closure state. Single-threaded by contract: the
+// caller serializes access (today the component's SingleThreadedExecutor,
+// later the shell's processing queue / the offline runner's bag loop).
+class BackendCore
+{
+public:
+  using CloudPtr = pcl::PointCloud<pcl::PointXYZI>::Ptr;
+  // Returns the voxel-filtered aggregate of the submap at idx and its
+  // recent neighbors, expressed in that submap's local frame.
+  using LocalSubmapProvider = std::function<CloudPtr(int idx)>;
+
+  void configure(const DescriptorConfig & config)
+  {
+    config_ = config;
+    bev_descriptor_db_.configure(
+      config.bev_descriptor_grid_size_m,
+      config.bev_descriptor_grid_cells,
+      config.bev_descriptor_yaw_bins);
+  }
+
+  // Keep every enabled descriptor database aligned 1:1 with submap
+  // indices, computing descriptors for indices that arrived since the
+  // last call. Each database family queries the provider independently
+  // (historical behavior; the provider result is deterministic, so the
+  // recompute is byte-identical).
+  void ingestDescriptors(int num_submaps, const LocalSubmapProvider & provider)
+  {
+    if (config_.use_scan_context && scan_context_db_.nextSubmapIndex() < num_submaps) {
+      for (int idx = scan_context_db_.nextSubmapIndex(); idx < num_submaps; ++idx) {
+        const auto filtered_aggregated_cloud = provider(idx);
+        if (filtered_aggregated_cloud->empty()) {
+          scan_context_db_.add(
+            idx, ScanContext::Descriptor::Zero(
+              ScanContext::NUM_RINGS,
+              ScanContext::NUM_SECTORS));
+          continue;
+        }
+        scan_context_db_.add(idx, ScanContext::computeDescriptor(filtered_aggregated_cloud));
+      }
+    }
+
+    if (config_.use_bev_descriptor && bev_descriptor_db_.nextSubmapIndex() < num_submaps) {
+      for (int idx = bev_descriptor_db_.nextSubmapIndex(); idx < num_submaps; ++idx) {
+        const auto filtered_aggregated_cloud = provider(idx);
+        bev_descriptor_db_.add(
+          idx,
+          SubmapBEVDescriptor::computeDescriptor(
+            filtered_aggregated_cloud,
+            config_.bev_descriptor_grid_size_m,
+            config_.bev_descriptor_grid_cells));
+      }
+    }
+    if (config_.use_solid_descriptor && solid_descriptor_db_.nextSubmapIndex() < num_submaps) {
+      for (int idx = solid_descriptor_db_.nextSubmapIndex(); idx < num_submaps; ++idx) {
+        const auto filtered_aggregated_cloud = provider(idx);
+        solid_descriptor_db_.add(
+          idx,
+          SolidDescriptor::computeDescriptor(filtered_aggregated_cloud));
+      }
+    }
+    if (config_.use_triangle_descriptor && triangle_next_submap_idx_ < num_submaps) {
+      triangle::KeypointExtractionConfig kp_cfg;
+      if (config_.triangle_descriptor_keypoint_mode == "edge_3d") {
+        kp_cfg.mode = triangle::KeypointMode::EDGE_3D;
+      } else {
+        kp_cfg.mode = triangle::KeypointMode::BEV_MAX_HEIGHT;
+      }
+      kp_cfg.grid_size_m = config_.triangle_descriptor_grid_size_m;
+      kp_cfg.grid_cells = config_.triangle_descriptor_grid_cells;
+      kp_cfg.min_salience_m = static_cast<float>(config_.triangle_descriptor_min_salience_m);
+      kp_cfg.max_keypoints = config_.triangle_descriptor_max_keypoints;
+      kp_cfg.edge_voxel_size_m =
+        static_cast<float>(config_.triangle_descriptor_edge_voxel_size_m);
+      kp_cfg.edge_neighbor_radius_m =
+        static_cast<float>(config_.triangle_descriptor_edge_neighbor_radius_m);
+      kp_cfg.edge_min_neighbors = config_.triangle_descriptor_edge_min_neighbors;
+      kp_cfg.edge_min_edgeness =
+        static_cast<float>(config_.triangle_descriptor_edge_min_edgeness);
+      kp_cfg.edge_nms_radius_m =
+        static_cast<float>(config_.triangle_descriptor_edge_nms_radius_m);
+      triangle::TriangleBuildConfig build_cfg;
+      build_cfg.min_edge_m = static_cast<float>(config_.triangle_descriptor_min_edge_m);
+      build_cfg.max_edge_m = static_cast<float>(config_.triangle_descriptor_max_edge_m);
+      build_cfg.max_triangles = config_.triangle_descriptor_max_triangles;
+      triangle::HashConfig hash_cfg;
+      hash_cfg.edge_bin_m = static_cast<float>(config_.triangle_descriptor_edge_bin_m);
+      hash_cfg.quad_feature_bin_m =
+        static_cast<float>(config_.triangle_descriptor_quad_feature_bin_m);
+      for (int idx = triangle_next_submap_idx_; idx < num_submaps; ++idx) {
+        const auto filtered_aggregated_cloud = provider(idx);
+        std::vector<triangle::Keypoint> kps;
+        std::vector<triangle::TriangleDescriptor> tris;
+        if (filtered_aggregated_cloud && !filtered_aggregated_cloud->empty()) {
+          kps = triangle::extractKeypoints(*filtered_aggregated_cloud, kp_cfg);
+          tris = triangle::buildTriangles(kps, build_cfg);
+        }
+        candidate_aggregator::TriangleSubmapFeatures entry;
+        entry.keypoints = kps;
+        entry.triangles = tris;
+        triangle_per_submap_.push_back(entry);
+        triangle_db_.addSubmap(idx, kps, tris, hash_cfg);
+      }
+      triangle_next_submap_idx_ = num_submaps;
+    }
+  }
+
+  const DescriptorConfig & config() const {return config_;}
+
+  ScanContext::Database & scanContextDb() {return scan_context_db_;}
+  SubmapBEVDescriptor::Database & bevDescriptorDb() {return bev_descriptor_db_;}
+  SolidDescriptor::Database & solidDescriptorDb() {return solid_descriptor_db_;}
+  triangle::TriangleDatabase & triangleDb() {return triangle_db_;}
+  const std::vector<candidate_aggregator::TriangleSubmapFeatures> & trianglePerSubmap() const
+  {
+    return triangle_per_submap_;
+  }
+
+private:
+  DescriptorConfig config_;
+  ScanContext::Database scan_context_db_;
+  SubmapBEVDescriptor::Database bev_descriptor_db_;
+  SolidDescriptor::Database solid_descriptor_db_;
+  triangle::TriangleDatabase triangle_db_;
+  std::vector<candidate_aggregator::TriangleSubmapFeatures> triangle_per_submap_;
+  int triangle_next_submap_idx_{0};
+};
+
+}  // namespace backend_core
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__BACKEND_CORE_HPP_

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -119,6 +119,7 @@ extern "C" {
 #include "g2o/types/slam3d/se3quat.h"
 #include "g2o/types/slam3d/vertex_pointxyz.h"
 #include "g2o/types/slam3d/vertex_se3.h"
+#include "graph_based_slam/backend_core.hpp"
 #include "graph_based_slam/candidate_aggregator.hpp"
 #include "graph_based_slam/gnss_weighting.hpp"
 #include "graph_based_slam/scan_context.hpp"
@@ -145,6 +146,10 @@ private:
 
     boost::shared_ptr < pcl::Registration < pcl::PointXYZI, pcl::PointXYZI >> registration_;
     pcl::VoxelGrid < pcl::PointXYZI > voxelgrid_;
+
+    // ROS-free backend state (descriptor databases; the search and
+    // optimization orchestration migrate here across Phase 2).
+    backend_core::BackendCore backend_core_;
 
     lidarslam_msgs::msg::MapArray map_array_msg_;
     rclcpp::Subscription < lidarslam_msgs::msg::MapArray > ::SharedPtr map_array_sub_;
@@ -257,7 +262,6 @@ private:
     bool use_scan_context_ {false};
     double scan_context_threshold_ {0.3};
     bool prefer_scan_context_candidates_ {false};
-    ScanContext::Database scan_context_db_;
     bool use_bev_descriptor_ {false};
     double bev_descriptor_threshold_ {0.20};
     double bev_descriptor_grid_size_m_ {80.0};
@@ -273,7 +277,6 @@ private:
     bool bev_use_mutual_visibility_ {false};
     double bev_mutual_visibility_min_overlap_ratio_ {0.05};
     double bev_mutual_visibility_occupancy_eps_ {0.5};
-    SubmapBEVDescriptor::Database bev_descriptor_db_;
     // Triangle (STD/BTC-style) descriptor place-recognition path. Built on the
     // BSD-2 primitives in graph_based_slam/triangle_descriptor*. Default off
     // so the existing default workflow stays unchanged.
@@ -355,17 +358,12 @@ private:
     // facades) at the cost of triangle-only recall.
     bool triangle_verify_with_bev_ {false};
     double triangle_verify_bev_max_distance_ {0.30};
-    graphslam::triangle::TriangleDatabase triangle_descriptor_db_;
-    using TrianglePerSubmap = candidate_aggregator::TriangleSubmapFeatures;
-    std::vector < TrianglePerSubmap > triangle_descriptor_per_submap_;
-    int triangle_descriptor_next_submap_idx_ {0};
     bool use_solid_descriptor_ {false};
     double solid_descriptor_min_similarity_ {0.70};
     int solid_descriptor_sequence_window_ {0};
     double solid_descriptor_sequence_min_similarity_ {-1.0};
     double solid_descriptor_pose_consistency_threshold_m_ {-1.0};
     double solid_descriptor_max_euclidean_distance_m_ {-1.0};
-    SolidDescriptor::Database solid_descriptor_db_;
     bool use_3d_bbs_for_scan_context_ {false};
     double three_d_bbs_min_level_res_ {1.0};
     int three_d_bbs_max_level_ {3};

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -1085,10 +1085,36 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     exit(1);
   }
 
-  bev_descriptor_db_.configure(
-    bev_descriptor_grid_size_m_,
-    bev_descriptor_grid_cells_,
-    bev_descriptor_yaw_bins_);
+  backend_core::DescriptorConfig descriptor_config;
+  descriptor_config.use_scan_context = use_scan_context_;
+  descriptor_config.use_bev_descriptor = use_bev_descriptor_;
+  descriptor_config.use_solid_descriptor = use_solid_descriptor_;
+  descriptor_config.use_triangle_descriptor = use_triangle_descriptor_;
+  descriptor_config.bev_descriptor_grid_size_m = bev_descriptor_grid_size_m_;
+  descriptor_config.bev_descriptor_grid_cells = bev_descriptor_grid_cells_;
+  descriptor_config.bev_descriptor_yaw_bins = bev_descriptor_yaw_bins_;
+  descriptor_config.triangle_descriptor_keypoint_mode = triangle_descriptor_keypoint_mode_;
+  descriptor_config.triangle_descriptor_grid_size_m = triangle_descriptor_grid_size_m_;
+  descriptor_config.triangle_descriptor_grid_cells = triangle_descriptor_grid_cells_;
+  descriptor_config.triangle_descriptor_min_salience_m = triangle_descriptor_min_salience_m_;
+  descriptor_config.triangle_descriptor_max_keypoints = triangle_descriptor_max_keypoints_;
+  descriptor_config.triangle_descriptor_edge_voxel_size_m =
+    triangle_descriptor_edge_voxel_size_m_;
+  descriptor_config.triangle_descriptor_edge_neighbor_radius_m =
+    triangle_descriptor_edge_neighbor_radius_m_;
+  descriptor_config.triangle_descriptor_edge_min_neighbors =
+    triangle_descriptor_edge_min_neighbors_;
+  descriptor_config.triangle_descriptor_edge_min_edgeness =
+    triangle_descriptor_edge_min_edgeness_;
+  descriptor_config.triangle_descriptor_edge_nms_radius_m =
+    triangle_descriptor_edge_nms_radius_m_;
+  descriptor_config.triangle_descriptor_min_edge_m = triangle_descriptor_min_edge_m_;
+  descriptor_config.triangle_descriptor_max_edge_m = triangle_descriptor_max_edge_m_;
+  descriptor_config.triangle_descriptor_max_triangles = triangle_descriptor_max_triangles_;
+  descriptor_config.triangle_descriptor_edge_bin_m = triangle_descriptor_edge_bin_m_;
+  descriptor_config.triangle_descriptor_quad_feature_bin_m =
+    triangle_descriptor_quad_feature_bin_m_;
+  backend_core_.configure(descriptor_config);
 
   initializePubSub();
 
@@ -1349,81 +1375,8 @@ void GraphBasedSlamComponent::searchLoop()
       return filtered_cloud;
     };
 
-  // Keep Scan Context database aligned 1:1 with submap indices.
-  if (use_scan_context_ && scan_context_db_.nextSubmapIndex() < num_submaps) {
-    for (int idx = scan_context_db_.nextSubmapIndex(); idx < num_submaps; ++idx) {
-      const auto filtered_aggregated_cloud = build_filtered_local_submap(idx);
-      if (filtered_aggregated_cloud->empty()) {
-        scan_context_db_.add(
-          idx, ScanContext::Descriptor::Zero(
-            ScanContext::NUM_RINGS,
-            ScanContext::NUM_SECTORS));
-        continue;
-      }
-      scan_context_db_.add(idx, ScanContext::computeDescriptor(filtered_aggregated_cloud));
-    }
-  }
-
-  if (use_bev_descriptor_ && bev_descriptor_db_.nextSubmapIndex() < num_submaps) {
-    for (int idx = bev_descriptor_db_.nextSubmapIndex(); idx < num_submaps; ++idx) {
-      const auto filtered_aggregated_cloud = build_filtered_local_submap(idx);
-      bev_descriptor_db_.add(
-        idx,
-        SubmapBEVDescriptor::computeDescriptor(
-          filtered_aggregated_cloud,
-          bev_descriptor_grid_size_m_,
-          bev_descriptor_grid_cells_));
-    }
-  }
-  if (use_solid_descriptor_ && solid_descriptor_db_.nextSubmapIndex() < num_submaps) {
-    for (int idx = solid_descriptor_db_.nextSubmapIndex(); idx < num_submaps; ++idx) {
-      const auto filtered_aggregated_cloud = build_filtered_local_submap(idx);
-      solid_descriptor_db_.add(
-        idx,
-        SolidDescriptor::computeDescriptor(filtered_aggregated_cloud));
-    }
-  }
-  if (use_triangle_descriptor_ && triangle_descriptor_next_submap_idx_ < num_submaps) {
-    graphslam::triangle::KeypointExtractionConfig kp_cfg;
-    if (triangle_descriptor_keypoint_mode_ == "edge_3d") {
-      kp_cfg.mode = graphslam::triangle::KeypointMode::EDGE_3D;
-    } else {
-      kp_cfg.mode = graphslam::triangle::KeypointMode::BEV_MAX_HEIGHT;
-    }
-    kp_cfg.grid_size_m = triangle_descriptor_grid_size_m_;
-    kp_cfg.grid_cells = triangle_descriptor_grid_cells_;
-    kp_cfg.min_salience_m = static_cast<float>(triangle_descriptor_min_salience_m_);
-    kp_cfg.max_keypoints = triangle_descriptor_max_keypoints_;
-    kp_cfg.edge_voxel_size_m = static_cast<float>(triangle_descriptor_edge_voxel_size_m_);
-    kp_cfg.edge_neighbor_radius_m =
-      static_cast<float>(triangle_descriptor_edge_neighbor_radius_m_);
-    kp_cfg.edge_min_neighbors = triangle_descriptor_edge_min_neighbors_;
-    kp_cfg.edge_min_edgeness = static_cast<float>(triangle_descriptor_edge_min_edgeness_);
-    kp_cfg.edge_nms_radius_m = static_cast<float>(triangle_descriptor_edge_nms_radius_m_);
-    graphslam::triangle::TriangleBuildConfig build_cfg;
-    build_cfg.min_edge_m = static_cast<float>(triangle_descriptor_min_edge_m_);
-    build_cfg.max_edge_m = static_cast<float>(triangle_descriptor_max_edge_m_);
-    build_cfg.max_triangles = triangle_descriptor_max_triangles_;
-    graphslam::triangle::HashConfig hash_cfg;
-    hash_cfg.edge_bin_m = static_cast<float>(triangle_descriptor_edge_bin_m_);
-    hash_cfg.quad_feature_bin_m =
-      static_cast<float>(triangle_descriptor_quad_feature_bin_m_);
-    for (int idx = triangle_descriptor_next_submap_idx_; idx < num_submaps; ++idx) {
-      const auto filtered_aggregated_cloud = build_filtered_local_submap(idx);
-      std::vector<graphslam::triangle::Keypoint> kps;
-      std::vector<graphslam::triangle::TriangleDescriptor> tris;
-      if (filtered_aggregated_cloud && !filtered_aggregated_cloud->empty()) {
-        kps = graphslam::triangle::extractKeypoints(*filtered_aggregated_cloud, kp_cfg);
-        tris = graphslam::triangle::buildTriangles(kps, build_cfg);
-      }
-      TrianglePerSubmap entry;
-      entry.keypoints = kps;
-      entry.triangles = tris;
-      triangle_descriptor_per_submap_.push_back(entry);
-      triangle_descriptor_db_.addSubmap(idx, kps, tris, hash_cfg);
-    }
-    triangle_descriptor_next_submap_idx_ = num_submaps;
-  }
+  // Keep every enabled descriptor database aligned 1:1 with submap indices.
+  backend_core_.ingestDescriptors(num_submaps, build_filtered_local_submap);
 
   if (deterministic_loop_scheduling_) {
     // Catch up over every submap not yet used as a loop-search query so the
@@ -1632,7 +1585,7 @@ void GraphBasedSlamComponent::searchLoopForLatest(
   if (use_scan_context_) {
     std::vector<candidate_aggregator::LogLine> aggregator_logs;
     candidate_aggregator::collectScanContextCandidate(
-      scan_context_db_,
+      backend_core_.scanContextDb(),
       submap_travel_distances,
       latest_idx,
       aggregator_config,
@@ -1642,11 +1595,11 @@ void GraphBasedSlamComponent::searchLoopForLatest(
   }
 
   if (use_bev_descriptor_ &&
-    bev_descriptor_db_.size() > SubmapBEVDescriptor::DEFAULT_EXCLUDE_RECENT)
+    backend_core_.bevDescriptorDb().size() > SubmapBEVDescriptor::DEFAULT_EXCLUDE_RECENT)
   {
     std::vector<candidate_aggregator::LogLine> aggregator_logs;
     candidate_aggregator::rerankDistanceCandidatesWithBev(
-      bev_descriptor_db_,
+      backend_core_.bevDescriptorDb(),
       submap_affines,
       latest_idx,
       aggregator_config,
@@ -1661,7 +1614,7 @@ void GraphBasedSlamComponent::searchLoopForLatest(
   if (use_solid_descriptor_) {
     std::vector<candidate_aggregator::LogLine> aggregator_logs;
     candidate_aggregator::collectSolidCandidates(
-      solid_descriptor_db_,
+      backend_core_.solidDescriptorDb(),
       submap_affines,
       distance_candidates,
       latest_idx,
@@ -1674,9 +1627,9 @@ void GraphBasedSlamComponent::searchLoopForLatest(
   if (use_triangle_descriptor_) {
     std::vector<candidate_aggregator::LogLine> aggregator_logs;
     candidate_aggregator::collectTriangleCandidate(
-      triangle_descriptor_db_,
-      triangle_descriptor_per_submap_,
-      bev_descriptor_db_,
+      backend_core_.triangleDb(),
+      backend_core_.trianglePerSubmap(),
+      backend_core_.bevDescriptorDb(),
       use_bev_descriptor_,
       submap_travel_distances,
       latest_idx,

--- a/graph_based_slam/test/test_backend_core.cpp
+++ b/graph_based_slam/test/test_backend_core.cpp
@@ -1,0 +1,219 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Characterization tests for the BackendCore descriptor ingestion moved
+// out of searchLoop. These pin the historical catch-up semantics (each
+// enabled database family queries the provider independently for exactly
+// the missing indices, scan context stores a zero descriptor for empty
+// clouds while the other families always store a computed one) and the
+// determinism contract seed: the same ordered input produces bitwise
+// identical descriptor state across instances.
+
+#include <gtest/gtest.h>
+
+#include <utility>
+#include <vector>
+
+#include "graph_based_slam/backend_core.hpp"
+
+namespace graphslam
+{
+namespace
+{
+
+using backend_core::BackendCore;
+using backend_core::DescriptorConfig;
+using CloudPtr = BackendCore::CloudPtr;
+
+CloudPtr makeCloud(int idx)
+{
+  CloudPtr cloud(new pcl::PointCloud<pcl::PointXYZI>);
+  for (int i = 0; i < 8; ++i) {
+    for (int j = 0; j < 8; ++j) {
+      pcl::PointXYZI pt;
+      pt.x = static_cast<float>(i * 2 + idx);
+      pt.y = static_cast<float>(j * 2 - idx);
+      pt.z = static_cast<float>((i + j + idx) % 4);
+      pt.intensity = 1.0f;
+      cloud->push_back(pt);
+    }
+  }
+  return cloud;
+}
+
+// Provider that records every requested index in call order.
+struct RecordingProvider
+{
+  std::vector<int> calls;
+  bool return_empty{false};
+
+  BackendCore::LocalSubmapProvider asProvider()
+  {
+    return [this](int idx) -> CloudPtr {
+             calls.push_back(idx);
+             if (return_empty) {
+               return CloudPtr(new pcl::PointCloud<pcl::PointXYZI>);
+             }
+             return makeCloud(idx);
+           };
+  }
+};
+
+TEST(BackendCoreIngestion, CatchesUpOnlyTheMissingIndices)
+{
+  DescriptorConfig config;
+  config.use_scan_context = true;
+  BackendCore core;
+  core.configure(config);
+  RecordingProvider provider;
+
+  core.ingestDescriptors(3, provider.asProvider());
+  EXPECT_EQ(provider.calls, (std::vector<int>{0, 1, 2}));
+  EXPECT_EQ(core.scanContextDb().nextSubmapIndex(), 3);
+
+  provider.calls.clear();
+  core.ingestDescriptors(5, provider.asProvider());
+  EXPECT_EQ(provider.calls, (std::vector<int>{3, 4}));
+  EXPECT_EQ(core.scanContextDb().nextSubmapIndex(), 5);
+
+  provider.calls.clear();
+  core.ingestDescriptors(5, provider.asProvider());
+  EXPECT_TRUE(provider.calls.empty());
+}
+
+TEST(BackendCoreIngestion, DisabledFamiliesNeverQueryTheProvider)
+{
+  DescriptorConfig config;
+  BackendCore core;
+  core.configure(config);
+  RecordingProvider provider;
+
+  core.ingestDescriptors(4, provider.asProvider());
+  EXPECT_TRUE(provider.calls.empty());
+  EXPECT_EQ(core.scanContextDb().size(), 0);
+  EXPECT_EQ(core.bevDescriptorDb().size(), 0);
+  EXPECT_EQ(core.solidDescriptorDb().size(), 0);
+  EXPECT_EQ(core.triangleDb().submapCount(), 0u);
+}
+
+TEST(BackendCoreIngestion, EachEnabledFamilyQueriesIndependentlyInOrder)
+{
+  DescriptorConfig config;
+  config.use_scan_context = true;
+  config.use_bev_descriptor = true;
+  BackendCore core;
+  core.configure(config);
+  RecordingProvider provider;
+
+  core.ingestDescriptors(2, provider.asProvider());
+  EXPECT_EQ(provider.calls, (std::vector<int>{0, 1, 0, 1}));
+  EXPECT_EQ(core.scanContextDb().size(), 2);
+  EXPECT_EQ(core.bevDescriptorDb().size(), 2);
+}
+
+TEST(BackendCoreIngestion, EmptyCloudStoresZeroScanContextDescriptor)
+{
+  DescriptorConfig config;
+  config.use_scan_context = true;
+  config.use_solid_descriptor = true;
+  BackendCore core;
+  core.configure(config);
+  RecordingProvider provider;
+  provider.return_empty = true;
+
+  core.ingestDescriptors(1, provider.asProvider());
+  ASSERT_EQ(core.scanContextDb().size(), 1);
+  const auto & desc = core.scanContextDb().descriptors[0];
+  EXPECT_EQ(static_cast<int>(desc.rows()), static_cast<int>(ScanContext::NUM_RINGS));
+  EXPECT_EQ(static_cast<int>(desc.cols()), static_cast<int>(ScanContext::NUM_SECTORS));
+  EXPECT_DOUBLE_EQ(desc.cwiseAbs().maxCoeff(), 0.0);
+  // The other families historically add a descriptor computed from the
+  // empty cloud rather than skipping the index.
+  EXPECT_EQ(core.solidDescriptorDb().size(), 1);
+}
+
+TEST(BackendCoreIngestion, TriangleFeaturesStayAlignedWithSubmapIndices)
+{
+  DescriptorConfig config;
+  config.use_triangle_descriptor = true;
+  BackendCore core;
+  core.configure(config);
+  RecordingProvider provider;
+
+  core.ingestDescriptors(3, provider.asProvider());
+  EXPECT_EQ(provider.calls, (std::vector<int>{0, 1, 2}));
+  EXPECT_EQ(core.trianglePerSubmap().size(), 3u);
+  EXPECT_EQ(core.triangleDb().submapCount(), 3u);
+
+  provider.calls.clear();
+  core.ingestDescriptors(3, provider.asProvider());
+  EXPECT_TRUE(provider.calls.empty());
+  EXPECT_EQ(core.trianglePerSubmap().size(), 3u);
+}
+
+TEST(BackendCoreIngestion, SameOrderedInputProducesBitwiseIdenticalState)
+{
+  DescriptorConfig config;
+  config.use_scan_context = true;
+  config.use_bev_descriptor = true;
+  config.use_solid_descriptor = true;
+  BackendCore core_a;
+  BackendCore core_b;
+  core_a.configure(config);
+  core_b.configure(config);
+  RecordingProvider provider_a;
+  RecordingProvider provider_b;
+
+  core_a.ingestDescriptors(2, provider_a.asProvider());
+  core_a.ingestDescriptors(4, provider_a.asProvider());
+  core_b.ingestDescriptors(2, provider_b.asProvider());
+  core_b.ingestDescriptors(4, provider_b.asProvider());
+
+  ASSERT_EQ(core_a.scanContextDb().size(), 4);
+  ASSERT_EQ(core_b.scanContextDb().size(), 4);
+  for (int i = 0; i < 4; ++i) {
+    const auto & desc_a = core_a.scanContextDb().descriptors[i];
+    const auto & desc_b = core_b.scanContextDb().descriptors[i];
+    EXPECT_DOUBLE_EQ((desc_a - desc_b).cwiseAbs().maxCoeff(), 0.0);
+    const auto & bev_a = core_a.bevDescriptorDb().descriptors[i];
+    const auto & bev_b = core_b.bevDescriptorDb().descriptors[i];
+    EXPECT_FLOAT_EQ((bev_a.occupancy - bev_b.occupancy).cwiseAbs().maxCoeff(), 0.0f);
+    EXPECT_FLOAT_EQ((bev_a.density - bev_b.density).cwiseAbs().maxCoeff(), 0.0f);
+    EXPECT_FLOAT_EQ((bev_a.max_height - bev_b.max_height).cwiseAbs().maxCoeff(), 0.0f);
+    EXPECT_FLOAT_EQ((bev_a.coarse_key - bev_b.coarse_key).cwiseAbs().maxCoeff(), 0.0f);
+    const auto & solid_a = core_a.solidDescriptorDb().descriptors[i];
+    const auto & solid_b = core_b.solidDescriptorDb().descriptors[i];
+    EXPECT_DOUBLE_EQ((solid_a.range - solid_b.range).cwiseAbs().maxCoeff(), 0.0);
+    EXPECT_DOUBLE_EQ((solid_a.angle - solid_b.angle).cwiseAbs().maxCoeff(), 0.0);
+    EXPECT_DOUBLE_EQ((solid_a.solid - solid_b.solid).cwiseAbs().maxCoeff(), 0.0);
+  }
+}
+
+}  // namespace
+}  // namespace graphslam


### PR DESCRIPTION
## 概要

v0.6 決定論リファクタ **Phase 2 開始**(docs/roadmap/v0.6.md §3)。ROS-free な `BackendCore` クラス(`backend_core.hpp`、18 個目のテスト済みヘッダ)を導入し、最初の移設として 4 つのループクロージャ記述子 DB(ScanContext / BEV / SOLiD / triangle)と submap インジェスト・ロジックを core に移す。

- `configure()` + `ingestDescriptors(num_submaps, provider)`: 各 DB を submap インデックスと 1:1 整列に保つ歴史的キャッチアップをそのまま移設
- 点群はシェルが provider コールバック(`build_filtered_local_submap`)で供給 — message-vs-PCD-cache の選択はシェルの関心のまま
- 有効ファミリごとの独立 provider クエリも保存(計算は決定的なので再計算はバイト同一)
- component は DB メンバー 6 個 → `backend_core_` 1 個、インジェスト 75 行 → 1 行に。探索・最適化オーケストレーションは後続 PR で段階移設

## テスト

- 特性テスト 6 本(`test_backend_core.cpp`): 不足インデックスのみのキャッチアップ、無効ファミリの provider 非呼出、ファミリ独立クエリ順序、空雲→ScanContext ゼロ記述子(他ファミリは計算値格納)、triangle 特徴の 1:1 整列、**同一順序入力 → 2 インスタンスでビット同一の記述子状態**(Phase 2 決定論契約テストの種)
- `colcon test`(4 パッケージ): **1081 tests, 0 failures**
- `run_release_readiness_checks.sh`: 全プロファイル PASS/TARGET_MET、`mid360_gt_rtkslam_stadtgarten_seq2` score_raw = **0.835**(抽出 PR 系列で 7 回連続ビット一致 = 挙動保存)

## 再現コマンド

```bash
colcon build --symlink-install --packages-select graph_based_slam --cmake-args -DCMAKE_BUILD_TYPE=Release
colcon test --packages-select lidarslam_msgs scanmatcher graph_based_slam lidarslam
bash scripts/run_release_readiness_checks.sh
```