### PR TITLE
refactor(scanmatcher): extract the pose-acceptance core into a pure header

### DIFF
--- a/scanmatcher/CMakeLists.txt
+++ b/scanmatcher/CMakeLists.txt
@@ -99,6 +99,10 @@ if(BUILD_TESTING)
   ament_add_gtest(test_pose_prediction test/test_pose_prediction.cpp)
   target_include_directories(test_pose_prediction PRIVATE include ${EIGEN3_INCLUDE_DIR})
   ament_target_dependencies(test_pose_prediction tf2)
+
+  ament_add_gtest(test_pose_acceptance test/test_pose_acceptance.cpp)
+  target_include_directories(test_pose_acceptance PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  ament_target_dependencies(test_pose_acceptance tf2 tf2_geometry_msgs geometry_msgs)
 endif()
 
 add_library(scanmatcher_component SHARED

--- a/scanmatcher/include/scanmatcher/pose_acceptance.hpp
+++ b/scanmatcher/include/scanmatcher/pose_acceptance.hpp
@@ -1,0 +1,586 @@
+#ifndef SCANMATCHER_POSE_ACCEPTANCE_HPP_
+#define SCANMATCHER_POSE_ACCEPTANCE_HPP_
+
+#include <algorithm>
+#include <cmath>
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <geometry_msgs/msg/quaternion.hpp>
+
+namespace graphslam
+{
+namespace pose_acceptance
+{
+
+enum class TrackingState
+{
+  Tracking,
+  Suspect,
+  Recovery
+};
+
+// Mirror of the ScanMatcherComponent pose-acceptance parameters (same names
+// and defaults as the component members).
+struct Config
+{
+  double diagnostic_warn_trans_jump {0.75};
+  double diagnostic_warn_yaw_jump_deg {12.0};
+  bool reject_nonconverged_pose_update {true};
+  double reject_fitness_score {0.0};
+  double reject_fitness_ratio {2.5};
+  double reject_fitness_only_ratio {8.0};
+  double reject_trans_only_ratio {0.0};
+  int reject_trans_streak_scans {0};
+  double reject_fitness_streak_ratio {0.0};
+  int reject_fitness_streak_scans {0};
+  double reject_hard_fitness_ratio {0.0};
+  double reject_trans_jump {1.0};
+  double reject_trans_jump_ratio {3.0};
+  double reject_hard_trans_ratio {0.0};
+  double reject_ema_alpha {0.1};
+  bool motion_gate_enable {true};
+  double motion_gate_max_linear_velocity {8.0};
+  double motion_gate_max_yaw_rate_deg {120.0};
+  double motion_gate_hard_multiplier {4.0};
+  int reject_warmup_scans {20};
+  int reject_map_update_cooldown_scans {2};
+  int hard_reject_map_update_cooldown_scans {4};
+  int reject_recovery_scans {0};
+  int recovery_clear_consecutive_accepted {1};
+  int suspect_clear_consecutive_accepted {2};
+  double scan_period {0.1};
+  std::string robot_frame_id {"base_link"};
+};
+
+// Mutable acceptance state, previously scattered across component members.
+// The pose stamp itself stays in the shell (clock handling): the shell
+// passes dt and the stamps as seconds.
+struct State
+{
+  bool previous_pose_diagnostic_valid {false};
+  Eigen::Vector3d previous_pose_diagnostic_position {Eigen::Vector3d::Zero()};
+  double previous_pose_diagnostic_yaw {0.0};
+  bool reject_stats_initialized {false};
+  double accepted_fitness_ema {0.0};
+  double accepted_trans_ema {0.0};
+  int accepted_pose_count {0};
+  int elevated_trans_streak {0};
+  int elevated_fitness_streak {0};
+  int consecutive_reject_count {0};
+  int state_clean_consecutive_accepted {0};
+  TrackingState tracking_state {TrackingState::Tracking};
+  bool recovery_target_active {false};
+  bool last_accepted_delta_valid {false};
+  Eigen::Vector3d last_accepted_delta_position {Eigen::Vector3d::Zero()};
+  tf2::Quaternion last_accepted_delta_quat {0.0, 0.0, 0.0, 1.0};
+  int reject_map_update_cooldown_remaining {0};
+};
+
+// One aligned scan as seen by the acceptance logic.
+struct Input
+{
+  Eigen::Vector3d position {Eigen::Vector3d::Zero()};
+  geometry_msgs::msg::Quaternion orientation {};
+  // Orientation of the previous accepted pose (current_pose_stamped before
+  // this scan updates it).
+  geometry_msgs::msg::Quaternion previous_orientation {};
+  bool has_converged {true};
+  double fitness_score {0.0};
+  double stamp_sec {0.0};
+  double previous_stamp_sec {0.0};
+  // (stamp - previous_pose_stamp).seconds(), 0.0 on the first diagnostic
+  // scan; computed by the shell from the rclcpp::Time pair so the rounding
+  // matches the historical Duration::seconds() exactly.
+  double dt {0.0};
+  // True while the asynchronous map-update thread is running.
+  bool mapping_in_progress {false};
+};
+
+struct Outcome
+{
+  Eigen::Vector3d accepted_position {Eigen::Vector3d::Zero()};
+  geometry_msgs::msg::Quaternion accepted_quat_msg {};
+  bool hard_reject_pose_update {false};
+  bool soft_reject_map_update {false};
+  bool suppress_map_update {false};
+  // When true the shell must refresh the recovery registration target and
+  // store the result in State::recovery_target_active (the decision is
+  // pure, the PCL/registration side effect is not).
+  bool request_recovery_target_refresh {false};
+  // RCLCPP_WARN lines, byte-identical to the historical component output.
+  std::vector<std::string> warn_lines;
+};
+
+inline double wrapAngleRad(double angle)
+{
+  while (angle > M_PI) {angle -= 2.0 * M_PI;}
+  while (angle < -M_PI) {angle += 2.0 * M_PI;}
+  return angle;
+}
+
+inline Eigen::Vector3d clampVectorNorm(const Eigen::Vector3d & v, double max_norm)
+{
+  if (max_norm <= 0.0) {
+    return v;
+  }
+  const double norm = v.norm();
+  if (norm <= max_norm || norm < 1e-9) {
+    return v;
+  }
+  return v * (max_norm / norm);
+}
+
+inline geometry_msgs::msg::Quaternion quaternionFromRPY(double roll, double pitch, double yaw)
+{
+  tf2::Quaternion q;
+  q.setRPY(roll, pitch, yaw);
+  q.normalize();
+  return tf2::toMsg(q);
+}
+
+inline std::string formatWarn(const char * fmt, ...)
+{
+  char buffer[1024];
+  va_list args;
+  va_start(args, fmt);
+  vsnprintf(buffer, sizeof(buffer), fmt, args);
+  va_end(args);
+  return std::string(buffer);
+}
+
+// Verbatim transplant of the publishMapAndPose acceptance block: pose-jump
+// diagnostics, adaptive fitness/translation gates, motion gate, accept /
+// clip / predict selection, accepted-statistics EMA, the
+// Tracking/Suspect/Recovery state machine and the map-update cooldown.
+inline Outcome evaluate(const Config & config, State & state, const Input & input)
+{
+  const Eigen::Vector3d & position = input.position;
+  const geometry_msgs::msg::Quaternion & quat_msg = input.orientation;
+  const bool has_converged = input.has_converged;
+  const double fitness_score = input.fitness_score;
+  tf2::Quaternion diag_quat_tf;
+  double diag_roll, diag_pitch, diag_yaw;
+  tf2::fromMsg(quat_msg, diag_quat_tf);
+  tf2::Matrix3x3(diag_quat_tf).getRPY(diag_roll, diag_pitch, diag_yaw);
+  double dt = 0.0;
+  double trans_jump = 0.0;
+  double yaw_jump_deg = 0.0;
+  double fitness_ratio = 1.0;
+  double trans_ratio = 1.0;
+  double fitness_ref = fitness_score;
+  double trans_ref = 0.0;
+  bool warmup_complete = false;
+  bool reject_pose_update = false;
+  bool hard_reject_pose_update = false;
+  bool soft_reject_map_update = false;
+  bool adaptive_ratio_reject = false;
+  bool fitness_only_map_reject = false;
+  bool trans_only_map_reject = false;
+  bool trans_streak_map_reject = false;
+  bool fitness_streak_map_reject = false;
+  bool hard_ratio_reject = false;
+  bool motion_gate_suspect = false;
+  bool motion_gate_hard = false;
+  double motion_gate_trans_limit = 0.0;
+  double motion_gate_yaw_limit_deg = 0.0;
+  constexpr double kFitnessScoreSanityLimit = 1.0e4;
+  const bool invalid_fitness_score =
+    !std::isfinite(fitness_score) || fitness_score >= kFitnessScoreSanityLimit;
+
+  Outcome outcome;
+
+  if (state.previous_pose_diagnostic_valid) {
+    dt = input.dt;
+    trans_jump = (position - state.previous_pose_diagnostic_position).norm();
+    yaw_jump_deg =
+      std::abs(wrapAngleRad(diag_yaw - state.previous_pose_diagnostic_yaw)) * 180.0 / M_PI;
+
+    if (dt <= 0.0) {
+      outcome.warn_lines.push_back(
+        formatWarn(
+          "POSE_STAMP_NONMONOTONIC stamp=%.9f prev_stamp=%.9f dt=%.6f frame=%s",
+          input.stamp_sec,
+          input.previous_stamp_sec,
+          dt,
+          config.robot_frame_id.c_str()));
+    }
+
+    if (!has_converged || trans_jump >= config.diagnostic_warn_trans_jump ||
+      yaw_jump_deg >= config.diagnostic_warn_yaw_jump_deg)
+    {
+      outcome.warn_lines.push_back(
+        formatWarn(
+          "POSE_JUMP stamp=%.9f dt=%.6f trans=%.6f yaw_deg=%.3f converged=%s fitness=%.6f frame=%s",
+          input.stamp_sec,
+          dt,
+          trans_jump,
+          yaw_jump_deg,
+          has_converged ? "true" : "false",
+          fitness_score,
+          config.robot_frame_id.c_str()));
+    }
+
+    if (state.reject_stats_initialized) {
+      fitness_ref = state.accepted_fitness_ema;
+      trans_ref = state.accepted_trans_ema;
+      if (
+        !std::isfinite(fitness_ref) || fitness_ref <= 0.0 ||
+        fitness_ref >= kFitnessScoreSanityLimit ||
+        !std::isfinite(trans_ref) || trans_ref < 0.0)
+      {
+        state.reject_stats_initialized = false;
+        state.accepted_fitness_ema = 0.0;
+        state.accepted_trans_ema = 0.0;
+        state.accepted_pose_count = 0;
+        fitness_ref = fitness_score;
+        trans_ref = trans_jump;
+      }
+    } else {
+      fitness_ref = fitness_score;
+      trans_ref = trans_jump;
+    }
+
+    const double fitness_ref_safe = (fitness_ref > 1e-6) ? fitness_ref : 1e-6;
+    const double trans_ref_safe = (trans_ref > 1e-3) ? trans_ref : 1e-3;
+    fitness_ratio = fitness_score / fitness_ref_safe;
+    trans_ratio = trans_jump / trans_ref_safe;
+
+    if (
+      config.motion_gate_enable &&
+      config.motion_gate_max_linear_velocity > 0.0 &&
+      config.motion_gate_max_yaw_rate_deg > 0.0)
+    {
+      const double effective_dt = std::max(dt, config.scan_period);
+      motion_gate_trans_limit = config.motion_gate_max_linear_velocity * effective_dt;
+      motion_gate_yaw_limit_deg = config.motion_gate_max_yaw_rate_deg * effective_dt;
+      motion_gate_suspect =
+        trans_jump > motion_gate_trans_limit ||
+        yaw_jump_deg > motion_gate_yaw_limit_deg;
+      motion_gate_hard =
+        config.motion_gate_hard_multiplier > 1.0 &&
+        (
+        trans_jump > motion_gate_trans_limit * config.motion_gate_hard_multiplier ||
+        yaw_jump_deg > motion_gate_yaw_limit_deg * config.motion_gate_hard_multiplier);
+    }
+
+    warmup_complete = state.accepted_pose_count >= config.reject_warmup_scans;
+    adaptive_ratio_reject =
+      warmup_complete &&
+      state.reject_stats_initialized &&
+      config.reject_fitness_ratio > 0.0 &&
+      config.reject_trans_jump_ratio > 0.0 &&
+      fitness_ratio >= config.reject_fitness_ratio &&
+      trans_ratio >= config.reject_trans_jump_ratio;
+    fitness_only_map_reject =
+      warmup_complete &&
+      state.reject_stats_initialized &&
+      config.reject_fitness_only_ratio > 0.0 &&
+      fitness_ratio >= config.reject_fitness_only_ratio;
+    trans_only_map_reject =
+      warmup_complete &&
+      state.reject_stats_initialized &&
+      config.reject_trans_only_ratio > 0.0 &&
+      trans_jump >= config.diagnostic_warn_trans_jump &&
+      trans_ratio >= config.reject_trans_only_ratio;
+    if (
+      trans_jump >= config.diagnostic_warn_trans_jump &&
+      trans_ratio >= config.reject_trans_jump_ratio)
+    {
+      state.elevated_trans_streak += 1;
+    } else {
+      state.elevated_trans_streak = 0;
+    }
+    trans_streak_map_reject =
+      config.reject_trans_streak_scans > 0 &&
+      state.elevated_trans_streak >= config.reject_trans_streak_scans;
+    if (
+      warmup_complete &&
+      state.reject_stats_initialized &&
+      config.reject_fitness_streak_ratio > 0.0 &&
+      fitness_ratio >= config.reject_fitness_streak_ratio)
+    {
+      state.elevated_fitness_streak += 1;
+    } else {
+      state.elevated_fitness_streak = 0;
+    }
+    fitness_streak_map_reject =
+      config.reject_fitness_streak_scans > 0 &&
+      state.elevated_fitness_streak >= config.reject_fitness_streak_scans;
+    hard_ratio_reject =
+      warmup_complete &&
+      state.reject_stats_initialized &&
+      config.reject_hard_fitness_ratio > 0.0 &&
+      config.reject_hard_trans_ratio > 0.0 &&
+      fitness_ratio >= config.reject_hard_fitness_ratio &&
+      trans_ratio >= config.reject_hard_trans_ratio;
+
+    hard_reject_pose_update =
+      invalid_fitness_score ||
+      (config.reject_nonconverged_pose_update && !has_converged) ||
+      (config.reject_fitness_score > 0.0 && fitness_score > config.reject_fitness_score) ||
+      (
+      !config.motion_gate_enable &&
+      config.reject_trans_jump > 0.0 &&
+      trans_jump >= config.reject_trans_jump) ||
+      motion_gate_hard ||
+      hard_ratio_reject;
+    soft_reject_map_update =
+      (adaptive_ratio_reject || fitness_only_map_reject || trans_only_map_reject ||
+      trans_streak_map_reject || fitness_streak_map_reject || motion_gate_suspect) &&
+      !hard_reject_pose_update;
+    reject_pose_update = hard_reject_pose_update;
+  }
+
+  Eigen::Vector3d accepted_position = position;
+  geometry_msgs::msg::Quaternion accepted_quat_msg = quat_msg;
+  double accepted_yaw = diag_yaw;
+  Eigen::Vector3d predicted_position = position;
+  geometry_msgs::msg::Quaternion predicted_quat_msg = quat_msg;
+  double predicted_yaw = diag_yaw;
+  Eigen::Vector3d clipped_position = position;
+  geometry_msgs::msg::Quaternion clipped_quat_msg = quat_msg;
+  double clipped_yaw = diag_yaw;
+  if (state.previous_pose_diagnostic_valid) {
+    predicted_position = state.previous_pose_diagnostic_position;
+    predicted_quat_msg = input.previous_orientation;
+    predicted_yaw = state.previous_pose_diagnostic_yaw;
+    if (state.last_accepted_delta_valid) {
+      predicted_position += state.last_accepted_delta_position;
+      tf2::Quaternion prev_quat_tf;
+      tf2::Quaternion predicted_quat_tf;
+      tf2::fromMsg(input.previous_orientation, prev_quat_tf);
+      predicted_quat_tf = prev_quat_tf * state.last_accepted_delta_quat;
+      predicted_quat_tf.normalize();
+      predicted_quat_msg = tf2::toMsg(predicted_quat_tf);
+      double predicted_roll;
+      double predicted_pitch;
+      tf2::Matrix3x3(predicted_quat_tf).getRPY(predicted_roll, predicted_pitch, predicted_yaw);
+    }
+
+    if (config.motion_gate_enable && motion_gate_trans_limit > 0.0 &&
+      motion_gate_yaw_limit_deg > 0.0)
+    {
+      const Eigen::Vector3d candidate_delta = position - predicted_position;
+      clipped_position =
+        predicted_position + clampVectorNorm(candidate_delta, motion_gate_trans_limit);
+
+      const double max_yaw_delta = motion_gate_yaw_limit_deg * M_PI / 180.0;
+      const double candidate_yaw_delta = wrapAngleRad(diag_yaw - predicted_yaw);
+      const double clipped_yaw_delta =
+        std::clamp(candidate_yaw_delta, -max_yaw_delta, max_yaw_delta);
+      clipped_yaw = predicted_yaw + clipped_yaw_delta;
+      clipped_quat_msg = quaternionFromRPY(diag_roll, diag_pitch, clipped_yaw);
+    }
+  }
+  if (state.previous_pose_diagnostic_valid && hard_reject_pose_update) {
+    accepted_position = predicted_position;
+    accepted_quat_msg = predicted_quat_msg;
+    accepted_yaw = predicted_yaw;
+  } else if (state.previous_pose_diagnostic_valid && soft_reject_map_update) {
+    accepted_position = clipped_position;
+    accepted_quat_msg = clipped_quat_msg;
+    accepted_yaw = clipped_yaw;
+  } else if (state.previous_pose_diagnostic_valid &&
+    state.tracking_state == TrackingState::Recovery)
+  {
+    accepted_position = clipped_position;
+    accepted_quat_msg = clipped_quat_msg;
+    accepted_yaw = clipped_yaw;
+  } else if (state.previous_pose_diagnostic_valid &&
+    state.tracking_state == TrackingState::Suspect)
+  {
+    accepted_position = clipped_position;
+    accepted_quat_msg = clipped_quat_msg;
+    accepted_yaw = clipped_yaw;
+  }
+  if (state.previous_pose_diagnostic_valid &&
+    (hard_reject_pose_update || soft_reject_map_update))
+  {
+    if (invalid_fitness_score) {
+      outcome.warn_lines.push_back(
+        formatWarn(
+          "POSE_FITNESS_INVALID stamp=%.9f fitness=%.6f frame=%s",
+          input.stamp_sec,
+          fitness_score,
+          config.robot_frame_id.c_str()));
+    }
+    outcome.warn_lines.push_back(
+      formatWarn(
+        "POSE_REJECT stamp=%.9f dt=%.6f trans=%.6f yaw_deg=%.3f converged=%s fitness=%.6f fitness_ref=%.6f fitness_ratio=%.3f trans_ref=%.6f trans_ratio=%.3f motion_gate=%s motion_gate_hard=%s trans_limit=%.3f yaw_limit_deg=%.3f adaptive=%s fitness_only=%s trans_only=%s trans_streak=%s fitness_streak=%s hard_ratio=%s streak_count=%d mode=%s cooldown=%d reject_nonconv=%s reject_fitness=%.3f reject_trans=%.3f frame=%s",
+        input.stamp_sec,
+        dt,
+        trans_jump,
+        yaw_jump_deg,
+        has_converged ? "true" : "false",
+        fitness_score,
+        fitness_ref,
+        fitness_ratio,
+        trans_ref,
+        trans_ratio,
+        motion_gate_suspect ? "true" : "false",
+        motion_gate_hard ? "true" : "false",
+        motion_gate_trans_limit,
+        motion_gate_yaw_limit_deg,
+        adaptive_ratio_reject ? "true" : "false",
+        fitness_only_map_reject ? "true" : "false",
+        trans_only_map_reject ? "true" : "false",
+        trans_streak_map_reject ? "true" : "false",
+        fitness_streak_map_reject ? "true" : "false",
+        hard_ratio_reject ? "true" : "false",
+        state.elevated_fitness_streak,
+        hard_reject_pose_update ? "hard" : "map_only",
+        config.reject_map_update_cooldown_scans,
+        config.reject_nonconverged_pose_update ? "true" : "false",
+        config.reject_fitness_score,
+        config.reject_trans_jump,
+        config.robot_frame_id.c_str()));
+  }
+
+  if (!reject_pose_update && !soft_reject_map_update) {
+    double alpha = config.reject_ema_alpha;
+    if (alpha <= 0.0 || alpha > 1.0) {alpha = 0.1;}
+    double fitness_sample = fitness_score;
+    double trans_sample = trans_jump;
+    if (!state.reject_stats_initialized) {
+      state.accepted_fitness_ema = fitness_sample;
+      state.accepted_trans_ema = trans_sample;
+      state.reject_stats_initialized = true;
+    } else {
+      if (state.accepted_pose_count >= config.reject_warmup_scans) {
+        if (config.reject_fitness_ratio > 0.0 && state.accepted_fitness_ema > 1e-6) {
+          const double fitness_cap = state.accepted_fitness_ema * config.reject_fitness_ratio;
+          if (fitness_sample > fitness_cap) {fitness_sample = fitness_cap;}
+        }
+        if (config.reject_trans_jump_ratio > 0.0 && state.accepted_trans_ema > 1e-3) {
+          const double trans_cap = state.accepted_trans_ema * config.reject_trans_jump_ratio;
+          if (trans_sample > trans_cap) {trans_sample = trans_cap;}
+        }
+      }
+      state.accepted_fitness_ema =
+        (1.0 - alpha) * state.accepted_fitness_ema + alpha * fitness_sample;
+      state.accepted_trans_ema =
+        (1.0 - alpha) * state.accepted_trans_ema + alpha * trans_sample;
+    }
+    state.accepted_pose_count += 1;
+  }
+  if (reject_pose_update || soft_reject_map_update) {
+    state.consecutive_reject_count += 1;
+  } else {
+    state.consecutive_reject_count = 0;
+  }
+  if (hard_reject_pose_update) {
+    state.last_accepted_delta_valid = false;
+  }
+  if (hard_reject_pose_update) {
+    const bool activate_recovery_target =
+      !input.mapping_in_progress &&
+      (
+      config.reject_recovery_scans <= 1 ||
+      state.consecutive_reject_count >= config.reject_recovery_scans);
+    if (activate_recovery_target) {
+      outcome.request_recovery_target_refresh = true;
+      state.consecutive_reject_count = 0;
+      outcome.warn_lines.push_back(
+        formatWarn(
+          "POSE_REJECT_HARD_RECOVERY stamp=%.9f frame=%s",
+          input.stamp_sec,
+          config.robot_frame_id.c_str()));
+    }
+    state.reject_stats_initialized = false;
+    state.accepted_fitness_ema = 0.0;
+    state.accepted_trans_ema = 0.0;
+    state.accepted_pose_count = 0;
+    state.elevated_fitness_streak = 0;
+    state.elevated_trans_streak = 0;
+    state.state_clean_consecutive_accepted = 0;
+    state.tracking_state = TrackingState::Recovery;
+    outcome.warn_lines.push_back(
+      formatWarn(
+        "POSE_REJECT_HARD_RECOVERY stamp=%.9f frame=%s",
+        input.stamp_sec,
+        config.robot_frame_id.c_str()));
+  }
+  if (hard_reject_pose_update) {
+    state.state_clean_consecutive_accepted = 0;
+    if (state.tracking_state != TrackingState::Recovery) {
+      state.tracking_state = TrackingState::Recovery;
+      outcome.warn_lines.push_back(
+        formatWarn("TRACKING_STATE recovery stamp=%.9f", input.stamp_sec));
+    }
+  } else if (soft_reject_map_update) {
+    state.state_clean_consecutive_accepted = 0;
+    if (state.tracking_state == TrackingState::Tracking) {
+      state.tracking_state = TrackingState::Suspect;
+      outcome.warn_lines.push_back(
+        formatWarn("TRACKING_STATE suspect stamp=%.9f", input.stamp_sec));
+    }
+  } else if (state.tracking_state != TrackingState::Tracking) {
+    state.state_clean_consecutive_accepted += 1;
+    if (
+      state.tracking_state == TrackingState::Recovery &&
+      state.state_clean_consecutive_accepted >= config.recovery_clear_consecutive_accepted)
+    {
+      state.tracking_state = TrackingState::Suspect;
+      state.state_clean_consecutive_accepted = 0;
+      outcome.warn_lines.push_back(
+        formatWarn("TRACKING_STATE suspect stamp=%.9f", input.stamp_sec));
+    } else if (
+      state.tracking_state == TrackingState::Suspect &&
+      state.state_clean_consecutive_accepted >= config.suspect_clear_consecutive_accepted)
+    {
+      state.tracking_state = TrackingState::Tracking;
+      state.state_clean_consecutive_accepted = 0;
+      state.recovery_target_active = false;
+      outcome.warn_lines.push_back(
+        formatWarn("TRACKING_STATE tracking stamp=%.9f", input.stamp_sec));
+    }
+  }
+  if (state.previous_pose_diagnostic_valid && !hard_reject_pose_update) {
+    state.last_accepted_delta_position =
+      accepted_position - state.previous_pose_diagnostic_position;
+    tf2::Quaternion previous_quat_tf;
+    tf2::Quaternion current_quat_tf;
+    tf2::fromMsg(input.previous_orientation, previous_quat_tf);
+    tf2::fromMsg(accepted_quat_msg, current_quat_tf);
+    state.last_accepted_delta_quat = previous_quat_tf.inverse() * current_quat_tf;
+    state.last_accepted_delta_quat.normalize();
+    state.last_accepted_delta_valid = true;
+  }
+  state.previous_pose_diagnostic_position = accepted_position;
+  state.previous_pose_diagnostic_yaw = accepted_yaw;
+  state.previous_pose_diagnostic_valid = true;
+
+  const bool reject_map_update_now = hard_reject_pose_update || soft_reject_map_update;
+  const bool suppress_map_update =
+    reject_map_update_now || state.reject_map_update_cooldown_remaining > 0 ||
+    state.tracking_state != TrackingState::Tracking;
+  if (hard_reject_pose_update) {
+    state.reject_map_update_cooldown_remaining = config.hard_reject_map_update_cooldown_scans;
+  } else if (soft_reject_map_update) {
+    state.reject_map_update_cooldown_remaining = config.reject_map_update_cooldown_scans;
+  } else if (state.reject_map_update_cooldown_remaining > 0) {
+    state.reject_map_update_cooldown_remaining -= 1;
+  }
+
+  outcome.accepted_position = accepted_position;
+  outcome.accepted_quat_msg = accepted_quat_msg;
+  outcome.hard_reject_pose_update = hard_reject_pose_update;
+  outcome.soft_reject_map_update = soft_reject_map_update;
+  outcome.suppress_map_update = suppress_map_update;
+  return outcome;
+}
+
+}  // namespace pose_acceptance
+}  // namespace graphslam
+
+#endif  // SCANMATCHER_POSE_ACCEPTANCE_HPP_

--- a/scanmatcher/include/scanmatcher/scanmatcher_component.h
+++ b/scanmatcher/include/scanmatcher/scanmatcher_component.h
@@ -58,6 +58,7 @@ extern "C" {
 
 #include <lidarslam_msgs/msg/map_array.hpp>
 #include "scanmatcher/lidar_undistortion.hpp"
+#include "scanmatcher/pose_acceptance.hpp"
 #include "scanmatcher/pose_prediction.hpp"
 #include "scanmatcher/voxel_hash_map.hpp"
 
@@ -90,12 +91,7 @@ public:
     explicit ScanMatcherComponent(const rclcpp::NodeOptions & options);
 
 private:
-    enum class TrackingState
-    {
-      Tracking,
-      Suspect,
-      Recovery
-    };
+    using TrackingState = pose_acceptance::TrackingState;
 
     rclcpp::Clock clock_;
     tf2_ros::Buffer tfbuffer_;
@@ -149,6 +145,7 @@ private:
       const std::string & stage);
     Eigen::Matrix4f getTransformation(const geometry_msgs::msg::Pose pose);
     pose_prediction::ImuPredictionConfig makeImuPredictionConfig() const;
+    pose_acceptance::Config makePoseAcceptanceConfig() const;
     void publishMap(const lidarslam_msgs::msg::MapArray & map_array_msg, const std::string & map_frame_id);
     void updateMap(
       const pcl::PointCloud < pcl::PointXYZI > ::ConstPtr cloud_ptr,
@@ -247,28 +244,14 @@ private:
     int reject_warmup_scans_ {20};
     int reject_map_update_cooldown_scans_ {2};
     int hard_reject_map_update_cooldown_scans_ {4};
-    int reject_map_update_cooldown_remaining_ {0};
     int reject_fitness_streak_scans_ {0};
-    int elevated_fitness_streak_ {0};
-    int elevated_trans_streak_ {0};
     int reject_recovery_scans_ {0};
-    int consecutive_reject_count_ {0};
-    double accepted_fitness_ema_ {0.0};
-    double accepted_trans_ema_ {0.0};
-    int accepted_pose_count_ {0};
-    bool reject_stats_initialized_ {false};
     rclcpp::Time previous_pose_stamp_ {0, 0, RCL_ROS_TIME};
     rclcpp::Time last_cloud_stamp_ {0, 0, RCL_ROS_TIME};
     bool last_cloud_stamp_valid_ {false};
-    Eigen::Vector3d previous_pose_diagnostic_position_ {Eigen::Vector3d::Zero()};
-    double previous_pose_diagnostic_yaw_ {0.0};
-    bool previous_pose_diagnostic_valid_ {false};
-    Eigen::Vector3d last_accepted_delta_position_ {Eigen::Vector3d::Zero()};
-    tf2::Quaternion last_accepted_delta_quat_ {0.0, 0.0, 0.0, 1.0};
-    bool last_accepted_delta_valid_ {false};
-    TrackingState tracking_state_ {TrackingState::Tracking};
-    int state_clean_consecutive_accepted_ {0};
-    bool recovery_target_active_ {false};
+    // Pose-acceptance core state (diagnostics, adaptive gates, tracking
+    // state machine, map-update cooldown) — see pose_acceptance.hpp.
+    pose_acceptance::State pose_acceptance_state_;
 
     // map
     Eigen::Vector3d previous_position_;

--- a/scanmatcher/src/scanmatcher_component.cpp
+++ b/scanmatcher/src/scanmatcher_component.cpp
@@ -928,7 +928,7 @@ void ScanMatcherComponent::receiveCloud(
         }
       }
       if (targeted_cloud_ptr) {
-        if (!recovery_target_active_) {
+        if (!pose_acceptance_state_.recovery_target_active) {
           if (registration_method_ == "NDT") {
             registration_->setInputTarget(targeted_cloud_ptr);
           } else {
@@ -980,9 +980,9 @@ void ScanMatcherComponent::receiveCloud(
   sim_trans = pose_prediction::applyConstantVelocityPrediction(
     sim_trans,
     use_constant_velocity_model_,
-    last_accepted_delta_valid_,
-    tracking_state_ == TrackingState::Tracking,
-    last_accepted_delta_position_);
+    pose_acceptance_state_.last_accepted_delta_valid,
+    pose_acceptance_state_.tracking_state == TrackingState::Tracking,
+    pose_acceptance_state_.last_accepted_delta_position);
 
   // IMU initial guess modification (only when complementary filter is disabled)
   if (!imu_complementary_enable_) {
@@ -996,7 +996,8 @@ void ScanMatcherComponent::receiveCloud(
       imu_prediction_config,
       imu_observation,
       current_orientation_quat,
-      tracking_state_ != TrackingState::Tracking || recovery_target_active_);
+      pose_acceptance_state_.tracking_state != TrackingState::Tracking ||
+      pose_acceptance_state_.recovery_target_active);
   }
 
   if (use_odom_) {
@@ -1016,8 +1017,8 @@ void ScanMatcherComponent::receiveCloud(
       if (previous_odom_valid_) {
         const bool odom_prior_active =
           !odom_prior_suspect_recovery_only_ ||
-          tracking_state_ != TrackingState::Tracking ||
-          recovery_target_active_;
+          pose_acceptance_state_.tracking_state != TrackingState::Tracking ||
+          pose_acceptance_state_.recovery_target_active;
         if (odom_prior_active) {
           const Eigen::Matrix4f odom_delta = previous_odom_mat_.inverse() * odom_mat;
           const Eigen::Matrix4f filtered_odom_delta = odom_prior::filterAndBlendDelta(
@@ -1182,393 +1183,34 @@ void ScanMatcherComponent::publishMapAndPose(
   geometry_msgs::msg::Quaternion quat_msg = tf2::toMsg(quat_eig);
   const bool has_converged = registration_->hasConverged();
   const double fitness_score = registration_->getFitnessScore();
-  tf2::Quaternion diag_quat_tf;
-  double diag_roll, diag_pitch, diag_yaw;
-  tf2::fromMsg(quat_msg, diag_quat_tf);
-  tf2::Matrix3x3(diag_quat_tf).getRPY(diag_roll, diag_pitch, diag_yaw);
-  double dt = 0.0;
-  double trans_jump = 0.0;
-  double yaw_jump_deg = 0.0;
-  double fitness_ratio = 1.0;
-  double trans_ratio = 1.0;
-  double fitness_ref = fitness_score;
-  double trans_ref = 0.0;
-  bool warmup_complete = false;
-  bool reject_pose_update = false;
-  bool hard_reject_pose_update = false;
-  bool soft_reject_map_update = false;
-  bool adaptive_ratio_reject = false;
-  bool fitness_only_map_reject = false;
-  bool trans_only_map_reject = false;
-  bool trans_streak_map_reject = false;
-  bool fitness_streak_map_reject = false;
-  bool hard_ratio_reject = false;
-  bool motion_gate_suspect = false;
-  bool motion_gate_hard = false;
-  double motion_gate_trans_limit = 0.0;
-  double motion_gate_yaw_limit_deg = 0.0;
-  constexpr double kFitnessScoreSanityLimit = 1.0e4;
-  const bool invalid_fitness_score =
-    !std::isfinite(fitness_score) || fitness_score >= kFitnessScoreSanityLimit;
+  pose_acceptance::Input acceptance_input;
+  acceptance_input.position = position;
+  acceptance_input.orientation = quat_msg;
+  acceptance_input.previous_orientation = current_pose_stamped_.pose.orientation;
+  acceptance_input.has_converged = has_converged;
+  acceptance_input.fitness_score = fitness_score;
+  acceptance_input.stamp_sec = stamp.seconds();
+  acceptance_input.previous_stamp_sec = previous_pose_stamp_.seconds();
+  // Duration::seconds() on the rclcpp::Time pair, exactly as the historical
+  // inline block computed dt (double-double subtraction rounds differently).
+  acceptance_input.dt = pose_acceptance_state_.previous_pose_diagnostic_valid ?
+    (stamp - previous_pose_stamp_).seconds() : 0.0;
+  acceptance_input.mapping_in_progress = mapping_flag_;
 
-  if (previous_pose_diagnostic_valid_) {
-    dt = (stamp - previous_pose_stamp_).seconds();
-    trans_jump = (position - previous_pose_diagnostic_position_).norm();
-    yaw_jump_deg =
-      std::abs(wrapAngleRad(diag_yaw - previous_pose_diagnostic_yaw_)) * 180.0 / M_PI;
-
-    if (dt <= 0.0) {
-      RCLCPP_WARN(
-        get_logger(),
-        "POSE_STAMP_NONMONOTONIC stamp=%.9f prev_stamp=%.9f dt=%.6f frame=%s",
-        stamp.seconds(),
-        previous_pose_stamp_.seconds(),
-        dt,
-        robot_frame_id_.c_str());
-    }
-
-    if (!has_converged || trans_jump >= diagnostic_warn_trans_jump_ ||
-      yaw_jump_deg >= diagnostic_warn_yaw_jump_deg_)
-    {
-      RCLCPP_WARN(
-        get_logger(),
-        "POSE_JUMP stamp=%.9f dt=%.6f trans=%.6f yaw_deg=%.3f converged=%s fitness=%.6f frame=%s",
-        stamp.seconds(),
-        dt,
-        trans_jump,
-        yaw_jump_deg,
-        has_converged ? "true" : "false",
-        fitness_score,
-        robot_frame_id_.c_str());
-    }
-
-    if (reject_stats_initialized_) {
-      fitness_ref = accepted_fitness_ema_;
-      trans_ref = accepted_trans_ema_;
-      if (
-        !std::isfinite(fitness_ref) || fitness_ref <= 0.0 ||
-        fitness_ref >= kFitnessScoreSanityLimit ||
-        !std::isfinite(trans_ref) || trans_ref < 0.0)
-      {
-        reject_stats_initialized_ = false;
-        accepted_fitness_ema_ = 0.0;
-        accepted_trans_ema_ = 0.0;
-        accepted_pose_count_ = 0;
-        fitness_ref = fitness_score;
-        trans_ref = trans_jump;
-      }
-    } else {
-      fitness_ref = fitness_score;
-      trans_ref = trans_jump;
-    }
-
-    const double fitness_ref_safe = (fitness_ref > 1e-6) ? fitness_ref : 1e-6;
-    const double trans_ref_safe = (trans_ref > 1e-3) ? trans_ref : 1e-3;
-    fitness_ratio = fitness_score / fitness_ref_safe;
-    trans_ratio = trans_jump / trans_ref_safe;
-
-    if (
-      motion_gate_enable_ &&
-      motion_gate_max_linear_velocity_ > 0.0 &&
-      motion_gate_max_yaw_rate_deg_ > 0.0)
-    {
-      const double effective_dt = std::max(dt, scan_period_);
-      motion_gate_trans_limit = motion_gate_max_linear_velocity_ * effective_dt;
-      motion_gate_yaw_limit_deg = motion_gate_max_yaw_rate_deg_ * effective_dt;
-      motion_gate_suspect =
-        trans_jump > motion_gate_trans_limit ||
-        yaw_jump_deg > motion_gate_yaw_limit_deg;
-      motion_gate_hard =
-        motion_gate_hard_multiplier_ > 1.0 &&
-        (
-        trans_jump > motion_gate_trans_limit * motion_gate_hard_multiplier_ ||
-        yaw_jump_deg > motion_gate_yaw_limit_deg * motion_gate_hard_multiplier_);
-    }
-
-    warmup_complete = accepted_pose_count_ >= reject_warmup_scans_;
-    adaptive_ratio_reject =
-      warmup_complete &&
-      reject_stats_initialized_ &&
-      reject_fitness_ratio_ > 0.0 &&
-      reject_trans_jump_ratio_ > 0.0 &&
-      fitness_ratio >= reject_fitness_ratio_ &&
-      trans_ratio >= reject_trans_jump_ratio_;
-    fitness_only_map_reject =
-      warmup_complete &&
-      reject_stats_initialized_ &&
-      reject_fitness_only_ratio_ > 0.0 &&
-      fitness_ratio >= reject_fitness_only_ratio_;
-    trans_only_map_reject =
-      warmup_complete &&
-      reject_stats_initialized_ &&
-      reject_trans_only_ratio_ > 0.0 &&
-      trans_jump >= diagnostic_warn_trans_jump_ &&
-      trans_ratio >= reject_trans_only_ratio_;
-    if (
-      trans_jump >= diagnostic_warn_trans_jump_ &&
-      trans_ratio >= reject_trans_jump_ratio_)
-    {
-      elevated_trans_streak_ += 1;
-    } else {
-      elevated_trans_streak_ = 0;
-    }
-    trans_streak_map_reject =
-      reject_trans_streak_scans_ > 0 &&
-      elevated_trans_streak_ >= reject_trans_streak_scans_;
-    if (
-      warmup_complete &&
-      reject_stats_initialized_ &&
-      reject_fitness_streak_ratio_ > 0.0 &&
-      fitness_ratio >= reject_fitness_streak_ratio_)
-    {
-      elevated_fitness_streak_ += 1;
-    } else {
-      elevated_fitness_streak_ = 0;
-    }
-    fitness_streak_map_reject =
-      reject_fitness_streak_scans_ > 0 &&
-      elevated_fitness_streak_ >= reject_fitness_streak_scans_;
-    hard_ratio_reject =
-      warmup_complete &&
-      reject_stats_initialized_ &&
-      reject_hard_fitness_ratio_ > 0.0 &&
-      reject_hard_trans_ratio_ > 0.0 &&
-      fitness_ratio >= reject_hard_fitness_ratio_ &&
-      trans_ratio >= reject_hard_trans_ratio_;
-
-    hard_reject_pose_update =
-      invalid_fitness_score ||
-      (reject_nonconverged_pose_update_ && !has_converged) ||
-      (reject_fitness_score_ > 0.0 && fitness_score > reject_fitness_score_) ||
-      (
-      !motion_gate_enable_ &&
-      reject_trans_jump_ > 0.0 &&
-      trans_jump >= reject_trans_jump_) ||
-      motion_gate_hard ||
-      hard_ratio_reject;
-    soft_reject_map_update =
-      (adaptive_ratio_reject || fitness_only_map_reject || trans_only_map_reject ||
-      trans_streak_map_reject || fitness_streak_map_reject || motion_gate_suspect) &&
-      !hard_reject_pose_update;
-    reject_pose_update = hard_reject_pose_update;
+  pose_acceptance::Outcome acceptance = pose_acceptance::evaluate(
+    makePoseAcceptanceConfig(), pose_acceptance_state_, acceptance_input);
+  for (const auto & warn_line : acceptance.warn_lines) {
+    RCLCPP_WARN(get_logger(), "%s", warn_line.c_str());
   }
-
-  Eigen::Vector3d accepted_position = position;
-  geometry_msgs::msg::Quaternion accepted_quat_msg = quat_msg;
-  double accepted_yaw = diag_yaw;
-  Eigen::Vector3d predicted_position = position;
-  geometry_msgs::msg::Quaternion predicted_quat_msg = quat_msg;
-  double predicted_yaw = diag_yaw;
-  Eigen::Vector3d clipped_position = position;
-  geometry_msgs::msg::Quaternion clipped_quat_msg = quat_msg;
-  double clipped_yaw = diag_yaw;
-  if (previous_pose_diagnostic_valid_) {
-    predicted_position = previous_pose_diagnostic_position_;
-    predicted_quat_msg = current_pose_stamped_.pose.orientation;
-    predicted_yaw = previous_pose_diagnostic_yaw_;
-    if (last_accepted_delta_valid_) {
-      predicted_position += last_accepted_delta_position_;
-      tf2::Quaternion prev_quat_tf;
-      tf2::Quaternion predicted_quat_tf;
-      tf2::fromMsg(current_pose_stamped_.pose.orientation, prev_quat_tf);
-      predicted_quat_tf = prev_quat_tf * last_accepted_delta_quat_;
-      predicted_quat_tf.normalize();
-      predicted_quat_msg = tf2::toMsg(predicted_quat_tf);
-      double predicted_roll;
-      double predicted_pitch;
-      tf2::Matrix3x3(predicted_quat_tf).getRPY(predicted_roll, predicted_pitch, predicted_yaw);
-    }
-
-    if (motion_gate_enable_ && motion_gate_trans_limit > 0.0 && motion_gate_yaw_limit_deg > 0.0) {
-      const Eigen::Vector3d candidate_delta = position - predicted_position;
-      clipped_position =
-        predicted_position + clampVectorNorm(candidate_delta, motion_gate_trans_limit);
-
-      const double max_yaw_delta = motion_gate_yaw_limit_deg * M_PI / 180.0;
-      const double candidate_yaw_delta = wrapAngleRad(diag_yaw - predicted_yaw);
-      const double clipped_yaw_delta =
-        std::clamp(candidate_yaw_delta, -max_yaw_delta, max_yaw_delta);
-      clipped_yaw = predicted_yaw + clipped_yaw_delta;
-      clipped_quat_msg = quaternionFromRPY(diag_roll, diag_pitch, clipped_yaw);
-    }
-  }
-  if (previous_pose_diagnostic_valid_ && hard_reject_pose_update) {
-    accepted_position = predicted_position;
-    accepted_quat_msg = predicted_quat_msg;
-    accepted_yaw = predicted_yaw;
-  } else if (previous_pose_diagnostic_valid_ && soft_reject_map_update) {
-    accepted_position = clipped_position;
-    accepted_quat_msg = clipped_quat_msg;
-    accepted_yaw = clipped_yaw;
-  } else if (previous_pose_diagnostic_valid_ && tracking_state_ == TrackingState::Recovery) {
-    accepted_position = clipped_position;
-    accepted_quat_msg = clipped_quat_msg;
-    accepted_yaw = clipped_yaw;
-  } else if (previous_pose_diagnostic_valid_ && tracking_state_ == TrackingState::Suspect) {
-    accepted_position = clipped_position;
-    accepted_quat_msg = clipped_quat_msg;
-    accepted_yaw = clipped_yaw;
-  }
-  if (previous_pose_diagnostic_valid_ && (hard_reject_pose_update || soft_reject_map_update)) {
-    if (invalid_fitness_score) {
-      RCLCPP_WARN(
-        get_logger(),
-        "POSE_FITNESS_INVALID stamp=%.9f fitness=%.6f frame=%s",
-        stamp.seconds(),
-        fitness_score,
-        robot_frame_id_.c_str());
-    }
-    RCLCPP_WARN(
-      get_logger(),
-      "POSE_REJECT stamp=%.9f dt=%.6f trans=%.6f yaw_deg=%.3f converged=%s fitness=%.6f fitness_ref=%.6f fitness_ratio=%.3f trans_ref=%.6f trans_ratio=%.3f motion_gate=%s motion_gate_hard=%s trans_limit=%.3f yaw_limit_deg=%.3f adaptive=%s fitness_only=%s trans_only=%s trans_streak=%s fitness_streak=%s hard_ratio=%s streak_count=%d mode=%s cooldown=%d reject_nonconv=%s reject_fitness=%.3f reject_trans=%.3f frame=%s",
-      stamp.seconds(),
-      dt,
-      trans_jump,
-      yaw_jump_deg,
-      has_converged ? "true" : "false",
-      fitness_score,
-      fitness_ref,
-      fitness_ratio,
-      trans_ref,
-      trans_ratio,
-      motion_gate_suspect ? "true" : "false",
-      motion_gate_hard ? "true" : "false",
-      motion_gate_trans_limit,
-      motion_gate_yaw_limit_deg,
-      adaptive_ratio_reject ? "true" : "false",
-      fitness_only_map_reject ? "true" : "false",
-      trans_only_map_reject ? "true" : "false",
-      trans_streak_map_reject ? "true" : "false",
-      fitness_streak_map_reject ? "true" : "false",
-      hard_ratio_reject ? "true" : "false",
-      elevated_fitness_streak_,
-      hard_reject_pose_update ? "hard" : "map_only",
-      reject_map_update_cooldown_scans_,
-      reject_nonconverged_pose_update_ ? "true" : "false",
-      reject_fitness_score_,
-      reject_trans_jump_,
-      robot_frame_id_.c_str());
-  }
-
-  if (!reject_pose_update && !soft_reject_map_update) {
-    double alpha = reject_ema_alpha_;
-    if (alpha <= 0.0 || alpha > 1.0) {alpha = 0.1;}
-    double fitness_sample = fitness_score;
-    double trans_sample = trans_jump;
-    if (!reject_stats_initialized_) {
-      accepted_fitness_ema_ = fitness_sample;
-      accepted_trans_ema_ = trans_sample;
-      reject_stats_initialized_ = true;
-    } else {
-      if (accepted_pose_count_ >= reject_warmup_scans_) {
-        if (reject_fitness_ratio_ > 0.0 && accepted_fitness_ema_ > 1e-6) {
-          const double fitness_cap = accepted_fitness_ema_ * reject_fitness_ratio_;
-          if (fitness_sample > fitness_cap) {fitness_sample = fitness_cap;}
-        }
-        if (reject_trans_jump_ratio_ > 0.0 && accepted_trans_ema_ > 1e-3) {
-          const double trans_cap = accepted_trans_ema_ * reject_trans_jump_ratio_;
-          if (trans_sample > trans_cap) {trans_sample = trans_cap;}
-        }
-      }
-      accepted_fitness_ema_ = (1.0 - alpha) * accepted_fitness_ema_ + alpha * fitness_sample;
-      accepted_trans_ema_ = (1.0 - alpha) * accepted_trans_ema_ + alpha * trans_sample;
-    }
-    accepted_pose_count_ += 1;
-  }
-  if (reject_pose_update || soft_reject_map_update) {
-    consecutive_reject_count_ += 1;
-  } else {
-    consecutive_reject_count_ = 0;
-  }
-  if (hard_reject_pose_update) {
-    last_accepted_delta_valid_ = false;
-  }
-  if (hard_reject_pose_update) {
-    const bool activate_recovery_target =
-      !mapping_flag_ &&
-      (
-      reject_recovery_scans_ <= 1 ||
-      consecutive_reject_count_ >= reject_recovery_scans_);
-    if (activate_recovery_target) {
-      recovery_target_active_ = refreshRegistrationTargetFromTargetedCloud();
-      consecutive_reject_count_ = 0;
-      RCLCPP_WARN(
-        get_logger(),
-        "POSE_REJECT_HARD_RECOVERY stamp=%.9f frame=%s",
-        stamp.seconds(),
-        robot_frame_id_.c_str());
-    }
-    reject_stats_initialized_ = false;
-    accepted_fitness_ema_ = 0.0;
-    accepted_trans_ema_ = 0.0;
-    accepted_pose_count_ = 0;
-    elevated_fitness_streak_ = 0;
-    elevated_trans_streak_ = 0;
-    state_clean_consecutive_accepted_ = 0;
-    tracking_state_ = TrackingState::Recovery;
-    RCLCPP_WARN(
-      get_logger(),
-      "POSE_REJECT_HARD_RECOVERY stamp=%.9f frame=%s",
-      stamp.seconds(),
-      robot_frame_id_.c_str());
-  }
-  if (hard_reject_pose_update) {
-    state_clean_consecutive_accepted_ = 0;
-    if (tracking_state_ != TrackingState::Recovery) {
-      tracking_state_ = TrackingState::Recovery;
-      RCLCPP_WARN(get_logger(), "TRACKING_STATE recovery stamp=%.9f", stamp.seconds());
-    }
-  } else if (soft_reject_map_update) {
-    state_clean_consecutive_accepted_ = 0;
-    if (tracking_state_ == TrackingState::Tracking) {
-      tracking_state_ = TrackingState::Suspect;
-      RCLCPP_WARN(get_logger(), "TRACKING_STATE suspect stamp=%.9f", stamp.seconds());
-    }
-  } else if (tracking_state_ != TrackingState::Tracking) {
-    state_clean_consecutive_accepted_ += 1;
-    if (
-      tracking_state_ == TrackingState::Recovery &&
-      state_clean_consecutive_accepted_ >= recovery_clear_consecutive_accepted_)
-    {
-      tracking_state_ = TrackingState::Suspect;
-      state_clean_consecutive_accepted_ = 0;
-      RCLCPP_WARN(get_logger(), "TRACKING_STATE suspect stamp=%.9f", stamp.seconds());
-    } else if (
-      tracking_state_ == TrackingState::Suspect &&
-      state_clean_consecutive_accepted_ >= suspect_clear_consecutive_accepted_)
-    {
-      tracking_state_ = TrackingState::Tracking;
-      state_clean_consecutive_accepted_ = 0;
-      recovery_target_active_ = false;
-      RCLCPP_WARN(get_logger(), "TRACKING_STATE tracking stamp=%.9f", stamp.seconds());
-    }
-  }
-  if (previous_pose_diagnostic_valid_ && !hard_reject_pose_update) {
-    last_accepted_delta_position_ = accepted_position - previous_pose_diagnostic_position_;
-    tf2::Quaternion previous_quat_tf;
-    tf2::Quaternion current_quat_tf;
-    tf2::fromMsg(current_pose_stamped_.pose.orientation, previous_quat_tf);
-    tf2::fromMsg(accepted_quat_msg, current_quat_tf);
-    last_accepted_delta_quat_ = previous_quat_tf.inverse() * current_quat_tf;
-    last_accepted_delta_quat_.normalize();
-    last_accepted_delta_valid_ = true;
+  if (acceptance.request_recovery_target_refresh) {
+    // The decision is pure; the registration-target side effect is not.
+    pose_acceptance_state_.recovery_target_active = refreshRegistrationTargetFromTargetedCloud();
   }
   previous_pose_stamp_ = stamp;
-  previous_pose_diagnostic_position_ = accepted_position;
-  previous_pose_diagnostic_yaw_ = accepted_yaw;
-  previous_pose_diagnostic_valid_ = true;
 
-  const bool reject_map_update_now = hard_reject_pose_update || soft_reject_map_update;
-  const bool suppress_map_update =
-    reject_map_update_now || reject_map_update_cooldown_remaining_ > 0 ||
-    tracking_state_ != TrackingState::Tracking;
-  if (hard_reject_pose_update) {
-    reject_map_update_cooldown_remaining_ = hard_reject_map_update_cooldown_scans_;
-  } else if (soft_reject_map_update) {
-    reject_map_update_cooldown_remaining_ = reject_map_update_cooldown_scans_;
-  } else if (reject_map_update_cooldown_remaining_ > 0) {
-    reject_map_update_cooldown_remaining_ -= 1;
-  }
+  const Eigen::Vector3d accepted_position = acceptance.accepted_position;
+  const geometry_msgs::msg::Quaternion accepted_quat_msg = acceptance.accepted_quat_msg;
+  const bool suppress_map_update = acceptance.suppress_map_update;
 
   // Post-NDT complementary filter: blend roll/pitch with IMU for output only
   // current_pose_stamped_ keeps raw NDT result for next-frame initial guess
@@ -1577,7 +1219,7 @@ void ScanMatcherComponent::publishMapAndPose(
   if (
     imu_complementary_enable_ && imu_complementary_alpha_ > 0.0 &&
     use_imu_ && latest_imu_orientation_valid_ && cloud_imu_reference_valid_ &&
-    previous_pose_diagnostic_valid_)
+    pose_acceptance_state_.previous_pose_diagnostic_valid)
   {
     const double imu_age = std::abs((stamp - latest_imu_stamp_).seconds());
     if (imu_age <= imu_pose_prediction_max_age_) {
@@ -1876,6 +1518,39 @@ Eigen::Matrix4f ScanMatcherComponent::getTransformation(const geometry_msgs::msg
   tf2::fromMsg(pose, affine);
   Eigen::Matrix4f sim_trans = affine.matrix().cast<float>();
   return sim_trans;
+}
+
+pose_acceptance::Config ScanMatcherComponent::makePoseAcceptanceConfig() const
+{
+  pose_acceptance::Config config;
+  config.diagnostic_warn_trans_jump = diagnostic_warn_trans_jump_;
+  config.diagnostic_warn_yaw_jump_deg = diagnostic_warn_yaw_jump_deg_;
+  config.reject_nonconverged_pose_update = reject_nonconverged_pose_update_;
+  config.reject_fitness_score = reject_fitness_score_;
+  config.reject_fitness_ratio = reject_fitness_ratio_;
+  config.reject_fitness_only_ratio = reject_fitness_only_ratio_;
+  config.reject_trans_only_ratio = reject_trans_only_ratio_;
+  config.reject_trans_streak_scans = reject_trans_streak_scans_;
+  config.reject_fitness_streak_ratio = reject_fitness_streak_ratio_;
+  config.reject_fitness_streak_scans = reject_fitness_streak_scans_;
+  config.reject_hard_fitness_ratio = reject_hard_fitness_ratio_;
+  config.reject_trans_jump = reject_trans_jump_;
+  config.reject_trans_jump_ratio = reject_trans_jump_ratio_;
+  config.reject_hard_trans_ratio = reject_hard_trans_ratio_;
+  config.reject_ema_alpha = reject_ema_alpha_;
+  config.motion_gate_enable = motion_gate_enable_;
+  config.motion_gate_max_linear_velocity = motion_gate_max_linear_velocity_;
+  config.motion_gate_max_yaw_rate_deg = motion_gate_max_yaw_rate_deg_;
+  config.motion_gate_hard_multiplier = motion_gate_hard_multiplier_;
+  config.reject_warmup_scans = reject_warmup_scans_;
+  config.reject_map_update_cooldown_scans = reject_map_update_cooldown_scans_;
+  config.hard_reject_map_update_cooldown_scans = hard_reject_map_update_cooldown_scans_;
+  config.reject_recovery_scans = reject_recovery_scans_;
+  config.recovery_clear_consecutive_accepted = recovery_clear_consecutive_accepted_;
+  config.suspect_clear_consecutive_accepted = suspect_clear_consecutive_accepted_;
+  config.scan_period = scan_period_;
+  config.robot_frame_id = robot_frame_id_;
+  return config;
 }
 
 pose_prediction::ImuPredictionConfig ScanMatcherComponent::makeImuPredictionConfig() const

--- a/scanmatcher/test/test_pose_acceptance.cpp
+++ b/scanmatcher/test/test_pose_acceptance.cpp
@@ -1,0 +1,276 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "scanmatcher/pose_acceptance.hpp"
+
+namespace
+{
+using graphslam::pose_acceptance::Config;
+using graphslam::pose_acceptance::evaluate;
+using graphslam::pose_acceptance::Input;
+using graphslam::pose_acceptance::Outcome;
+using graphslam::pose_acceptance::State;
+using graphslam::pose_acceptance::TrackingState;
+
+geometry_msgs::msg::Quaternion identityQuat()
+{
+  geometry_msgs::msg::Quaternion quat;
+  quat.w = 1.0;
+  return quat;
+}
+
+Input makeInput(
+  const Eigen::Vector3d & position,
+  const double stamp_sec,
+  const double dt,
+  const geometry_msgs::msg::Quaternion & previous_orientation)
+{
+  Input input;
+  input.position = position;
+  input.orientation = identityQuat();
+  input.previous_orientation = previous_orientation;
+  input.has_converged = true;
+  input.fitness_score = 0.5;
+  input.stamp_sec = stamp_sec;
+  input.previous_stamp_sec = stamp_sec - dt;
+  input.dt = dt;
+  input.mapping_in_progress = false;
+  return input;
+}
+
+// Drive one clean accepted scan (small motion, good fitness).
+Outcome stepAccepted(const Config & config, State & state, const double stamp_sec)
+{
+  Input input = makeInput(
+    state.previous_pose_diagnostic_position + Eigen::Vector3d(0.05, 0.0, 0.0),
+    stamp_sec, 0.1, identityQuat());
+  return evaluate(config, state, input);
+}
+}  // namespace
+
+TEST(PoseAcceptanceTest, FirstScanAcceptsRawPoseAndInitializesState)
+{
+  Config config;
+  State state;
+  const Input input = makeInput(Eigen::Vector3d(1.0, 2.0, 3.0), 10.0, 0.0, identityQuat());
+
+  const Outcome outcome = evaluate(config, state, input);
+
+  EXPECT_TRUE(outcome.accepted_position.isApprox(input.position, 0.0));
+  EXPECT_FALSE(outcome.hard_reject_pose_update);
+  EXPECT_FALSE(outcome.soft_reject_map_update);
+  EXPECT_FALSE(outcome.suppress_map_update);
+  EXPECT_TRUE(outcome.warn_lines.empty());
+  EXPECT_TRUE(state.previous_pose_diagnostic_valid);
+  EXPECT_TRUE(state.reject_stats_initialized);
+  EXPECT_EQ(state.accepted_pose_count, 1);
+  EXPECT_DOUBLE_EQ(state.accepted_fitness_ema, 0.5);
+  // The frame-to-frame delta needs a previous diagnostic pose.
+  EXPECT_FALSE(state.last_accepted_delta_valid);
+  EXPECT_EQ(state.tracking_state, TrackingState::Tracking);
+}
+
+TEST(PoseAcceptanceTest, MotionGateSoftRejectClipsThePoseAndEntersSuspect)
+{
+  Config config;
+  State state;
+  evaluate(config, state, makeInput(Eigen::Vector3d::Zero(), 1.0, 0.0, identityQuat()));
+
+  // 1.5 m in 0.1 s: over the 8 m/s * 0.1 s = 0.8 m gate, under the 4x hard
+  // multiplier (3.2 m) -> soft reject, clipped to the gate limit.
+  const Input jump = makeInput(Eigen::Vector3d(1.5, 0.0, 0.0), 1.1, 0.1, identityQuat());
+  const Outcome outcome = evaluate(config, state, jump);
+
+  EXPECT_FALSE(outcome.hard_reject_pose_update);
+  EXPECT_TRUE(outcome.soft_reject_map_update);
+  EXPECT_TRUE(outcome.suppress_map_update);
+  EXPECT_TRUE(outcome.accepted_position.isApprox(Eigen::Vector3d(0.8, 0.0, 0.0), 1e-12));
+  EXPECT_EQ(state.tracking_state, TrackingState::Suspect);
+  EXPECT_EQ(state.reject_map_update_cooldown_remaining, config.reject_map_update_cooldown_scans);
+
+  ASSERT_EQ(outcome.warn_lines.size(), 3u);
+  EXPECT_EQ(outcome.warn_lines[0].rfind("POSE_JUMP stamp=1.100000000 dt=0.100000", 0), 0u);
+  EXPECT_EQ(outcome.warn_lines[1].rfind("POSE_REJECT stamp=1.100000000", 0), 0u);
+  EXPECT_NE(outcome.warn_lines[1].find("mode=map_only"), std::string::npos);
+  EXPECT_NE(outcome.warn_lines[1].find("motion_gate=true"), std::string::npos);
+  EXPECT_NE(outcome.warn_lines[1].find("motion_gate_hard=false"), std::string::npos);
+  EXPECT_EQ(outcome.warn_lines[2], "TRACKING_STATE suspect stamp=1.100000000");
+}
+
+TEST(PoseAcceptanceTest, NonConvergedScanHardRejectsIntoRecovery)
+{
+  Config config;
+  State state;
+  evaluate(config, state, makeInput(Eigen::Vector3d::Zero(), 1.0, 0.0, identityQuat()));
+
+  Input bad = makeInput(Eigen::Vector3d(0.05, 0.0, 0.0), 1.1, 0.1, identityQuat());
+  bad.has_converged = false;
+  const Outcome outcome = evaluate(config, state, bad);
+
+  EXPECT_TRUE(outcome.hard_reject_pose_update);
+  EXPECT_FALSE(outcome.soft_reject_map_update);
+  EXPECT_TRUE(outcome.suppress_map_update);
+  // Hard reject falls back to the predicted pose (= previous, no delta yet).
+  EXPECT_TRUE(outcome.accepted_position.isApprox(Eigen::Vector3d::Zero(), 0.0));
+  EXPECT_EQ(state.tracking_state, TrackingState::Recovery);
+  EXPECT_FALSE(state.last_accepted_delta_valid);
+  EXPECT_FALSE(state.reject_stats_initialized);
+  EXPECT_EQ(state.accepted_pose_count, 0);
+  EXPECT_EQ(
+    state.reject_map_update_cooldown_remaining,
+    config.hard_reject_map_update_cooldown_scans);
+  // reject_recovery_scans <= 1 and no mapping thread -> immediate refresh
+  // request, and the historical duplicated HARD_RECOVERY warn is preserved.
+  EXPECT_TRUE(outcome.request_recovery_target_refresh);
+  int hard_recovery_lines = 0;
+  for (const auto & line : outcome.warn_lines) {
+    if (line.rfind("POSE_REJECT_HARD_RECOVERY", 0) == 0) {hard_recovery_lines += 1;}
+  }
+  EXPECT_EQ(hard_recovery_lines, 2);
+}
+
+TEST(PoseAcceptanceTest, InvalidFitnessEmitsTheDedicatedWarn)
+{
+  Config config;
+  State state;
+  evaluate(config, state, makeInput(Eigen::Vector3d::Zero(), 1.0, 0.0, identityQuat()));
+
+  Input bad = makeInput(Eigen::Vector3d(0.05, 0.0, 0.0), 1.1, 0.1, identityQuat());
+  bad.fitness_score = std::numeric_limits<double>::infinity();
+  const Outcome outcome = evaluate(config, state, bad);
+
+  EXPECT_TRUE(outcome.hard_reject_pose_update);
+  bool found = false;
+  for (const auto & line : outcome.warn_lines) {
+    if (line.rfind("POSE_FITNESS_INVALID stamp=1.100000000", 0) == 0) {found = true;}
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(PoseAcceptanceTest, RecoveryClearsThroughSuspectToTrackingOnCleanAccepts)
+{
+  Config config;
+  State state;
+  evaluate(config, state, makeInput(Eigen::Vector3d::Zero(), 1.0, 0.0, identityQuat()));
+
+  Input bad = makeInput(Eigen::Vector3d(0.05, 0.0, 0.0), 1.1, 0.1, identityQuat());
+  bad.has_converged = false;
+  evaluate(config, state, bad);
+  ASSERT_EQ(state.tracking_state, TrackingState::Recovery);
+  state.recovery_target_active = true;  // shell refresh result
+
+  // recovery_clear_consecutive_accepted = 1: first clean accept -> Suspect.
+  Outcome outcome = stepAccepted(config, state, 1.2);
+  EXPECT_EQ(state.tracking_state, TrackingState::Suspect);
+  ASSERT_FALSE(outcome.warn_lines.empty());
+  EXPECT_EQ(outcome.warn_lines.back(), "TRACKING_STATE suspect stamp=1.200000000");
+
+  // suspect_clear_consecutive_accepted = 2: two more -> Tracking.
+  stepAccepted(config, state, 1.3);
+  outcome = stepAccepted(config, state, 1.4);
+  EXPECT_EQ(state.tracking_state, TrackingState::Tracking);
+  EXPECT_FALSE(state.recovery_target_active);
+  ASSERT_FALSE(outcome.warn_lines.empty());
+  EXPECT_EQ(outcome.warn_lines.back(), "TRACKING_STATE tracking stamp=1.400000000");
+}
+
+TEST(PoseAcceptanceTest, SuppressMapUpdateDuringCooldownAndNonTracking)
+{
+  Config config;
+  State state;
+  evaluate(config, state, makeInput(Eigen::Vector3d::Zero(), 1.0, 0.0, identityQuat()));
+
+  // Soft reject sets the cooldown (2 scans) and Suspect.
+  evaluate(config, state, makeInput(Eigen::Vector3d(1.5, 0.0, 0.0), 1.1, 0.1, identityQuat()));
+  ASSERT_EQ(state.reject_map_update_cooldown_remaining, 2);
+
+  // Clean accept while Suspect: still suppressed (cooldown + state),
+  // cooldown decrements.
+  Outcome outcome = stepAccepted(config, state, 1.2);
+  EXPECT_TRUE(outcome.suppress_map_update);
+  EXPECT_EQ(state.reject_map_update_cooldown_remaining, 1);
+
+  // Second clean accept returns to Tracking (suspect_clear = 2) but the
+  // remaining cooldown still suppresses this scan.
+  outcome = stepAccepted(config, state, 1.3);
+  EXPECT_EQ(state.tracking_state, TrackingState::Tracking);
+  EXPECT_TRUE(outcome.suppress_map_update);
+  EXPECT_EQ(state.reject_map_update_cooldown_remaining, 0);
+
+  // Cooldown drained and Tracking: map updates allowed again.
+  outcome = stepAccepted(config, state, 1.4);
+  EXPECT_FALSE(outcome.suppress_map_update);
+}
+
+TEST(PoseAcceptanceTest, NonMonotonicStampWarns)
+{
+  Config config;
+  State state;
+  evaluate(config, state, makeInput(Eigen::Vector3d::Zero(), 1.0, 0.0, identityQuat()));
+
+  Input input = makeInput(Eigen::Vector3d(0.05, 0.0, 0.0), 0.9, -0.1, identityQuat());
+  const Outcome outcome = evaluate(config, state, input);
+
+  ASSERT_FALSE(outcome.warn_lines.empty());
+  EXPECT_EQ(
+    outcome.warn_lines[0],
+    "POSE_STAMP_NONMONOTONIC stamp=0.900000000 prev_stamp=1.000000000 dt=-0.100000 "
+    "frame=base_link");
+}
+
+TEST(PoseAcceptanceTest, AcceptedEmaFollowsTheHistoricalAlphaBlend)
+{
+  Config config;
+  State state;
+  Input first = makeInput(Eigen::Vector3d::Zero(), 1.0, 0.0, identityQuat());
+  first.fitness_score = 0.5;
+  evaluate(config, state, first);
+
+  Input second = makeInput(Eigen::Vector3d(0.05, 0.0, 0.0), 1.1, 0.1, identityQuat());
+  second.fitness_score = 1.0;
+  evaluate(config, state, second);
+
+  // alpha = 0.1, no cap before warmup: 0.9 * 0.5 + 0.1 * 1.0.
+  EXPECT_DOUBLE_EQ(state.accepted_fitness_ema, 0.9 * 0.5 + 0.1 * 1.0);
+  EXPECT_DOUBLE_EQ(state.accepted_trans_ema, 0.9 * 0.0 + 0.1 * 0.05);
+  EXPECT_EQ(state.accepted_pose_count, 2);
+  EXPECT_TRUE(state.last_accepted_delta_valid);
+  EXPECT_TRUE(state.last_accepted_delta_position.isApprox(Eigen::Vector3d(0.05, 0.0, 0.0), 0.0));
+}
+
+TEST(PoseAcceptanceTest, SameSequenceProducesBitwiseIdenticalOutcomes)
+{
+  Config config;
+  const std::vector<Eigen::Vector3d> positions = {
+    Eigen::Vector3d(0.0, 0.0, 0.0),
+    Eigen::Vector3d(0.05, 0.01, 0.0),
+    Eigen::Vector3d(1.5, 0.0, 0.0),
+    Eigen::Vector3d(1.55, 0.01, 0.0),
+    Eigen::Vector3d(1.6, 0.02, 0.0),
+  };
+
+  State state_a;
+  State state_b;
+  for (size_t i = 0; i < positions.size(); ++i) {
+    const double stamp_sec = 1.0 + 0.1 * static_cast<double>(i);
+    const double dt = (i == 0) ? 0.0 : 0.1;
+    const Outcome a = evaluate(config, state_a,
+      makeInput(positions[i], stamp_sec, dt, identityQuat()));
+    const Outcome b = evaluate(config, state_b,
+      makeInput(positions[i], stamp_sec, dt, identityQuat()));
+    EXPECT_EQ(
+      0,
+      std::memcmp(
+        a.accepted_position.data(), b.accepted_position.data(), sizeof(double) * 3));
+    EXPECT_EQ(a.warn_lines, b.warn_lines);
+    EXPECT_EQ(a.suppress_map_update, b.suppress_map_update);
+  }
+  EXPECT_EQ(state_a.tracking_state, state_b.tracking_state);
+  EXPECT_EQ(
+    0,
+    std::memcmp(&state_a.accepted_fitness_ema, &state_b.accepted_fitness_ema, sizeof(double)));
+}


### PR DESCRIPTION
## Summary

Second v0.6 **Phase 4** extraction (docs/roadmap/v0.6.md): the `publishMapAndPose` acceptance block — ~390 lines covering pose-jump diagnostics, adaptive fitness/translation gates, the motion gate, accept/clip/predict selection, the accepted-statistics EMA, the Tracking/Suspect/Recovery state machine and the map-update cooldown — moves verbatim into a pure header `scanmatcher/include/scanmatcher/pose_acceptance.hpp` (`graphslam::pose_acceptance`).

- `Config` / `State` / `Input` / `Outcome` structs: 17 scattered component state members collapse into a single `pose_acceptance::State` member; the component shrinks by ~360 lines.
- All `RCLCPP_WARN` output is reproduced **byte-identically** as `Outcome::warn_lines` (the LogLine pattern proven in the backend refactor) — including the historical duplicated `POSE_REJECT_HARD_RECOVERY` warn and the dead `TRACKING_STATE recovery` branch, both preserved verbatim.
- The recovery-target refresh stays a shell side effect: the core returns `request_recovery_target_refresh`, the shell performs the PCL/registration call and writes the result back into the state. Deferring the assignment is safe — the flag is not read again within the same `evaluate` call.
- `dt` stays `Duration::seconds()` on the `rclcpp::Time` pair in the shell (a double-double subtraction rounds differently, and dt feeds motion-gate comparisons).
- `TrackingState` moves into the pure header; the component aliases it, so `receiveCloud`'s state gating is unchanged.

## Tests

9 characterization tests in `test_pose_acceptance.cpp`, pinning among others:
- exact warn-line bytes (`POSE_STAMP_NONMONOTONIC`, `POSE_JUMP`, `POSE_REJECT` fields, `TRACKING_STATE` transitions)
- motion-gate clip math (translation norm clamp to 8 m/s × dt, yaw delta clamp)
- the EMA alpha blend and warmup behavior
- the Recovery → Suspect → Tracking ladder with the consecutive-accepted thresholds and recovery-target clearing
- map-update suppression through cooldown countdown and non-Tracking states
- the duplicated HARD_RECOVERY warn (2 lines per hard reject)
- bitwise determinism over a 5-scan sequence (two State instances, memcmp)

## Validation

- `colcon test` scanmatcher: **53 tests, 0 failures** (+9 new)
- `ament_uncrustify` clean on the new files
- Full release gate PASS with the offline determinism stage: all profiles PASS/TARGET_MET, `mid360_gt_rtkslam_stadtgarten_seq2` raw **0.835** — 15th consecutive bit-identical; `DETERMINISM_OK` (md5 unchanged)
