### PR TITLE
feat(slam): add opt-in event-driven loop search scheduling

### DIFF
--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -176,6 +176,11 @@ private:
       const MapSaveRequest request,
       const MapSaveResponse response);
     void searchLoop();
+    // Event-driven scheduling (docs/roadmap/v0.6.md, Phase 2): drain every
+    // submap not yet used as a loop-search query, in arrival order, each
+    // against exactly the map state [0..q] so the result is a function of
+    // the data, not of how the executor batched arrivals.
+    void runEventDrivenLoopSearch();
     // Per-query loop search body, factored out of searchLoop() so the scheduler
     // can run it for one (default) or many (deterministic mode) query submaps.
     void searchLoopForLatest(
@@ -183,6 +188,10 @@ private:
       LoopEdges & loop_edges,
       int num_submaps,
       int latest_idx);
+    // Voxel-filtered local aggregate of a submap and its recent neighbors;
+    // the returned provider borrows map_array_msg and must not outlive it.
+    backend_core::BackendCore::LocalSubmapProvider makeFilteredLocalSubmapProvider(
+      const lidarslam_msgs::msg::MapArray & map_array_msg);
     bool snapshotGraphState(
       lidarslam_msgs::msg::MapArray & map_array_msg,
       LoopEdges & loop_edges,
@@ -220,6 +229,12 @@ private:
     // queries is a pure function of the map regardless of tick timing.
     bool deterministic_loop_scheduling_ {false};
     int last_searched_submap_idx_ {-1};
+    // Event-driven loop search (opt-in, v0.6 Phase 2). When true, loop search
+    // runs once per submap arrival in arrival order (each query sees exactly
+    // the map state up to itself) and the wall timer becomes a no-op; the
+    // legacy timer-driven path above stays the default. Subsumes
+    // deterministic_loop_scheduling, which is retired in Phase 3.
+    bool event_driven_loop_search_ {false};
 
     // pose graph optimization parameter
     int num_adjacent_pose_cnstraints_;

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -78,6 +78,8 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("loop_detection_period", loop_detection_period_);
   declare_parameter("deterministic_loop_scheduling", false);
   get_parameter("deterministic_loop_scheduling", deterministic_loop_scheduling_);
+  declare_parameter("event_driven_loop_search", false);
+  get_parameter("event_driven_loop_search", event_driven_loop_search_);
   declare_parameter("threshold_loop_closure_score", 1.0);
   get_parameter("threshold_loop_closure_score", threshold_loop_closure_score_);
   declare_parameter("scan_context_loop_closure_score_threshold", -1.0);
@@ -1135,24 +1137,29 @@ void GraphBasedSlamComponent::initializePubSub()
   auto map_array_callback =
     [this](const typename lidarslam_msgs::msg::MapArray::SharedPtr msg_ptr) -> void
     {
-      std::lock_guard<std::mutex> lock(mtx_);
-      map_array_msg_ = *msg_ptr;
-      // Save new submaps to PCD and clear cloud from memory
-      if (use_pcd_cache_) {
-        for (int i = 0; i < static_cast<int>(map_array_msg_.submaps.size()); i++) {
-          auto & sub = map_array_msg_.submaps[i];
-          if (sub.cloud.data.size() > 0) {
-            pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
-            pcl::fromROSMsg(sub.cloud, *cloud);
-            if (cloud->size() > 0) {
-              saveSubmapToPCD(i, cloud);
-              sub.cloud = sensor_msgs::msg::PointCloud2();  // Free memory
+      {
+        std::lock_guard<std::mutex> lock(mtx_);
+        map_array_msg_ = *msg_ptr;
+        // Save new submaps to PCD and clear cloud from memory
+        if (use_pcd_cache_) {
+          for (int i = 0; i < static_cast<int>(map_array_msg_.submaps.size()); i++) {
+            auto & sub = map_array_msg_.submaps[i];
+            if (sub.cloud.data.size() > 0) {
+              pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
+              pcl::fromROSMsg(sub.cloud, *cloud);
+              if (cloud->size() > 0) {
+                saveSubmapToPCD(i, cloud);
+                sub.cloud = sensor_msgs::msg::PointCloud2();  // Free memory
+              }
             }
           }
         }
+        initial_map_array_received_ = true;
+        is_map_array_updated_ = true;
       }
-      initial_map_array_received_ = true;
-      is_map_array_updated_ = true;
+      if (event_driven_loop_search_) {
+        runEventDrivenLoopSearch();
+      }
     };
 
   map_array_sub_ =
@@ -1307,8 +1314,55 @@ bool GraphBasedSlamComponent::upsertLoopEdge(const LoopEdge & loop_edge)
   loop_edges_.push_back(normalized);
   return true;
 }
+backend_core::BackendCore::LocalSubmapProvider
+GraphBasedSlamComponent::makeFilteredLocalSubmapProvider(
+  const lidarslam_msgs::msg::MapArray & map_array_msg)
+{
+  return [this, &map_array_msg](int ref_idx) -> pcl::PointCloud<pcl::PointXYZI>::Ptr {
+           pcl::PointCloud<pcl::PointXYZI>::Ptr aggregated_cloud(
+             new pcl::PointCloud<pcl::PointXYZI>);
+           Eigen::Affine3d reference_affine;
+           tf2::fromMsg(map_array_msg.submaps[ref_idx].pose, reference_affine);
+           for (int k = 0; k < search_submap_num_ && (ref_idx - k) >= 0; ++k) {
+             const int src_idx = ref_idx - k;
+             pcl::PointCloud<pcl::PointXYZI>::Ptr cloud;
+             if (use_pcd_cache_) {
+               cloud = loadSubmapFromPCD(src_idx);
+             } else {
+               cloud.reset(new pcl::PointCloud<pcl::PointXYZI>);
+               pcl::fromROSMsg(map_array_msg.submaps[src_idx].cloud, *cloud);
+             }
+             if (!cloud || cloud->empty()) {
+               continue;
+             }
+             Eigen::Affine3d src_affine;
+             tf2::fromMsg(map_array_msg.submaps[src_idx].pose, src_affine);
+             pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_cloud(
+               new pcl::PointCloud<pcl::PointXYZI>);
+             const Eigen::Matrix4f local_transform =
+               (reference_affine.inverse() * src_affine).matrix().cast<float>();
+             pcl::transformPointCloud(*cloud, *transformed_cloud, local_transform);
+             *aggregated_cloud += *transformed_cloud;
+           }
+
+           pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_cloud(
+             new pcl::PointCloud<pcl::PointXYZI>);
+           if (aggregated_cloud->empty()) {
+             return filtered_cloud;
+           }
+           voxelgrid_.setInputCloud(aggregated_cloud);
+           voxelgrid_.filter(*filtered_cloud);
+           return filtered_cloud;
+         };
+}
+
 void GraphBasedSlamComponent::searchLoop()
 {
+  if (event_driven_loop_search_) {
+    // Loop search runs on submap arrival (runEventDrivenLoopSearch); the
+    // wall timer stays registered only as unchanged online pacing.
+    return;
+  }
   lidarslam_msgs::msg::MapArray map_array_msg;
   LoopEdges loop_edges;
   if (!snapshotGraphState(map_array_msg, loop_edges, true)) {return;}
@@ -1322,43 +1376,7 @@ void GraphBasedSlamComponent::searchLoop()
     RCLCPP_INFO(get_logger(), "searching Loop, num_submaps:%d", num_submaps);
   }
 
-  const auto build_filtered_local_submap =
-    [this, &map_array_msg](int ref_idx) -> pcl::PointCloud<pcl::PointXYZI>::Ptr {
-      pcl::PointCloud<pcl::PointXYZI>::Ptr aggregated_cloud(
-        new pcl::PointCloud<pcl::PointXYZI>);
-      Eigen::Affine3d reference_affine;
-      tf2::fromMsg(map_array_msg.submaps[ref_idx].pose, reference_affine);
-      for (int k = 0; k < search_submap_num_ && (ref_idx - k) >= 0; ++k) {
-        const int src_idx = ref_idx - k;
-        pcl::PointCloud<pcl::PointXYZI>::Ptr cloud;
-        if (use_pcd_cache_) {
-          cloud = loadSubmapFromPCD(src_idx);
-        } else {
-          cloud.reset(new pcl::PointCloud<pcl::PointXYZI>);
-          pcl::fromROSMsg(map_array_msg.submaps[src_idx].cloud, *cloud);
-        }
-        if (!cloud || cloud->empty()) {
-          continue;
-        }
-        Eigen::Affine3d src_affine;
-        tf2::fromMsg(map_array_msg.submaps[src_idx].pose, src_affine);
-        pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_cloud(
-          new pcl::PointCloud<pcl::PointXYZI>);
-        const Eigen::Matrix4f local_transform =
-          (reference_affine.inverse() * src_affine).matrix().cast<float>();
-        pcl::transformPointCloud(*cloud, *transformed_cloud, local_transform);
-        *aggregated_cloud += *transformed_cloud;
-      }
-
-      pcl::PointCloud<pcl::PointXYZI>::Ptr filtered_cloud(
-        new pcl::PointCloud<pcl::PointXYZI>);
-      if (aggregated_cloud->empty()) {
-        return filtered_cloud;
-      }
-      voxelgrid_.setInputCloud(aggregated_cloud);
-      voxelgrid_.filter(*filtered_cloud);
-      return filtered_cloud;
-    };
+  const auto build_filtered_local_submap = makeFilteredLocalSubmapProvider(map_array_msg);
 
   // Keep every enabled descriptor database aligned 1:1 with submap indices.
   backend_core_.ingestDescriptors(num_submaps, build_filtered_local_submap);
@@ -1376,6 +1394,37 @@ void GraphBasedSlamComponent::searchLoop()
   } else {
     // Default (historical) behaviour: query only the single latest submap.
     searchLoopForLatest(map_array_msg, loop_edges, num_submaps, num_submaps - 1);
+  }
+}
+
+void GraphBasedSlamComponent::runEventDrivenLoopSearch()
+{
+  while (rclcpp::ok()) {
+    lidarslam_msgs::msg::MapArray map_array_msg;
+    LoopEdges loop_edges;
+    if (!snapshotGraphState(map_array_msg, loop_edges, false)) {return;}
+    const int num_submaps = static_cast<int>(map_array_msg.submaps.size());
+    if (num_submaps < 2) {return;}
+    int query_idx = last_searched_submap_idx_ + 1;
+    if (query_idx < 1) {query_idx = 1;}
+    if (query_idx >= num_submaps) {return;}
+    if (map_array_msg.cloud_coordinate != map_array_msg.LOCAL) {
+      RCLCPP_WARN(get_logger(), "cloud_coordinate should be local, but it's not local.");
+    }
+    if (debug_flag_) {
+      RCLCPP_INFO(
+        get_logger(), "event-driven loop search, query submap %d of %d", query_idx,
+        num_submaps);
+    }
+    // The query for submap q runs against exactly the map state [0..q]:
+    // descriptor ingestion, candidate generation and the accepted-edge pose
+    // adjustment are functions of the data up to q, independent of how the
+    // executor batched arrivals (the v0.4 D1 nondeterminism root cause).
+    map_array_msg.submaps.resize(query_idx + 1);
+    const auto build_filtered_local_submap = makeFilteredLocalSubmapProvider(map_array_msg);
+    backend_core_.ingestDescriptors(query_idx + 1, build_filtered_local_submap);
+    searchLoopForLatest(map_array_msg, loop_edges, query_idx + 1, query_idx);
+    last_searched_submap_idx_ = query_idx;
   }
 }
 
@@ -2163,6 +2212,10 @@ void GraphBasedSlamComponent::tryCreateSubmap(
 
   if (n % 50 == 0) {
     RCLCPP_INFO(get_logger(), "Odom input: %d submaps, distance: %.1fm", n, accumulated_distance_);
+  }
+
+  if (event_driven_loop_search_) {
+    runEventDrivenLoopSearch();
   }
 }
 

--- a/graph_based_slam/test/test_backend_core.cpp
+++ b/graph_based_slam/test/test_backend_core.cpp
@@ -380,44 +380,47 @@ TEST(BackendCoreSearch, TranslationCapRejectionKeepsBestAttemptLine)
   EXPECT_TRUE(has_best_attempt);
 }
 
-TEST(BackendCoreSearch, ArrivalBatchingDoesNotChangeTheResultStream)
+// Event-driven drain helper: ingest [0..q], then search q against the
+// truncated map state, for every query not yet processed.
+void drainArrivals(
+  SearchHarness & harness,
+  int & next_query,
+  int available,
+  std::vector<backend_core::LoopSearchOutput> & outputs)
 {
-  // Simulate the event-driven drain (ingest [0..q], then search q against
-  // the truncated map state) under two arrival patterns of the same
-  // 11-submap revisit stream: one-at-a-time vs two large batches. The
-  // proposal and log streams must be identical — the v0.4 D1 failure mode
-  // (results coupled to arrival batching) pinned as a core-level test.
   const auto trajectory = makeRevisitTrajectory();
   const auto provider = makeRevisitProvider();
   const auto config = makeRevisitSearchConfig();
+  while (next_query < available) {
+    harness.core.ingestDescriptors(next_query + 1, provider);
+    const std::vector<backend_core::SubmapMeta> visible(
+      trajectory.begin(), trajectory.begin() + next_query + 1);
+    outputs.push_back(
+      harness.core.searchLoopForSubmap(
+        visible, next_query, config, provider, harness.ndt, harness.voxelgrid,
+        harness.bbs_verifier));
+    ++next_query;
+  }
+}
 
-  const auto drain =
-    [&](SearchHarness & harness, int & next_query, int available,
-    std::vector<backend_core::LoopSearchOutput> & outputs) {
-      while (next_query < available) {
-        harness.core.ingestDescriptors(next_query + 1, provider);
-        const std::vector<backend_core::SubmapMeta> visible(
-          trajectory.begin(), trajectory.begin() + next_query + 1);
-        outputs.push_back(
-          harness.core.searchLoopForSubmap(
-            visible, next_query, config, provider, harness.ndt, harness.voxelgrid,
-            harness.bbs_verifier));
-        ++next_query;
-      }
-    };
-
+TEST(BackendCoreSearch, ArrivalBatchingDoesNotChangeTheResultStream)
+{
+  // Simulate the event-driven drain under two arrival patterns of the same
+  // 11-submap revisit stream: one-at-a-time vs two large batches. The
+  // proposal and log streams must be identical — the v0.4 D1 failure mode
+  // (results coupled to arrival batching) pinned as a core-level test.
   SearchHarness one_by_one;
   int next_a = 1;
   std::vector<backend_core::LoopSearchOutput> outputs_a;
   for (int available = 2; available <= 11; ++available) {
-    drain(one_by_one, next_a, available, outputs_a);
+    drainArrivals(one_by_one, next_a, available, outputs_a);
   }
 
   SearchHarness batched;
   int next_b = 1;
   std::vector<backend_core::LoopSearchOutput> outputs_b;
-  drain(batched, next_b, 6, outputs_b);
-  drain(batched, next_b, 11, outputs_b);
+  drainArrivals(batched, next_b, 6, outputs_b);
+  drainArrivals(batched, next_b, 11, outputs_b);
 
   ASSERT_EQ(outputs_a.size(), outputs_b.size());
   ASSERT_EQ(outputs_a.size(), 10u);

--- a/graph_based_slam/test/test_backend_core.cpp
+++ b/graph_based_slam/test/test_backend_core.cpp
@@ -380,6 +380,66 @@ TEST(BackendCoreSearch, TranslationCapRejectionKeepsBestAttemptLine)
   EXPECT_TRUE(has_best_attempt);
 }
 
+TEST(BackendCoreSearch, ArrivalBatchingDoesNotChangeTheResultStream)
+{
+  // Simulate the event-driven drain (ingest [0..q], then search q against
+  // the truncated map state) under two arrival patterns of the same
+  // 11-submap revisit stream: one-at-a-time vs two large batches. The
+  // proposal and log streams must be identical — the v0.4 D1 failure mode
+  // (results coupled to arrival batching) pinned as a core-level test.
+  const auto trajectory = makeRevisitTrajectory();
+  const auto provider = makeRevisitProvider();
+  const auto config = makeRevisitSearchConfig();
+
+  const auto drain =
+    [&](SearchHarness & harness, int & next_query, int available,
+    std::vector<backend_core::LoopSearchOutput> & outputs) {
+      while (next_query < available) {
+        harness.core.ingestDescriptors(next_query + 1, provider);
+        const std::vector<backend_core::SubmapMeta> visible(
+          trajectory.begin(), trajectory.begin() + next_query + 1);
+        outputs.push_back(
+          harness.core.searchLoopForSubmap(
+            visible, next_query, config, provider, harness.ndt, harness.voxelgrid,
+            harness.bbs_verifier));
+        ++next_query;
+      }
+    };
+
+  SearchHarness one_by_one;
+  int next_a = 1;
+  std::vector<backend_core::LoopSearchOutput> outputs_a;
+  for (int available = 2; available <= 11; ++available) {
+    drain(one_by_one, next_a, available, outputs_a);
+  }
+
+  SearchHarness batched;
+  int next_b = 1;
+  std::vector<backend_core::LoopSearchOutput> outputs_b;
+  drain(batched, next_b, 6, outputs_b);
+  drain(batched, next_b, 11, outputs_b);
+
+  ASSERT_EQ(outputs_a.size(), outputs_b.size());
+  ASSERT_EQ(outputs_a.size(), 10u);
+  bool any_found = false;
+  for (std::size_t i = 0; i < outputs_a.size(); ++i) {
+    EXPECT_EQ(outputs_a[i].proposal.found, outputs_b[i].proposal.found);
+    EXPECT_EQ(outputs_a[i].proposal.pair_id, outputs_b[i].proposal.pair_id);
+    EXPECT_DOUBLE_EQ(
+      outputs_a[i].proposal.fitness_score, outputs_b[i].proposal.fitness_score);
+    EXPECT_DOUBLE_EQ(
+      (outputs_a[i].proposal.relative_pose.matrix() -
+      outputs_b[i].proposal.relative_pose.matrix()).cwiseAbs().maxCoeff(),
+      0.0);
+    ASSERT_EQ(outputs_a[i].logs.size(), outputs_b[i].logs.size());
+    for (std::size_t j = 0; j < outputs_a[i].logs.size(); ++j) {
+      EXPECT_EQ(outputs_a[i].logs[j].text, outputs_b[i].logs[j].text);
+    }
+    any_found = any_found || outputs_a[i].proposal.found;
+  }
+  EXPECT_TRUE(any_found);
+}
+
 TEST(BackendCoreSearch, EmptyCloudsReturnNoProposalAndNoLogs)
 {
   SearchHarness harness;


### PR DESCRIPTION
## 概要

v0.6 Phase 2 第 3 弾。`event_driven_loop_search` パラメータ(**default off** — legacy wall-clock timer 経路が default のまま)を追加する。

on のとき:
- ループ探索は timer ではなく **submap 到着ごと**に実行(map_array callback / odom 直結入力の両経路)。未クエリの submap を到着順にドレイン
- クエリ q は **ちょうど [0..q] に切り詰めたスナップショット**に対して実行 — 記述子インジェスト・候補生成・採択時のポーズ調整が「データの関数」になり、executor の到着バッチングから切り離される(v0.4 D1 で確定した非決定性の根本原因への対処)
- wall timer は no-op 化。`deterministic_loop_scheduling` は包含(Phase 3 で廃止予定)

切り詰めの安全性: `doPoseAdjustment` はメンバーへ書き戻さず raw odometry ポーズ + 累積ループエッジから毎回グラフを再構築するため、q 時点状態での探索・調整が後続状態を壊さない。

## テスト

- 新テスト `ArrivalBatchingDoesNotChangeTheResultStream`: 同一 11-submap revisit ストリームを「1 個ずつ」vs「6+5 バッチ」でドレイン → **proposal・ログ列がビット同一**(D1 故障モードの core レベル固定)
- `colcon test`(4 パッケージ): **1086 tests, 0 failures**
- `run_release_readiness_checks.sh`(default off での無回帰): 全プロファイル PASS/TARGET_MET、stadtgarten_seq2 score_raw = **0.835**(系列 9 回連続ビット一致)
- フラグ on の実データ E2E(3-run ループエッジ集合完全一致)は次のオフラインランナー PR のハードゲートで検証

## 再現コマンド

```bash
colcon build --symlink-install --packages-select graph_based_slam --cmake-args -DCMAKE_BUILD_TYPE=Release
colcon test --packages-select lidarslam_msgs scanmatcher graph_based_slam lidarslam
bash scripts/run_release_readiness_checks.sh
```