### PR TITLE
refactor(slam): move the loop-search orchestration into BackendCore

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -224,10 +224,14 @@ if(BUILD_TESTING)
   ament_add_gtest(
     test_backend_core
     test/test_backend_core.cpp
+    src/three_d_bbs_loop_verifier.cpp
   )
   if(TARGET test_backend_core)
     target_include_directories(test_backend_core PRIVATE include ${EIGEN3_INCLUDE_DIR})
-    target_link_libraries(test_backend_core ${PCL_LIBRARIES})
+    ament_target_dependencies(test_backend_core ndt_omp_ros2)
+    target_link_libraries(
+      test_backend_core ${PCL_LIBRARIES} graph_based_slam_3d_bbs_vendor
+    )
   endif()
   ament_add_gtest(
     test_pose_graph_optimization

--- a/graph_based_slam/include/graph_based_slam/backend_core.hpp
+++ b/graph_based_slam/include/graph_based_slam/backend_core.hpp
@@ -38,17 +38,25 @@
 // state, independent of wall-clock timing. The shell supplies clouds via
 // a provider callback, so message-vs-PCD-cache stays its concern.
 
+#include <cstdio>
 #include <functional>
+#include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include <pcl/common/transforms.h>  // NOLINT(build/include_order)
+#include <pcl/filters/voxel_grid.h>  // NOLINT(build/include_order)
 #include <pcl/point_cloud.h>  // NOLINT(build/include_order)
 #include <pcl/point_types.h>  // NOLINT(build/include_order)
+#include <pcl/registration/registration.h>  // NOLINT(build/include_order)
 
 #include "graph_based_slam/candidate_aggregator.hpp"
+#include "graph_based_slam/loop_verifier.hpp"
 #include "graph_based_slam/scan_context.hpp"
 #include "graph_based_slam/solid_descriptor.hpp"
 #include "graph_based_slam/submap_bev_descriptor.hpp"
+#include "graph_based_slam/three_d_bbs_loop_verifier.hpp"
 #include "graph_based_slam/triangle_descriptor.hpp"
 #include "graph_based_slam/triangle_descriptor_database.hpp"
 
@@ -81,6 +89,49 @@ struct DescriptorConfig
   int triangle_descriptor_max_triangles{3000};
   double triangle_descriptor_edge_bin_m{0.5};
   double triangle_descriptor_quad_feature_bin_m{0.0};
+};
+
+// Pose and travel distance of one submap, pre-converted by the shell
+// (tf2::fromMsg once per submap; translation() is bit-identical to the
+// message position doubles).
+struct SubmapMeta
+{
+  Eigen::Affine3d pose{Eigen::Affine3d::Identity()};
+  double travel_distance{0.0};
+};
+
+struct LoopEdgeProposal
+{
+  bool found{false};
+  std::pair<int, int> pair_id{-1, -1};
+  Eigen::Isometry3d relative_pose{Eigen::Isometry3d::Identity()};
+  double fitness_score{0.0};
+};
+
+struct LoopSearchOutput
+{
+  LoopEdgeProposal proposal;
+  std::vector<candidate_aggregator::LogLine> logs;
+};
+
+struct LoopSearchConfig
+{
+  int search_submap_num{3};
+  bool prefer_scan_context_candidates{false};
+  bool use_3d_bbs_for_scan_context{false};
+  int three_d_bbs_source_submap_num{2};
+  int three_d_bbs_target_submap_radius{1};
+  double three_d_bbs_voxel_leaf_size{1.0};
+  double three_d_bbs_min_level_res{1.0};
+  int three_d_bbs_max_level{3};
+  double three_d_bbs_score_threshold_percentage{0.25};
+  int three_d_bbs_timeout_msec{50};
+  int three_d_bbs_num_threads{0};
+  double three_d_bbs_translation_search_margin_m{15.0};
+  double three_d_bbs_roll_pitch_search_deg{10.0};
+  double three_d_bbs_yaw_search_deg{180.0};
+  candidate_aggregator::Config aggregator;
+  loop_verifier::GateConfig gates;
 };
 
 // Backend-owned loop-closure state. Single-threaded by contract: the
@@ -187,6 +238,471 @@ public:
       }
       triangle_next_submap_idx_ = num_submaps;
     }
+  }
+
+  // The complete loop search for one query submap: candidate generation
+  // (pure aggregator calls over the descriptor databases), registration
+  // verification and best-candidate selection. Raw submap clouds come
+  // from the provider (message vs PCD cache stays the shell's concern);
+  // the registration / voxel filter / 3D-BBS compute objects are injected
+  // so the shell and the offline runner can own their own instances.
+  // Every operator-visible line is returned as a LogLine so the shell
+  // emits byte-identical output.
+  LoopSearchOutput searchLoopForSubmap(
+    const std::vector<SubmapMeta> & submaps,
+    int latest_idx,
+    const LoopSearchConfig & search_config,
+    const LocalSubmapProvider & raw_cloud_provider,
+    pcl::Registration<pcl::PointXYZI, pcl::PointXYZI> & registration,
+    pcl::VoxelGrid<pcl::PointXYZI> & voxelgrid,
+    ThreeDBBSLoopVerifier & three_d_bbs_verifier)
+  {
+    using LoopCandidate = loop_verifier::LoopCandidate;
+    using LoopCandidateResult = loop_verifier::LoopCandidateResult;
+
+    LoopSearchOutput output;
+    const int num_submaps = static_cast<int>(submaps.size());
+    const Eigen::Affine3d & latest_affine = submaps[latest_idx].pose;
+
+    // Aggregate latest N submaps as source (improves matching quality)
+    pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_latest_submap_cloud_ptr(
+      new pcl::PointCloud<pcl::PointXYZI>);
+    pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_latest_submap_cloud_sc_ptr(
+      new pcl::PointCloud<pcl::PointXYZI>);
+    pcl::PointCloud<pcl::PointXYZI>::Ptr latest_submap_cloud_local_ptr(
+      new pcl::PointCloud<pcl::PointXYZI>);
+    pcl::PointCloud<pcl::PointXYZI>::Ptr latest_submap_cloud_local_bbs_ptr(
+      new pcl::PointCloud<pcl::PointXYZI>);
+    for (int k = 0; k < search_config.search_submap_num && (latest_idx - k) >= 0; k++) {
+      int src_idx = latest_idx - k;
+      pcl::PointCloud<pcl::PointXYZI>::Ptr src_cloud = raw_cloud_provider(src_idx);
+      if (src_cloud->empty()) {
+        continue;
+      }
+      pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_src(new pcl::PointCloud<pcl::PointXYZI>);
+      const Eigen::Affine3d & src_affine = submaps[src_idx].pose;
+      pcl::transformPointCloud(*src_cloud, *transformed_src, src_affine.matrix().cast<float>());
+      *transformed_latest_submap_cloud_ptr += *transformed_src;
+      if (k < search_config.three_d_bbs_source_submap_num) {
+        *transformed_latest_submap_cloud_sc_ptr += *transformed_src;
+      }
+
+      pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_src_local(
+        new pcl::PointCloud<pcl::PointXYZI>);
+      const Eigen::Matrix4f latest_frame_transform =
+        (latest_affine.inverse() * src_affine).matrix().cast<float>();
+      pcl::transformPointCloud(*src_cloud, *transformed_src_local, latest_frame_transform);
+      *latest_submap_cloud_local_ptr += *transformed_src_local;
+      if (k < search_config.three_d_bbs_source_submap_num) {
+        *latest_submap_cloud_local_bbs_ptr += *transformed_src_local;
+      }
+    }
+    if (
+      transformed_latest_submap_cloud_ptr->empty() ||
+      transformed_latest_submap_cloud_sc_ptr->empty() ||
+      latest_submap_cloud_local_ptr->empty() ||
+      latest_submap_cloud_local_bbs_ptr->empty())
+    {
+      return output;
+    }
+
+    pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_source(new pcl::PointCloud<pcl::PointXYZI>);
+    voxelgrid.setInputCloud(transformed_latest_submap_cloud_ptr);
+    voxelgrid.filter(*filtered_source);
+    if (filtered_source->empty()) {
+      return output;
+    }
+    pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_source_sc(
+      new pcl::PointCloud<pcl::PointXYZI>);
+    voxelgrid.setInputCloud(transformed_latest_submap_cloud_sc_ptr);
+    voxelgrid.filter(*filtered_source_sc);
+    if (filtered_source_sc->empty()) {
+      return output;
+    }
+    pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_source_local(
+      new pcl::PointCloud<pcl::PointXYZI>);
+    voxelgrid.setInputCloud(latest_submap_cloud_local_ptr);
+    voxelgrid.filter(*filtered_source_local);
+    if (filtered_source_local->empty()) {
+      return output;
+    }
+    pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_source_local_bbs(
+      new pcl::PointCloud<pcl::PointXYZI>);
+    voxelgrid.setInputCloud(latest_submap_cloud_local_bbs_ptr);
+    voxelgrid.filter(*filtered_source_local_bbs);
+    if (filtered_source_local_bbs->empty()) {
+      return output;
+    }
+    registration.setInputSource(filtered_source);
+
+    const double latest_moving_distance = submaps[latest_idx].travel_distance;
+    const Eigen::Vector3d latest_submap_pos = latest_affine.translation();
+
+    std::vector<LoopCandidate> candidates;
+
+    std::vector<Eigen::Vector3d> submap_positions;
+    std::vector<double> submap_travel_distances;
+    std::vector<Eigen::Affine3d> submap_affines;
+    submap_positions.reserve(latest_idx + 1);
+    submap_travel_distances.reserve(latest_idx + 1);
+    submap_affines.reserve(latest_idx + 1);
+    for (int i = 0; i <= latest_idx; i++) {
+      submap_positions.emplace_back(submaps[i].pose.translation());
+      submap_travel_distances.push_back(submaps[i].travel_distance);
+      submap_affines.push_back(submaps[i].pose);
+    }
+
+    std::vector<std::pair<double, int>> distance_candidates =
+      candidate_aggregator::collectDistanceCandidates(
+      submap_positions, submap_travel_distances, latest_idx, search_config.aggregator);
+
+    if (config_.use_scan_context) {
+      candidate_aggregator::collectScanContextCandidate(
+        scan_context_db_,
+        submap_travel_distances,
+        latest_idx,
+        search_config.aggregator,
+        candidates,
+        output.logs);
+    }
+
+    if (config_.use_bev_descriptor &&
+      bev_descriptor_db_.size() > SubmapBEVDescriptor::DEFAULT_EXCLUDE_RECENT)
+    {
+      candidate_aggregator::rerankDistanceCandidatesWithBev(
+        bev_descriptor_db_,
+        submap_affines,
+        latest_idx,
+        search_config.aggregator,
+        distance_candidates,
+        candidates,
+        output.logs);
+    } else {
+      candidate_aggregator::appendTopDistanceCandidates(
+        distance_candidates, search_config.aggregator, candidates);
+    }
+    if (config_.use_solid_descriptor) {
+      candidate_aggregator::collectSolidCandidates(
+        solid_descriptor_db_,
+        submap_affines,
+        distance_candidates,
+        latest_idx,
+        search_config.aggregator,
+        candidates,
+        output.logs);
+    }
+
+    if (config_.use_triangle_descriptor) {
+      candidate_aggregator::collectTriangleCandidate(
+        triangle_db_,
+        triangle_per_submap_,
+        bev_descriptor_db_,
+        config_.use_bev_descriptor,
+        submap_travel_distances,
+        latest_idx,
+        search_config.aggregator,
+        candidates,
+        output.logs);
+    }
+    if (candidates.empty()) {
+      return output;
+    }
+
+    const bool debug = search_config.aggregator.debug;
+    char log_buffer[512];
+
+    loop_verifier::SelectionState selection;
+    bool attempted_registration = false;
+
+    for (const auto & candidate : candidates) {
+      if (candidate.index < 0 || candidate.index >= latest_idx) {
+        continue;
+      }
+
+      const Eigen::Affine3d & candidate_affine = submaps[candidate.index].pose;
+      pcl::PointCloud<pcl::PointXYZI>::Ptr submap_clouds_ptr(
+        new pcl::PointCloud<pcl::PointXYZI>);
+      pcl::PointCloud<pcl::PointXYZI>::Ptr submap_clouds_bbs_ptr(
+        new pcl::PointCloud<pcl::PointXYZI>);
+      for (int offset = -search_config.search_submap_num;
+        offset <= search_config.search_submap_num; ++offset)
+      {
+        const int near_idx = candidate.index + offset;
+        if (near_idx < 0 || near_idx >= num_submaps) {
+          continue;
+        }
+        pcl::PointCloud<pcl::PointXYZI>::Ptr submap_cloud_ptr = raw_cloud_provider(near_idx);
+        if (submap_cloud_ptr->empty()) {
+          continue;
+        }
+        pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_submap_cloud_ptr(
+          new pcl::PointCloud<pcl::PointXYZI>);
+        const Eigen::Affine3d & affine = submaps[near_idx].pose;
+        pcl::transformPointCloud(
+          *submap_cloud_ptr, *transformed_submap_cloud_ptr,
+          affine.matrix().cast<float>());
+        *submap_clouds_ptr += *transformed_submap_cloud_ptr;
+        if (std::abs(offset) <= search_config.three_d_bbs_target_submap_radius) {
+          *submap_clouds_bbs_ptr += *transformed_submap_cloud_ptr;
+        }
+      }
+      if (submap_clouds_ptr->empty() || submap_clouds_bbs_ptr->empty()) {
+        continue;
+      }
+
+      pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_clouds_ptr(
+        new pcl::PointCloud<pcl::PointXYZI>());
+      voxelgrid.setInputCloud(submap_clouds_ptr);
+      voxelgrid.filter(*filtered_clouds_ptr);
+      if (filtered_clouds_ptr->empty()) {
+        continue;
+      }
+      pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_clouds_sc_ptr(
+        new pcl::PointCloud<pcl::PointXYZI>());
+      voxelgrid.setInputCloud(submap_clouds_bbs_ptr);
+      voxelgrid.filter(*filtered_clouds_sc_ptr);
+      if (filtered_clouds_sc_ptr->empty()) {
+        continue;
+      }
+
+      pcl::PointCloud<pcl::PointXYZI>::Ptr output_cloud_ptr(
+        new pcl::PointCloud<pcl::PointXYZI>);
+      bool used_3d_bbs = false;
+      double three_d_bbs_score_percentage = 0.0;
+      double three_d_bbs_elapsed_msec = 0.0;
+      Eigen::Matrix4f initial_guess =
+        loop_verifier::computeInitialGuess(candidate_affine, latest_affine, candidate);
+      if (candidate.source == LoopCandidate::Source::SCAN_CONTEXT) {
+        registration.setInputSource(filtered_source_sc);
+        registration.setInputTarget(filtered_clouds_sc_ptr);
+      } else {
+        registration.setInputSource(filtered_source);
+        registration.setInputTarget(filtered_clouds_ptr);
+      }
+      if (candidate.source == LoopCandidate::Source::SCAN_CONTEXT &&
+        search_config.use_3d_bbs_for_scan_context)
+      {
+        pcl::VoxelGrid<pcl::PointXYZI> three_d_bbs_voxelgrid;
+        three_d_bbs_voxelgrid.setLeafSize(
+          search_config.three_d_bbs_voxel_leaf_size,
+          search_config.three_d_bbs_voxel_leaf_size,
+          search_config.three_d_bbs_voxel_leaf_size);
+        pcl::PointCloud<pcl::PointXYZI>::Ptr three_d_bbs_source(
+          new pcl::PointCloud<pcl::PointXYZI>);
+        pcl::PointCloud<pcl::PointXYZI>::Ptr three_d_bbs_target(
+          new pcl::PointCloud<pcl::PointXYZI>);
+        three_d_bbs_voxelgrid.setInputCloud(filtered_source_local_bbs);
+        three_d_bbs_voxelgrid.filter(*three_d_bbs_source);
+        three_d_bbs_voxelgrid.setInputCloud(submap_clouds_bbs_ptr);
+        three_d_bbs_voxelgrid.filter(*three_d_bbs_target);
+
+        ThreeDBBSLoopVerifierConfig bbs_config;
+        bbs_config.min_level_res = search_config.three_d_bbs_min_level_res;
+        bbs_config.max_level = search_config.three_d_bbs_max_level;
+        bbs_config.score_threshold_percentage =
+          search_config.three_d_bbs_score_threshold_percentage;
+        bbs_config.timeout_msec = search_config.three_d_bbs_timeout_msec;
+        bbs_config.num_threads = search_config.three_d_bbs_num_threads;
+        bbs_config.translation_search_margin_m =
+          search_config.three_d_bbs_translation_search_margin_m;
+        bbs_config.roll_pitch_search_deg = search_config.three_d_bbs_roll_pitch_search_deg;
+        bbs_config.yaw_search_deg = search_config.three_d_bbs_yaw_search_deg;
+        const auto bbs_result = three_d_bbs_verifier.localize(
+          three_d_bbs_source,
+          three_d_bbs_target,
+          Eigen::Isometry3d(latest_affine.matrix()),
+          Eigen::Isometry3d(candidate_affine.matrix()),
+          bbs_config);
+        if (bbs_result.available) {
+          three_d_bbs_score_percentage = bbs_result.score_percentage;
+          three_d_bbs_elapsed_msec = bbs_result.elapsed_msec;
+          used_3d_bbs = bbs_result.localized;
+          if (bbs_result.localized) {
+            initial_guess = bbs_result.correction_guess;
+          }
+          if (debug) {
+            std::snprintf(
+              log_buffer, sizeof(log_buffer),
+              "3D-BBS %s for loop candidate %d -> %d "
+              "(score=%.3f elapsed=%.2f ms timed_out=%s "
+              "src=%zu tar=%zu)",
+              bbs_result.localized ? "localized" : "missed",
+              candidate.index,
+              latest_idx,
+              bbs_result.score_percentage,
+              bbs_result.elapsed_msec,
+              bbs_result.timed_out ? "true" : "false",
+              three_d_bbs_source->size(),
+              three_d_bbs_target->size());
+            output.logs.push_back({true, std::string(log_buffer)});
+          }
+        }
+      }
+      if (loop_verifier::shouldUseInitialGuess(candidate.source, used_3d_bbs)) {
+        registration.align(*output_cloud_ptr, initial_guess);
+      } else {
+        registration.align(*output_cloud_ptr);
+      }
+      attempted_registration = true;
+      if (!registration.hasConverged()) {
+        if (debug) {
+          std::snprintf(
+            log_buffer, sizeof(log_buffer),
+            "Rejected loop candidate %d -> %d because registration did not converge",
+            candidate.index,
+            latest_idx);
+          output.logs.push_back({true, std::string(log_buffer)});
+        }
+        continue;
+      }
+
+      const double fitness_score = registration.getFitnessScore();
+      const Eigen::Matrix4f final_transformation = registration.getFinalTransformation();
+      const loop_verifier::RegistrationDelta registration_delta =
+        loop_verifier::computeRegistrationDelta(final_transformation);
+
+      LoopCandidateResult candidate_result;
+      candidate_result.index = candidate.index;
+      candidate_result.selection_metric = candidate.selection_metric;
+      candidate_result.fitness_score = fitness_score;
+      candidate_result.travel_distance =
+        latest_moving_distance - submaps[candidate.index].travel_distance;
+      const Eigen::Vector3d candidate_submap_pos = candidate_affine.translation();
+      candidate_result.euclidean_distance = (latest_submap_pos - candidate_submap_pos).norm();
+      candidate_result.translation_delta_m = registration_delta.translation_m;
+      candidate_result.rotation_delta_deg = registration_delta.rotation_deg;
+      candidate_result.source = candidate.source;
+      candidate_result.used_3d_bbs = used_3d_bbs;
+      candidate_result.three_d_bbs_score_percentage = three_d_bbs_score_percentage;
+      candidate_result.three_d_bbs_elapsed_msec = three_d_bbs_elapsed_msec;
+      candidate_result.final_transformation = final_transformation;
+
+      selection.considerConverged(candidate_result);
+
+      const loop_verifier::GateResult gate = loop_verifier::evaluateGates(
+        candidate.source, fitness_score, registration_delta, search_config.gates);
+      if (gate.rejection != loop_verifier::GateRejection::NONE) {
+        if (debug) {
+          switch (gate.rejection) {
+            case loop_verifier::GateRejection::FITNESS:
+              std::snprintf(
+                log_buffer, sizeof(log_buffer),
+                "Rejected loop candidate %d -> %d because fitness %.6f exceeds threshold %.6f",
+                candidate.index,
+                latest_idx,
+                fitness_score,
+                gate.score_threshold);
+              output.logs.push_back({true, std::string(log_buffer)});
+              break;
+            case loop_verifier::GateRejection::TRANSLATION:
+              std::snprintf(
+                log_buffer, sizeof(log_buffer),
+                "Rejected loop candidate %d -> %d because translation correction %.3f m "
+                "exceeds %.3f m",
+                candidate.index,
+                latest_idx,
+                registration_delta.translation_m,
+                gate.translation_cap_m);
+              output.logs.push_back({true, std::string(log_buffer)});
+              break;
+            case loop_verifier::GateRejection::ROTATION:
+              std::snprintf(
+                log_buffer, sizeof(log_buffer),
+                "Rejected loop candidate %d -> %d because rotation correction %.3f deg "
+                "exceeds %.3f deg",
+                candidate.index,
+                latest_idx,
+                registration_delta.rotation_deg,
+                gate.rotation_cap_deg);
+              output.logs.push_back({true, std::string(log_buffer)});
+              break;
+            default:
+              break;
+          }
+        }
+        continue;
+      }
+
+      candidate_result.valid = true;
+      selection.considerValid(candidate_result);
+    }
+
+    if (search_config.prefer_scan_context_candidates && selection.best_scan_context.valid) {
+      if (
+        !selection.best_valid.valid ||
+        selection.best_valid.index != selection.best_scan_context.index ||
+        selection.best_valid.source != LoopCandidate::Source::SCAN_CONTEXT)
+      {
+        std::ostringstream prefer_line;
+        prefer_line << "Preferring valid ScanContext candidate id:" <<
+          selection.best_scan_context.index << " over best candidate id:" <<
+          (selection.best_valid.valid ?
+        std::to_string(selection.best_valid.index) : std::string("none"));
+        output.logs.push_back({false, prefer_line.str()});
+      }
+    }
+    const LoopCandidateResult best_candidate =
+      selection.select(search_config.prefer_scan_context_candidates);
+
+    if (!best_candidate.valid) {
+      const LoopCandidateResult & best_attempt = selection.best_attempt;
+      if (best_attempt.index >= 0) {
+        std::ostringstream attempt_line;
+        attempt_line << "best_loop_candidate id:" << best_attempt.index
+                     << " source:" << loop_verifier::sourceName(best_attempt.source)
+                     << " latest_id:" << latest_idx
+                     << " travel_distance:" << best_attempt.travel_distance
+                     << " euclidean_distance:" << best_attempt.euclidean_distance
+                     << " fitness:" << best_attempt.fitness_score
+                     << " correction_translation:" << best_attempt.translation_delta_m
+                     << " correction_rotation_deg:" << best_attempt.rotation_delta_deg
+                     << " used_3d_bbs:" << best_attempt.used_3d_bbs
+                     << " 3d_bbs_score:" << best_attempt.three_d_bbs_score_percentage;
+        output.logs.push_back({false, attempt_line.str()});
+      } else if (attempted_registration && debug) {
+        std::snprintf(
+          log_buffer, sizeof(log_buffer),
+          "No converged loop candidate remained for latest submap %d",
+          latest_idx);
+        output.logs.push_back({true, std::string(log_buffer)});
+      }
+      return output;
+    }
+
+    output.proposal.found = true;
+    output.proposal.pair_id = std::pair<int, int>(best_candidate.index, latest_idx);
+    output.proposal.relative_pose = loop_verifier::composeLoopRelativePose(
+      submaps[best_candidate.index].pose, latest_affine, best_candidate.final_transformation);
+    output.proposal.fitness_score = best_candidate.fitness_score;
+
+    output.logs.push_back({false, "---"});
+    std::ostringstream adjustment_line;
+    adjustment_line << "PoseAdjustment distance:" << best_candidate.travel_distance
+                    << ", score:" << best_candidate.fitness_score;
+    output.logs.push_back({false, adjustment_line.str()});
+    std::ostringstream id_line;
+    id_line << "id_loop_point 1:" << best_candidate.index
+            << " id_loop_point 2:" << latest_idx;
+    output.logs.push_back({false, id_line.str()});
+    std::ostringstream source_line;
+    source_line << "loop_candidate_source:" << loop_verifier::sourceName(best_candidate.source);
+    output.logs.push_back({false, source_line.str()});
+    if (best_candidate.used_3d_bbs) {
+      std::ostringstream bbs_line;
+      bbs_line << "3d_bbs_score_percentage:" << best_candidate.three_d_bbs_score_percentage
+               << " elapsed_msec:" << best_candidate.three_d_bbs_elapsed_msec;
+      output.logs.push_back({false, bbs_line.str()});
+    }
+    std::ostringstream correction_line;
+    correction_line << "correction translation[m]:" << best_candidate.translation_delta_m
+                    << " rotation[deg]:" << best_candidate.rotation_delta_deg;
+    output.logs.push_back({false, correction_line.str()});
+    output.logs.push_back({false, "final transformation:"});
+    std::ostringstream transformation_line;
+    transformation_line << best_candidate.final_transformation;
+    output.logs.push_back({false, transformation_line.str()});
+
+    return output;
   }
 
   const DescriptorConfig & config() const {return config_;}

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -1307,21 +1307,6 @@ bool GraphBasedSlamComponent::upsertLoopEdge(const LoopEdge & loop_edge)
   loop_edges_.push_back(normalized);
   return true;
 }
-namespace
-{
-// The candidate/result types and every verification decision (initial
-// guess, gates, best-candidate selection) live in loop_verifier.hpp so the
-// offline BackendCore can reuse them; this file only does the I/O around
-// them (cloud aggregation, registration, logging).
-using LoopCandidate = loop_verifier::LoopCandidate;
-using LoopCandidateResult = loop_verifier::LoopCandidateResult;
-
-const char * candidate_source_name(LoopCandidate::Source source)
-{
-  return loop_verifier::sourceName(source);
-}
-}  // namespace
-
 void GraphBasedSlamComponent::searchLoop()
 {
   lidarslam_msgs::msg::MapArray map_array_msg;
@@ -1400,107 +1385,45 @@ void GraphBasedSlamComponent::searchLoopForLatest(
   int num_submaps,
   int latest_idx)
 {
-  const auto & latest_submap = map_array_msg.submaps[latest_idx];
-  Eigen::Affine3d latest_affine;
-  tf2::fromMsg(latest_submap.pose, latest_affine);
-
-  // Aggregate latest N submaps as source (improves matching quality)
-  pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_latest_submap_cloud_ptr(
-    new pcl::PointCloud<pcl::PointXYZI>);
-  pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_latest_submap_cloud_sc_ptr(
-    new pcl::PointCloud<pcl::PointXYZI>);
-  pcl::PointCloud<pcl::PointXYZI>::Ptr latest_submap_cloud_local_ptr(
-    new pcl::PointCloud<pcl::PointXYZI>);
-  pcl::PointCloud<pcl::PointXYZI>::Ptr latest_submap_cloud_local_bbs_ptr(
-    new pcl::PointCloud<pcl::PointXYZI>);
-  for (int k = 0; k < search_submap_num_ && (latest_idx - k) >= 0; k++) {
-    int src_idx = latest_idx - k;
-    const auto & src_submap = map_array_msg.submaps[src_idx];
-    pcl::PointCloud<pcl::PointXYZI>::Ptr src_cloud;
-    if (use_pcd_cache_) {
-      src_cloud = loadSubmapFromPCD(src_idx);
-    } else {
-      src_cloud.reset(new pcl::PointCloud<pcl::PointXYZI>);
-      pcl::fromROSMsg(src_submap.cloud, *src_cloud);
-    }
-    if (src_cloud->empty()) {
-      continue;
-    }
-    pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_src(new pcl::PointCloud<pcl::PointXYZI>);
-    Eigen::Affine3d src_affine;
-    tf2::fromMsg(src_submap.pose, src_affine);
-    pcl::transformPointCloud(*src_cloud, *transformed_src, src_affine.matrix().cast<float>());
-    *transformed_latest_submap_cloud_ptr += *transformed_src;
-    if (k < three_d_bbs_source_submap_num_) {
-      *transformed_latest_submap_cloud_sc_ptr += *transformed_src;
-    }
-
-    pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_src_local(
-      new pcl::PointCloud<pcl::PointXYZI>);
-    const Eigen::Matrix4f latest_frame_transform =
-      (latest_affine.inverse() * src_affine).matrix().cast<float>();
-    pcl::transformPointCloud(*src_cloud, *transformed_src_local, latest_frame_transform);
-    *latest_submap_cloud_local_ptr += *transformed_src_local;
-    if (k < three_d_bbs_source_submap_num_) {
-      *latest_submap_cloud_local_bbs_ptr += *transformed_src_local;
-    }
-  }
-  if (
-    transformed_latest_submap_cloud_ptr->empty() ||
-    transformed_latest_submap_cloud_sc_ptr->empty() ||
-    latest_submap_cloud_local_ptr->empty() ||
-    latest_submap_cloud_local_bbs_ptr->empty())
-  {
-    return;
+  static_cast<void>(num_submaps);
+  std::vector<backend_core::SubmapMeta> submaps;
+  submaps.reserve(map_array_msg.submaps.size());
+  for (const auto & submap : map_array_msg.submaps) {
+    backend_core::SubmapMeta meta;
+    tf2::fromMsg(submap.pose, meta.pose);
+    meta.travel_distance = submap.distance;
+    submaps.push_back(meta);
   }
 
-  pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_source(new pcl::PointCloud<pcl::PointXYZI>);
-  voxelgrid_.setInputCloud(transformed_latest_submap_cloud_ptr);
-  voxelgrid_.filter(*filtered_source);
-  if (filtered_source->empty()) {
-    return;
-  }
-  pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_source_sc(new pcl::PointCloud<pcl::PointXYZI>);
-  voxelgrid_.setInputCloud(transformed_latest_submap_cloud_sc_ptr);
-  voxelgrid_.filter(*filtered_source_sc);
-  if (filtered_source_sc->empty()) {
-    return;
-  }
-  pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_source_local(new pcl::PointCloud<pcl::PointXYZI>);
-  voxelgrid_.setInputCloud(latest_submap_cloud_local_ptr);
-  voxelgrid_.filter(*filtered_source_local);
-  if (filtered_source_local->empty()) {
-    return;
-  }
-  pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_source_local_bbs(
-    new pcl::PointCloud<pcl::PointXYZI>);
-  voxelgrid_.setInputCloud(latest_submap_cloud_local_bbs_ptr);
-  voxelgrid_.filter(*filtered_source_local_bbs);
-  if (filtered_source_local_bbs->empty()) {
-    return;
-  }
-  registration_->setInputSource(filtered_source);
-
-  const double latest_moving_distance = latest_submap.distance;
-  const Eigen::Vector3d latest_submap_pos{
-    latest_submap.pose.position.x,
-    latest_submap.pose.position.y,
-    latest_submap.pose.position.z};
-
-  std::vector<LoopCandidate> candidates;
-  auto add_candidate =
-    [&candidates](
-    int index,
-    double selection_metric,
-    LoopCandidate::Source source,
-    double yaw_rad = 0.0,
-    const Eigen::Matrix4f * relative_transform = nullptr)
-    {
-      candidate_aggregator::upsertCandidate(
-        candidates, index, selection_metric, source, yaw_rad, relative_transform);
+  const auto raw_cloud_provider =
+    [this, &map_array_msg](int idx) -> pcl::PointCloud<pcl::PointXYZI>::Ptr {
+      if (use_pcd_cache_) {
+        return loadSubmapFromPCD(idx);
+      }
+      pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
+      pcl::fromROSMsg(map_array_msg.submaps[idx].cloud, *cloud);
+      return cloud;
     };
 
-  candidate_aggregator::Config aggregator_config;
+  backend_core::LoopSearchConfig search_config;
+  search_config.search_submap_num = search_submap_num_;
+  search_config.prefer_scan_context_candidates = prefer_scan_context_candidates_;
+  search_config.use_3d_bbs_for_scan_context = use_3d_bbs_for_scan_context_;
+  search_config.three_d_bbs_source_submap_num = three_d_bbs_source_submap_num_;
+  search_config.three_d_bbs_target_submap_radius = three_d_bbs_target_submap_radius_;
+  search_config.three_d_bbs_voxel_leaf_size = three_d_bbs_voxel_leaf_size_;
+  search_config.three_d_bbs_min_level_res = three_d_bbs_min_level_res_;
+  search_config.three_d_bbs_max_level = three_d_bbs_max_level_;
+  search_config.three_d_bbs_score_threshold_percentage =
+    three_d_bbs_score_threshold_percentage_;
+  search_config.three_d_bbs_timeout_msec = three_d_bbs_timeout_msec_;
+  search_config.three_d_bbs_num_threads = three_d_bbs_num_threads_;
+  search_config.three_d_bbs_translation_search_margin_m =
+    three_d_bbs_translation_search_margin_m_;
+  search_config.three_d_bbs_roll_pitch_search_deg = three_d_bbs_roll_pitch_search_deg_;
+  search_config.three_d_bbs_yaw_search_deg = three_d_bbs_yaw_search_deg_;
+
+  candidate_aggregator::Config & aggregator_config = search_config.aggregator;
   aggregator_config.debug = debug_flag_;
   aggregator_config.max_loop_candidate_count = max_loop_candidate_count_;
   aggregator_config.distance_loop_closure = distance_loop_closure_;
@@ -1549,100 +1472,7 @@ void GraphBasedSlamComponent::searchLoopForLatest(
   aggregator_config.triangle_verify_with_bev = triangle_verify_with_bev_;
   aggregator_config.triangle_verify_bev_max_distance = triangle_verify_bev_max_distance_;
 
-  auto emit_aggregator_logs =
-    [this](const std::vector<candidate_aggregator::LogLine> & logs) {
-      for (const auto & line : logs) {
-        if (line.via_logger) {
-          RCLCPP_INFO(get_logger(), "%s", line.text.c_str());
-        } else {
-          std::cout << line.text << std::endl;
-        }
-      }
-    };
-
-  std::vector<Eigen::Vector3d> submap_positions;
-  std::vector<double> submap_travel_distances;
-  std::vector<Eigen::Affine3d> submap_affines;
-  submap_positions.reserve(latest_idx + 1);
-  submap_travel_distances.reserve(latest_idx + 1);
-  submap_affines.reserve(latest_idx + 1);
-  for (int i = 0; i <= latest_idx; i++) {
-    const auto & submap = map_array_msg.submaps[i];
-    submap_positions.emplace_back(
-      submap.pose.position.x,
-      submap.pose.position.y,
-      submap.pose.position.z);
-    submap_travel_distances.push_back(submap.distance);
-    Eigen::Affine3d submap_affine;
-    tf2::fromMsg(submap.pose, submap_affine);
-    submap_affines.push_back(submap_affine);
-  }
-
-  std::vector<std::pair<double, int>> distance_candidates =
-    candidate_aggregator::collectDistanceCandidates(
-    submap_positions, submap_travel_distances, latest_idx, aggregator_config);
-
-  if (use_scan_context_) {
-    std::vector<candidate_aggregator::LogLine> aggregator_logs;
-    candidate_aggregator::collectScanContextCandidate(
-      backend_core_.scanContextDb(),
-      submap_travel_distances,
-      latest_idx,
-      aggregator_config,
-      candidates,
-      aggregator_logs);
-    emit_aggregator_logs(aggregator_logs);
-  }
-
-  if (use_bev_descriptor_ &&
-    backend_core_.bevDescriptorDb().size() > SubmapBEVDescriptor::DEFAULT_EXCLUDE_RECENT)
-  {
-    std::vector<candidate_aggregator::LogLine> aggregator_logs;
-    candidate_aggregator::rerankDistanceCandidatesWithBev(
-      backend_core_.bevDescriptorDb(),
-      submap_affines,
-      latest_idx,
-      aggregator_config,
-      distance_candidates,
-      candidates,
-      aggregator_logs);
-    emit_aggregator_logs(aggregator_logs);
-  } else {
-    candidate_aggregator::appendTopDistanceCandidates(
-      distance_candidates, aggregator_config, candidates);
-  }
-  if (use_solid_descriptor_) {
-    std::vector<candidate_aggregator::LogLine> aggregator_logs;
-    candidate_aggregator::collectSolidCandidates(
-      backend_core_.solidDescriptorDb(),
-      submap_affines,
-      distance_candidates,
-      latest_idx,
-      aggregator_config,
-      candidates,
-      aggregator_logs);
-    emit_aggregator_logs(aggregator_logs);
-  }
-
-  if (use_triangle_descriptor_) {
-    std::vector<candidate_aggregator::LogLine> aggregator_logs;
-    candidate_aggregator::collectTriangleCandidate(
-      backend_core_.triangleDb(),
-      backend_core_.trianglePerSubmap(),
-      backend_core_.bevDescriptorDb(),
-      use_bev_descriptor_,
-      submap_travel_distances,
-      latest_idx,
-      aggregator_config,
-      candidates,
-      aggregator_logs);
-    emit_aggregator_logs(aggregator_logs);
-  }
-  if (candidates.empty()) {
-    return;
-  }
-
-  loop_verifier::GateConfig gate_config;
+  loop_verifier::GateConfig & gate_config = search_config.gates;
   gate_config.generic_score_threshold = threshold_loop_closure_score_;
   gate_config.scan_context_score_threshold = scan_context_loop_closure_score_threshold_;
   gate_config.max_translation_m = loop_max_translation_delta_;
@@ -1650,291 +1480,39 @@ void GraphBasedSlamComponent::searchLoopForLatest(
   gate_config.max_translation_descriptor_m = loop_max_translation_delta_descriptor_;
   gate_config.max_rotation_descriptor_deg = loop_max_rotation_delta_deg_descriptor_;
 
-  loop_verifier::SelectionState selection;
-  bool attempted_registration = false;
+  const backend_core::LoopSearchOutput search_output = backend_core_.searchLoopForSubmap(
+    submaps,
+    latest_idx,
+    search_config,
+    raw_cloud_provider,
+    *registration_,
+    voxelgrid_,
+    three_d_bbs_loop_verifier_);
 
-  for (const auto & candidate : candidates) {
-    if (candidate.index < 0 || candidate.index >= latest_idx) {
-      continue;
-    }
-
-    const auto & candidate_submap = map_array_msg.submaps[candidate.index];
-    Eigen::Affine3d candidate_affine;
-    tf2::fromMsg(candidate_submap.pose, candidate_affine);
-    pcl::PointCloud<pcl::PointXYZI>::Ptr submap_clouds_ptr(new pcl::PointCloud<pcl::PointXYZI>);
-    pcl::PointCloud<pcl::PointXYZI>::Ptr submap_clouds_bbs_ptr(
-      new pcl::PointCloud<pcl::PointXYZI>);
-    for (int offset = -search_submap_num_; offset <= search_submap_num_; ++offset) {
-      const int near_idx = candidate.index + offset;
-      if (near_idx < 0 || near_idx >= num_submaps) {
-        continue;
-      }
-      const auto & near_submap = map_array_msg.submaps[near_idx];
-      pcl::PointCloud<pcl::PointXYZI>::Ptr submap_cloud_ptr;
-      if (use_pcd_cache_) {
-        submap_cloud_ptr = loadSubmapFromPCD(near_idx);
-      } else {
-        submap_cloud_ptr.reset(new pcl::PointCloud<pcl::PointXYZI>);
-        pcl::fromROSMsg(near_submap.cloud, *submap_cloud_ptr);
-      }
-      if (submap_cloud_ptr->empty()) {
-        continue;
-      }
-      pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_submap_cloud_ptr(
-        new pcl::PointCloud<pcl::PointXYZI>);
-      Eigen::Affine3d affine;
-      tf2::fromMsg(near_submap.pose, affine);
-      pcl::transformPointCloud(
-        *submap_cloud_ptr, *transformed_submap_cloud_ptr,
-        affine.matrix().cast<float>());
-      *submap_clouds_ptr += *transformed_submap_cloud_ptr;
-      if (std::abs(offset) <= three_d_bbs_target_submap_radius_) {
-        *submap_clouds_bbs_ptr += *transformed_submap_cloud_ptr;
-      }
-    }
-    if (submap_clouds_ptr->empty() || submap_clouds_bbs_ptr->empty()) {
-      continue;
-    }
-
-    pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_clouds_ptr(new pcl::PointCloud<pcl::PointXYZI>());
-    voxelgrid_.setInputCloud(submap_clouds_ptr);
-    voxelgrid_.filter(*filtered_clouds_ptr);
-    if (filtered_clouds_ptr->empty()) {
-      continue;
-    }
-    pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_clouds_sc_ptr(
-      new pcl::PointCloud<pcl::PointXYZI>());
-    voxelgrid_.setInputCloud(submap_clouds_bbs_ptr);
-    voxelgrid_.filter(*filtered_clouds_sc_ptr);
-    if (filtered_clouds_sc_ptr->empty()) {
-      continue;
-    }
-
-    pcl::PointCloud<pcl::PointXYZI>::Ptr output_cloud_ptr(new pcl::PointCloud<pcl::PointXYZI>);
-    bool used_3d_bbs = false;
-    double three_d_bbs_score_percentage = 0.0;
-    double three_d_bbs_elapsed_msec = 0.0;
-    Eigen::Matrix4f initial_guess =
-      loop_verifier::computeInitialGuess(candidate_affine, latest_affine, candidate);
-    if (candidate.source == LoopCandidate::Source::SCAN_CONTEXT) {
-      registration_->setInputSource(filtered_source_sc);
-      registration_->setInputTarget(filtered_clouds_sc_ptr);
+  for (const auto & line : search_output.logs) {
+    if (line.via_logger) {
+      RCLCPP_INFO(get_logger(), "%s", line.text.c_str());
     } else {
-      registration_->setInputSource(filtered_source);
-      registration_->setInputTarget(filtered_clouds_ptr);
+      std::cout << line.text << std::endl;
     }
-    if (candidate.source == LoopCandidate::Source::SCAN_CONTEXT && use_3d_bbs_for_scan_context_) {
-      pcl::VoxelGrid<pcl::PointXYZI> three_d_bbs_voxelgrid;
-      three_d_bbs_voxelgrid.setLeafSize(
-        three_d_bbs_voxel_leaf_size_,
-        three_d_bbs_voxel_leaf_size_,
-        three_d_bbs_voxel_leaf_size_);
-      pcl::PointCloud<pcl::PointXYZI>::Ptr three_d_bbs_source(
-        new pcl::PointCloud<pcl::PointXYZI>);
-      pcl::PointCloud<pcl::PointXYZI>::Ptr three_d_bbs_target(
-        new pcl::PointCloud<pcl::PointXYZI>);
-      three_d_bbs_voxelgrid.setInputCloud(filtered_source_local_bbs);
-      three_d_bbs_voxelgrid.filter(*three_d_bbs_source);
-      three_d_bbs_voxelgrid.setInputCloud(submap_clouds_bbs_ptr);
-      three_d_bbs_voxelgrid.filter(*three_d_bbs_target);
-
-      ThreeDBBSLoopVerifierConfig bbs_config;
-      bbs_config.min_level_res = three_d_bbs_min_level_res_;
-      bbs_config.max_level = three_d_bbs_max_level_;
-      bbs_config.score_threshold_percentage = three_d_bbs_score_threshold_percentage_;
-      bbs_config.timeout_msec = three_d_bbs_timeout_msec_;
-      bbs_config.num_threads = three_d_bbs_num_threads_;
-      bbs_config.translation_search_margin_m = three_d_bbs_translation_search_margin_m_;
-      bbs_config.roll_pitch_search_deg = three_d_bbs_roll_pitch_search_deg_;
-      bbs_config.yaw_search_deg = three_d_bbs_yaw_search_deg_;
-      const auto bbs_result = three_d_bbs_loop_verifier_.localize(
-        three_d_bbs_source,
-        three_d_bbs_target,
-        Eigen::Isometry3d(latest_affine.matrix()),
-        Eigen::Isometry3d(candidate_affine.matrix()),
-        bbs_config);
-      if (bbs_result.available) {
-        three_d_bbs_score_percentage = bbs_result.score_percentage;
-        three_d_bbs_elapsed_msec = bbs_result.elapsed_msec;
-        used_3d_bbs = bbs_result.localized;
-        if (bbs_result.localized) {
-          initial_guess = bbs_result.correction_guess;
-        }
-        if (debug_flag_) {
-          RCLCPP_INFO(
-            get_logger(),
-            "3D-BBS %s for loop candidate %d -> %d "
-            "(score=%.3f elapsed=%.2f ms timed_out=%s "
-            "src=%zu tar=%zu)",
-            bbs_result.localized ? "localized" : "missed",
-            candidate.index,
-            latest_idx,
-            bbs_result.score_percentage,
-            bbs_result.elapsed_msec,
-            bbs_result.timed_out ? "true" : "false",
-            three_d_bbs_source->size(),
-            three_d_bbs_target->size());
-        }
-      }
-    }
-    if (loop_verifier::shouldUseInitialGuess(candidate.source, used_3d_bbs)) {
-      registration_->align(*output_cloud_ptr, initial_guess);
-    } else {
-      registration_->align(*output_cloud_ptr);
-    }
-    attempted_registration = true;
-    if (!registration_->hasConverged()) {
-      if (debug_flag_) {
-        RCLCPP_INFO(
-          get_logger(),
-          "Rejected loop candidate %d -> %d because registration did not converge",
-          candidate.index,
-          latest_idx);
-      }
-      continue;
-    }
-
-    const double fitness_score = registration_->getFitnessScore();
-    const Eigen::Matrix4f final_transformation = registration_->getFinalTransformation();
-    const loop_verifier::RegistrationDelta registration_delta =
-      loop_verifier::computeRegistrationDelta(final_transformation);
-
-    LoopCandidateResult candidate_result;
-    candidate_result.index = candidate.index;
-    candidate_result.selection_metric = candidate.selection_metric;
-    candidate_result.fitness_score = fitness_score;
-    candidate_result.travel_distance = latest_moving_distance - candidate_submap.distance;
-    const Eigen::Vector3d candidate_submap_pos(
-      candidate_submap.pose.position.x,
-      candidate_submap.pose.position.y,
-      candidate_submap.pose.position.z);
-    candidate_result.euclidean_distance = (latest_submap_pos - candidate_submap_pos).norm();
-    candidate_result.translation_delta_m = registration_delta.translation_m;
-    candidate_result.rotation_delta_deg = registration_delta.rotation_deg;
-    candidate_result.source = candidate.source;
-    candidate_result.used_3d_bbs = used_3d_bbs;
-    candidate_result.three_d_bbs_score_percentage = three_d_bbs_score_percentage;
-    candidate_result.three_d_bbs_elapsed_msec = three_d_bbs_elapsed_msec;
-    candidate_result.final_transformation = final_transformation;
-
-    selection.considerConverged(candidate_result);
-
-    const loop_verifier::GateResult gate = loop_verifier::evaluateGates(
-      candidate.source, fitness_score, registration_delta, gate_config);
-    if (gate.rejection != loop_verifier::GateRejection::NONE) {
-      if (debug_flag_) {
-        switch (gate.rejection) {
-          case loop_verifier::GateRejection::FITNESS:
-            RCLCPP_INFO(
-              get_logger(),
-              "Rejected loop candidate %d -> %d because fitness %.6f exceeds threshold %.6f",
-              candidate.index,
-              latest_idx,
-              fitness_score,
-              gate.score_threshold);
-            break;
-          case loop_verifier::GateRejection::TRANSLATION:
-            RCLCPP_INFO(
-              get_logger(),
-              "Rejected loop candidate %d -> %d because translation correction %.3f m "
-              "exceeds %.3f m",
-              candidate.index,
-              latest_idx,
-              registration_delta.translation_m,
-              gate.translation_cap_m);
-            break;
-          case loop_verifier::GateRejection::ROTATION:
-            RCLCPP_INFO(
-              get_logger(),
-              "Rejected loop candidate %d -> %d because rotation correction %.3f deg "
-              "exceeds %.3f deg",
-              candidate.index,
-              latest_idx,
-              registration_delta.rotation_deg,
-              gate.rotation_cap_deg);
-            break;
-          default:
-            break;
-        }
-      }
-      continue;
-    }
-
-    candidate_result.valid = true;
-    selection.considerValid(candidate_result);
   }
 
-  if (prefer_scan_context_candidates_ && selection.best_scan_context.valid) {
-    if (
-      !selection.best_valid.valid ||
-      selection.best_valid.index != selection.best_scan_context.index ||
-      selection.best_valid.source != LoopCandidate::Source::SCAN_CONTEXT)
-    {
-      std::cout << "Preferring valid ScanContext candidate id:" <<
-        selection.best_scan_context.index << " over best candidate id:" <<
-        (selection.best_valid.valid ?
-      std::to_string(selection.best_valid.index) : std::string("none"))
-                << std::endl;
-    }
-  }
-  const LoopCandidateResult best_candidate = selection.select(prefer_scan_context_candidates_);
-
-  if (!best_candidate.valid) {
-    const LoopCandidateResult & best_attempt = selection.best_attempt;
-    if (best_attempt.index >= 0) {
-      std::cout << "best_loop_candidate id:" << best_attempt.index
-                << " source:" << candidate_source_name(best_attempt.source)
-                << " latest_id:" << latest_idx
-                << " travel_distance:" << best_attempt.travel_distance
-                << " euclidean_distance:" << best_attempt.euclidean_distance
-                << " fitness:" << best_attempt.fitness_score
-                << " correction_translation:" << best_attempt.translation_delta_m
-                << " correction_rotation_deg:" << best_attempt.rotation_delta_deg
-                << " used_3d_bbs:" << best_attempt.used_3d_bbs
-                << " 3d_bbs_score:" << best_attempt.three_d_bbs_score_percentage
-                << std::endl;
-    } else if (attempted_registration && debug_flag_) {
-      RCLCPP_INFO(
-        get_logger(), "No converged loop candidate remained for latest submap %d",
-        latest_idx);
-    }
+  if (!search_output.proposal.found) {
     return;
   }
 
-  Eigen::Affine3d init_affine;
-  tf2::fromMsg(latest_submap.pose, init_affine);
-  Eigen::Affine3d submap_affine;
-  tf2::fromMsg(map_array_msg.submaps[best_candidate.index].pose, submap_affine);
-
   LoopEdge loop_edge;
-  loop_edge.pair_id = std::pair<int, int>(best_candidate.index, latest_idx);
-  loop_edge.relative_pose = loop_verifier::composeLoopRelativePose(
-    submap_affine, init_affine, best_candidate.final_transformation);
-  loop_edge.fitness_score = best_candidate.fitness_score;
+  loop_edge.pair_id = search_output.proposal.pair_id;
+  loop_edge.relative_pose = search_output.proposal.relative_pose;
+  loop_edge.fitness_score = search_output.proposal.fitness_score;
   const bool graph_changed = upsertLoopEdge(loop_edge);
-
-  std::cout << "---" << std::endl;
-  std::cout << "PoseAdjustment distance:" << best_candidate.travel_distance
-            << ", score:" << best_candidate.fitness_score << std::endl;
-  std::cout << "id_loop_point 1:" << best_candidate.index
-            << " id_loop_point 2:" << latest_idx << std::endl;
-  std::cout << "loop_candidate_source:" << candidate_source_name(best_candidate.source) <<
-    std::endl;
-  if (best_candidate.used_3d_bbs) {
-    std::cout << "3d_bbs_score_percentage:" << best_candidate.three_d_bbs_score_percentage
-              << " elapsed_msec:" << best_candidate.three_d_bbs_elapsed_msec << std::endl;
-  }
-  std::cout << "correction translation[m]:" << best_candidate.translation_delta_m
-            << " rotation[deg]:" << best_candidate.rotation_delta_deg << std::endl;
-  std::cout << "final transformation:" << std::endl;
-  std::cout << best_candidate.final_transformation << std::endl;
   if (!graph_changed) {
     std::cout << "loop edge skipped as redundant or lower quality" << std::endl;
     return;
   }
   snapshotLoopEdges(loop_edges);
   doPoseAdjustment(map_array_msg, loop_edges, use_save_map_in_loop_);
-}  // NOLINT(readability/fn_size)
+}
 
 void GraphBasedSlamComponent::doPoseAdjustment(
   lidarslam_msgs::msg::MapArray map_array_msg,

--- a/graph_based_slam/test/test_backend_core.cpp
+++ b/graph_based_slam/test/test_backend_core.cpp
@@ -37,8 +37,16 @@
 
 #include <gtest/gtest.h>
 
+#include <random>
+#include <string>
 #include <utility>
 #include <vector>
+
+#include <pclomp/ndt_omp.h>  // NOLINT(build/include_order)
+// The prebuilt ndt_omp library only instantiates PointXYZ; pull in the
+// template implementations for the PointXYZI instantiation used here.
+#include <pclomp/ndt_omp_impl.hpp>  // NOLINT(build/include_order)
+#include <pclomp/voxel_grid_covariance_omp_impl.hpp>  // NOLINT(build/include_order)
 
 #include "graph_based_slam/backend_core.hpp"
 
@@ -213,6 +221,177 @@ TEST(BackendCoreIngestion, SameOrderedInputProducesBitwiseIdenticalState)
     EXPECT_DOUBLE_EQ((solid_a.angle - solid_b.angle).cwiseAbs().maxCoeff(), 0.0);
     EXPECT_DOUBLE_EQ((solid_a.solid - solid_b.solid).cwiseAbs().maxCoeff(), 0.0);
   }
+}
+
+// --- searchLoopForSubmap characterization -------------------------------
+//
+// A revisit scenario driven by the DISTANCE source only: submap 0 and the
+// query submap share the same structured cloud near the origin, the
+// in-between submaps sit far away (and return empty clouds), so the only
+// loop candidate is 0 and real NDT verifies it.
+
+pcl::PointCloud<pcl::PointXYZI>::Ptr makeStructuredCloud()
+{
+  pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<float> jitter(-0.05f, 0.05f);
+  for (int i = 0; i < 20; ++i) {
+    for (int j = 0; j < 20; ++j) {
+      pcl::PointXYZI pt;
+      pt.x = static_cast<float>(i) - 10.0f + jitter(rng);
+      pt.y = static_cast<float>(j) - 10.0f + jitter(rng);
+      pt.z = static_cast<float>((i * 7 + j * 3) % 5) * 0.4f + jitter(rng);
+      pt.intensity = 1.0f;
+      cloud->push_back(pt);
+    }
+  }
+  return cloud;
+}
+
+std::vector<backend_core::SubmapMeta> makeRevisitTrajectory()
+{
+  std::vector<backend_core::SubmapMeta> submaps(11);
+  for (int i = 0; i < 11; ++i) {
+    submaps[i].travel_distance = 10.0 * i;
+    if (i == 0) {
+      submaps[i].pose = Eigen::Affine3d::Identity();
+    } else if (i == 10) {
+      submaps[i].pose = Eigen::Affine3d(Eigen::Translation3d(0.3, 0.0, 0.0));
+    } else {
+      submaps[i].pose = Eigen::Affine3d(Eigen::Translation3d(0.0, 1000.0 + i, 0.0));
+    }
+  }
+  return submaps;
+}
+
+BackendCore::LocalSubmapProvider makeRevisitProvider()
+{
+  return [](int idx) -> CloudPtr {
+           if (idx == 0 || idx == 10) {
+             return makeStructuredCloud();
+           }
+           return CloudPtr(new pcl::PointCloud<pcl::PointXYZI>);
+         };
+}
+
+backend_core::LoopSearchConfig makeRevisitSearchConfig()
+{
+  backend_core::LoopSearchConfig config;
+  config.search_submap_num = 1;
+  config.aggregator.max_loop_candidate_count = 3;
+  config.aggregator.distance_loop_closure = 20.0;
+  config.aggregator.range_of_searching_loop_closure = 10.0;
+  config.gates.generic_score_threshold = 10.0;
+  config.gates.max_translation_m = 10.0;
+  config.gates.max_rotation_deg = 180.0;
+  return config;
+}
+
+struct SearchHarness
+{
+  BackendCore core;
+  pclomp::NormalDistributionsTransform<pcl::PointXYZI, pcl::PointXYZI> ndt;
+  pcl::VoxelGrid<pcl::PointXYZI> voxelgrid;
+  ThreeDBBSLoopVerifier bbs_verifier;
+
+  SearchHarness()
+  {
+    DescriptorConfig descriptor_config;
+    core.configure(descriptor_config);
+    ndt.setNumThreads(1);
+    ndt.setNeighborhoodSearchMethod(pclomp::DIRECT7);
+    ndt.setResolution(2.0F);
+    ndt.setMaximumIterations(35);
+    ndt.setTransformationEpsilon(0.01);
+    voxelgrid.setLeafSize(0.2f, 0.2f, 0.2f);
+  }
+
+  backend_core::LoopSearchOutput run(const backend_core::LoopSearchConfig & config)
+  {
+    return core.searchLoopForSubmap(
+      makeRevisitTrajectory(), 10, config, makeRevisitProvider(), ndt, voxelgrid,
+      bbs_verifier);
+  }
+};
+
+TEST(BackendCoreSearch, FindsTheDistanceRevisitLoop)
+{
+  SearchHarness harness;
+  const auto output = harness.run(makeRevisitSearchConfig());
+
+  ASSERT_TRUE(output.proposal.found);
+  EXPECT_EQ(output.proposal.pair_id, (std::pair<int, int>(0, 10)));
+  EXPECT_LT(output.proposal.fitness_score, 10.0);
+  ASSERT_FALSE(output.logs.empty());
+  EXPECT_EQ(output.logs[0].text, "---");
+  EXPECT_FALSE(output.logs[0].via_logger);
+  bool has_id_line = false;
+  for (const auto & line : output.logs) {
+    if (line.text == "id_loop_point 1:0 id_loop_point 2:10") {
+      has_id_line = true;
+    }
+  }
+  EXPECT_TRUE(has_id_line);
+}
+
+TEST(BackendCoreSearch, SameInputProducesBitwiseIdenticalProposalAndLogs)
+{
+  SearchHarness harness_a;
+  SearchHarness harness_b;
+  const auto output_a = harness_a.run(makeRevisitSearchConfig());
+  const auto output_b = harness_b.run(makeRevisitSearchConfig());
+
+  ASSERT_TRUE(output_a.proposal.found);
+  ASSERT_TRUE(output_b.proposal.found);
+  EXPECT_DOUBLE_EQ(
+    (output_a.proposal.relative_pose.matrix() -
+    output_b.proposal.relative_pose.matrix()).cwiseAbs().maxCoeff(),
+    0.0);
+  EXPECT_DOUBLE_EQ(output_a.proposal.fitness_score, output_b.proposal.fitness_score);
+  ASSERT_EQ(output_a.logs.size(), output_b.logs.size());
+  for (std::size_t i = 0; i < output_a.logs.size(); ++i) {
+    EXPECT_EQ(output_a.logs[i].via_logger, output_b.logs[i].via_logger);
+    EXPECT_EQ(output_a.logs[i].text, output_b.logs[i].text);
+  }
+}
+
+TEST(BackendCoreSearch, TranslationCapRejectionKeepsBestAttemptLine)
+{
+  SearchHarness harness;
+  backend_core::LoopSearchConfig config = makeRevisitSearchConfig();
+  config.aggregator.debug = true;
+  config.gates.max_translation_m = 1e-9;
+  const auto output = harness.run(config);
+
+  EXPECT_FALSE(output.proposal.found);
+  bool has_rejection = false;
+  bool has_best_attempt = false;
+  for (const auto & line : output.logs) {
+    if (line.via_logger &&
+      line.text.rfind("Rejected loop candidate 0 -> 10 because translation correction", 0) == 0)
+    {
+      has_rejection = true;
+    }
+    if (!line.via_logger && line.text.rfind("best_loop_candidate id:0", 0) == 0) {
+      has_best_attempt = true;
+    }
+  }
+  EXPECT_TRUE(has_rejection);
+  EXPECT_TRUE(has_best_attempt);
+}
+
+TEST(BackendCoreSearch, EmptyCloudsReturnNoProposalAndNoLogs)
+{
+  SearchHarness harness;
+  const auto provider = [](int) -> CloudPtr {
+      return CloudPtr(new pcl::PointCloud<pcl::PointXYZI>);
+    };
+  const auto output = harness.core.searchLoopForSubmap(
+    makeRevisitTrajectory(), 10, makeRevisitSearchConfig(), provider, harness.ndt,
+    harness.voxelgrid, harness.bbs_verifier);
+
+  EXPECT_FALSE(output.proposal.found);
+  EXPECT_TRUE(output.logs.empty());
 }
 
 }  // namespace


### PR DESCRIPTION
## 概要

v0.6 Phase 2 第 2 弾。`searchLoopForLatest` の本体(候補生成 → registration 検証 → ゲート → 選択)を `BackendCore::searchLoopForSubmap` に移設し、`LoopEdgeProposal` を返す形にする。

- submap ポーズは shell が前変換(`SubmapMeta`)、生点群は provider コールバック(msg-vs-PCD-cache は shell の関心のまま)
- registration / voxel filter / 3D-BBS は注入 — shell とオフラインランナーが各自のインスタンスを持てる
- オペレータ可視の全行を LogLine データで返却し shell が順序どおり emit(RCLCPP フォーマットは snprintf、cout は ostringstream で**バイト同一**)
- component の `searchLoopForLatest` はメタ変換 + config 組み立て + ログ emit + エッジ upsert + doPoseAdjustment の薄いラッパーに(**2775 → 2271 行**)
- ログの行内容・順序は不変(emit タイミングのみ探索完了後に後ろ倒し)

## テスト

- 特性テスト 4 本追加(計 1085 本): 実 pclomp NDT で探索全体を実行
  - DISTANCE ソースの revisit ループを検出し pair {0,10} を構成
  - **同一入力 → proposal とログ列がインスタンス間でビット同一**(Phase 2 決定論契約を探索スコープで初検証)
  - translation cap 棄却で best_attempt 行が残る
  - 空雲は proposal なし・ログなしで早期 return
- lint 全パス(uncrustify / cpplint ほか)
- `run_release_readiness_checks.sh`: 全プロファイル PASS/TARGET_MET、`mid360_gt_rtkslam_stadtgarten_seq2` score_raw = **0.835**(系列 8 回連続ビット一致 = 挙動保存)

## 再現コマンド

```bash
colcon build --symlink-install --packages-select graph_based_slam --cmake-args -DCMAKE_BUILD_TYPE=Release
colcon test --packages-select lidarslam_msgs scanmatcher graph_based_slam lidarslam
bash scripts/run_release_readiness_checks.sh
```