### PR TITLE
feat(release): wire the offline determinism hard gate into the release readiness checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,8 @@ python3 scripts/simple_lanelet2_generator.py \
 | スクリプト | 用途 |
 |-----------|------|
 | `run_default_ci_checks.sh` | ローカル CI（ビルド＋テスト）|
-| `run_release_readiness_checks.sh` | リリースゲート（APE 閾値）|
+| `run_release_readiness_checks.sh` | リリースゲート（APE 閾値、`--offline-determinism-bag` で決定論ハードゲート）|
+| `run_offline_determinism_check.sh` | オフラインバックエンド決定論ゲート（N-run バイト一致 + 任意 APE レポート）|
 | `run_rko_lio_graph_benchmark.sh` | ベンチマークパイプライン |
 | `run_autoware_quickstart.sh` | NTU VIRAL → Autoware マップ E2E |
 | `download_ntu_viral_tnp01.sh` | NTU VIRAL データダウンロード |

--- a/docs/roadmap/v0.6.md
+++ b/docs/roadmap/v0.6.md
@@ -122,6 +122,12 @@ rule after).
 - **Gate (hard)**: offline runner produces an *identical* loop-edge set
   across 3 runs on the MID-360 and NTU substrates; live mode within noise of
   legacy on the release gates.
+- Status 2026-06-12: MID-360 substrate **passed** (3 runs, byte-identical
+  `loop_edges.csv` *and* `trajectory_optimized.tum`, 2766 input pairs /
+  640 submaps / 1079 m; the Phase 0 harness produced a different edge set
+  every run on the same bag). The gate is wired into
+  `run_release_readiness_checks.sh --offline-determinism-bag`. The NTU
+  substrate needs a recorded backend-input bag first (follow-up).
 
 ### Phase 3 — default flip + cleanup
 - Flip the default to event-driven on release-gate evidence; retire

--- a/docs/roadmap/v0.6.md
+++ b/docs/roadmap/v0.6.md
@@ -122,12 +122,13 @@ rule after).
 - **Gate (hard)**: offline runner produces an *identical* loop-edge set
   across 3 runs on the MID-360 and NTU substrates; live mode within noise of
   legacy on the release gates.
-- Status 2026-06-12: MID-360 substrate **passed** (3 runs, byte-identical
-  `loop_edges.csv` *and* `trajectory_optimized.tum`, 2766 input pairs /
-  640 submaps / 1079 m; the Phase 0 harness produced a different edge set
-  every run on the same bag). The gate is wired into
-  `run_release_readiness_checks.sh --offline-determinism-bag`. The NTU
-  substrate needs a recorded backend-input bag first (follow-up).
+- Status 2026-06-12: **passed on both substrates** (3 runs each,
+  byte-identical `loop_edges.csv` *and* `trajectory_optimized.tum`).
+  MID-360: 2766 input pairs / 640 submaps / 1079 m, 1 loop edge; the
+  Phase 0 harness produced a different edge set every run on the same bag.
+  NTU tnp_01: 5790 input pairs, 9 loop edges, APE vs the Leica GT
+  identical to the last digit (0.8460511516520233) across runs. The gate
+  is wired into `run_release_readiness_checks.sh --offline-determinism-bag`.
 
 ### Phase 3 — default flip + cleanup
 - Flip the default to event-driven on release-gate evidence; retire

--- a/scripts/run_offline_determinism_check.sh
+++ b/scripts/run_offline_determinism_check.sh
@@ -3,13 +3,20 @@ set -euo pipefail
 
 # Phase 2 hard gate (docs/roadmap/v0.6.md): run the offline deterministic
 # backend runner N times on the same recorded backend-input bag and require
-# the loop-edge sets to be byte-identical across runs.
+# the loop-edge sets AND the optimized trajectories to be byte-identical
+# across runs.
 #
 # Usage:
 #   bash scripts/run_offline_determinism_check.sh \
 #     --bag output/backend_replay_x/backend_input \
 #     [--params lidarslam/param/lidarslam_mid360_rko_graph.yaml] \
-#     [--runs 3] [--output-dir output/offline_determinism_<timestamp>]
+#     [--runs 3] [--output-dir output/offline_determinism_<timestamp>] \
+#     [--reference-tum output/glim_mid360_reference.tum]
+#
+# When --reference-tum is given, each run's trajectory_optimized.tum is also
+# scored with scripts/ape_from_tum.py (report only; the gate is byte
+# identity, not an APE threshold). A markdown summary in the same shape as
+# the legacy backend_replay_summary.md is always written.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -18,6 +25,7 @@ BAG=""
 PARAMS="${REPO_ROOT}/lidarslam/param/lidarslam_mid360_rko_graph.yaml"
 RUNS=3
 OUTPUT_DIR="${REPO_ROOT}/output/offline_determinism_$(date +%Y%m%d_%H%M%S)"
+REFERENCE_TUM=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -25,6 +33,7 @@ while [[ $# -gt 0 ]]; do
     --params) PARAMS="$2"; shift 2 ;;
     --runs) RUNS="$2"; shift 2 ;;
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    --reference-tum) REFERENCE_TUM="$2"; shift 2 ;;
     *) echo "unknown option: $1" >&2; exit 2 ;;
   esac
 done
@@ -58,22 +67,64 @@ for i in $(seq 1 "${RUNS}"); do
     -p bag_path:="${BAG}" \
     -p output_dir:="${run_dir}" \
     > "${run_dir}/runner.log" 2>&1
-  md5sum "${run_dir}/loop_edges.csv"
+  md5sum "${run_dir}/loop_edges.csv" "${run_dir}/trajectory_optimized.tum"
+  if [[ -n "${REFERENCE_TUM}" ]]; then
+    python3 "${SCRIPT_DIR}/ape_from_tum.py" \
+      --ref "${REFERENCE_TUM}" \
+      --est "${run_dir}/trajectory_optimized.tum" \
+      --out "${run_dir}/ape.txt" \
+      > "${run_dir}/ape_postprocess.log" 2>&1 \
+      || echo "WARN: APE post-processing failed in run ${i}; continuing" >&2
+  fi
 done
 
+ape_rmse_for_run() {
+  local run_dir="$1"
+  if [[ -f "${run_dir}/ape.txt" ]]; then
+    awk '/^\s*rmse:/ {print $2; exit}' "${run_dir}/ape.txt"
+  fi
+}
+
 echo "--- verdict"
-reference="${OUTPUT_DIR}/run1/loop_edges.csv"
-edge_count=$(($(wc -l < "${reference}") - 1))
+edges_ref="${OUTPUT_DIR}/run1/loop_edges.csv"
+traj_ref="${OUTPUT_DIR}/run1/trajectory_optimized.tum"
+edge_count=$(($(wc -l < "${edges_ref}") - 1))
 status=0
 for i in $(seq 2 "${RUNS}"); do
-  if ! diff -q "${reference}" "${OUTPUT_DIR}/run${i}/loop_edges.csv" > /dev/null; then
-    echo "MISMATCH: run1 vs run${i}"
-    diff "${reference}" "${OUTPUT_DIR}/run${i}/loop_edges.csv" | head -10 || true
+  if ! diff -q "${edges_ref}" "${OUTPUT_DIR}/run${i}/loop_edges.csv" > /dev/null; then
+    echo "MISMATCH (loop edges): run1 vs run${i}"
+    diff "${edges_ref}" "${OUTPUT_DIR}/run${i}/loop_edges.csv" | head -10 || true
+    status=1
+  fi
+  if ! diff -q "${traj_ref}" "${OUTPUT_DIR}/run${i}/trajectory_optimized.tum" > /dev/null; then
+    echo "MISMATCH (optimized trajectory): run1 vs run${i}"
     status=1
   fi
 done
+
+summary="${OUTPUT_DIR}/offline_determinism_summary.md"
+{
+  echo "| run | ape_rmse | n_loop_edges | loop_edges_md5 | trajectory_md5 |"
+  echo "| --- | ---: | ---: | --- | --- |"
+  for i in $(seq 1 "${RUNS}"); do
+    run_dir="${OUTPUT_DIR}/run${i}"
+    n_edges=$(($(wc -l < "${run_dir}/loop_edges.csv") - 1))
+    edges_md5=$(md5sum "${run_dir}/loop_edges.csv" | cut -c1-12)
+    traj_md5=$(md5sum "${run_dir}/trajectory_optimized.tum" | cut -c1-12)
+    rmse=$(ape_rmse_for_run "${run_dir}")
+    echo "| run${i} | ${rmse:-n/a} | ${n_edges} | \`${edges_md5}\` | \`${traj_md5}\` |"
+  done
+  echo ""
+  if [[ ${status} -eq 0 ]]; then
+    echo "edge_sets_identical: true"
+    echo "optimized_trajectories_identical: true"
+  else
+    echo "edge_sets_or_trajectories_identical: false"
+  fi
+} | tee "${summary}"
+
 if [[ ${status} -eq 0 ]]; then
-  echo "DETERMINISM_OK: ${RUNS} runs produced byte-identical loop_edges.csv (${edge_count} edges)"
+  echo "DETERMINISM_OK: ${RUNS} runs produced byte-identical loop_edges.csv and trajectory_optimized.tum (${edge_count} edges)"
 else
   echo "DETERMINISM_FAILED"
 fi

--- a/scripts/run_release_readiness_checks.sh
+++ b/scripts/run_release_readiness_checks.sh
@@ -38,6 +38,19 @@ Options:
                                 Override segment-reset dashboard HTML
   --public-mid360-min-segment-rko-poses <n>
                                 Minimum TUM poses for each reset segment
+  --offline-determinism-bag <dir>
+                                Run the offline backend determinism hard gate
+                                (Phase 2, docs/roadmap/v0.6.md) on this
+                                recorded backend-input bag; any byte-level
+                                mismatch across runs fails the gate
+  --offline-determinism-runs <n>
+                                Run count for the determinism gate (default: 3)
+  --offline-determinism-params <yaml>
+                                Parameter file for the determinism gate
+                                (default: lidarslam/param/lidarslam_mid360_rko_graph.yaml)
+  --offline-determinism-reference-tum <tum>
+                                Optional reference trajectory; adds per-run APE
+                                to the determinism report (report only)
   --dogfood                     Run the Autoware pointcloud-map dogfood flow
   --autoware-core-dir <dir>     autoware_core checkout for dogfood
   --work-dir <dir>              Runtime workspace directory for dogfood
@@ -51,7 +64,9 @@ It can run:
   1. local build/test verification
   2. benchmark summary and HTML report generation from existing metrics.json runs
   3. optional public MID-360 segment-reset completion gate
-  4. optional Autoware map dogfood
+  4. optional offline backend determinism hard gate (byte-identical loop edges
+     and optimized trajectory across N runs on a recorded backend-input bag)
+  5. optional Autoware map dogfood
 
 When --ape-threshold is provided, the benchmark summary becomes a hard gate and
 the script exits non-zero if any selected run is missing APE or exceeds the
@@ -89,6 +104,11 @@ PUBLIC_MID360_SEGMENT_MAP_ALIGNMENT=""
 PUBLIC_MID360_ADOPTION_GATE=""
 PUBLIC_MID360_DASHBOARD_HTML=""
 PUBLIC_MID360_MIN_SEGMENT_RKO_POSES=""
+
+OFFLINE_DETERMINISM_BAG=""
+OFFLINE_DETERMINISM_RUNS=""
+OFFLINE_DETERMINISM_PARAMS=""
+OFFLINE_DETERMINISM_REFERENCE_TUM=""
 
 AUTOWARE_CORE_DIR=""
 WORK_DIR=""
@@ -186,6 +206,26 @@ while [[ $# -gt 0 ]]; do
     --public-mid360-min-segment-rko-poses)
       [[ $# -ge 2 ]] || usage
       PUBLIC_MID360_MIN_SEGMENT_RKO_POSES="$2"
+      shift 2
+      ;;
+    --offline-determinism-bag)
+      [[ $# -ge 2 ]] || usage
+      OFFLINE_DETERMINISM_BAG=$(realpath -m "$2")
+      shift 2
+      ;;
+    --offline-determinism-runs)
+      [[ $# -ge 2 ]] || usage
+      OFFLINE_DETERMINISM_RUNS="$2"
+      shift 2
+      ;;
+    --offline-determinism-params)
+      [[ $# -ge 2 ]] || usage
+      OFFLINE_DETERMINISM_PARAMS=$(realpath -m "$2")
+      shift 2
+      ;;
+    --offline-determinism-reference-tum)
+      [[ $# -ge 2 ]] || usage
+      OFFLINE_DETERMINISM_REFERENCE_TUM=$(realpath -m "$2")
       shift 2
       ;;
     --dogfood)
@@ -314,6 +354,26 @@ if [[ "${RUN_PUBLIC_MID360_COMPLETION}" == "true" ]]; then
   "${PUBLIC_MID360_CMD[@]}" 2>&1 | tee "${OUT_DIR}/public_mid360_completion_gate.log"
 fi
 
+if [[ -n "${OFFLINE_DETERMINISM_BAG}" ]]; then
+  echo "==> Running offline backend determinism hard gate"
+  OFFLINE_DETERMINISM_CMD=(
+    bash
+    "${REPO_ROOT}/scripts/run_offline_determinism_check.sh"
+    --bag "${OFFLINE_DETERMINISM_BAG}"
+    --output-dir "${OUT_DIR}/offline_determinism"
+  )
+  if [[ -n "${OFFLINE_DETERMINISM_RUNS}" ]]; then
+    OFFLINE_DETERMINISM_CMD+=(--runs "${OFFLINE_DETERMINISM_RUNS}")
+  fi
+  if [[ -n "${OFFLINE_DETERMINISM_PARAMS}" ]]; then
+    OFFLINE_DETERMINISM_CMD+=(--params "${OFFLINE_DETERMINISM_PARAMS}")
+  fi
+  if [[ -n "${OFFLINE_DETERMINISM_REFERENCE_TUM}" ]]; then
+    OFFLINE_DETERMINISM_CMD+=(--reference-tum "${OFFLINE_DETERMINISM_REFERENCE_TUM}")
+  fi
+  "${OFFLINE_DETERMINISM_CMD[@]}" 2>&1 | tee "${OUT_DIR}/offline_determinism.log"
+fi
+
 if [[ "${RUN_DOGFOOD}" == "true" ]]; then
   echo "==> Running Autoware pointcloud-map dogfood"
   DOGFOOD_CMD=(
@@ -356,4 +416,7 @@ fi
 if [[ -n "${PUBLIC_MID360_COMPLETION_OUTPUT_DIR}" \
   && -f "${PUBLIC_MID360_COMPLETION_OUTPUT_DIR}/mid360_robot_public_completion_gate.md" ]]; then
   echo "  public_mid360_completion_gate_md: ${PUBLIC_MID360_COMPLETION_OUTPUT_DIR}/mid360_robot_public_completion_gate.md"
+fi
+if [[ -f "${OUT_DIR}/offline_determinism/offline_determinism_summary.md" ]]; then
+  echo "  offline_determinism_summary_md: ${OUT_DIR}/offline_determinism/offline_determinism_summary.md"
 fi


### PR DESCRIPTION
## Summary

Institutionalizes the Phase 2 hard gate (docs/roadmap/v0.6.md) so backend determinism is checked by the release gate from now on, not just measured once.

- `scripts/run_offline_determinism_check.sh`
  - The gate now requires **both** `loop_edges.csv` **and** `trajectory_optimized.tum` to be byte-identical across runs (the optimized trajectory was verified to be deterministic too, so the stronger check is free).
  - New `--reference-tum` option adds per-run APE (via `scripts/ape_from_tum.py`) to the report. Report only — the gate stays byte identity, not an APE threshold.
  - Always writes `offline_determinism_summary.md` in the same shape as the legacy `backend_replay_summary.md` so the before/after comparison is one table.
- `scripts/run_release_readiness_checks.sh`
  - New opt-in stage `--offline-determinism-bag <dir>` (+ `--offline-determinism-runs/-params/-reference-tum`). Any byte-level mismatch fails the release gate (non-zero exit).
- `docs/roadmap/v0.6.md`: Phase 2 hard-gate status recorded — **passed on both required substrates (MID-360 + NTU)**.

## Evidence

**MID-360** (recorded backend-input bag, 2766 odometry/cloud pairs, 640 submaps, 1079 m):

| run | ape_rmse | n_loop_edges | loop_edges_md5 | trajectory_md5 |
| --- | ---: | ---: | --- | --- |
| run1 | 7.262851264566504 | 1 | `feee9547ccaa` | `92676db47106` |
| run2 | 7.262851264566504 | 1 | `feee9547ccaa` | `92676db47106` |
| run3 | 7.262851264566504 | 1 | `feee9547ccaa` | `92676db47106` |

For contrast, the legacy live-replay harness on the **same bag** (`output/backend_replay_mid360_p1after/backend_replay_summary.md`): APE 7.17–7.23 (σ 0.032) against the same GLIM reference, and a **different** loop-edge set every run. The offline path reproduces the APE to the last digit.

**NTU VIRAL tnp_01** (newly recorded backend-input bag, 5790 pairs, 1:1):

| run | ape_rmse (vs Leica GT) | n_loop_edges | loop_edges_md5 | trajectory_md5 |
| --- | ---: | ---: | --- | --- |
| run1 | 0.8460511516520233 | 9 | `3834e121197c` | `bdbba9f742a9` |
| run2 | 0.8460511516520233 | 9 | `3834e121197c` | `bdbba9f742a9` |
| run3 | 0.8460511516520233 | 9 | `3834e121197c` | `bdbba9f742a9` |

9 loop edges byte-identical across runs — a much stronger exercise of the candidate/verification path than the single-edge MID-360 substrate.

## Validation

```bash
bash scripts/run_release_readiness_checks.sh --fail-on-profiles \
  --offline-determinism-bag output/backend_replay_mid360_p1after/backend_input \
  --offline-determinism-reference-tum output/glim_mid360_reference.tum
```

- Full release gate PASS with the new stage enabled (all profiles PASS/TARGET_MET; `mid360_gt_rtkslam_stadtgarten_seq2` raw **0.835** — 12th consecutive bit-identical result across this refactor track).
- `bash -n` clean on both scripts; shell-only change, no C++ touched.
