### PR TITLE
refactor(slam): move the accepted-loop-edge set into BackendCore

### DIFF
--- a/graph_based_slam/include/graph_based_slam/backend_core.hpp
+++ b/graph_based_slam/include/graph_based_slam/backend_core.hpp
@@ -39,6 +39,7 @@
 // a provider callback, so message-vs-PCD-cache stays its concern.
 
 #include <cstdio>
+#include <cstdlib>
 #include <functional>
 #include <sstream>
 #include <string>
@@ -106,6 +107,69 @@ struct LoopEdgeProposal
   std::pair<int, int> pair_id{-1, -1};
   Eigen::Isometry3d relative_pose{Eigen::Isometry3d::Identity()};
   double fitness_score{0.0};
+};
+
+// Accepted loop edges with the nearby-pair dedup/upsert policy
+// (semantics pinned by test_backend_core.cpp). Single-threaded by
+// contract like the rest of the core; the shell serializes access.
+class LoopEdgeSet
+{
+public:
+  struct Edge
+  {
+    std::pair<int, int> pair_id{-1, -1};
+    Eigen::Isometry3d relative_pose{Eigen::Isometry3d::Identity()};
+    double fitness_score{0.0};
+  };
+
+  void configure(int dedup_index_window) {dedup_index_window_ = dedup_index_window;}
+
+  // Historical upsertLoopEdge: reject negative/self pairs, normalize the
+  // index order (swap + inverse pose), and against a nearby existing edge
+  // (both indices within the dedup window) keep the better fitness —
+  // a positive existing fitness survives unless the new edge is strictly
+  // better; a non-positive one is always replaced.
+  bool upsert(const Edge & edge)
+  {
+    if (edge.pair_id.first < 0 || edge.pair_id.second < 0) {
+      return false;
+    }
+
+    Edge normalized = edge;
+    if (normalized.pair_id.first > normalized.pair_id.second) {
+      std::swap(normalized.pair_id.first, normalized.pair_id.second);
+      normalized.relative_pose = normalized.relative_pose.inverse();
+    }
+    if (normalized.pair_id.first == normalized.pair_id.second) {
+      return false;
+    }
+
+    auto is_nearby_pair = [this](const Edge & lhs, const Edge & rhs) {
+        return std::abs(lhs.pair_id.first - rhs.pair_id.first) <= dedup_index_window_ &&
+               std::abs(lhs.pair_id.second - rhs.pair_id.second) <= dedup_index_window_;
+      };
+    for (auto & existing : edges_) {
+      if (!is_nearby_pair(existing, normalized)) {
+        continue;
+      }
+      if (existing.fitness_score > 0.0 &&
+        normalized.fitness_score >= existing.fitness_score)
+      {
+        return false;
+      }
+      existing = normalized;
+      return true;
+    }
+
+    edges_.push_back(normalized);
+    return true;
+  }
+
+  const std::vector<Edge> & edges() const {return edges_;}
+
+private:
+  int dedup_index_window_{8};
+  std::vector<Edge> edges_;
 };
 
 struct LoopSearchOutput

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -159,12 +159,7 @@ private:
     rclcpp::TimerBase::SharedPtr loop_detect_timer_;
     rclcpp::Service < std_srvs::srv::Empty > ::SharedPtr map_save_srv_;
 
-    struct LoopEdge
-    {
-      std::pair < int, int > pair_id;
-      Eigen::Isometry3d relative_pose;
-      double fitness_score {0.0};
-    };
+    using LoopEdge = backend_core::LoopEdgeSet::Edge;
     using LoopEdges = std::vector < LoopEdge >;
     using MapSaveRequestHeader = std::shared_ptr < rmw_request_id_t >;
     using MapSaveRequest = std::shared_ptr < std_srvs::srv::Empty::Request >;
@@ -269,7 +264,7 @@ private:
     bool is_map_array_updated_ {false};
     int previous_submaps_num_ {0};
 
-    LoopEdges loop_edges_;
+    backend_core::LoopEdgeSet loop_edge_set_;
 
     bool debug_flag_ {false};
 

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -482,6 +482,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       loop_edge_dedup_index_window_);
     loop_edge_dedup_index_window_ = 0;
   }
+  loop_edge_set_.configure(loop_edge_dedup_index_window_);
   if (loop_max_translation_delta_ <= 0.0) {
     RCLCPP_WARN(
       get_logger(),
@@ -1265,7 +1266,7 @@ bool GraphBasedSlamComponent::snapshotGraphState(
   }
 
   map_array_msg = map_array_msg_;
-  loop_edges = loop_edges_;
+  loop_edges = loop_edge_set_.edges();
   if (consume_map_update) {
     is_map_array_updated_ = false;
   }
@@ -1275,44 +1276,13 @@ bool GraphBasedSlamComponent::snapshotGraphState(
 void GraphBasedSlamComponent::snapshotLoopEdges(LoopEdges & loop_edges)
 {
   std::lock_guard<std::mutex> lock(mtx_);
-  loop_edges = loop_edges_;
+  loop_edges = loop_edge_set_.edges();
 }
 
 bool GraphBasedSlamComponent::upsertLoopEdge(const LoopEdge & loop_edge)
 {
-  if (loop_edge.pair_id.first < 0 || loop_edge.pair_id.second < 0) {
-    return false;
-  }
-
-  LoopEdge normalized = loop_edge;
-  if (normalized.pair_id.first > normalized.pair_id.second) {
-    std::swap(normalized.pair_id.first, normalized.pair_id.second);
-    normalized.relative_pose = normalized.relative_pose.inverse();
-  }
-  if (normalized.pair_id.first == normalized.pair_id.second) {
-    return false;
-  }
-
   std::lock_guard<std::mutex> lock(mtx_);
-  auto is_nearby_pair = [this](const LoopEdge & lhs, const LoopEdge & rhs) {
-      return std::abs(lhs.pair_id.first - rhs.pair_id.first) <= loop_edge_dedup_index_window_ &&
-             std::abs(lhs.pair_id.second - rhs.pair_id.second) <= loop_edge_dedup_index_window_;
-    };
-  for (auto & existing : loop_edges_) {
-    if (!is_nearby_pair(existing, normalized)) {
-      continue;
-    }
-    if (existing.fitness_score > 0.0 &&
-      normalized.fitness_score >= existing.fitness_score)
-    {
-      return false;
-    }
-    existing = normalized;
-    return true;
-  }
-
-  loop_edges_.push_back(normalized);
-  return true;
+  return loop_edge_set_.upsert(loop_edge);
 }
 backend_core::BackendCore::LocalSubmapProvider
 GraphBasedSlamComponent::makeFilteredLocalSubmapProvider(

--- a/graph_based_slam/test/test_backend_core.cpp
+++ b/graph_based_slam/test/test_backend_core.cpp
@@ -223,6 +223,74 @@ TEST(BackendCoreIngestion, SameOrderedInputProducesBitwiseIdenticalState)
   }
 }
 
+// --- LoopEdgeSet characterization ----------------------------------------
+
+backend_core::LoopEdgeSet::Edge makeEdge(int first, int second, double fitness)
+{
+  backend_core::LoopEdgeSet::Edge edge;
+  edge.pair_id = std::make_pair(first, second);
+  edge.relative_pose = Eigen::Isometry3d(Eigen::Translation3d(1.0, 2.0, 3.0));
+  edge.fitness_score = fitness;
+  return edge;
+}
+
+TEST(LoopEdgeSet, NormalizesPairOrderAndInvertsThePose)
+{
+  backend_core::LoopEdgeSet edge_set;
+  EXPECT_TRUE(edge_set.upsert(makeEdge(5, 2, 0.5)));
+  ASSERT_EQ(edge_set.edges().size(), 1u);
+  EXPECT_EQ(edge_set.edges()[0].pair_id, (std::pair<int, int>(2, 5)));
+  const Eigen::Isometry3d expected =
+    Eigen::Isometry3d(Eigen::Translation3d(1.0, 2.0, 3.0)).inverse();
+  EXPECT_DOUBLE_EQ(
+    (edge_set.edges()[0].relative_pose.matrix() - expected.matrix()).cwiseAbs().maxCoeff(),
+    0.0);
+}
+
+TEST(LoopEdgeSet, RejectsNegativeAndSelfPairs)
+{
+  backend_core::LoopEdgeSet edge_set;
+  EXPECT_FALSE(edge_set.upsert(makeEdge(-1, 3, 0.5)));
+  EXPECT_FALSE(edge_set.upsert(makeEdge(3, -1, 0.5)));
+  EXPECT_FALSE(edge_set.upsert(makeEdge(4, 4, 0.5)));
+  EXPECT_TRUE(edge_set.edges().empty());
+}
+
+TEST(LoopEdgeSet, NearbyPairKeepsTheStrictlyBetterFitness)
+{
+  backend_core::LoopEdgeSet edge_set;
+  edge_set.configure(8);
+  EXPECT_TRUE(edge_set.upsert(makeEdge(10, 100, 0.5)));
+  // Equal fitness within the window is rejected (>= keeps the incumbent).
+  EXPECT_FALSE(edge_set.upsert(makeEdge(12, 104, 0.5)));
+  ASSERT_EQ(edge_set.edges().size(), 1u);
+  EXPECT_EQ(edge_set.edges()[0].pair_id, (std::pair<int, int>(10, 100)));
+  // Strictly better fitness replaces the nearby edge in place.
+  EXPECT_TRUE(edge_set.upsert(makeEdge(12, 104, 0.4)));
+  ASSERT_EQ(edge_set.edges().size(), 1u);
+  EXPECT_EQ(edge_set.edges()[0].pair_id, (std::pair<int, int>(12, 104)));
+  EXPECT_DOUBLE_EQ(edge_set.edges()[0].fitness_score, 0.4);
+}
+
+TEST(LoopEdgeSet, NonPositiveExistingFitnessIsAlwaysReplaced)
+{
+  backend_core::LoopEdgeSet edge_set;
+  edge_set.configure(8);
+  EXPECT_TRUE(edge_set.upsert(makeEdge(10, 100, 0.0)));
+  EXPECT_TRUE(edge_set.upsert(makeEdge(10, 100, 5.0)));
+  ASSERT_EQ(edge_set.edges().size(), 1u);
+  EXPECT_DOUBLE_EQ(edge_set.edges()[0].fitness_score, 5.0);
+}
+
+TEST(LoopEdgeSet, DistantPairAppends)
+{
+  backend_core::LoopEdgeSet edge_set;
+  edge_set.configure(8);
+  EXPECT_TRUE(edge_set.upsert(makeEdge(10, 100, 0.5)));
+  EXPECT_TRUE(edge_set.upsert(makeEdge(30, 200, 0.9)));
+  EXPECT_EQ(edge_set.edges().size(), 2u);
+}
+
 // --- searchLoopForSubmap characterization -------------------------------
 //
 // A revisit scenario driven by the DISTANCE source only: submap 0 and the


### PR DESCRIPTION
## 概要

v0.6 Phase 2 第 4 弾(小)。採択ループエッジの蓄積と dedup/upsert ポリシーを `backend_core::LoopEdgeSet` に移設する。

- `upsertLoopEdge` の歴史的セマンティクスを逐語移植: 負/自己ペア棄却、インデックス順正規化(swap + 逆ポーズ)、dedup window 内は「正の fitness の既存エッジは新エッジが厳密に良い時のみ置換、非正の既存は常に置換」
- component の `upsertLoopEdge` は lock + 委譲に、`LoopEdge` 型は core の `Edge` の alias に
- roadmap のコア 4 状態(SubmapStore・DescriptorIndexes・**LoopEdgeSet**・PoseGraph)の 3 つ目が core 入り — 次のオフライン決定論ランナーが ROS component なしでエッジを蓄積するための前提

## テスト

- 特性テスト 5 本追加(`test_backend_core.cpp`、計 **1091 tests, 0 failures**): 正規化 + ポーズ逆変換のビット一致、棄却 2 種、fitness 置換の両分岐(>= 棄却 / 非正は常時置換)、window 外 append
- `run_release_readiness_checks.sh`: 全プロファイル PASS/TARGET_MET、stadtgarten_seq2 score_raw = **0.835**(系列 10 回連続ビット一致)

## 再現コマンド

```bash
colcon build --symlink-install --packages-select graph_based_slam --cmake-args -DCMAKE_BUILD_TYPE=Release
colcon test --packages-select lidarslam_msgs scanmatcher graph_based_slam lidarslam
bash scripts/run_release_readiness_checks.sh
```