### PR TITLE
refactor(scanmatcher): extract the pose-prediction core into a pure header (v0.6 Phase 4 kickoff)

### DIFF
--- a/scanmatcher/CMakeLists.txt
+++ b/scanmatcher/CMakeLists.txt
@@ -95,6 +95,10 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_odom_prior_utils test/test_odom_prior_utils.cpp)
   target_include_directories(test_odom_prior_utils PRIVATE include ${EIGEN3_INCLUDE_DIR})
+
+  ament_add_gtest(test_pose_prediction test/test_pose_prediction.cpp)
+  target_include_directories(test_pose_prediction PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  ament_target_dependencies(test_pose_prediction tf2)
 endif()
 
 add_library(scanmatcher_component SHARED

--- a/scanmatcher/include/scanmatcher/pose_prediction.hpp
+++ b/scanmatcher/include/scanmatcher/pose_prediction.hpp
@@ -1,0 +1,156 @@
+#ifndef SCANMATCHER_POSE_PREDICTION_HPP_
+#define SCANMATCHER_POSE_PREDICTION_HPP_
+
+#include <algorithm>
+#include <cmath>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
+
+namespace graphslam
+{
+namespace pose_prediction
+{
+
+// Mirror of the ScanMatcherComponent IMU pose-prediction parameters
+// (same names and defaults as the component members).
+struct ImuPredictionConfig
+{
+  bool use_imu {false};
+  bool imu_pose_prediction_enable {true};
+  double imu_pose_prediction_weight {0.0};
+  double imu_pose_prediction_max_age {0.2};
+  double imu_pose_prediction_max_roll_pitch_deg {12.0};
+  double imu_pose_prediction_max_yaw_deg {20.0};
+};
+
+// Snapshot of the IMU state the shell holds when a cloud arrives.
+// imu_age_sec is std::abs((cloud_stamp - latest_imu_stamp).seconds()),
+// computed by the shell because clock handling stays a shell concern.
+struct ImuObservation
+{
+  bool latest_imu_orientation_valid {false};
+  bool cloud_imu_reference_valid {false};
+  tf2::Quaternion cloud_imu_reference_quat {0.0, 0.0, 0.0, 1.0};
+  tf2::Quaternion latest_imu_robot_quat {0.0, 0.0, 0.0, 1.0};
+  double imu_age_sec {0.0};
+};
+
+// Constant velocity motion model: predict the next pose from the last
+// frame-to-frame delta. Translation only — rotation prediction tends to
+// amplify NDT oscillation.
+inline Eigen::Matrix4f applyConstantVelocityPrediction(
+  Eigen::Matrix4f sim_trans,
+  const bool use_constant_velocity_model,
+  const bool last_accepted_delta_valid,
+  const bool tracking,
+  const Eigen::Vector3d & last_accepted_delta_position)
+{
+  if (use_constant_velocity_model && last_accepted_delta_valid && tracking) {
+    sim_trans.block<3, 1>(0, 3) += last_accepted_delta_position.cast<float>();
+  }
+  return sim_trans;
+}
+
+// Always-on IMU roll/pitch correction (gravity-constrained axes only, no
+// yaw): rotate the initial guess by the clamped roll/pitch part of the IMU
+// delta since the reference cloud.
+inline Eigen::Matrix4f applyImuRollPitchCorrection(
+  Eigen::Matrix4f sim_trans,
+  const ImuPredictionConfig & config,
+  const ImuObservation & imu,
+  const tf2::Quaternion & current_orientation)
+{
+  if (
+    config.use_imu && config.imu_pose_prediction_enable &&
+    imu.latest_imu_orientation_valid && imu.cloud_imu_reference_valid &&
+    config.imu_pose_prediction_weight > 0.0)
+  {
+    if (imu.imu_age_sec <= config.imu_pose_prediction_max_age) {
+      tf2::Quaternion imu_delta = imu.cloud_imu_reference_quat.inverse() *
+        imu.latest_imu_robot_quat;
+      imu_delta.normalize();
+      double imu_dr, imu_dp, imu_dy;
+      tf2::Matrix3x3(imu_delta).getRPY(imu_dr, imu_dp, imu_dy);
+      const double max_rp = config.imu_pose_prediction_weight * M_PI / 180.0;
+      imu_dr = std::clamp(imu_dr, -max_rp, max_rp);
+      imu_dp = std::clamp(imu_dp, -max_rp, max_rp);
+      tf2::Quaternion rp_delta;
+      rp_delta.setRPY(imu_dr, imu_dp, 0.0);
+      rp_delta.normalize();
+      tf2::Quaternion corrected = current_orientation * rp_delta;
+      corrected.normalize();
+      Eigen::Quaterniond corrected_eig(corrected.w(), corrected.x(), corrected.y(), corrected.z());
+      sim_trans.block<3, 3>(0, 0) = corrected_eig.toRotationMatrix().cast<float>();
+    }
+  }
+  return sim_trans;
+}
+
+// State-gated full IMU prediction (Suspect/Recovery only): replace the
+// rotation of the initial guess with the IMU-predicted orientation, with
+// roll/pitch and yaw clamped independently. state_gate_active is
+// (tracking_state != Tracking || recovery_target_active).
+inline Eigen::Matrix4f applyStateGatedImuPrediction(
+  Eigen::Matrix4f sim_trans,
+  const ImuPredictionConfig & config,
+  const ImuObservation & imu,
+  const tf2::Quaternion & current_orientation,
+  const bool state_gate_active)
+{
+  if (
+    config.use_imu && config.imu_pose_prediction_enable &&
+    imu.latest_imu_orientation_valid && imu.cloud_imu_reference_valid &&
+    state_gate_active)
+  {
+    if (imu.imu_age_sec <= config.imu_pose_prediction_max_age) {
+      tf2::Quaternion imu_delta = imu.cloud_imu_reference_quat.inverse() *
+        imu.latest_imu_robot_quat;
+      imu_delta.normalize();
+      double imu_delta_roll = 0.0;
+      double imu_delta_pitch = 0.0;
+      double imu_delta_yaw = 0.0;
+      tf2::Matrix3x3(imu_delta).getRPY(imu_delta_roll, imu_delta_pitch, imu_delta_yaw);
+      const double max_roll_pitch = config.imu_pose_prediction_max_roll_pitch_deg * M_PI / 180.0;
+      const double max_yaw = config.imu_pose_prediction_max_yaw_deg * M_PI / 180.0;
+      imu_delta_roll = std::clamp(imu_delta_roll, -max_roll_pitch, max_roll_pitch);
+      imu_delta_pitch = std::clamp(imu_delta_pitch, -max_roll_pitch, max_roll_pitch);
+      imu_delta_yaw = std::clamp(imu_delta_yaw, -max_yaw, max_yaw);
+      tf2::Quaternion imu_delta_clamped;
+      imu_delta_clamped.setRPY(imu_delta_roll, imu_delta_pitch, imu_delta_yaw);
+      imu_delta_clamped.normalize();
+
+      tf2::Quaternion predicted_quat = current_orientation * imu_delta_clamped;
+      predicted_quat.normalize();
+      Eigen::Quaterniond predicted_quat_eig(
+        predicted_quat.w(), predicted_quat.x(), predicted_quat.y(), predicted_quat.z());
+      sim_trans.block<3, 3>(0, 0) =
+        predicted_quat_eig.normalized().toRotationMatrix().cast<float>();
+    }
+  }
+  return sim_trans;
+}
+
+// IMU-predicted rotation as Euler angles matching NDT's internal convention
+// (XYZ intrinsic), used as the NDT rotation-prior mean. Gating (enable
+// flags, weight, age, registration method) stays with the shell.
+inline Eigen::Vector3d imuPredictedRotationRpy(
+  const ImuObservation & imu,
+  const tf2::Quaternion & current_orientation)
+{
+  tf2::Quaternion imu_delta = imu.cloud_imu_reference_quat.inverse() * imu.latest_imu_robot_quat;
+  imu_delta.normalize();
+  tf2::Quaternion predicted_quat = current_orientation * imu_delta;
+  predicted_quat.normalize();
+  Eigen::Quaterniond pred_eig(predicted_quat.w(), predicted_quat.x(),
+    predicted_quat.y(), predicted_quat.z());
+  return pred_eig.toRotationMatrix().eulerAngles(0, 1, 2);
+}
+
+}  // namespace pose_prediction
+}  // namespace graphslam
+
+#endif  // SCANMATCHER_POSE_PREDICTION_HPP_

--- a/scanmatcher/include/scanmatcher/scanmatcher_component.h
+++ b/scanmatcher/include/scanmatcher/scanmatcher_component.h
@@ -58,6 +58,7 @@ extern "C" {
 
 #include <lidarslam_msgs/msg/map_array.hpp>
 #include "scanmatcher/lidar_undistortion.hpp"
+#include "scanmatcher/pose_prediction.hpp"
 #include "scanmatcher/voxel_hash_map.hpp"
 
 #include <pclomp/ndt_omp.h>
@@ -147,6 +148,7 @@ private:
       int frame_index,
       const std::string & stage);
     Eigen::Matrix4f getTransformation(const geometry_msgs::msg::Pose pose);
+    pose_prediction::ImuPredictionConfig makeImuPredictionConfig() const;
     void publishMap(const lidarslam_msgs::msg::MapArray & map_array_msg, const std::string & map_frame_id);
     void updateMap(
       const pcl::PointCloud < pcl::PointXYZI > ::ConstPtr cloud_ptr,

--- a/scanmatcher/src/scanmatcher_component.cpp
+++ b/scanmatcher/src/scanmatcher_component.cpp
@@ -966,73 +966,37 @@ void ScanMatcherComponent::receiveCloud(
 
   Eigen::Matrix4f sim_trans = getTransformation(current_pose_stamped_.pose);
 
-  // Constant velocity motion model: predict next pose from last frame-to-frame delta
-  // Translation only — rotation prediction tends to amplify NDT oscillation
-  if (use_constant_velocity_model_ && last_accepted_delta_valid_ &&
-      tracking_state_ == TrackingState::Tracking) {
-    sim_trans.block<3, 1>(0, 3) += last_accepted_delta_position_.cast<float>();
-  }
+  const pose_prediction::ImuPredictionConfig imu_prediction_config = makeImuPredictionConfig();
+  pose_prediction::ImuObservation imu_observation;
+  imu_observation.latest_imu_orientation_valid = latest_imu_orientation_valid_;
+  imu_observation.cloud_imu_reference_valid = cloud_imu_reference_valid_;
+  imu_observation.cloud_imu_reference_quat = cloud_imu_reference_quat_;
+  imu_observation.latest_imu_robot_quat = latest_imu_robot_quat_;
+  imu_observation.imu_age_sec = latest_imu_orientation_valid_ ?
+    std::abs((stamp - latest_imu_stamp_).seconds()) : 0.0;
+  tf2::Quaternion current_orientation_quat;
+  tf2::fromMsg(current_pose_stamped_.pose.orientation, current_orientation_quat);
+
+  sim_trans = pose_prediction::applyConstantVelocityPrediction(
+    sim_trans,
+    use_constant_velocity_model_,
+    last_accepted_delta_valid_,
+    tracking_state_ == TrackingState::Tracking,
+    last_accepted_delta_position_);
 
   // IMU initial guess modification (only when complementary filter is disabled)
   if (!imu_complementary_enable_) {
-    // Always-on IMU roll/pitch correction (gravity-constrained axes only, no yaw)
-    if (
-      use_imu_ && imu_pose_prediction_enable_ && latest_imu_orientation_valid_ &&
-      cloud_imu_reference_valid_ && imu_pose_prediction_weight_ > 0.0)
-    {
-      const double imu_age = std::abs((stamp - latest_imu_stamp_).seconds());
-      if (imu_age <= imu_pose_prediction_max_age_) {
-        tf2::Quaternion imu_delta = cloud_imu_reference_quat_.inverse() * latest_imu_robot_quat_;
-        imu_delta.normalize();
-        double imu_dr, imu_dp, imu_dy;
-        tf2::Matrix3x3(imu_delta).getRPY(imu_dr, imu_dp, imu_dy);
-        const double max_rp = imu_pose_prediction_weight_ * M_PI / 180.0;
-        imu_dr = std::clamp(imu_dr, -max_rp, max_rp);
-        imu_dp = std::clamp(imu_dp, -max_rp, max_rp);
-        tf2::Quaternion rp_delta;
-        rp_delta.setRPY(imu_dr, imu_dp, 0.0);
-        rp_delta.normalize();
-        tf2::Quaternion pose_quat;
-        tf2::fromMsg(current_pose_stamped_.pose.orientation, pose_quat);
-        tf2::Quaternion corrected = pose_quat * rp_delta;
-        corrected.normalize();
-        Eigen::Quaterniond corrected_eig(corrected.w(), corrected.x(), corrected.y(), corrected.z());
-        sim_trans.block<3, 3>(0, 0) = corrected_eig.toRotationMatrix().cast<float>();
-      }
-    }
-    // State-gated full IMU prediction (Suspect/Recovery only)
-    if (
-      use_imu_ && imu_pose_prediction_enable_ && latest_imu_orientation_valid_ &&
-      cloud_imu_reference_valid_ &&
-      (tracking_state_ != TrackingState::Tracking || recovery_target_active_))
-    {
-      const double imu_age = std::abs((stamp - latest_imu_stamp_).seconds());
-      if (imu_age <= imu_pose_prediction_max_age_) {
-        tf2::Quaternion imu_delta = cloud_imu_reference_quat_.inverse() * latest_imu_robot_quat_;
-        imu_delta.normalize();
-        double imu_delta_roll = 0.0;
-        double imu_delta_pitch = 0.0;
-        double imu_delta_yaw = 0.0;
-        tf2::Matrix3x3(imu_delta).getRPY(imu_delta_roll, imu_delta_pitch, imu_delta_yaw);
-        const double max_roll_pitch = imu_pose_prediction_max_roll_pitch_deg_ * M_PI / 180.0;
-        const double max_yaw = imu_pose_prediction_max_yaw_deg_ * M_PI / 180.0;
-        imu_delta_roll = std::clamp(imu_delta_roll, -max_roll_pitch, max_roll_pitch);
-        imu_delta_pitch = std::clamp(imu_delta_pitch, -max_roll_pitch, max_roll_pitch);
-        imu_delta_yaw = std::clamp(imu_delta_yaw, -max_yaw, max_yaw);
-        tf2::Quaternion imu_delta_clamped;
-        imu_delta_clamped.setRPY(imu_delta_roll, imu_delta_pitch, imu_delta_yaw);
-        imu_delta_clamped.normalize();
-
-        tf2::Quaternion pose_quat;
-        tf2::fromMsg(current_pose_stamped_.pose.orientation, pose_quat);
-        tf2::Quaternion predicted_quat = pose_quat * imu_delta_clamped;
-        predicted_quat.normalize();
-        Eigen::Quaterniond predicted_quat_eig(
-          predicted_quat.w(), predicted_quat.x(), predicted_quat.y(), predicted_quat.z());
-        sim_trans.block<3, 3>(0, 0) =
-          predicted_quat_eig.normalized().toRotationMatrix().cast<float>();
-      }
-    }
+    sim_trans = pose_prediction::applyImuRollPitchCorrection(
+      sim_trans,
+      imu_prediction_config,
+      imu_observation,
+      current_orientation_quat);
+    sim_trans = pose_prediction::applyStateGatedImuPrediction(
+      sim_trans,
+      imu_prediction_config,
+      imu_observation,
+      current_orientation_quat,
+      tracking_state_ != TrackingState::Tracking || recovery_target_active_);
   }
 
   if (use_odom_) {
@@ -1077,17 +1041,11 @@ void ScanMatcherComponent::receiveCloud(
   {
     const double imu_age = std::abs((stamp - latest_imu_stamp_).seconds());
     if (imu_age <= imu_pose_prediction_max_age_) {
-      // Compute IMU-predicted rotation: previous pose + IMU delta
-      tf2::Quaternion imu_delta = cloud_imu_reference_quat_.inverse() * latest_imu_robot_quat_;
-      imu_delta.normalize();
-      tf2::Quaternion pose_quat;
-      tf2::fromMsg(current_pose_stamped_.pose.orientation, pose_quat);
-      tf2::Quaternion predicted_quat = pose_quat * imu_delta;
-      predicted_quat.normalize();
-      // Convert to Euler angles matching NDT's internal convention (XYZ intrinsic)
-      Eigen::Quaterniond pred_eig(predicted_quat.w(), predicted_quat.x(),
-        predicted_quat.y(), predicted_quat.z());
-      Eigen::Vector3d prior_rpy = pred_eig.toRotationMatrix().eulerAngles(0, 1, 2);
+      // IMU-predicted rotation (previous pose + IMU delta) as Euler angles
+      // matching NDT's internal convention (XYZ intrinsic)
+      const Eigen::Vector3d prior_rpy = pose_prediction::imuPredictedRotationRpy(
+        imu_observation,
+        current_orientation_quat);
       auto ndt_ptr = boost::dynamic_pointer_cast<
         pclomp::NormalDistributionsTransform<pcl::PointXYZI, pcl::PointXYZI>>(registration_);
       if (ndt_ptr) {
@@ -1918,6 +1876,18 @@ Eigen::Matrix4f ScanMatcherComponent::getTransformation(const geometry_msgs::msg
   tf2::fromMsg(pose, affine);
   Eigen::Matrix4f sim_trans = affine.matrix().cast<float>();
   return sim_trans;
+}
+
+pose_prediction::ImuPredictionConfig ScanMatcherComponent::makeImuPredictionConfig() const
+{
+  pose_prediction::ImuPredictionConfig config;
+  config.use_imu = use_imu_;
+  config.imu_pose_prediction_enable = imu_pose_prediction_enable_;
+  config.imu_pose_prediction_weight = imu_pose_prediction_weight_;
+  config.imu_pose_prediction_max_age = imu_pose_prediction_max_age_;
+  config.imu_pose_prediction_max_roll_pitch_deg = imu_pose_prediction_max_roll_pitch_deg_;
+  config.imu_pose_prediction_max_yaw_deg = imu_pose_prediction_max_yaw_deg_;
+  return config;
 }
 
 void ScanMatcherComponent::receiveImu(const sensor_msgs::msg::Imu msg)

--- a/scanmatcher/test/test_pose_prediction.cpp
+++ b/scanmatcher/test/test_pose_prediction.cpp
@@ -1,0 +1,256 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstring>
+
+#include "scanmatcher/pose_prediction.hpp"
+
+namespace
+{
+using graphslam::pose_prediction::ImuObservation;
+using graphslam::pose_prediction::ImuPredictionConfig;
+
+Eigen::Matrix4f makePose(
+  const Eigen::Vector3f & translation,
+  const float roll_rad,
+  const float pitch_rad,
+  const float yaw_rad)
+{
+  Eigen::AngleAxisf roll_axis(roll_rad, Eigen::Vector3f::UnitX());
+  Eigen::AngleAxisf pitch_axis(pitch_rad, Eigen::Vector3f::UnitY());
+  Eigen::AngleAxisf yaw_axis(yaw_rad, Eigen::Vector3f::UnitZ());
+  const Eigen::Matrix3f rotation = (yaw_axis * pitch_axis * roll_axis).toRotationMatrix();
+
+  Eigen::Matrix4f pose = Eigen::Matrix4f::Identity();
+  pose.block<3, 3>(0, 0) = rotation;
+  pose.block<3, 1>(0, 3) = translation;
+  return pose;
+}
+
+tf2::Quaternion quatFromRpy(const double roll, const double pitch, const double yaw)
+{
+  tf2::Quaternion quat;
+  quat.setRPY(roll, pitch, yaw);
+  quat.normalize();
+  return quat;
+}
+
+ImuPredictionConfig makeEnabledConfig()
+{
+  ImuPredictionConfig config;
+  config.use_imu = true;
+  config.imu_pose_prediction_enable = true;
+  config.imu_pose_prediction_weight = 5.0;
+  config.imu_pose_prediction_max_age = 0.2;
+  config.imu_pose_prediction_max_roll_pitch_deg = 12.0;
+  config.imu_pose_prediction_max_yaw_deg = 20.0;
+  return config;
+}
+
+ImuObservation makeValidObservation(
+  const tf2::Quaternion & reference_quat,
+  const tf2::Quaternion & latest_quat,
+  const double imu_age_sec)
+{
+  ImuObservation imu;
+  imu.latest_imu_orientation_valid = true;
+  imu.cloud_imu_reference_valid = true;
+  imu.cloud_imu_reference_quat = reference_quat;
+  imu.latest_imu_robot_quat = latest_quat;
+  imu.imu_age_sec = imu_age_sec;
+  return imu;
+}
+}  // namespace
+
+TEST(PosePredictionConstantVelocityTest, AddsTranslationOnlyWhenAllGatesPass)
+{
+  const Eigen::Matrix4f pose = makePose(Eigen::Vector3f(1.0f, 2.0f, 3.0f), 0.1f, 0.2f, 0.3f);
+  const Eigen::Vector3d delta(0.5, -0.25, 0.125);
+
+  const Eigen::Matrix4f predicted =
+    graphslam::pose_prediction::applyConstantVelocityPrediction(pose, true, true, true, delta);
+
+  Eigen::Matrix4f expected = pose;
+  expected.block<3, 1>(0, 3) += delta.cast<float>();
+  EXPECT_TRUE(predicted.isApprox(expected, 0.0f));
+  // Rotation untouched (translation-only model).
+  EXPECT_TRUE((
+      predicted.block<3, 3>(0, 0).isApprox(pose.block<3, 3>(0, 0), 0.0f)));
+}
+
+TEST(PosePredictionConstantVelocityTest, AnyFailedGateLeavesThePoseUnchanged)
+{
+  const Eigen::Matrix4f pose = makePose(Eigen::Vector3f(1.0f, 2.0f, 3.0f), 0.1f, 0.2f, 0.3f);
+  const Eigen::Vector3d delta(0.5, -0.25, 0.125);
+
+  EXPECT_TRUE(
+    graphslam::pose_prediction::applyConstantVelocityPrediction(pose, false, true, true, delta)
+    .isApprox(pose, 0.0f));
+  EXPECT_TRUE(
+    graphslam::pose_prediction::applyConstantVelocityPrediction(pose, true, false, true, delta)
+    .isApprox(pose, 0.0f));
+  EXPECT_TRUE(
+    graphslam::pose_prediction::applyConstantVelocityPrediction(pose, true, true, false, delta)
+    .isApprox(pose, 0.0f));
+}
+
+TEST(PosePredictionRollPitchTest, GatesDisableTheCorrection)
+{
+  const Eigen::Matrix4f pose = makePose(Eigen::Vector3f(1.0f, 0.0f, 0.0f), 0.0f, 0.0f, 0.5f);
+  const tf2::Quaternion current = quatFromRpy(0.0, 0.0, 0.5);
+  const ImuObservation imu =
+    makeValidObservation(quatFromRpy(0.0, 0.0, 0.0), quatFromRpy(0.05, -0.03, 0.4), 0.05);
+
+  ImuPredictionConfig config = makeEnabledConfig();
+  config.imu_pose_prediction_weight = 0.0;
+  EXPECT_TRUE(
+    graphslam::pose_prediction::applyImuRollPitchCorrection(pose, config, imu, current)
+    .isApprox(pose, 0.0f));
+
+  config = makeEnabledConfig();
+  config.use_imu = false;
+  EXPECT_TRUE(
+    graphslam::pose_prediction::applyImuRollPitchCorrection(pose, config, imu, current)
+    .isApprox(pose, 0.0f));
+
+  config = makeEnabledConfig();
+  ImuObservation stale = imu;
+  stale.imu_age_sec = config.imu_pose_prediction_max_age + 0.01;
+  EXPECT_TRUE(
+    graphslam::pose_prediction::applyImuRollPitchCorrection(pose, config, stale, current)
+    .isApprox(pose, 0.0f));
+}
+
+TEST(PosePredictionRollPitchTest, AppliesClampedRollPitchAndIgnoresYaw)
+{
+  const Eigen::Matrix4f pose = makePose(Eigen::Vector3f(1.0f, 2.0f, 3.0f), 0.0f, 0.0f, 0.5f);
+  const tf2::Quaternion current = quatFromRpy(0.0, 0.0, 0.5);
+  // IMU delta: roll well over the +/- weight-degree cap, plus a yaw component
+  // that the gravity-constrained correction must ignore.
+  const ImuObservation imu =
+    makeValidObservation(quatFromRpy(0.0, 0.0, 0.0), quatFromRpy(0.5, -0.02, 0.4), 0.05);
+  const ImuPredictionConfig config = makeEnabledConfig();
+
+  const Eigen::Matrix4f corrected =
+    graphslam::pose_prediction::applyImuRollPitchCorrection(pose, config, imu, current);
+
+  // Translation preserved verbatim.
+  EXPECT_TRUE((corrected.block<3, 1>(0, 3).isApprox(pose.block<3, 1>(0, 3), 0.0f)));
+
+  // Expected rotation: transplanted original formula.
+  tf2::Quaternion imu_delta = imu.cloud_imu_reference_quat.inverse() * imu.latest_imu_robot_quat;
+  imu_delta.normalize();
+  double imu_dr, imu_dp, imu_dy;
+  tf2::Matrix3x3(imu_delta).getRPY(imu_dr, imu_dp, imu_dy);
+  const double max_rp = config.imu_pose_prediction_weight * M_PI / 180.0;
+  imu_dr = std::clamp(imu_dr, -max_rp, max_rp);
+  imu_dp = std::clamp(imu_dp, -max_rp, max_rp);
+  EXPECT_DOUBLE_EQ(imu_dr, max_rp);  // the 0.5 rad roll delta hits the cap
+  tf2::Quaternion rp_delta;
+  rp_delta.setRPY(imu_dr, imu_dp, 0.0);
+  rp_delta.normalize();
+  tf2::Quaternion expected_quat = current * rp_delta;
+  expected_quat.normalize();
+  const Eigen::Quaterniond expected_eig(
+    expected_quat.w(), expected_quat.x(), expected_quat.y(), expected_quat.z());
+  EXPECT_TRUE((
+      corrected.block<3, 3>(0, 0).isApprox(
+      expected_eig.toRotationMatrix().cast<float>(), 0.0f)));
+}
+
+TEST(PosePredictionStateGatedTest, OnlyRunsWhenTheStateGateIsActive)
+{
+  const Eigen::Matrix4f pose = makePose(Eigen::Vector3f(0.0f, 0.0f, 0.0f), 0.0f, 0.0f, 0.0f);
+  const tf2::Quaternion current = quatFromRpy(0.0, 0.0, 0.0);
+  const ImuObservation imu =
+    makeValidObservation(quatFromRpy(0.0, 0.0, 0.0), quatFromRpy(0.1, 0.05, 0.2), 0.05);
+  const ImuPredictionConfig config = makeEnabledConfig();
+
+  EXPECT_TRUE(
+    graphslam::pose_prediction::applyStateGatedImuPrediction(pose, config, imu, current, false)
+    .isApprox(pose, 0.0f));
+  EXPECT_FALSE(
+    graphslam::pose_prediction::applyStateGatedImuPrediction(pose, config, imu, current, true)
+    .isApprox(pose, 0.0f));
+}
+
+TEST(PosePredictionStateGatedTest, ClampsRollPitchAndYawIndependently)
+{
+  const Eigen::Matrix4f pose = makePose(Eigen::Vector3f(1.0f, -2.0f, 0.5f), 0.0f, 0.0f, 1.0f);
+  const tf2::Quaternion current = quatFromRpy(0.0, 0.0, 1.0);
+  // Deltas beyond both caps: 30 deg roll (cap 12) and 45 deg yaw (cap 20).
+  const ImuObservation imu = makeValidObservation(
+    quatFromRpy(0.0, 0.0, 0.0),
+    quatFromRpy(30.0 * M_PI / 180.0, 0.0, 45.0 * M_PI / 180.0),
+    0.05);
+  const ImuPredictionConfig config = makeEnabledConfig();
+
+  const Eigen::Matrix4f predicted =
+    graphslam::pose_prediction::applyStateGatedImuPrediction(pose, config, imu, current, true);
+
+  // Translation preserved verbatim.
+  EXPECT_TRUE((predicted.block<3, 1>(0, 3).isApprox(pose.block<3, 1>(0, 3), 0.0f)));
+
+  // Expected rotation: transplanted original formula.
+  tf2::Quaternion imu_delta = imu.cloud_imu_reference_quat.inverse() * imu.latest_imu_robot_quat;
+  imu_delta.normalize();
+  double dr = 0.0, dp = 0.0, dy = 0.0;
+  tf2::Matrix3x3(imu_delta).getRPY(dr, dp, dy);
+  const double max_rp = config.imu_pose_prediction_max_roll_pitch_deg * M_PI / 180.0;
+  const double max_yaw = config.imu_pose_prediction_max_yaw_deg * M_PI / 180.0;
+  dr = std::clamp(dr, -max_rp, max_rp);
+  dp = std::clamp(dp, -max_rp, max_rp);
+  dy = std::clamp(dy, -max_yaw, max_yaw);
+  EXPECT_DOUBLE_EQ(dr, max_rp);
+  EXPECT_DOUBLE_EQ(dy, max_yaw);
+  tf2::Quaternion clamped;
+  clamped.setRPY(dr, dp, dy);
+  clamped.normalize();
+  tf2::Quaternion expected_quat = current * clamped;
+  expected_quat.normalize();
+  const Eigen::Quaterniond expected_eig(
+    expected_quat.w(), expected_quat.x(), expected_quat.y(), expected_quat.z());
+  EXPECT_TRUE((
+      predicted.block<3, 3>(0, 0).isApprox(
+      expected_eig.normalized().toRotationMatrix().cast<float>(), 0.0f)));
+}
+
+TEST(PosePredictionNdtPriorTest, IdentityDeltaReturnsCurrentOrientationAngles)
+{
+  const tf2::Quaternion current = quatFromRpy(0.1, -0.2, 0.3);
+  const ImuObservation imu =
+    makeValidObservation(quatFromRpy(0.0, 0.0, 0.0), quatFromRpy(0.0, 0.0, 0.0), 0.0);
+
+  const Eigen::Vector3d rpy =
+    graphslam::pose_prediction::imuPredictedRotationRpy(imu, current);
+
+  const Eigen::Quaterniond current_eig(current.w(), current.x(), current.y(), current.z());
+  const Eigen::Vector3d expected = current_eig.toRotationMatrix().eulerAngles(0, 1, 2);
+  EXPECT_DOUBLE_EQ(rpy.x(), expected.x());
+  EXPECT_DOUBLE_EQ(rpy.y(), expected.y());
+  EXPECT_DOUBLE_EQ(rpy.z(), expected.z());
+}
+
+TEST(PosePredictionDeterminismTest, SameInputsProduceBitwiseIdenticalResults)
+{
+  const Eigen::Matrix4f pose = makePose(Eigen::Vector3f(1.0f, 2.0f, 3.0f), 0.1f, -0.2f, 0.3f);
+  const tf2::Quaternion current = quatFromRpy(0.1, -0.2, 0.3);
+  const ImuObservation imu =
+    makeValidObservation(quatFromRpy(0.01, 0.02, 0.03), quatFromRpy(0.05, -0.04, 0.2), 0.1);
+  const ImuPredictionConfig config = makeEnabledConfig();
+
+  const Eigen::Matrix4f first = graphslam::pose_prediction::applyStateGatedImuPrediction(
+    graphslam::pose_prediction::applyImuRollPitchCorrection(
+      graphslam::pose_prediction::applyConstantVelocityPrediction(
+        pose, true, true, true, Eigen::Vector3d(0.5, -0.25, 0.125)),
+      config, imu, current),
+    config, imu, current, true);
+  const Eigen::Matrix4f second = graphslam::pose_prediction::applyStateGatedImuPrediction(
+    graphslam::pose_prediction::applyImuRollPitchCorrection(
+      graphslam::pose_prediction::applyConstantVelocityPrediction(
+        pose, true, true, true, Eigen::Vector3d(0.5, -0.25, 0.125)),
+      config, imu, current),
+    config, imu, current, true);
+
+  EXPECT_EQ(0, std::memcmp(first.data(), second.data(), sizeof(float) * 16));
+}


### PR DESCRIPTION
## Summary

v0.6 **Phase 4 kickoff** (docs/roadmap/v0.6.md): first scanmatcher core/shell extraction, following the exact pattern of the 17 backend pure headers — verbatim transplant + characterization tests, zero behavior change.

New pure header `scanmatcher/include/scanmatcher/pose_prediction.hpp` (`graphslam::pose_prediction`), extracted from `receiveCloud`:

- `applyConstantVelocityPrediction` — translation-only constant-velocity initial guess (Tracking state + valid-delta gated)
- `applyImuRollPitchCorrection` — always-on gravity-constrained roll/pitch correction (weight/age gated, yaw ignored)
- `applyStateGatedImuPrediction` — Suspect/Recovery full IMU prediction with independent roll/pitch and yaw clamps
- `imuPredictedRotationRpy` — NDT rotation-prior mean (XYZ intrinsic Euler); NDT-specific gating stays in the shell
- `ImuPredictionConfig` / `ImuObservation` mirror the component members and defaults; clock handling (IMU age) stays a shell concern

`receiveCloud` now snapshots the IMU state once and calls the pure functions; the NDT rotation-prior block reuses the same snapshot (single-threaded executor — no observable change).

## Tests

8 new characterization tests in `test_pose_prediction.cpp`: per-gate disable cases, clamp-at-cap checks against the transplanted original formulas (roll/pitch cap = weight° in the always-on path, independent 12°/20° caps in the state-gated path), translation preservation, and a bitwise-determinism check over the chained predictions.

## Validation

- `colcon test` scanmatcher: **43 tests, 0 failures** (+8 new)
- `ament_uncrustify` clean on the new files
- Full release gate PASS with the offline determinism stage: all profiles PASS/TARGET_MET, `mid360_gt_rtkslam_stadtgarten_seq2` raw **0.835** — 14th consecutive bit-identical; `DETERMINISM_OK` (md5 `feee9547` unchanged)
