### PR TITLE
refactor(scanmatcher): extract the map-update policy into a pure header (v0.6 Phase 4)

### DIFF
--- a/scanmatcher/CMakeLists.txt
+++ b/scanmatcher/CMakeLists.txt
@@ -107,6 +107,9 @@ if(BUILD_TESTING)
   ament_add_gtest(test_imu_processing test/test_imu_processing.cpp)
   target_include_directories(test_imu_processing PRIVATE include ${EIGEN3_INCLUDE_DIR})
   ament_target_dependencies(test_imu_processing tf2 tf2_geometry_msgs geometry_msgs)
+
+  ament_add_gtest(test_map_update_policy test/test_map_update_policy.cpp)
+  target_include_directories(test_map_update_policy PRIVATE include ${EIGEN3_INCLUDE_DIR})
 endif()
 
 add_library(scanmatcher_component SHARED

--- a/scanmatcher/include/scanmatcher/map_update_policy.hpp
+++ b/scanmatcher/include/scanmatcher/map_update_policy.hpp
@@ -1,0 +1,116 @@
+#ifndef SCANMATCHER_MAP_UPDATE_POLICY_HPP_
+#define SCANMATCHER_MAP_UPDATE_POLICY_HPP_
+
+#include <algorithm>
+#include <vector>
+
+#include <Eigen/Core>
+
+namespace graphslam
+{
+namespace map_update_policy
+{
+
+// Keyframe trigger: a map update starts once the robot moved far enough,
+// no async update is in flight, and pose acceptance did not suppress it.
+inline bool shouldTriggerMapUpdate(
+  const double trans,
+  const double trans_for_mapupdate,
+  const bool mapping_in_flight,
+  const bool suppress_map_update)
+{
+  return trans >= trans_for_mapupdate && !mapping_in_flight && !suppress_map_update;
+}
+
+// Async warmup gate: run the map update on a worker thread only after the
+// map holds enough submaps (warmup_submaps <= 0 disables the warmup).
+inline bool useAsyncMapUpdate(
+  const bool async_map_update,
+  const int async_map_update_warmup_submaps,
+  const int num_submaps)
+{
+  return async_map_update &&
+         (async_map_update_warmup_submaps <= 0 ||
+         num_submaps >= async_map_update_warmup_submaps);
+}
+
+// VoxelHashMap mode: local points within a spatial radius form the
+// registration target, capped at 50 m.
+inline double voxelHashLocalRadius(const double voxel_hash_map_max_distance)
+{
+  return std::min(voxel_hash_map_max_distance, 50.0);
+}
+
+// Spatial local map: walk submaps newest-first and keep those within the
+// radius of the current position, up to num_targeted_cloud - 1 entries
+// (the live scan itself is the remaining one). Returns indices in the
+// historical iteration order (newest to oldest).
+inline std::vector<int> selectSpatialSubmapIndices(
+  const std::vector<Eigen::Vector3d> & submap_positions,
+  const Eigen::Vector3d & current_position,
+  const double spatial_local_map_radius,
+  const int num_targeted_cloud)
+{
+  std::vector<int> indices;
+  const int num_submaps = static_cast<int>(submap_positions.size());
+  int added = 0;
+  for (int i = num_submaps - 1; i >= 0 && added < num_targeted_cloud - 1; i--) {
+    const double dist = (submap_positions[i] - current_position).norm();
+    if (dist <= spatial_local_map_radius) {
+      indices.push_back(i);
+      added++;
+    }
+  }
+  return indices;
+}
+
+// Temporal local map: the num_targeted_cloud - 1 most recent submaps,
+// newest first (original behavior).
+inline std::vector<int> selectTemporalSubmapIndices(
+  const int num_submaps,
+  const int num_targeted_cloud)
+{
+  std::vector<int> indices;
+  for (int i = 0; i < num_targeted_cloud - 1; i++) {
+    if (num_submaps - 1 - i < 0) {continue;}
+    indices.push_back(num_submaps - 1 - i);
+  }
+  return indices;
+}
+
+// Periodic full-map publish gate.
+inline bool shouldPublishMap(const double dt_sec, const double map_publish_period)
+{
+  return dt_sec > map_publish_period;
+}
+
+// Adaptive correspondence-distance EMA update after alignment. A
+// non-positive mean correspondence distance leaves the EMA unchanged; the
+// first positive sample seeds it.
+inline double updateAdaptiveCorrespondenceEma(
+  const double current_ema,
+  const double mean_correspondence_distance,
+  const double ema_alpha)
+{
+  if (mean_correspondence_distance > 0.0) {
+    if (current_ema <= 0.0) {
+      return mean_correspondence_distance;  // Initialize
+    }
+    return ema_alpha * mean_correspondence_distance + (1.0 - ema_alpha) * current_ema;
+  }
+  return current_ema;
+}
+
+// Max correspondence distance applied before alignment when the adaptive
+// threshold is active (the shell only applies it while the EMA is seeded).
+inline double adaptiveMaxCorrespondenceDistance(
+  const double adaptive_corr_dist_multiplier,
+  const double adaptive_corr_dist_ema)
+{
+  return adaptive_corr_dist_multiplier * adaptive_corr_dist_ema;
+}
+
+}  // namespace map_update_policy
+}  // namespace graphslam
+
+#endif  // SCANMATCHER_MAP_UPDATE_POLICY_HPP_

--- a/scanmatcher/include/scanmatcher/scanmatcher_component.h
+++ b/scanmatcher/include/scanmatcher/scanmatcher_component.h
@@ -59,6 +59,7 @@ extern "C" {
 #include <lidarslam_msgs/msg/map_array.hpp>
 #include "scanmatcher/lidar_undistortion.hpp"
 #include "scanmatcher/imu_processing.hpp"
+#include "scanmatcher/map_update_policy.hpp"
 #include "scanmatcher/pose_acceptance.hpp"
 #include "scanmatcher/pose_prediction.hpp"
 #include "scanmatcher/voxel_hash_map.hpp"
@@ -154,6 +155,7 @@ private:
       const geometry_msgs::msg::PoseStamped current_pose_stamped
     );
     bool refreshRegistrationTargetFromTargetedCloud();
+    void appendTransformedSubmaps(const std::vector<int> & submap_indices);
     geometry_msgs::msg::TransformStamped calculateMaptoOdomTransform(
       const geometry_msgs::msg::TransformStamped &base_to_map_msg,
       const rclcpp::Time stamp

--- a/scanmatcher/src/scanmatcher_component.cpp
+++ b/scanmatcher/src/scanmatcher_component.cpp
@@ -1044,7 +1044,8 @@ void ScanMatcherComponent::receiveCloud(
 
   // Set adaptive correspondence distance before alignment (all methods)
   if (adaptive_correspondence_threshold_ && adaptive_corr_dist_ema_ > 0.0) {
-    double max_dist = adaptive_corr_dist_multiplier_ * adaptive_corr_dist_ema_;
+    double max_dist = map_update_policy::adaptiveMaxCorrespondenceDistance(
+      adaptive_corr_dist_multiplier_, adaptive_corr_dist_ema_);
     if (registration_method_ == "NDT") {
       auto ndt_ptr = boost::dynamic_pointer_cast<
         pclomp::NormalDistributionsTransform<pcl::PointXYZI, pcl::PointXYZI>>(registration_);
@@ -1095,14 +1096,8 @@ void ScanMatcherComponent::receiveCloud(
       registration_->setMaxCorrespondenceDistance(
         std::numeric_limits<double>::max());  // Reset for next frame
     }
-    if (mean_corr > 0.0) {
-      if (adaptive_corr_dist_ema_ <= 0.0) {
-        adaptive_corr_dist_ema_ = mean_corr;  // Initialize
-      } else {
-        adaptive_corr_dist_ema_ = adaptive_corr_dist_ema_alpha_ * mean_corr +
-          (1.0 - adaptive_corr_dist_ema_alpha_) * adaptive_corr_dist_ema_;
-      }
-    }
+    adaptive_corr_dist_ema_ = map_update_policy::updateAdaptiveCorrespondenceEma(
+      adaptive_corr_dist_ema_, mean_corr, adaptive_corr_dist_ema_alpha_);
   }
 
   Eigen::Matrix4f final_transformation = registration_->getFinalTransformation();
@@ -1251,14 +1246,16 @@ void ScanMatcherComponent::publishMapAndPose(
   path_pub_->publish(path_);
 
   trans_ = (accepted_position - previous_position_).norm();
-  if (trans_ >= trans_for_mapupdate_ && !mapping_flag_ && !suppress_map_update) {
+  if (
+    map_update_policy::shouldTriggerMapUpdate(
+      trans_, trans_for_mapupdate_, mapping_flag_, suppress_map_update))
+  {
     geometry_msgs::msg::PoseStamped current_pose_stamped;
     current_pose_stamped = current_pose_stamped_;
     previous_position_ = accepted_position;
-    const bool use_async_map_update =
-      async_map_update_ &&
-      (async_map_update_warmup_submaps_ <= 0 ||
-      static_cast<int>(map_array_msg_.submaps.size()) >= async_map_update_warmup_submaps_);
+    const bool use_async_map_update = map_update_policy::useAsyncMapUpdate(
+      async_map_update_, async_map_update_warmup_submaps_,
+      static_cast<int>(map_array_msg_.submaps.size()));
     if (use_async_map_update) {
       mapping_task_ =
         std::packaged_task<void()>(
@@ -1314,7 +1311,7 @@ void ScanMatcherComponent::updateMap(
         current_pose_stamped.pose.position.z);
       voxel_hash_map_->update(transformed_cloud_ptr, current_pos);
       // Use local points within spatial radius for registration target
-      double local_radius = std::min(voxel_hash_map_max_distance_, 50.0);
+      double local_radius = map_update_policy::voxelHashLocalRadius(voxel_hash_map_max_distance_);
       auto voxel_cloud = voxel_hash_map_->getLocalPoints(current_pos, local_radius);
       targeted_cloud_.clear();
       targeted_cloud_ += *voxel_cloud;
@@ -1322,44 +1319,30 @@ void ScanMatcherComponent::updateMap(
       // Spatial local map: select submaps within radius of current position
       targeted_cloud_.clear();
       targeted_cloud_ += *transformed_cloud_ptr;
-      int num_submaps = map_array_msg_.submaps.size();
       Eigen::Vector3d current_pos(
         current_pose_stamped.pose.position.x,
         current_pose_stamped.pose.position.y,
         current_pose_stamped.pose.position.z);
-      int added = 0;
-      for (int i = num_submaps - 1; i >= 0 && added < num_targeted_cloud_ - 1; i--) {
-        Eigen::Vector3d submap_pos(
-          map_array_msg_.submaps[i].pose.position.x,
-          map_array_msg_.submaps[i].pose.position.y,
-          map_array_msg_.submaps[i].pose.position.z);
-        double dist = (submap_pos - current_pos).norm();
-        if (dist <= spatial_local_map_radius_) {
-          pcl::PointCloud<pcl::PointXYZI>::Ptr tmp_ptr(new pcl::PointCloud<pcl::PointXYZI>());
-          pcl::fromROSMsg(map_array_msg_.submaps[i].cloud, *tmp_ptr);
-          pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_tmp_ptr(new pcl::PointCloud<pcl::PointXYZI>());
-          Eigen::Affine3d submap_affine;
-          tf2::fromMsg(map_array_msg_.submaps[i].pose, submap_affine);
-          pcl::transformPointCloud(*tmp_ptr, *transformed_tmp_ptr, submap_affine.matrix());
-          targeted_cloud_ += *transformed_tmp_ptr;
-          added++;
-        }
+      std::vector<Eigen::Vector3d> submap_positions;
+      submap_positions.reserve(map_array_msg_.submaps.size());
+      for (const auto & submap_entry : map_array_msg_.submaps) {
+        submap_positions.emplace_back(
+          submap_entry.pose.position.x,
+          submap_entry.pose.position.y,
+          submap_entry.pose.position.z);
       }
+      const std::vector<int> selected_indices =
+        map_update_policy::selectSpatialSubmapIndices(
+        submap_positions, current_pos, spatial_local_map_radius_, num_targeted_cloud_);
+      appendTransformedSubmaps(selected_indices);
     } else {
       // Temporal local map: use N most recent submaps (original behavior)
       targeted_cloud_.clear();
       targeted_cloud_ += *transformed_cloud_ptr;
-      int num_submaps = map_array_msg_.submaps.size();
-      for (int i = 0; i < num_targeted_cloud_ - 1; i++) {
-        if (num_submaps - 1 - i < 0) {continue;}
-        pcl::PointCloud<pcl::PointXYZI>::Ptr tmp_ptr(new pcl::PointCloud<pcl::PointXYZI>());
-        pcl::fromROSMsg(map_array_msg_.submaps[num_submaps - 1 - i].cloud, *tmp_ptr);
-        pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_tmp_ptr(new pcl::PointCloud<pcl::PointXYZI>());
-        Eigen::Affine3d submap_affine;
-        tf2::fromMsg(map_array_msg_.submaps[num_submaps - 1 - i].pose, submap_affine);
-        pcl::transformPointCloud(*tmp_ptr, *transformed_tmp_ptr, submap_affine.matrix());
-        targeted_cloud_ += *transformed_tmp_ptr;
-      }
+      const std::vector<int> selected_indices =
+        map_update_policy::selectTemporalSubmapIndices(
+        static_cast<int>(map_array_msg_.submaps.size()), num_targeted_cloud_);
+      appendTransformedSubmaps(selected_indices);
     }
 
     map_array_msg_.header.stamp = current_pose_stamped.header.stamp;
@@ -1372,9 +1355,25 @@ void ScanMatcherComponent::updateMap(
 
   rclcpp::Time map_time = clock_.now();
   double dt = map_time.seconds() - last_map_time_.seconds();
-  if (dt > map_publish_period_) {
+  if (map_update_policy::shouldPublishMap(dt, map_publish_period_)) {
     publishMap(map_array_snapshot, global_frame_id_);
     last_map_time_ = map_time;
+  }
+}
+
+// Decode, transform into the map frame, and append the selected submaps to
+// targeted_cloud_. Cloud I/O for the pure index selection in
+// map_update_policy.hpp; expects mtx_ to be held by the caller.
+void ScanMatcherComponent::appendTransformedSubmaps(const std::vector<int> & submap_indices)
+{
+  for (const int i : submap_indices) {
+    pcl::PointCloud<pcl::PointXYZI>::Ptr tmp_ptr(new pcl::PointCloud<pcl::PointXYZI>());
+    pcl::fromROSMsg(map_array_msg_.submaps[i].cloud, *tmp_ptr);
+    pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_tmp_ptr(new pcl::PointCloud<pcl::PointXYZI>());
+    Eigen::Affine3d submap_affine;
+    tf2::fromMsg(map_array_msg_.submaps[i].pose, submap_affine);
+    pcl::transformPointCloud(*tmp_ptr, *transformed_tmp_ptr, submap_affine.matrix());
+    targeted_cloud_ += *transformed_tmp_ptr;
   }
 }
 

--- a/scanmatcher/test/test_map_update_policy.cpp
+++ b/scanmatcher/test/test_map_update_policy.cpp
@@ -1,0 +1,148 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <vector>
+
+#include "scanmatcher/map_update_policy.hpp"
+
+namespace
+{
+namespace policy = graphslam::map_update_policy;
+}  // namespace
+
+TEST(MapUpdatePolicy, ShouldTriggerMapUpdateRequiresAllConditions)
+{
+  // The historical condition: trans_ >= trans_for_mapupdate_ &&
+  // !mapping_flag_ && !suppress_map_update.
+  EXPECT_TRUE(policy::shouldTriggerMapUpdate(1.5, 1.5, false, false));  // >= boundary
+  EXPECT_TRUE(policy::shouldTriggerMapUpdate(2.0, 1.5, false, false));
+  EXPECT_FALSE(policy::shouldTriggerMapUpdate(1.4999, 1.5, false, false));
+  EXPECT_FALSE(policy::shouldTriggerMapUpdate(2.0, 1.5, true, false));   // async in flight
+  EXPECT_FALSE(policy::shouldTriggerMapUpdate(2.0, 1.5, false, true));   // reject cooldown
+}
+
+TEST(MapUpdatePolicy, UseAsyncMapUpdateWarmupGate)
+{
+  // warmup <= 0 disables the warmup entirely.
+  EXPECT_TRUE(policy::useAsyncMapUpdate(true, 0, 0));
+  EXPECT_TRUE(policy::useAsyncMapUpdate(true, -1, 0));
+  // Otherwise async starts only once the map holds warmup submaps.
+  EXPECT_FALSE(policy::useAsyncMapUpdate(true, 10, 9));
+  EXPECT_TRUE(policy::useAsyncMapUpdate(true, 10, 10));  // >= boundary
+  EXPECT_TRUE(policy::useAsyncMapUpdate(true, 10, 11));
+  // Async disabled wins regardless.
+  EXPECT_FALSE(policy::useAsyncMapUpdate(false, 0, 100));
+}
+
+TEST(MapUpdatePolicy, VoxelHashLocalRadiusCapsAtFifty)
+{
+  EXPECT_DOUBLE_EQ(policy::voxelHashLocalRadius(30.0), 30.0);
+  EXPECT_DOUBLE_EQ(policy::voxelHashLocalRadius(50.0), 50.0);
+  EXPECT_DOUBLE_EQ(policy::voxelHashLocalRadius(120.0), 50.0);
+}
+
+TEST(MapUpdatePolicy, SelectSpatialSubmapIndicesNewestFirstWithinRadius)
+{
+  // Submaps along x: 0, 1, 2, ..., 5; the robot sits at x = 5.
+  std::vector<Eigen::Vector3d> positions;
+  for (int i = 0; i <= 5; ++i) {
+    positions.emplace_back(static_cast<double>(i), 0.0, 0.0);
+  }
+  const Eigen::Vector3d current(5.0, 0.0, 0.0);
+
+  // Radius 2.0 admits x in [3, 5]; the cap (num_targeted_cloud - 1 = 10)
+  // does not bind. Historical iteration is newest to oldest.
+  const std::vector<int> indices =
+    policy::selectSpatialSubmapIndices(positions, current, 2.0, 11);
+  ASSERT_EQ(indices.size(), 3u);
+  EXPECT_EQ(indices[0], 5);
+  EXPECT_EQ(indices[1], 4);
+  EXPECT_EQ(indices[2], 3);
+
+  // dist == radius is included (<=).
+  const std::vector<int> boundary =
+    policy::selectSpatialSubmapIndices(positions, current, 1.0, 11);
+  ASSERT_EQ(boundary.size(), 2u);
+  EXPECT_EQ(boundary[1], 4);
+}
+
+TEST(MapUpdatePolicy, SelectSpatialSubmapIndicesCapsAtTargetedCloud)
+{
+  std::vector<Eigen::Vector3d> positions(20, Eigen::Vector3d::Zero());
+  const Eigen::Vector3d current(0.0, 0.0, 0.0);
+
+  // All 20 submaps are in range but only num_targeted_cloud - 1 = 4 fit.
+  const std::vector<int> indices =
+    policy::selectSpatialSubmapIndices(positions, current, 10.0, 5);
+  ASSERT_EQ(indices.size(), 4u);
+  EXPECT_EQ(indices[0], 19);
+  EXPECT_EQ(indices[3], 16);
+
+  // num_targeted_cloud = 1 leaves room for the live scan only.
+  EXPECT_TRUE(policy::selectSpatialSubmapIndices(positions, current, 10.0, 1).empty());
+}
+
+TEST(MapUpdatePolicy, SelectTemporalSubmapIndicesMostRecentFirst)
+{
+  // 10 submaps, num_targeted_cloud 4 -> the 3 most recent, newest first.
+  const std::vector<int> indices = policy::selectTemporalSubmapIndices(10, 4);
+  ASSERT_EQ(indices.size(), 3u);
+  EXPECT_EQ(indices[0], 9);
+  EXPECT_EQ(indices[1], 8);
+  EXPECT_EQ(indices[2], 7);
+
+  // Fewer submaps than requested: negative indices are skipped, not clamped.
+  const std::vector<int> sparse = policy::selectTemporalSubmapIndices(2, 4);
+  ASSERT_EQ(sparse.size(), 2u);
+  EXPECT_EQ(sparse[0], 1);
+  EXPECT_EQ(sparse[1], 0);
+
+  EXPECT_TRUE(policy::selectTemporalSubmapIndices(10, 1).empty());
+  EXPECT_TRUE(policy::selectTemporalSubmapIndices(0, 4).empty());
+}
+
+TEST(MapUpdatePolicy, ShouldPublishMapStrictGreaterThan)
+{
+  EXPECT_FALSE(policy::shouldPublishMap(1.0, 1.0));  // dt == period does not publish
+  EXPECT_TRUE(policy::shouldPublishMap(1.0001, 1.0));
+  EXPECT_FALSE(policy::shouldPublishMap(0.5, 1.0));
+}
+
+TEST(MapUpdatePolicy, UpdateAdaptiveCorrespondenceEmaSeedAndBlend)
+{
+  // First positive sample seeds the EMA.
+  EXPECT_DOUBLE_EQ(policy::updateAdaptiveCorrespondenceEma(0.0, 0.8, 0.1), 0.8);
+  EXPECT_DOUBLE_EQ(policy::updateAdaptiveCorrespondenceEma(-1.0, 0.8, 0.1), 0.8);
+
+  // Subsequent samples blend with the historical expression.
+  const double ema = 0.5;
+  const double mean_corr = 0.9;
+  const double alpha = 0.1;
+  const double expected = alpha * mean_corr + (1.0 - alpha) * ema;
+  EXPECT_DOUBLE_EQ(policy::updateAdaptiveCorrespondenceEma(ema, mean_corr, alpha), expected);
+
+  // A non-positive measurement leaves the EMA untouched.
+  EXPECT_DOUBLE_EQ(policy::updateAdaptiveCorrespondenceEma(0.5, 0.0, 0.1), 0.5);
+  EXPECT_DOUBLE_EQ(policy::updateAdaptiveCorrespondenceEma(0.5, -0.2, 0.1), 0.5);
+}
+
+TEST(MapUpdatePolicy, AdaptiveMaxCorrespondenceDistanceIsPlainProduct)
+{
+  EXPECT_DOUBLE_EQ(policy::adaptiveMaxCorrespondenceDistance(3.0, 0.4), 3.0 * 0.4);
+}
+
+TEST(MapUpdatePolicy, EmaChainBitwiseIdentical)
+{
+  const auto run_chain = [] {
+      double ema = 0.0;
+      for (int i = 1; i <= 100; ++i) {
+        const double mean_corr = (i % 5 == 0) ? 0.0 : 0.3 + 0.01 * (i % 17);
+        ema = policy::updateAdaptiveCorrespondenceEma(ema, mean_corr, 0.1);
+      }
+      return ema;
+    };
+
+  const double first = run_chain();
+  const double second = run_chain();
+  EXPECT_EQ(std::memcmp(&first, &second, sizeof(double)), 0);
+}


### PR DESCRIPTION
## Summary

v0.6 Phase 4 (scanmatcher core/shell) の継続。keyframe / ローカルマップ / adaptive correspondence のポリシー判定を純ヘッダ `scanmatcher/map_update_policy.hpp` に逐語移植する。

- `shouldTriggerMapUpdate`: keyframe トリガ(`trans >= trans_for_mapupdate && !mapping_in_flight && !suppress_map_update`)
- `useAsyncMapUpdate`: async warmup ゲート(`warmup <= 0` で無効、`>=` 境界)
- `voxelHashLocalRadius`: VoxelHashMap モードの 50 m cap
- `selectSpatialSubmapIndices` / `selectTemporalSubmapIndices`: registration target を構成する submap の index 選択(newest-first、cap = `num_targeted_cloud - 1`、spatial は `dist <= radius`)。**どの submap がローカルマップに入るかはフロントエンド決定論の核心判定**
- `shouldPublishMap`: 周期 publish ゲート(`>` 厳密)
- `updateAdaptiveCorrespondenceEma` / `adaptiveMaxCorrespondenceDistance`: align 前後の適応対応距離(seed / blend / 非正サンプルで不変)

updateMap に逐語重複していた submap 組み立てループ 2 つ(spatial/temporal)は cloud I/O ヘルパー `appendTransformedSubmaps`(`mtx_` 保持前提)に統合。component は index 選択をポリシーに委ね、デコード・変換・連結だけを行う。

## Tests

characterization 10 本 (`test_map_update_policy.cpp`):
- トリガ・warmup・publish の境界(`>=` / `>` の使い分けをそのまま固定)
- spatial 選択: newest-first 順序、`dist == radius` 包含、cap 動作、`num_targeted_cloud = 1` で空
- temporal 選択: 直近 N-1 newest-first、submap 不足時は skip(clamp ではない)
- EMA: seed / blend 式と `EXPECT_DOUBLE_EQ` 一致 / 非正で不変、チェーン 2 回 → `memcmp` ビット一致

## Verification

- `colcon build/test --packages-select scanmatcher`: 77 tests, 0 failures
- `ament_uncrustify` / `ament_cpplint`: 新規ファイル No problems
- リリースゲート(`--fail-on-profiles --offline-determinism-bag ... --offline-determinism-reference-tum ...`): 結果は下記コメント参照
