### PR TITLE
feat(slam)!: default to event-driven loop search and retire deterministic_loop_scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ artifacts you need downstream:
   ([accuracy](#accuracy)).
 - **Loop closure, GPL-free** — built-in Scan Context by default, plus opt-in
   BEV / SOLiD / STD/BTC-style Triangle descriptors and 3D-BBS verification.
+- **Deterministic offline mapping** — `graph_slam_offline_runner` replays a
+  recorded odometry bag through the backend and produces *byte-identical* loop
+  edges and optimized trajectory on every run (verified 3-run on MID-360 and
+  NTU VIRAL); the release gate enforces it
+  (`run_release_readiness_checks.sh --offline-determinism-bag`).
 - **GNSS georeferencing** — optional GNSS constraints and projector metadata for
   real-world coordinates.
 

--- a/docs/roadmap/v0.6.md
+++ b/docs/roadmap/v0.6.md
@@ -136,6 +136,14 @@ rule after).
   one release later.
 - Docs: comparison.md caveats shrink; README gains an honest
   "deterministic offline mapping" claim (also publicity material).
+- Status 2026-06-12: flipped. Live event-driven evidence: NTU tnp_01 live
+  bench corrected APE 0.965 (gate pass <= 1.00); MID-360 live replay on the
+  recorded bag improved to APE 6.28-6.49 vs legacy 7.17-7.23, with
+  near-identical edge sets across runs (same loop region, +/- a few submap
+  indices from input-boundary message timing) vs a completely different
+  edge set per run on legacy. Live mode is *not* claimed byte-deterministic
+  — that contract stays with the offline runner. The legacy timer path
+  stays behind `event_driven_loop_search: false` for one release.
 
 ### Phase 4 — scanmatcher core/shell
 - Same pattern on `scanmatcher_component.cpp` (2140 lines): extract the

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -554,8 +554,8 @@ if(BUILD_TESTING)
     TIMEOUT 60
   )
   ament_add_pytest_test(
-    test_deterministic_loop_scheduling_defaults
-    test/test_deterministic_loop_scheduling_defaults.py
+    test_event_driven_loop_search_defaults
+    test/test_event_driven_loop_search_defaults.py
     TIMEOUT 60
   )
   ament_add_pytest_test(

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -217,20 +217,15 @@ private:
     // -1.0 = disabled / fall back to the generic cap.
     double loop_max_translation_delta_descriptor_ {-1.0};
     double loop_max_rotation_delta_deg_descriptor_ {-1.0};
-    // Deterministic loop scheduling (opt-in, v0.4 D1). When false (default),
-    // searchLoop queries only the single latest submap per timer tick — the
-    // historical wall-clock-driven behaviour, whose (query, db) pair set depends
-    // on timer batching rather than the map. When true, searchLoop catches up
-    // over every submap index not yet used as a query, so the set of loop-search
-    // queries is a pure function of the map regardless of tick timing.
-    bool deterministic_loop_scheduling_ {false};
     int last_searched_submap_idx_ {-1};
-    // Event-driven loop search (opt-in, v0.6 Phase 2). When true, loop search
-    // runs once per submap arrival in arrival order (each query sees exactly
-    // the map state up to itself) and the wall timer becomes a no-op; the
-    // legacy timer-driven path above stays the default. Subsumes
-    // deterministic_loop_scheduling, which is retired in Phase 3.
-    bool event_driven_loop_search_ {false};
+    // Event-driven loop search (default on since v0.6 Phase 3). When true,
+    // loop search runs once per submap arrival in arrival order (each query
+    // sees exactly the map state up to itself) and the wall timer becomes a
+    // no-op. When false, the legacy wall-clock timer path queries only the
+    // single latest submap per tick (scheduled for removal one release after
+    // the default flip). Subsumes the retired deterministic_loop_scheduling
+    // parameter (v0.4 D1).
+    bool event_driven_loop_search_ {true};
 
     // pose graph optimization parameter
     int num_adjacent_pose_cnstraints_;

--- a/graph_based_slam/param/graphbasedslam.yaml
+++ b/graph_based_slam/param/graphbasedslam.yaml
@@ -4,12 +4,13 @@ graph_based_slam:
       ndt_resolution: 1.5
       voxel_leaf_size: 0.2
       loop_detection_period: 3000
-      # Opt-in (v0.4 D1). false = query only the latest submap per timer tick
-      # (historical wall-clock-driven behaviour). true = deterministically catch
-      # up over every un-queried submap so the loop-search query set no longer
-      # depends on timer batching. Default off; flip to true only after the
-      # 8-vs-16 reproducibility validation.
-      deterministic_loop_scheduling: false
+      # Default on (v0.6 Phase 3). true = loop search runs once per submap
+      # arrival in arrival order, so the (query, db) pair set is a pure
+      # function of the input stream instead of wall-clock timer batching.
+      # false = legacy timer path (latest submap only per tick), kept for one
+      # release after the default flip. Replaces the retired
+      # deterministic_loop_scheduling parameter.
+      event_driven_loop_search: true
       threshold_loop_closure_score: 1.5
       scan_context_loop_closure_score_threshold: -1.0
       distance_loop_closure: 30.0

--- a/graph_based_slam/param/graphbasedslam_indoor.yaml
+++ b/graph_based_slam/param/graphbasedslam_indoor.yaml
@@ -4,12 +4,13 @@ graph_based_slam:
       ndt_resolution: 1.5
       voxel_leaf_size: 0.2
       loop_detection_period: 3000
-      # Opt-in (v0.4 D1). false = query only the latest submap per timer tick
-      # (historical wall-clock-driven behaviour). true = deterministically catch
-      # up over every un-queried submap so the loop-search query set no longer
-      # depends on timer batching. Default off; flip to true only after the
-      # 8-vs-16 reproducibility validation.
-      deterministic_loop_scheduling: false
+      # Default on (v0.6 Phase 3). true = loop search runs once per submap
+      # arrival in arrival order, so the (query, db) pair set is a pure
+      # function of the input stream instead of wall-clock timer batching.
+      # false = legacy timer path (latest submap only per tick), kept for one
+      # release after the default flip. Replaces the retired
+      # deterministic_loop_scheduling parameter.
+      event_driven_loop_search: true
       threshold_loop_closure_score: 1.5
       scan_context_loop_closure_score_threshold: -1.0
       distance_loop_closure: 30.0

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -76,9 +76,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("ndt_num_threads", ndt_num_threads);
   declare_parameter("loop_detection_period", 1000);
   get_parameter("loop_detection_period", loop_detection_period_);
-  declare_parameter("deterministic_loop_scheduling", false);
-  get_parameter("deterministic_loop_scheduling", deterministic_loop_scheduling_);
-  declare_parameter("event_driven_loop_search", false);
+  declare_parameter("event_driven_loop_search", true);
   get_parameter("event_driven_loop_search", event_driven_loop_search_);
   declare_parameter("threshold_loop_closure_score", 1.0);
   get_parameter("threshold_loop_closure_score", threshold_loop_closure_score_);
@@ -1333,20 +1331,11 @@ void GraphBasedSlamComponent::searchLoop()
   // Keep every enabled descriptor database aligned 1:1 with submap indices.
   backend_core_.ingestDescriptors(num_submaps, build_filtered_local_submap);
 
-  if (deterministic_loop_scheduling_) {
-    // Catch up over every submap not yet used as a loop-search query so the
-    // query set is a deterministic function of the map, independent of how the
-    // wall-clock timer batched submap arrivals (v0.4 D1 reproducibility fix).
-    int query_start = last_searched_submap_idx_ + 1;
-    if (query_start < 1) {query_start = 1;}
-    for (int q = query_start; q < num_submaps; ++q) {
-      searchLoopForLatest(map_array_msg, loop_edges, num_submaps, q);
-    }
-    last_searched_submap_idx_ = num_submaps - 1;
-  } else {
-    // Default (historical) behaviour: query only the single latest submap.
-    searchLoopForLatest(map_array_msg, loop_edges, num_submaps, num_submaps - 1);
-  }
+  // Legacy (historical) behaviour: query only the single latest submap per
+  // timer tick. The deterministic_loop_scheduling catch-up variant (v0.4 D1)
+  // was retired in v0.6 Phase 3 — event-driven loop search subsumes it by
+  // querying every submap in arrival order.
+  searchLoopForLatest(map_array_msg, loop_edges, num_submaps, num_submaps - 1);
 }
 
 void GraphBasedSlamComponent::runEventDrivenLoopSearch()

--- a/graph_based_slam/test/test_event_driven_loop_search_defaults.py
+++ b/graph_based_slam/test/test_event_driven_loop_search_defaults.py
@@ -28,13 +28,16 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 """
-Regression tests for the deterministic_loop_scheduling default (v0.4 D1).
+Regression tests for the event_driven_loop_search default (v0.6 Phase 3).
 
-deterministic_loop_scheduling is the opt-in flag that switches searchLoop from
-the historical wall-clock-driven single-latest query to a deterministic
-catch-up over every un-queried submap. It MUST default off so the published
-benchmark behaviour stays the validated single-latest path; flipping it on is a
-behaviour change that needs the 8-vs-16 reproducibility validation first.
+event_driven_loop_search runs loop search once per submap arrival in arrival
+order, making the (query, db) pair set a pure function of the input stream
+instead of wall-clock timer batching (the v0.4 D1 nondeterminism root cause).
+It defaults ON since the v0.6 Phase 3 flip; the shipped parameter files must
+document the flag and keep it on so the published behaviour matches the
+determinism evidence (offline 3-run byte-identical loop edges on the MID-360
+and NTU substrates). The retired deterministic_loop_scheduling parameter must
+not reappear.
 """
 
 from __future__ import annotations
@@ -61,19 +64,28 @@ def _load_graph_params(path: Path) -> dict:
 
 
 @pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
-def test_deterministic_loop_scheduling_present(path):
+def test_event_driven_loop_search_present(path):
     params = _load_graph_params(path)
-    assert 'deterministic_loop_scheduling' in params, (
-        f'{path.name}: deterministic_loop_scheduling must be documented so '
-        'operators can discover the opt-in flag'
+    assert 'event_driven_loop_search' in params, (
+        f'{path.name}: event_driven_loop_search must be documented so '
+        'operators can discover the legacy-timer escape hatch'
     )
 
 
 @pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
-def test_deterministic_loop_scheduling_defaults_off(path):
+def test_event_driven_loop_search_defaults_on(path):
     params = _load_graph_params(path)
-    assert params['deterministic_loop_scheduling'] is False, (
-        f'{path.name}: deterministic_loop_scheduling must default off so the '
-        'published single-latest benchmark behaviour stays unchanged until the '
-        '8-vs-16 reproducibility validation lands'
+    assert params['event_driven_loop_search'] is True, (
+        f'{path.name}: event_driven_loop_search must stay on so the shipped '
+        'behaviour matches the v0.6 determinism evidence (3-run byte-identical '
+        'loop edges); the legacy timer path is an opt-out, not the default'
+    )
+
+
+@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
+def test_deterministic_loop_scheduling_is_retired(path):
+    params = _load_graph_params(path)
+    assert 'deterministic_loop_scheduling' not in params, (
+        f'{path.name}: deterministic_loop_scheduling was retired in v0.6 '
+        'Phase 3 (subsumed by event_driven_loop_search) and must not reappear'
     )


### PR DESCRIPTION
## Summary

v0.6 **Phase 3** (docs/roadmap/v0.6.md): flip the loop-search default to event-driven and retire `deterministic_loop_scheduling`.

- `event_driven_loop_search` now **defaults on**: loop search runs once per submap arrival in arrival order, each query seeing exactly the map state up to itself — the (query, db) pair set becomes a pure function of the input stream instead of wall-clock timer batching (the v0.4 D1 nondeterminism root cause).
- The legacy timer path stays available behind `event_driven_loop_search: false` for one release, then gets removed.
- `deterministic_loop_scheduling` (v0.4 D1 opt-in catch-up on the timer path) is **retired** — event-driven scheduling subsumes it. The regression test now pins `event_driven_loop_search: true` in the shipped param files and asserts the retired parameter does not reappear.
- README gains the "deterministic offline mapping" claim (offline runner + release-gate enforcement, landed in #254/#255).

## Evidence for the flip

**NTU VIRAL tnp_01, live bench with event-driven on**: corrected APE **0.965** — passes the `ntu_viral_tnp_01` profile (pass ≤ 1.00).

**MID-360 live replay variance** (same recorded backend-input bag as the Phase 0/2 measurements, 3 runs each):

| | legacy live (Phase 1) | event-driven live | offline runner |
|---|---|---|---|
| APE vs GLIM ref | 7.17–7.23 (σ 0.032) | **6.28–6.49** (σ 0.111) | 7.263, identical to the last digit |
| loop-edge sets | completely different every run | near-identical (same loop region, ± a few submap indices) | byte-identical |

The residual live variance comes from the input boundary (pub/sub message timing shifts submap creation), not the search logic — live mode is *not* claimed byte-deterministic; that contract stays with the offline runner, as documented.

**Offline determinism unaffected** (the runner drives the core explicitly): gate md5 unchanged (`feee9547`).

## Validation

- `colcon test` graph_based_slam: **971 tests, 0 failures** (+6 new default-pin tests)
- `ament_uncrustify` / `ament_flake8` clean on changed files
- Full release gate PASS with the determinism stage enabled: all profiles PASS/TARGET_MET, `mid360_gt_rtkslam_stadtgarten_seq2` raw **0.835** — 13th consecutive bit-identical, `DETERMINISM_OK`
