### PR TITLE
refactor(scanmatcher): extract the IMU processing core into a pure header (v0.6 Phase 4)

### DIFF
--- a/scanmatcher/CMakeLists.txt
+++ b/scanmatcher/CMakeLists.txt
@@ -103,6 +103,10 @@ if(BUILD_TESTING)
   ament_add_gtest(test_pose_acceptance test/test_pose_acceptance.cpp)
   target_include_directories(test_pose_acceptance PRIVATE include ${EIGEN3_INCLUDE_DIR})
   ament_target_dependencies(test_pose_acceptance tf2 tf2_geometry_msgs geometry_msgs)
+
+  ament_add_gtest(test_imu_processing test/test_imu_processing.cpp)
+  target_include_directories(test_imu_processing PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  ament_target_dependencies(test_imu_processing tf2 tf2_geometry_msgs geometry_msgs)
 endif()
 
 add_library(scanmatcher_component SHARED

--- a/scanmatcher/include/scanmatcher/imu_processing.hpp
+++ b/scanmatcher/include/scanmatcher/imu_processing.hpp
@@ -1,0 +1,203 @@
+#ifndef SCANMATCHER_IMU_PROCESSING_HPP_
+#define SCANMATCHER_IMU_PROCESSING_HPP_
+
+#include <cmath>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <geometry_msgs/msg/quaternion.hpp>
+
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Vector3.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+namespace graphslam
+{
+namespace imu_processing
+{
+
+inline double wrapAngleRad(double angle)
+{
+  while (angle > M_PI) {angle -= 2.0 * M_PI;}
+  while (angle < -M_PI) {angle += 2.0 * M_PI;}
+  return angle;
+}
+
+// Angular velocity / linear acceleration pair expressed in some frame.
+struct ImuVectors
+{
+  tf2::Vector3 angular_velocity {0.0, 0.0, 0.0};
+  tf2::Vector3 linear_acceleration {0.0, 0.0, 0.0};
+};
+
+// Rotate IMU angular velocity and linear acceleration from the IMU frame
+// into the robot frame using the robot<-imu rotation. This is the body of
+// the historical duplicated try/fallback blocks in receiveImu.
+inline ImuVectors rotateImuVectorsIntoRobotFrame(
+  const ImuVectors & imu_vectors,
+  const tf2::Quaternion & q_robot_imu)
+{
+  ImuVectors robot_vectors;
+  robot_vectors.angular_velocity = tf2::quatRotate(q_robot_imu, imu_vectors.angular_velocity);
+  robot_vectors.linear_acceleration =
+    tf2::quatRotate(q_robot_imu, imu_vectors.linear_acceleration);
+  return robot_vectors;
+}
+
+// Yaw-integration state owned by the shell across IMU messages.
+struct OrientationState
+{
+  double last_imu_time {0.0};
+  double integrated_yaw {0.0};
+  bool integrated_yaw_valid {false};
+};
+
+// Per-message inputs for the orientation resolution. The linear
+// acceleration and angular velocity are already expressed in the robot
+// frame (rotateImuVectorsIntoRobotFrame ran first when needed).
+struct OrientationInput
+{
+  tf2::Quaternion q_world_imu {0.0, 0.0, 0.0, 1.0};
+  // msg.orientation_covariance[0]; negative marks the orientation invalid
+  // per REP-145 (the historical .empty() guard on the std::array is always
+  // false, so the < 0.0 test is the only live condition).
+  double orientation_covariance0 {0.0};
+  double linear_acceleration_x {0.0};
+  double linear_acceleration_y {0.0};
+  double linear_acceleration_z {0.0};
+  double angular_velocity_z {0.0};
+  double imu_time {0.0};
+  bool have_imu_tf {false};
+  bool frame_differs {false};
+  tf2::Quaternion q_robot_imu {0.0, 0.0, 0.0, 1.0};
+};
+
+struct OrientationResult
+{
+  tf2::Quaternion q_world_robot {0.0, 0.0, 0.0, 1.0};
+  double roll {0.0};
+  double pitch {0.0};
+  double yaw {0.0};
+};
+
+// Resolve the robot orientation for one IMU message: use the reported
+// orientation when valid (composing the IMU->robot frame change), else
+// estimate roll/pitch from gravity and integrate yaw from the gyro.
+// Verbatim transplant of the receiveImu orientation block.
+inline OrientationResult resolveOrientation(
+  const OrientationInput & input,
+  OrientationState & state)
+{
+  bool orientation_valid = true;
+  if (input.orientation_covariance0 < 0.0) {
+    orientation_valid = false;
+  }
+  if (input.q_world_imu.length2() < 1e-12) {
+    orientation_valid = false;
+  }
+
+  OrientationResult result;
+  if (orientation_valid) {
+    if (input.have_imu_tf && input.frame_differs) {
+      // q_world_robot = q_world_imu * q_imu_robot
+      const tf2::Quaternion q_imu_robot = input.q_robot_imu.inverse();
+      result.q_world_robot = input.q_world_imu * q_imu_robot;
+    } else {
+      result.q_world_robot = input.q_world_imu;
+    }
+    tf2::Matrix3x3(result.q_world_robot).getRPY(result.roll, result.pitch, result.yaw);
+    state.integrated_yaw = result.yaw;
+    state.integrated_yaw_valid = true;
+  } else {
+    const double ax = input.linear_acceleration_x;
+    const double ay = input.linear_acceleration_y;
+    const double az = input.linear_acceleration_z;
+    result.roll = std::atan2(ay, az);
+    result.pitch = std::atan2(-ax, std::sqrt(ay * ay + az * az));
+    const double dt = input.imu_time - state.last_imu_time;
+    if (state.integrated_yaw_valid && dt > 0.0 && dt < 1.0) {
+      state.integrated_yaw = wrapAngleRad(
+        state.integrated_yaw + input.angular_velocity_z * dt);
+    } else if (!state.integrated_yaw_valid) {
+      state.integrated_yaw = 0.0;
+      state.integrated_yaw_valid = true;
+    }
+    result.yaw = state.integrated_yaw;
+    result.q_world_robot.setRPY(result.roll, result.pitch, result.yaw);
+  }
+  state.last_imu_time = input.imu_time;
+  return result;
+}
+
+// Remove the gravity component from a robot-frame acceleration using the
+// resolved roll/pitch. Exact expressions from receiveImu (double trig,
+// float truncation at assignment).
+inline Eigen::Vector3f gravityCompensatedAcceleration(
+  const double linear_acceleration_x,
+  const double linear_acceleration_y,
+  const double linear_acceleration_z,
+  const double roll,
+  const double pitch)
+{
+  float acc_x = static_cast<float>(linear_acceleration_x) + sin(pitch) * 9.81;
+  float acc_y = static_cast<float>(linear_acceleration_y) - cos(pitch) * sin(roll) * 9.81;
+  float acc_z = static_cast<float>(linear_acceleration_z) - cos(pitch) * cos(roll) * 9.81;
+  return Eigen::Vector3f{acc_x, acc_y, acc_z};
+}
+
+// Inputs for the post-registration complementary roll/pitch blend.
+// Gating (enable flag, alpha > 0, IMU validity/age, diagnostic validity)
+// stays with the shell; this is only the blend arithmetic.
+struct ComplementaryBlendInput
+{
+  // cloud_imu_reference_quat_: IMU orientation captured at the previous cloud
+  tf2::Quaternion imu_reference_quat {0.0, 0.0, 0.0, 1.0};
+  tf2::Quaternion latest_imu_robot_quat {0.0, 0.0, 0.0, 1.0};
+  // Accepted registration orientation for this frame
+  geometry_msgs::msg::Quaternion accepted_quat_msg;
+  // Rotation block of ndt_pose_ (last published orientation)
+  Eigen::Matrix3f previous_published_rotation {Eigen::Matrix3f::Identity()};
+  double alpha {0.0};
+};
+
+// Post-NDT complementary filter: blend roll/pitch with the IMU-predicted
+// orientation for output only; yaw stays with the registration result.
+// Verbatim transplant of the publishMapAndPose blend block.
+inline geometry_msgs::msg::Quaternion blendComplementaryRollPitch(
+  const ComplementaryBlendInput & input)
+{
+  tf2::Quaternion imu_delta = input.imu_reference_quat.inverse() * input.latest_imu_robot_quat;
+  imu_delta.normalize();
+  double imu_dr, imu_dp, imu_dy;
+  tf2::Matrix3x3(imu_delta).getRPY(imu_dr, imu_dp, imu_dy);
+
+  tf2::Quaternion ndt_quat;
+  tf2::fromMsg(input.accepted_quat_msg, ndt_quat);
+  double ndt_roll, ndt_pitch, ndt_yaw;
+  tf2::Matrix3x3(ndt_quat).getRPY(ndt_roll, ndt_pitch, ndt_yaw);
+
+  // Previous published rotation (ndt_pose_ stores last published RPY)
+  Eigen::Quaternionf prev_q_eig(input.previous_published_rotation);
+  tf2::Quaternion prev_pub_quat(prev_q_eig.x(), prev_q_eig.y(), prev_q_eig.z(), prev_q_eig.w());
+  double prev_roll, prev_pitch, prev_yaw;
+  tf2::Matrix3x3(prev_pub_quat).getRPY(prev_roll, prev_pitch, prev_yaw);
+
+  double imu_pred_roll = prev_roll + imu_dr;
+  double imu_pred_pitch = prev_pitch + imu_dp;
+
+  const double a = input.alpha;
+  double blended_roll = (1.0 - a) * ndt_roll + a * imu_pred_roll;
+  double blended_pitch = (1.0 - a) * ndt_pitch + a * imu_pred_pitch;
+
+  tf2::Quaternion blended_quat;
+  blended_quat.setRPY(blended_roll, blended_pitch, ndt_yaw);
+  blended_quat.normalize();
+  return tf2::toMsg(blended_quat);
+}
+
+}  // namespace imu_processing
+}  // namespace graphslam
+
+#endif  // SCANMATCHER_IMU_PROCESSING_HPP_

--- a/scanmatcher/include/scanmatcher/scanmatcher_component.h
+++ b/scanmatcher/include/scanmatcher/scanmatcher_component.h
@@ -58,6 +58,7 @@ extern "C" {
 
 #include <lidarslam_msgs/msg/map_array.hpp>
 #include "scanmatcher/lidar_undistortion.hpp"
+#include "scanmatcher/imu_processing.hpp"
 #include "scanmatcher/pose_acceptance.hpp"
 #include "scanmatcher/pose_prediction.hpp"
 #include "scanmatcher/voxel_hash_map.hpp"
@@ -273,9 +274,9 @@ private:
 
     // imu
     double scan_period_ {0.1};
-    double last_imu_time_ {0.0};
-    double imu_integrated_yaw_ {0.0};
-    bool imu_integrated_yaw_valid_ {false};
+    // Yaw-integration state owned by the pure orientation core — see
+    // imu_processing.hpp.
+    imu_processing::OrientationState imu_orientation_state_;
     tf2::Quaternion latest_imu_robot_quat_ {0.0, 0.0, 0.0, 1.0};
     rclcpp::Time latest_imu_stamp_ {0, 0, RCL_ROS_TIME};
     bool latest_imu_orientation_valid_ {false};

--- a/scanmatcher/src/scanmatcher_component.cpp
+++ b/scanmatcher/src/scanmatcher_component.cpp
@@ -25,13 +25,6 @@ struct PointCloudExtractionResult
   std::vector<float> point_times {};
 };
 
-double wrapAngleRad(double angle)
-{
-  while (angle > M_PI) {angle -= 2.0 * M_PI;}
-  while (angle < -M_PI) {angle += 2.0 * M_PI;}
-  return angle;
-}
-
 bool pointCloudHasField(const sensor_msgs::msg::PointCloud2 & msg, const std::string & name)
 {
   for (const auto & field : msg.fields) {
@@ -112,26 +105,6 @@ PointCloudExtractionResult extractPointCloudXYZIAndTimes(const sensor_msgs::msg:
   result.cloud->height = 1;
   result.cloud->is_dense = msg.is_dense;
   return result;
-}
-
-Eigen::Vector3d clampVectorNorm(const Eigen::Vector3d & v, double max_norm)
-{
-  if (max_norm <= 0.0) {
-    return v;
-  }
-  const double norm = v.norm();
-  if (norm <= max_norm || norm < 1e-9) {
-    return v;
-  }
-  return v * (max_norm / norm);
-}
-
-geometry_msgs::msg::Quaternion quaternionFromRPY(double roll, double pitch, double yaw)
-{
-  tf2::Quaternion q;
-  q.setRPY(roll, pitch, yaw);
-  q.normalize();
-  return tf2::toMsg(q);
 }
 }
 
@@ -1223,34 +1196,13 @@ void ScanMatcherComponent::publishMapAndPose(
   {
     const double imu_age = std::abs((stamp - latest_imu_stamp_).seconds());
     if (imu_age <= imu_pose_prediction_max_age_) {
-      tf2::Quaternion imu_delta = cloud_imu_reference_quat_.inverse() * latest_imu_robot_quat_;
-      imu_delta.normalize();
-      double imu_dr, imu_dp, imu_dy;
-      tf2::Matrix3x3(imu_delta).getRPY(imu_dr, imu_dp, imu_dy);
-
-      tf2::Quaternion ndt_quat;
-      tf2::fromMsg(accepted_quat_msg, ndt_quat);
-      double ndt_roll, ndt_pitch, ndt_yaw;
-      tf2::Matrix3x3(ndt_quat).getRPY(ndt_roll, ndt_pitch, ndt_yaw);
-
-      // Previous published rotation (ndt_pose_ stores last published RPY)
-      Eigen::Matrix3f prev_rot = ndt_pose_.block<3, 3>(0, 0);
-      Eigen::Quaternionf prev_q_eig(prev_rot);
-      tf2::Quaternion prev_pub_quat(prev_q_eig.x(), prev_q_eig.y(), prev_q_eig.z(), prev_q_eig.w());
-      double prev_roll, prev_pitch, prev_yaw;
-      tf2::Matrix3x3(prev_pub_quat).getRPY(prev_roll, prev_pitch, prev_yaw);
-
-      double imu_pred_roll = prev_roll + imu_dr;
-      double imu_pred_pitch = prev_pitch + imu_dp;
-
-      const double a = imu_complementary_alpha_;
-      double blended_roll = (1.0 - a) * ndt_roll + a * imu_pred_roll;
-      double blended_pitch = (1.0 - a) * ndt_pitch + a * imu_pred_pitch;
-
-      tf2::Quaternion blended_quat;
-      blended_quat.setRPY(blended_roll, blended_pitch, ndt_yaw);
-      blended_quat.normalize();
-      published_quat_msg = tf2::toMsg(blended_quat);
+      imu_processing::ComplementaryBlendInput blend_input;
+      blend_input.imu_reference_quat = cloud_imu_reference_quat_;
+      blend_input.latest_imu_robot_quat = latest_imu_robot_quat_;
+      blend_input.accepted_quat_msg = accepted_quat_msg;
+      blend_input.previous_published_rotation = ndt_pose_.block<3, 3>(0, 0);
+      blend_input.alpha = imu_complementary_alpha_;
+      published_quat_msg = imu_processing::blendComplementaryRollPitch(blend_input);
     }
   }
   // Store published rotation for next frame's complementary filter
@@ -1579,6 +1531,9 @@ void ScanMatcherComponent::receiveImu(const sensor_msgs::msg::Imu msg)
   bool have_imu_tf = (imu_frame_id == robot_frame_id_);
 
   if (!have_imu_tf) {
+    // The TF lookup (with its stamped -> latest-static -> identity fallback
+    // ladder) is a shell concern; the vector rotation itself is pure.
+    bool rotate_into_robot_frame = false;
     try {
       tf2::TimePoint time_point;
       if (imu_msg.header.stamp.sec == 0 && imu_msg.header.stamp.nanosec == 0) {
@@ -1591,52 +1546,14 @@ void ScanMatcherComponent::receiveImu(const sensor_msgs::msg::Imu msg)
       const geometry_msgs::msg::TransformStamped tf = tfbuffer_.lookupTransform(
         robot_frame_id_, imu_frame_id, time_point);
       tf2::fromMsg(tf.transform.rotation, q_robot_imu);
-
-      tf2::Vector3 w_imu(
-        imu_msg.angular_velocity.x,
-        imu_msg.angular_velocity.y,
-        imu_msg.angular_velocity.z);
-      tf2::Vector3 a_imu(
-        imu_msg.linear_acceleration.x,
-        imu_msg.linear_acceleration.y,
-        imu_msg.linear_acceleration.z);
-
-      tf2::Vector3 w_robot = tf2::quatRotate(q_robot_imu, w_imu);
-      tf2::Vector3 a_robot = tf2::quatRotate(q_robot_imu, a_imu);
-
-      imu_msg.angular_velocity.x = w_robot.x();
-      imu_msg.angular_velocity.y = w_robot.y();
-      imu_msg.angular_velocity.z = w_robot.z();
-      imu_msg.linear_acceleration.x = a_robot.x();
-      imu_msg.linear_acceleration.y = a_robot.y();
-      imu_msg.linear_acceleration.z = a_robot.z();
-
+      rotate_into_robot_frame = true;
       have_imu_tf = true;
     } catch (tf2::TransformException & e) {
       try {
         const geometry_msgs::msg::TransformStamped tf = tfbuffer_.lookupTransform(
           robot_frame_id_, imu_frame_id, tf2::TimePointZero);
         tf2::fromMsg(tf.transform.rotation, q_robot_imu);
-
-        tf2::Vector3 w_imu(
-          imu_msg.angular_velocity.x,
-          imu_msg.angular_velocity.y,
-          imu_msg.angular_velocity.z);
-        tf2::Vector3 a_imu(
-          imu_msg.linear_acceleration.x,
-          imu_msg.linear_acceleration.y,
-          imu_msg.linear_acceleration.z);
-
-        tf2::Vector3 w_robot = tf2::quatRotate(q_robot_imu, w_imu);
-        tf2::Vector3 a_robot = tf2::quatRotate(q_robot_imu, a_imu);
-
-        imu_msg.angular_velocity.x = w_robot.x();
-        imu_msg.angular_velocity.y = w_robot.y();
-        imu_msg.angular_velocity.z = w_robot.z();
-        imu_msg.linear_acceleration.x = a_robot.x();
-        imu_msg.linear_acceleration.y = a_robot.y();
-        imu_msg.linear_acceleration.z = a_robot.z();
-
+        rotate_into_robot_frame = true;
         have_imu_tf = true;
         RCLCPP_WARN_ONCE(
           get_logger(),
@@ -1652,76 +1569,69 @@ void ScanMatcherComponent::receiveImu(const sensor_msgs::msg::Imu msg)
         have_imu_tf = false;
       }
     }
+    if (rotate_into_robot_frame) {
+      imu_processing::ImuVectors imu_vectors;
+      imu_vectors.angular_velocity = tf2::Vector3(
+        imu_msg.angular_velocity.x,
+        imu_msg.angular_velocity.y,
+        imu_msg.angular_velocity.z);
+      imu_vectors.linear_acceleration = tf2::Vector3(
+        imu_msg.linear_acceleration.x,
+        imu_msg.linear_acceleration.y,
+        imu_msg.linear_acceleration.z);
+      const imu_processing::ImuVectors robot_vectors =
+        imu_processing::rotateImuVectorsIntoRobotFrame(imu_vectors, q_robot_imu);
+      imu_msg.angular_velocity.x = robot_vectors.angular_velocity.x();
+      imu_msg.angular_velocity.y = robot_vectors.angular_velocity.y();
+      imu_msg.angular_velocity.z = robot_vectors.angular_velocity.z();
+      imu_msg.linear_acceleration.x = robot_vectors.linear_acceleration.x();
+      imu_msg.linear_acceleration.y = robot_vectors.linear_acceleration.y();
+      imu_msg.linear_acceleration.z = robot_vectors.linear_acceleration.z();
+    }
   }
 
   // Determine orientation (roll/pitch) in robot_frame_id_. If orientation is missing, estimate it from acceleration.
   tf2::Quaternion q_world_imu;
   tf2::fromMsg(imu_msg.orientation, q_world_imu);
 
-  bool orientation_valid = true;
-  if (!imu_msg.orientation_covariance.empty() && imu_msg.orientation_covariance[0] < 0.0) {
-    orientation_valid = false;
-  }
-  if (q_world_imu.length2() < 1e-12) {
-    orientation_valid = false;
-  }
-
   const double imu_time = imu_msg.header.stamp.sec + imu_msg.header.stamp.nanosec * 1e-9;
-  double roll = 0.0;
-  double pitch = 0.0;
-  double yaw = 0.0;
-  tf2::Quaternion q_world_robot(0.0, 0.0, 0.0, 1.0);
 
-  if (orientation_valid) {
-    if (have_imu_tf && imu_frame_id != robot_frame_id_) {
-      // q_world_robot = q_world_imu * q_imu_robot
-      const tf2::Quaternion q_imu_robot = q_robot_imu.inverse();
-      q_world_robot = q_world_imu * q_imu_robot;
-    } else {
-      q_world_robot = q_world_imu;
-    }
-    tf2::Matrix3x3(q_world_robot).getRPY(roll, pitch, yaw);
-    imu_integrated_yaw_ = yaw;
-    imu_integrated_yaw_valid_ = true;
-  } else {
-    const double ax = imu_msg.linear_acceleration.x;
-    const double ay = imu_msg.linear_acceleration.y;
-    const double az = imu_msg.linear_acceleration.z;
-    roll = std::atan2(ay, az);
-    pitch = std::atan2(-ax, std::sqrt(ay * ay + az * az));
-    const double dt = imu_time - last_imu_time_;
-    if (imu_integrated_yaw_valid_ && dt > 0.0 && dt < 1.0) {
-      imu_integrated_yaw_ = wrapAngleRad(
-        imu_integrated_yaw_ + static_cast<double>(imu_msg.angular_velocity.z) * dt);
-    } else if (!imu_integrated_yaw_valid_) {
-      imu_integrated_yaw_ = 0.0;
-      imu_integrated_yaw_valid_ = true;
-    }
-    yaw = imu_integrated_yaw_;
-    q_world_robot.setRPY(roll, pitch, yaw);
-  }
-  last_imu_time_ = imu_time;
-  latest_imu_robot_quat_ = q_world_robot;
+  imu_processing::OrientationInput orientation_input;
+  orientation_input.q_world_imu = q_world_imu;
+  orientation_input.orientation_covariance0 = imu_msg.orientation_covariance[0];
+  orientation_input.linear_acceleration_x = imu_msg.linear_acceleration.x;
+  orientation_input.linear_acceleration_y = imu_msg.linear_acceleration.y;
+  orientation_input.linear_acceleration_z = imu_msg.linear_acceleration.z;
+  orientation_input.angular_velocity_z = imu_msg.angular_velocity.z;
+  orientation_input.imu_time = imu_time;
+  orientation_input.have_imu_tf = have_imu_tf;
+  orientation_input.frame_differs = imu_frame_id != robot_frame_id_;
+  orientation_input.q_robot_imu = q_robot_imu;
+
+  const imu_processing::OrientationResult orientation =
+    imu_processing::resolveOrientation(orientation_input, imu_orientation_state_);
+
+  latest_imu_robot_quat_ = orientation.q_world_robot;
   latest_imu_stamp_ = imu_msg.header.stamp;
   latest_imu_orientation_valid_ = true;
-
-  float acc_x = static_cast<float>(imu_msg.linear_acceleration.x) + sin(pitch) * 9.81;
-  float acc_y = static_cast<float>(imu_msg.linear_acceleration.y) - cos(pitch) * sin(roll) * 9.81;
-  float acc_z = static_cast<float>(imu_msg.linear_acceleration.z) - cos(pitch) * cos(roll) * 9.81;
 
   Eigen::Vector3f angular_velo{
     static_cast<float>(imu_msg.angular_velocity.x),
     static_cast<float>(imu_msg.angular_velocity.y),
     static_cast<float>(imu_msg.angular_velocity.z)};
-  Eigen::Vector3f acc{acc_x, acc_y, acc_z};
+  Eigen::Vector3f acc = imu_processing::gravityCompensatedAcceleration(
+    imu_msg.linear_acceleration.x,
+    imu_msg.linear_acceleration.y,
+    imu_msg.linear_acceleration.z,
+    orientation.roll,
+    orientation.pitch);
   Eigen::Quaternionf quat{
-    static_cast<float>(q_world_robot.w()),
-    static_cast<float>(q_world_robot.x()),
-    static_cast<float>(q_world_robot.y()),
-    static_cast<float>(q_world_robot.z())};
+    static_cast<float>(orientation.q_world_robot.w()),
+    static_cast<float>(orientation.q_world_robot.x()),
+    static_cast<float>(orientation.q_world_robot.y()),
+    static_cast<float>(orientation.q_world_robot.z())};
 
   lidar_undistortion_.getImu(angular_velo, acc, quat, imu_time);
-
 }
 
 void ScanMatcherComponent::publishMap(const lidarslam_msgs::msg::MapArray & map_array_msg , const std::string & map_frame_id)

--- a/scanmatcher/test/test_imu_processing.cpp
+++ b/scanmatcher/test/test_imu_processing.cpp
@@ -1,0 +1,360 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+#include "scanmatcher/imu_processing.hpp"
+
+namespace
+{
+using graphslam::imu_processing::ComplementaryBlendInput;
+using graphslam::imu_processing::ImuVectors;
+using graphslam::imu_processing::OrientationInput;
+using graphslam::imu_processing::OrientationResult;
+using graphslam::imu_processing::OrientationState;
+
+tf2::Quaternion quatFromRpy(const double roll, const double pitch, const double yaw)
+{
+  tf2::Quaternion quat;
+  quat.setRPY(roll, pitch, yaw);
+  quat.normalize();
+  return quat;
+}
+
+OrientationInput makeValidOrientationInput(const tf2::Quaternion & q_world_imu)
+{
+  OrientationInput input;
+  input.q_world_imu = q_world_imu;
+  input.orientation_covariance0 = 0.01;
+  input.imu_time = 10.0;
+  return input;
+}
+
+}  // namespace
+
+TEST(ImuProcessing, RotateVectorsIdentityQuatIsNoop)
+{
+  ImuVectors imu_vectors;
+  imu_vectors.angular_velocity = tf2::Vector3(0.1, -0.2, 0.3);
+  imu_vectors.linear_acceleration = tf2::Vector3(1.0, 2.0, 9.81);
+
+  const ImuVectors robot_vectors = graphslam::imu_processing::rotateImuVectorsIntoRobotFrame(
+    imu_vectors, tf2::Quaternion(0.0, 0.0, 0.0, 1.0));
+
+  EXPECT_DOUBLE_EQ(robot_vectors.angular_velocity.x(), 0.1);
+  EXPECT_DOUBLE_EQ(robot_vectors.angular_velocity.y(), -0.2);
+  EXPECT_DOUBLE_EQ(robot_vectors.angular_velocity.z(), 0.3);
+  EXPECT_DOUBLE_EQ(robot_vectors.linear_acceleration.x(), 1.0);
+  EXPECT_DOUBLE_EQ(robot_vectors.linear_acceleration.y(), 2.0);
+  EXPECT_DOUBLE_EQ(robot_vectors.linear_acceleration.z(), 9.81);
+}
+
+TEST(ImuProcessing, RotateVectorsMatchesHistoricalQuatRotate)
+{
+  // 90 degree yaw: x maps to y. Expectation computed with the exact
+  // tf2::quatRotate call the historical inline block used.
+  const tf2::Quaternion q_robot_imu = quatFromRpy(0.0, 0.0, M_PI / 2.0);
+  ImuVectors imu_vectors;
+  imu_vectors.angular_velocity = tf2::Vector3(0.4, 0.0, 0.0);
+  imu_vectors.linear_acceleration = tf2::Vector3(2.0, 0.5, -1.0);
+
+  const ImuVectors robot_vectors = graphslam::imu_processing::rotateImuVectorsIntoRobotFrame(
+    imu_vectors, q_robot_imu);
+
+  const tf2::Vector3 expected_w = tf2::quatRotate(q_robot_imu, imu_vectors.angular_velocity);
+  const tf2::Vector3 expected_a = tf2::quatRotate(q_robot_imu, imu_vectors.linear_acceleration);
+  EXPECT_DOUBLE_EQ(robot_vectors.angular_velocity.x(), expected_w.x());
+  EXPECT_DOUBLE_EQ(robot_vectors.angular_velocity.y(), expected_w.y());
+  EXPECT_DOUBLE_EQ(robot_vectors.angular_velocity.z(), expected_w.z());
+  EXPECT_DOUBLE_EQ(robot_vectors.linear_acceleration.x(), expected_a.x());
+  EXPECT_DOUBLE_EQ(robot_vectors.linear_acceleration.y(), expected_a.y());
+  EXPECT_DOUBLE_EQ(robot_vectors.linear_acceleration.z(), expected_a.z());
+  EXPECT_NEAR(robot_vectors.angular_velocity.y(), 0.4, 1e-12);
+}
+
+TEST(ImuProcessing, ValidOrientationSameFrameUsesImuQuat)
+{
+  OrientationState state;
+  const tf2::Quaternion q_world_imu = quatFromRpy(0.05, -0.02, 1.2);
+  OrientationInput input = makeValidOrientationInput(q_world_imu);
+
+  const OrientationResult result = graphslam::imu_processing::resolveOrientation(input, state);
+
+  double expected_roll, expected_pitch, expected_yaw;
+  tf2::Matrix3x3(q_world_imu).getRPY(expected_roll, expected_pitch, expected_yaw);
+  EXPECT_DOUBLE_EQ(result.roll, expected_roll);
+  EXPECT_DOUBLE_EQ(result.pitch, expected_pitch);
+  EXPECT_DOUBLE_EQ(result.yaw, expected_yaw);
+  EXPECT_DOUBLE_EQ(result.q_world_robot.x(), q_world_imu.x());
+  EXPECT_DOUBLE_EQ(result.q_world_robot.w(), q_world_imu.w());
+  // A valid orientation re-seeds the integrated yaw.
+  EXPECT_TRUE(state.integrated_yaw_valid);
+  EXPECT_DOUBLE_EQ(state.integrated_yaw, expected_yaw);
+  EXPECT_DOUBLE_EQ(state.last_imu_time, 10.0);
+}
+
+TEST(ImuProcessing, ValidOrientationComposesFrameChange)
+{
+  OrientationState state;
+  const tf2::Quaternion q_world_imu = quatFromRpy(0.0, 0.0, 1.0);
+  const tf2::Quaternion q_robot_imu = quatFromRpy(0.0, 0.0, M_PI / 2.0);
+
+  OrientationInput input = makeValidOrientationInput(q_world_imu);
+  input.have_imu_tf = true;
+  input.frame_differs = true;
+  input.q_robot_imu = q_robot_imu;
+
+  const OrientationResult result = graphslam::imu_processing::resolveOrientation(input, state);
+
+  // q_world_robot = q_world_imu * q_imu_robot (historical composition).
+  const tf2::Quaternion expected = q_world_imu * q_robot_imu.inverse();
+  EXPECT_DOUBLE_EQ(result.q_world_robot.x(), expected.x());
+  EXPECT_DOUBLE_EQ(result.q_world_robot.y(), expected.y());
+  EXPECT_DOUBLE_EQ(result.q_world_robot.z(), expected.z());
+  EXPECT_DOUBLE_EQ(result.q_world_robot.w(), expected.w());
+
+  // Without a usable TF the composition is skipped even if frames differ.
+  OrientationState state_no_tf;
+  OrientationInput input_no_tf = makeValidOrientationInput(q_world_imu);
+  input_no_tf.have_imu_tf = false;
+  input_no_tf.frame_differs = true;
+  input_no_tf.q_robot_imu = q_robot_imu;
+  const OrientationResult result_no_tf = graphslam::imu_processing::resolveOrientation(
+    input_no_tf, state_no_tf);
+  EXPECT_DOUBLE_EQ(result_no_tf.q_world_robot.x(), q_world_imu.x());
+  EXPECT_DOUBLE_EQ(result_no_tf.q_world_robot.w(), q_world_imu.w());
+}
+
+TEST(ImuProcessing, NegativeCovarianceFallsBackToAccel)
+{
+  OrientationState state;
+  state.integrated_yaw = 0.5;
+  state.integrated_yaw_valid = true;
+  state.last_imu_time = 9.9;
+
+  OrientationInput input;
+  input.q_world_imu = quatFromRpy(0.3, 0.2, 0.1);  // present but marked invalid
+  input.orientation_covariance0 = -1.0;
+  input.linear_acceleration_x = 0.5;
+  input.linear_acceleration_y = 0.3;
+  input.linear_acceleration_z = 9.7;
+  input.angular_velocity_z = 0.2;
+  input.imu_time = 10.0;
+
+  const OrientationResult result = graphslam::imu_processing::resolveOrientation(input, state);
+
+  const double expected_roll = std::atan2(0.3, 9.7);
+  const double expected_pitch = std::atan2(-0.5, std::sqrt(0.3 * 0.3 + 9.7 * 9.7));
+  const double expected_yaw = 0.5 + 0.2 * (10.0 - 9.9);
+  EXPECT_DOUBLE_EQ(result.roll, expected_roll);
+  EXPECT_DOUBLE_EQ(result.pitch, expected_pitch);
+  EXPECT_DOUBLE_EQ(result.yaw, expected_yaw);
+  EXPECT_DOUBLE_EQ(state.integrated_yaw, expected_yaw);
+
+  const tf2::Quaternion expected_quat = quatFromRpy(expected_roll, expected_pitch, expected_yaw);
+  EXPECT_NEAR(result.q_world_robot.x(), expected_quat.x(), 1e-15);
+  EXPECT_NEAR(result.q_world_robot.w(), expected_quat.w(), 1e-15);
+}
+
+TEST(ImuProcessing, ZeroQuaternionFallsBackToAccel)
+{
+  OrientationState state;
+  OrientationInput input;
+  input.q_world_imu = tf2::Quaternion(0.0, 0.0, 0.0, 0.0);
+  input.orientation_covariance0 = 0.0;
+  input.linear_acceleration_z = 9.81;
+  input.imu_time = 1.0;
+
+  const OrientationResult result = graphslam::imu_processing::resolveOrientation(input, state);
+
+  EXPECT_DOUBLE_EQ(result.roll, 0.0);
+  EXPECT_DOUBLE_EQ(result.pitch, 0.0);
+  // First invalid sample initializes the integrated yaw to zero.
+  EXPECT_DOUBLE_EQ(result.yaw, 0.0);
+  EXPECT_TRUE(state.integrated_yaw_valid);
+}
+
+TEST(ImuProcessing, YawIntegrationGatesOnDt)
+{
+  // dt <= 0: the gyro is not integrated, yaw holds.
+  OrientationState state;
+  state.integrated_yaw = 0.7;
+  state.integrated_yaw_valid = true;
+  state.last_imu_time = 10.0;
+
+  OrientationInput input;
+  input.q_world_imu = tf2::Quaternion(0.0, 0.0, 0.0, 0.0);
+  input.angular_velocity_z = 1.0;
+  input.linear_acceleration_z = 9.81;
+  input.imu_time = 10.0;
+  graphslam::imu_processing::resolveOrientation(input, state);
+  EXPECT_DOUBLE_EQ(state.integrated_yaw, 0.7);
+
+  // dt >= 1.0 (message gap): the gyro is not integrated either.
+  state.last_imu_time = 10.0;
+  input.imu_time = 11.5;
+  graphslam::imu_processing::resolveOrientation(input, state);
+  EXPECT_DOUBLE_EQ(state.integrated_yaw, 0.7);
+  EXPECT_DOUBLE_EQ(state.last_imu_time, 11.5);
+
+  // Healthy dt integrates.
+  input.imu_time = 11.6;
+  graphslam::imu_processing::resolveOrientation(input, state);
+  EXPECT_NEAR(state.integrated_yaw, 0.7 + 1.0 * 0.1, 1e-12);
+}
+
+TEST(ImuProcessing, YawWrapsAroundPi)
+{
+  OrientationState state;
+  state.integrated_yaw = M_PI - 0.05;
+  state.integrated_yaw_valid = true;
+  state.last_imu_time = 0.0;
+
+  OrientationInput input;
+  input.q_world_imu = tf2::Quaternion(0.0, 0.0, 0.0, 0.0);
+  input.angular_velocity_z = 1.0;
+  input.linear_acceleration_z = 9.81;
+  input.imu_time = 0.1;
+
+  const OrientationResult result = graphslam::imu_processing::resolveOrientation(input, state);
+
+  EXPECT_NEAR(result.yaw, M_PI - 0.05 + 0.1 - 2.0 * M_PI, 1e-12);
+  EXPECT_LE(result.yaw, M_PI);
+}
+
+TEST(ImuProcessing, GravityCompensationMatchesTransplantedExpressions)
+{
+  const double ax = 0.4;
+  const double ay = -0.2;
+  const double az = 9.5;
+  const double roll = 0.07;
+  const double pitch = -0.03;
+
+  const Eigen::Vector3f acc = graphslam::imu_processing::gravityCompensatedAcceleration(
+    ax, ay, az, roll, pitch);
+
+  // Exact float truncation of the historical inline expressions.
+  const float expected_x = static_cast<float>(ax) + sin(pitch) * 9.81;
+  const float expected_y = static_cast<float>(ay) - cos(pitch) * sin(roll) * 9.81;
+  const float expected_z = static_cast<float>(az) - cos(pitch) * cos(roll) * 9.81;
+  EXPECT_EQ(acc.x(), expected_x);
+  EXPECT_EQ(acc.y(), expected_y);
+  EXPECT_EQ(acc.z(), expected_z);
+
+  // Level pose with nominal gravity cancels to (numerically) zero z.
+  const Eigen::Vector3f level = graphslam::imu_processing::gravityCompensatedAcceleration(
+    0.0, 0.0, 9.81, 0.0, 0.0);
+  EXPECT_NEAR(level.z(), 0.0f, 1e-6f);
+}
+
+TEST(ImuProcessing, ComplementaryBlendMatchesTransplantedFormula)
+{
+  ComplementaryBlendInput input;
+  input.imu_reference_quat = quatFromRpy(0.01, 0.02, 0.5);
+  input.latest_imu_robot_quat = quatFromRpy(0.05, -0.01, 0.52);
+  const tf2::Quaternion ndt_quat = quatFromRpy(0.02, 0.01, 0.55);
+  input.accepted_quat_msg = tf2::toMsg(ndt_quat);
+  const Eigen::Quaternionf prev_quat(
+    Eigen::AngleAxisf(0.48f, Eigen::Vector3f::UnitZ()) *
+    Eigen::AngleAxisf(0.015f, Eigen::Vector3f::UnitY()) *
+    Eigen::AngleAxisf(0.025f, Eigen::Vector3f::UnitX()));
+  input.previous_published_rotation = prev_quat.toRotationMatrix();
+  input.alpha = 0.3;
+
+  const geometry_msgs::msg::Quaternion blended =
+    graphslam::imu_processing::blendComplementaryRollPitch(input);
+
+  // Reproduce the historical arithmetic step by step.
+  tf2::Quaternion imu_delta = input.imu_reference_quat.inverse() * input.latest_imu_robot_quat;
+  imu_delta.normalize();
+  double imu_dr, imu_dp, imu_dy;
+  tf2::Matrix3x3(imu_delta).getRPY(imu_dr, imu_dp, imu_dy);
+  double ndt_roll, ndt_pitch, ndt_yaw;
+  tf2::Matrix3x3(ndt_quat).getRPY(ndt_roll, ndt_pitch, ndt_yaw);
+  Eigen::Quaternionf prev_q_eig(input.previous_published_rotation);
+  tf2::Quaternion prev_pub_quat(prev_q_eig.x(), prev_q_eig.y(), prev_q_eig.z(), prev_q_eig.w());
+  double prev_roll, prev_pitch, prev_yaw;
+  tf2::Matrix3x3(prev_pub_quat).getRPY(prev_roll, prev_pitch, prev_yaw);
+  const double a = input.alpha;
+  tf2::Quaternion expected_quat;
+  expected_quat.setRPY(
+    (1.0 - a) * ndt_roll + a * (prev_roll + imu_dr),
+    (1.0 - a) * ndt_pitch + a * (prev_pitch + imu_dp),
+    ndt_yaw);
+  expected_quat.normalize();
+  const geometry_msgs::msg::Quaternion expected = tf2::toMsg(expected_quat);
+
+  EXPECT_DOUBLE_EQ(blended.x, expected.x);
+  EXPECT_DOUBLE_EQ(blended.y, expected.y);
+  EXPECT_DOUBLE_EQ(blended.z, expected.z);
+  EXPECT_DOUBLE_EQ(blended.w, expected.w);
+}
+
+TEST(ImuProcessing, ComplementaryBlendZeroAlphaKeepsRegistrationRotation)
+{
+  ComplementaryBlendInput input;
+  input.imu_reference_quat = quatFromRpy(0.0, 0.0, 0.0);
+  input.latest_imu_robot_quat = quatFromRpy(0.3, 0.2, 0.0);
+  const tf2::Quaternion ndt_quat = quatFromRpy(0.02, 0.01, 0.55);
+  input.accepted_quat_msg = tf2::toMsg(ndt_quat);
+  input.previous_published_rotation = Eigen::Matrix3f::Identity();
+  input.alpha = 0.0;
+
+  const geometry_msgs::msg::Quaternion blended =
+    graphslam::imu_processing::blendComplementaryRollPitch(input);
+
+  double ndt_roll, ndt_pitch, ndt_yaw;
+  tf2::Matrix3x3(ndt_quat).getRPY(ndt_roll, ndt_pitch, ndt_yaw);
+  tf2::Quaternion expected_quat;
+  expected_quat.setRPY(ndt_roll, ndt_pitch, ndt_yaw);
+  expected_quat.normalize();
+  const geometry_msgs::msg::Quaternion expected = tf2::toMsg(expected_quat);
+  EXPECT_DOUBLE_EQ(blended.x, expected.x);
+  EXPECT_DOUBLE_EQ(blended.y, expected.y);
+  EXPECT_DOUBLE_EQ(blended.z, expected.z);
+  EXPECT_DOUBLE_EQ(blended.w, expected.w);
+}
+
+TEST(ImuProcessing, SameSequenceBitwiseIdentical)
+{
+  const auto run_sequence = [](std::vector<OrientationResult> & results) {
+      OrientationState state;
+      for (int i = 0; i < 50; ++i) {
+        OrientationInput input;
+        if (i % 3 == 0) {
+          input.q_world_imu = quatFromRpy(0.01 * i, -0.005 * i, 0.1 * i);
+          input.orientation_covariance0 = 0.01;
+        } else {
+          input.q_world_imu = tf2::Quaternion(0.0, 0.0, 0.0, 0.0);
+          input.orientation_covariance0 = -1.0;
+        }
+        input.linear_acceleration_x = 0.01 * i;
+        input.linear_acceleration_y = -0.02 * i;
+        input.linear_acceleration_z = 9.81;
+        input.angular_velocity_z = 0.05 * (i % 7);
+        input.imu_time = 0.1 * i;
+        results.push_back(graphslam::imu_processing::resolveOrientation(input, state));
+      }
+    };
+
+  std::vector<OrientationResult> first;
+  std::vector<OrientationResult> second;
+  run_sequence(first);
+  run_sequence(second);
+
+  ASSERT_EQ(first.size(), second.size());
+  for (size_t i = 0; i < first.size(); ++i) {
+    const double lhs[4] =
+    {first[i].q_world_robot.x(), first[i].q_world_robot.y(), first[i].q_world_robot.z(),
+      first[i].q_world_robot.w()};
+    const double rhs[4] =
+    {second[i].q_world_robot.x(), second[i].q_world_robot.y(), second[i].q_world_robot.z(),
+      second[i].q_world_robot.w()};
+    EXPECT_EQ(std::memcmp(lhs, rhs, sizeof(lhs)), 0);
+    EXPECT_EQ(
+      std::memcmp(&first[i].roll, &second[i].roll, sizeof(double)), 0);
+    EXPECT_EQ(
+      std::memcmp(&first[i].yaw, &second[i].yaw, sizeof(double)), 0);
+  }
+}


### PR DESCRIPTION
## Summary

v0.6 Phase 4 (scanmatcher core/shell) の継続。`receiveImu` の IMU 姿勢処理コアと `publishMapAndPose` の相補フィルタブレンドを純ヘッダ `scanmatcher/imu_processing.hpp` に逐語移植する。

- `rotateImuVectorsIntoRobotFrame`: receiveImu に逐語重複していた try/フォールバックの 2 ブロック(角速度・加速度の robot frame 回転)を 1 つの純関数に統合。TF lookup のラダー(stamped → latest static → identity)は shell に残置
- `resolveOrientation`: orientation 有効判定(covariance[0] < 0 / ゼロ四元数)、フレーム合成 `q_world_robot = q_world_imu * q_imu_robot`、加速度からの roll/pitch 推定、gyro yaw 積分(dt ∈ (0, 1) ゲート + wrap)を `OrientationState` 付き純関数化
- `gravityCompensatedAcceleration`: 重力除去の float 切り捨てを含む正確な式を移植
- `blendComplementaryRollPitch`: post-NDT 相補フィルタのブレンド算術。ゲーティング(enable/alpha/IMU age/diagnostic valid)は shell 残置
- 状態メンバ 3 個(`last_imu_time_` / `imu_integrated_yaw_` / `imu_integrated_yaw_valid_`)を `imu_processing::OrientationState` 1 個に置換
- PR #258 以降 dead code だった cpp ローカルの `wrapAngleRad` / `clampVectorNorm` / `quaternionFromRPY` を削除

`scanmatcher_component.cpp` は 1785 → 1695 行。

## Tests

characterization 12 本 (`test_imu_processing.cpp`):
- ベクトル回転: identity no-op / 歴史的 `tf2::quatRotate` と完全一致
- orientation: 同一フレーム時の IMU quat 直用、フレーム合成、TF 不在時は合成スキップ
- accel フォールバック: covariance 負 / ゼロ四元数 → roll=atan2(ay,az) ほか移植式と `EXPECT_DOUBLE_EQ` 一致、yaw 積分
- yaw 積分ゲート (dt≤0 / dt≥1 で保持)、±π wrap
- 重力補償: 移植式と float ビット一致
- 相補ブレンド: 段階再現した歴史的算術と完全一致、alpha=0 で registration 回転保持
- 同一系列 2 回 → `memcmp` ビット一致(決定論契約)

## Verification

- `colcon build/test --packages-select scanmatcher`: 66 tests, 0 failures
- `ament_uncrustify` / `ament_cpplint`: 新規ファイル No problems
- リリースゲート(`--fail-on-profiles --offline-determinism-bag ... --offline-determinism-reference-tum ...`): PASS、stadtgarten_seq2 raw 0.835 再現、オフライン決定論 3-run md5 一致(数値は下記コメント参照)
