### PR TITLE
feat(scanmatcher): offline deterministic frontend runner (v0.6 Phase 4 gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ python3 scripts/simple_lanelet2_generator.py \
 | `run_default_ci_checks.sh` | ローカル CI（ビルド＋テスト）|
 | `run_release_readiness_checks.sh` | リリースゲート（APE 閾値、`--offline-determinism-bag` で決定論ハードゲート）|
 | `run_offline_determinism_check.sh` | オフラインバックエンド決定論ゲート（N-run バイト一致 + 任意 APE レポート）|
+| `run_frontend_determinism_check.sh` | オフラインフロントエンド決定論ゲート（scanmatcher lockstep、N-run バイト一致）|
 | `run_rko_lio_graph_benchmark.sh` | ベンチマークパイプライン |
 | `run_autoware_quickstart.sh` | NTU VIRAL → Autoware マップ E2E |
 | `download_ntu_viral_tnp01.sh` | NTU VIRAL データダウンロード |

--- a/docs/roadmap/v0.6.md
+++ b/docs/roadmap/v0.6.md
@@ -153,6 +153,18 @@ rule after).
 - **Gate**: scanmatcher-frontend release profiles unchanged; new unit tests
   for the extracted core; offline runner supports the scanmatcher frontend
   path end-to-end deterministically.
+- **Status (2026-06-12)**: pure-header extractions landed —
+  `pose_prediction` (#257), `pose_acceptance` incl. the
+  Tracking/Suspect/Recovery state machine (#258), `imu_processing` (#259),
+  `map_update_policy` (#260); `scanmatcher_component.cpp` is 2140 → 1694
+  lines and the remaining shell is registration/PCD/pub-sub I/O. The
+  frontend E2E determinism gate **passed**: `scan_matcher_offline_runner`
+  drives the real component in lockstep (intra-process, spin_all-drained,
+  async_map_update forbidden) over the raw NTU tnp_01 bag, and
+  `run_frontend_determinism_check.sh` produced 3 byte-identical runs
+  (5795 poses, 133 submaps, GT APE 2.299132170580928 identical to the last
+  digit). This is the first determinism coverage for the scanmatcher (NDT)
+  frontend — all release profiles exercise the RKO-LIO frontend.
 
 ## 4. Risks
 

--- a/scanmatcher/CMakeLists.txt
+++ b/scanmatcher/CMakeLists.txt
@@ -130,6 +130,15 @@ scanmatcher_component ${PCL_LIBRARIES})
 ament_target_dependencies(scanmatcher_node
   rclcpp)
 
+find_package(rosbag2_cpp REQUIRED)
+add_executable(scan_matcher_offline_runner
+  src/scan_matcher_offline_runner.cpp
+)
+target_link_libraries(scan_matcher_offline_runner
+  scanmatcher_component ${PCL_LIBRARIES})
+ament_target_dependencies(scan_matcher_offline_runner
+  rclcpp rosbag2_cpp sensor_msgs geometry_msgs lidarslam_msgs pcl_conversions)
+
 if(small_gicp_FOUND)
   add_executable(small_gicp_odom_node
   src/small_gicp_odom_node.cpp
@@ -170,7 +179,7 @@ install(TARGETS
   RUNTIME DESTINATION bin
 )
 
-set(INSTALL_TARGETS scanmatcher_node)
+set(INSTALL_TARGETS scanmatcher_node scan_matcher_offline_runner)
 if(small_gicp_FOUND)
   list(APPEND INSTALL_TARGETS small_gicp_odom_node)
 endif()

--- a/scanmatcher/package.xml
+++ b/scanmatcher/package.xml
@@ -22,6 +22,7 @@
   <depend>tf2_eigen</depend>
   <depend>pcl_conversions</depend>
   <depend>lidarslam_msgs</depend>
+  <depend>rosbag2_cpp</depend>
   <depend>ndt_omp_ros2</depend>
   <!-- Optional: fast_gicp and small_gicp (from Thirdparty) -->
   <!-- <depend>fast_gicp</depend> -->

--- a/scanmatcher/src/scan_matcher_offline_runner.cpp
+++ b/scanmatcher/src/scan_matcher_offline_runner.cpp
@@ -1,0 +1,264 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// The offline deterministic frontend runner (docs/roadmap/v0.6.md, Phase 4):
+// read a raw sensor bag (LiDAR clouds + optional IMU) directly with
+// rosbag2_cpp and drive the real ScanMatcherComponent in lockstep — publish
+// one message at a time over intra-process pub/sub and drain a
+// single-threaded executor until idle before the next message. Bag order is
+// a total order, the async map-update worker is forbidden
+// (async_map_update must be false), and a fixed registration thread count
+// keeps ndt_omp bitwise reproducible, so the contract "same bag + same
+// config => identical frontend trajectory and submap stream" becomes
+// testable; scripts/run_frontend_determinism_check.sh runs this N times and
+// diffs the outputs.
+//
+// The component keeps its production node name (scan_matcher) so existing
+// presets (e.g. lidarslam/param/lidarslam.yaml) apply unchanged:
+//
+//   ros2 run scanmatcher scan_matcher_offline_runner --ros-args \
+//     --params-file lidarslam/param/lidarslam.yaml \
+//     -p async_map_update:=false \
+//     -p bag_path:=demo_data/ntu_viral/tnp_01_points_restamped_vn100_rosbag2 \
+//     -p cloud_topic:=/os1_cloud_node1/points \
+//     -p output_dir:=/tmp/frontend_run1
+//
+// TF determinism note: the component's tf2 listener spins on its own
+// thread, so feeding the sensor->base extrinsic over /tf_static would race
+// the first cloud lookup. Instead the runner rewrites the cloud frame_id to
+// the component's robot_frame_id (force_cloud_frame_to_robot_frame, default
+// true): lookupTransform(robot, robot) is an identity that needs no TF
+// data, and tf2::doTransform with the identity is a bitwise copy of the
+// points. Mount extrinsics, when they matter, belong in a pre-transformed
+// bag, exactly like the backend-input recording flow.
+
+#include <pcl_conversions/pcl_conversions.h>  // NOLINT(build/include_order)
+
+#include <chrono>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <lidarslam_msgs/msg/map_array.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/serialization.hpp>
+#include <rosbag2_cpp/reader.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include "scanmatcher/scanmatcher_component.h"
+
+namespace
+{
+
+void writeTum(const std::string & path, const std::vector<geometry_msgs::msg::PoseStamped> & poses)
+{
+  std::ofstream out(path);
+  char line[256];
+  for (const auto & pose : poses) {
+    const double stamp_sec = pose.header.stamp.sec + pose.header.stamp.nanosec * 1e-9;
+    std::snprintf(
+      line, sizeof(line), "%.9f %.9f %.9f %.9f %.9f %.9f %.9f %.9f",
+      stamp_sec,
+      pose.pose.position.x, pose.pose.position.y, pose.pose.position.z,
+      pose.pose.orientation.x, pose.pose.orientation.y, pose.pose.orientation.z,
+      pose.pose.orientation.w);
+    out << line << "\n";
+  }
+}
+
+void writeSubmapsCsv(const std::string & path, const lidarslam_msgs::msg::MapArray & map_array)
+{
+  std::ofstream out(path);
+  out << "index,stamp_sec,distance,x,y,z,qx,qy,qz,qw,cloud_points\n";
+  char line[512];
+  for (std::size_t i = 0; i < map_array.submaps.size(); ++i) {
+    const auto & submap = map_array.submaps[i];
+    const double stamp_sec = submap.header.stamp.sec + submap.header.stamp.nanosec * 1e-9;
+    const std::size_t cloud_points =
+      static_cast<std::size_t>(submap.cloud.width) * static_cast<std::size_t>(submap.cloud.height);
+    std::snprintf(
+      line, sizeof(line),
+      "%zu,%.9f,%.17g,%.17g,%.17g,%.17g,%.17g,%.17g,%.17g,%.17g,%zu",
+      i, stamp_sec, submap.distance,
+      submap.pose.position.x, submap.pose.position.y, submap.pose.position.z,
+      submap.pose.orientation.x, submap.pose.orientation.y, submap.pose.orientation.z,
+      submap.pose.orientation.w, cloud_points);
+    out << line << "\n";
+  }
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto runner = std::make_shared<rclcpp::Node>(
+    "scan_matcher_offline_runner",
+    rclcpp::NodeOptions().use_intra_process_comms(true));
+  const std::string bag_path = runner->declare_parameter<std::string>("bag_path", "");
+  const std::string output_dir = runner->declare_parameter<std::string>("output_dir", "");
+  const std::string cloud_topic = runner->declare_parameter<std::string>("cloud_topic", "");
+  const std::string imu_topic = runner->declare_parameter<std::string>("imu_topic", "");
+  const bool force_cloud_frame = runner->declare_parameter<bool>(
+    "force_cloud_frame_to_robot_frame", true);
+  // 0 = whole bag; a positive cap supports smoke tests and quick gates.
+  const int max_clouds = runner->declare_parameter<int>("max_clouds", 0);
+
+  if (bag_path.empty() || output_dir.empty() || cloud_topic.empty()) {
+    RCLCPP_ERROR(
+      runner->get_logger(),
+      "bag_path, output_dir and cloud_topic are required");
+    rclcpp::shutdown();
+    return 1;
+  }
+  std::filesystem::create_directories(output_dir);
+
+  auto component = std::make_shared<graphslam::ScanMatcherComponent>(
+    rclcpp::NodeOptions().use_intra_process_comms(true));
+
+  // The async map-update worker hands updateMap to a wall-clock-raced
+  // thread; the determinism contract requires the synchronous path.
+  if (component->get_parameter("async_map_update").as_bool()) {
+    RCLCPP_ERROR(
+      runner->get_logger(),
+      "async_map_update must be false for the offline runner "
+      "(add -p async_map_update:=false)");
+    rclcpp::shutdown();
+    return 1;
+  }
+  if (!component->get_parameter("set_initial_pose").as_bool()) {
+    RCLCPP_ERROR(
+      runner->get_logger(),
+      "set_initial_pose must be true for the offline runner "
+      "(there is no initial_pose publisher in the lockstep pipeline)");
+    rclcpp::shutdown();
+    return 1;
+  }
+  const std::string robot_frame_id =
+    component->get_parameter("robot_frame_id").as_string();
+
+  std::vector<geometry_msgs::msg::PoseStamped> poses;
+  auto pose_sub = runner->create_subscription<geometry_msgs::msg::PoseStamped>(
+    "current_pose", rclcpp::QoS(100),
+    [&poses](geometry_msgs::msg::PoseStamped::SharedPtr msg) {
+      poses.push_back(*msg);
+    });
+  lidarslam_msgs::msg::MapArray latest_map_array;
+  bool map_array_received = false;
+  auto map_array_sub = runner->create_subscription<lidarslam_msgs::msg::MapArray>(
+    "map_array", rclcpp::QoS(rclcpp::KeepLast(1)).reliable(),
+    [&latest_map_array, &map_array_received](lidarslam_msgs::msg::MapArray::SharedPtr msg) {
+      latest_map_array = *msg;
+      map_array_received = true;
+    });
+
+  auto cloud_qos = rclcpp::SensorDataQoS();
+  cloud_qos.keep_last(10);
+  auto cloud_pub = runner->create_publisher<sensor_msgs::msg::PointCloud2>(
+    "input_cloud", cloud_qos);
+  auto imu_pub = runner->create_publisher<sensor_msgs::msg::Imu>(
+    "imu", rclcpp::SensorDataQoS());
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(component);
+  executor.add_node(runner);
+  // Let discovery/intra-process wiring settle before the first message.
+  executor.spin_all(std::chrono::seconds(1));
+
+  rclcpp::Serialization<sensor_msgs::msg::PointCloud2> cloud_serialization;
+  rclcpp::Serialization<sensor_msgs::msg::Imu> imu_serialization;
+
+  rosbag2_cpp::Reader reader;
+  reader.open(bag_path);
+
+  std::size_t cloud_count = 0;
+  std::size_t imu_count = 0;
+  while (reader.has_next() && rclcpp::ok()) {
+    if (max_clouds > 0 && cloud_count >= static_cast<std::size_t>(max_clouds)) {
+      break;
+    }
+    auto bag_message = reader.read_next();
+    const rclcpp::SerializedMessage serialized(*bag_message->serialized_data);
+    if (bag_message->topic_name == cloud_topic) {
+      auto cloud = std::make_unique<sensor_msgs::msg::PointCloud2>();
+      cloud_serialization.deserialize_message(&serialized, cloud.get());
+      if (force_cloud_frame) {
+        cloud->header.frame_id = robot_frame_id;
+      }
+      cloud_pub->publish(std::move(cloud));
+      executor.spin_all(std::chrono::seconds(60));
+      ++cloud_count;
+      if (cloud_count % 500 == 0) {
+        RCLCPP_INFO(
+          runner->get_logger(), "processed %zu clouds (%zu poses)",
+          cloud_count, poses.size());
+      }
+    } else if (!imu_topic.empty() && bag_message->topic_name == imu_topic) {
+      auto imu = std::make_unique<sensor_msgs::msg::Imu>();
+      imu_serialization.deserialize_message(&serialized, imu.get());
+      imu_pub->publish(std::move(imu));
+      executor.spin_all(std::chrono::seconds(60));
+      ++imu_count;
+    }
+  }
+  executor.spin_all(std::chrono::seconds(60));
+
+  if (poses.empty() || !map_array_received) {
+    RCLCPP_ERROR(
+      runner->get_logger(),
+      "frontend produced no output (clouds=%zu poses=%zu map_array=%d) — "
+      "check cloud_topic and the scan_matcher parameters",
+      cloud_count, poses.size(), static_cast<int>(map_array_received));
+    rclcpp::shutdown();
+    return 1;
+  }
+
+  const auto trajectory_path =
+    (std::filesystem::path(output_dir) / "trajectory_frontend.tum").string();
+  const auto submaps_path =
+    (std::filesystem::path(output_dir) / "submaps_frontend.csv").string();
+  writeTum(trajectory_path, poses);
+  writeSubmapsCsv(submaps_path, latest_map_array);
+
+  RCLCPP_INFO(
+    runner->get_logger(),
+    "frontend offline run complete: clouds=%zu imu=%zu poses=%zu submaps=%zu",
+    cloud_count, imu_count, poses.size(), latest_map_array.submaps.size());
+  RCLCPP_INFO(runner->get_logger(), "trajectory: %s", trajectory_path.c_str());
+  RCLCPP_INFO(runner->get_logger(), "submaps:    %s", submaps_path.c_str());
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/scripts/run_frontend_determinism_check.sh
+++ b/scripts/run_frontend_determinism_check.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Phase 4 hard gate (docs/roadmap/v0.6.md): run the offline deterministic
+# frontend runner N times on the same raw sensor bag and require the
+# frontend trajectory AND the submap stream summary to be byte-identical
+# across runs.
+#
+# Usage:
+#   bash scripts/run_frontend_determinism_check.sh \
+#     --bag demo_data/ntu_viral/tnp_01_points_restamped_vn100_rosbag2 \
+#     --cloud-topic /os1_cloud_node1/points \
+#     [--imu-topic /imu/imu] \
+#     [--params lidarslam/param/lidarslam.yaml] \
+#     [--runs 3] [--max-clouds 0] \
+#     [--output-dir output/frontend_determinism_<timestamp>] \
+#     [--reference-tum demo_data/ntu_viral/tnp_01/leica_pose.tum]
+#
+# When --reference-tum is given, each run's trajectory_frontend.tum is also
+# scored with scripts/ape_from_tum.py (report only; the gate is byte
+# identity, not an APE threshold).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+BAG=""
+CLOUD_TOPIC=""
+IMU_TOPIC=""
+PARAMS="${REPO_ROOT}/lidarslam/param/lidarslam.yaml"
+RUNS=3
+MAX_CLOUDS=0
+OUTPUT_DIR="${REPO_ROOT}/output/frontend_determinism_$(date +%Y%m%d_%H%M%S)"
+REFERENCE_TUM=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bag) BAG="$2"; shift 2 ;;
+    --cloud-topic) CLOUD_TOPIC="$2"; shift 2 ;;
+    --imu-topic) IMU_TOPIC="$2"; shift 2 ;;
+    --params) PARAMS="$2"; shift 2 ;;
+    --runs) RUNS="$2"; shift 2 ;;
+    --max-clouds) MAX_CLOUDS="$2"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    --reference-tum) REFERENCE_TUM="$2"; shift 2 ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "${BAG}" || -z "${CLOUD_TOPIC}" ]]; then
+  echo "--bag <raw bag dir> and --cloud-topic <topic> are required" >&2
+  exit 2
+fi
+if [[ ! -f "${REPO_ROOT}/install/setup.bash" ]]; then
+  echo "install/setup.bash not found; build the workspace first" >&2
+  exit 2
+fi
+
+# shellcheck disable=SC1091
+set +u
+source "${REPO_ROOT}/install/setup.bash"
+set -u
+
+mkdir -p "${OUTPUT_DIR}"
+echo "bag:         ${BAG}"
+echo "cloud_topic: ${CLOUD_TOPIC}"
+echo "imu_topic:   ${IMU_TOPIC:-<none>}"
+echo "params:      ${PARAMS}"
+echo "runs:        ${RUNS}"
+echo "max_clouds:  ${MAX_CLOUDS}"
+echo "out:         ${OUTPUT_DIR}"
+
+for i in $(seq 1 "${RUNS}"); do
+  run_dir="${OUTPUT_DIR}/run${i}"
+  mkdir -p "${run_dir}"
+  echo "--- run ${i}/${RUNS}"
+  imu_topic_args=()
+  if [[ -n "${IMU_TOPIC}" ]]; then
+    imu_topic_args=(-p imu_topic:="${IMU_TOPIC}")
+  fi
+  ros2 run scanmatcher scan_matcher_offline_runner --ros-args \
+    --params-file "${PARAMS}" \
+    -p async_map_update:=false \
+    -p bag_path:="${BAG}" \
+    -p cloud_topic:="${CLOUD_TOPIC}" \
+    "${imu_topic_args[@]}" \
+    -p max_clouds:="${MAX_CLOUDS}" \
+    -p output_dir:="${run_dir}" \
+    > "${run_dir}/runner.log" 2>&1
+  md5sum "${run_dir}/trajectory_frontend.tum" "${run_dir}/submaps_frontend.csv"
+  if [[ -n "${REFERENCE_TUM}" ]]; then
+    python3 "${SCRIPT_DIR}/ape_from_tum.py" \
+      --ref "${REFERENCE_TUM}" \
+      --est "${run_dir}/trajectory_frontend.tum" \
+      --out "${run_dir}/ape.txt" \
+      > "${run_dir}/ape_postprocess.log" 2>&1 \
+      || echo "WARN: APE post-processing failed in run ${i}; continuing" >&2
+  fi
+done
+
+ape_rmse_for_run() {
+  local run_dir="$1"
+  if [[ -f "${run_dir}/ape.txt" ]]; then
+    awk '/^\s*rmse:/ {print $2; exit}' "${run_dir}/ape.txt"
+  fi
+}
+
+echo "--- verdict"
+traj_ref="${OUTPUT_DIR}/run1/trajectory_frontend.tum"
+submaps_ref="${OUTPUT_DIR}/run1/submaps_frontend.csv"
+pose_count=$(wc -l < "${traj_ref}")
+submap_count=$(($(wc -l < "${submaps_ref}") - 1))
+status=0
+for i in $(seq 2 "${RUNS}"); do
+  if ! diff -q "${traj_ref}" "${OUTPUT_DIR}/run${i}/trajectory_frontend.tum" > /dev/null; then
+    echo "MISMATCH (frontend trajectory): run1 vs run${i}"
+    diff "${traj_ref}" "${OUTPUT_DIR}/run${i}/trajectory_frontend.tum" | head -10 || true
+    status=1
+  fi
+  if ! diff -q "${submaps_ref}" "${OUTPUT_DIR}/run${i}/submaps_frontend.csv" > /dev/null; then
+    echo "MISMATCH (submap stream): run1 vs run${i}"
+    diff "${submaps_ref}" "${OUTPUT_DIR}/run${i}/submaps_frontend.csv" | head -10 || true
+    status=1
+  fi
+done
+
+summary="${OUTPUT_DIR}/frontend_determinism_summary.md"
+{
+  echo "| run | ape_rmse | n_poses | n_submaps | trajectory_md5 | submaps_md5 |"
+  echo "| --- | ---: | ---: | ---: | --- | --- |"
+  for i in $(seq 1 "${RUNS}"); do
+    run_dir="${OUTPUT_DIR}/run${i}"
+    n_poses=$(wc -l < "${run_dir}/trajectory_frontend.tum")
+    n_submaps=$(($(wc -l < "${run_dir}/submaps_frontend.csv") - 1))
+    traj_md5=$(md5sum "${run_dir}/trajectory_frontend.tum" | cut -c1-12)
+    submaps_md5=$(md5sum "${run_dir}/submaps_frontend.csv" | cut -c1-12)
+    rmse=$(ape_rmse_for_run "${run_dir}")
+    echo "| run${i} | ${rmse:-n/a} | ${n_poses} | ${n_submaps} | \`${traj_md5}\` | \`${submaps_md5}\` |"
+  done
+  echo ""
+  if [[ ${status} -eq 0 ]]; then
+    echo "frontend_trajectories_identical: true"
+    echo "submap_streams_identical: true"
+  else
+    echo "frontend_trajectories_or_submap_streams_identical: false"
+  fi
+} | tee "${summary}"
+
+if [[ ${status} -eq 0 ]]; then
+  echo "FRONTEND_DETERMINISM_OK: ${RUNS} runs produced byte-identical trajectory_frontend.tum and submaps_frontend.csv (${pose_count} poses, ${submap_count} submaps)"
+else
+  echo "FRONTEND_DETERMINISM_FAILED"
+fi
+exit ${status}


### PR DESCRIPTION
## Summary

v0.6 Phase 4 ゲートの主要素「オフラインランナーの scanmatcher フロントエンド対応(E2E 決定論)」を実装する。

- **`scan_matcher_offline_runner`**(scanmatcher パッケージの新実行ファイル): raw センサー bag(LiDAR cloud + 任意 IMU)を rosbag2_cpp で直読みし、**本物の `ScanMatcherComponent` を lockstep 駆動**する — メッセージを 1 つずつ intra-process pub/sub で注入し、次のメッセージ前に SingleThreadedExecutor を `spin_all` でドレイン。bag 順序が全順序になり、「同一 bag + 同一設定 ⇒ 同一フロントエンド軌跡 + 同一 submap ストリーム」が検証可能になる
  - `async_map_update: false` を必須化(wall-clock race する worker thread の禁止)、`set_initial_pose: true` 必須
  - **TF 決定論ノート**: component の tf2 listener は専用スレッド spin のため `/tf_static` 供給は最初の cloud lookup と race する。代わりに cloud の frame_id を `robot_frame_id` に書き換えて注入(`force_cloud_frame_to_robot_frame`、default true)— identity lookup は TF データ不要、`tf2::doTransform` の identity 適用は点群のビット同一コピー
  - 出力: `trajectory_frontend.tum`(per-scan 受理ポーズ)+ `submaps_frontend.csv`(index/stamp/distance/pose %.17g/点数)
  - `max_clouds` でスモーク・クイックゲート対応
- **`scripts/run_frontend_determinism_check.sh`**: N-run 実行 → 両出力のバイト一致を要求(mismatch で非ゼロ exit)、`--reference-tum` で per-run APE レポート(report-only)、`frontend_determinism_summary.md` を出力
- ノード名は production と同じ `scan_matcher` なので既存プリセット(`lidarslam/param/lidarslam.yaml` 等)がそのまま効く

## ハードゲート実走(NTU VIRAL tnp_01 raw bag, 5795 clouds)

| run | ape_rmse (Leica GT, report-only) | n_poses | n_submaps | trajectory_md5 | submaps_md5 |
| --- | ---: | ---: | ---: | --- | --- |
| run1–3 | 2.299132170580928 | 5795 | 133 | `71c8ff4ea23e` | `8df3163ce13d` |

`FRONTEND_DETERMINISM_OK` — 3-run バイト一致、GT APE は最後の桁まで一致。

scanmatcher フロントエンド(NDT 経路)はこれまでリリースゲートの決定論カバレッジがゼロだった(全プロファイルは RKO-LIO フロントエンド)。本 PR が初のカバレッジ。

## Verification

- `colcon build/test --packages-select scanmatcher`: 77 tests, 0 failures
- `ament_uncrustify` / `ament_cpplint`: 新規ファイル No problems
- 50-cloud スモーク 2-run: trajectory/submaps とも md5 一致
- リリースゲート(`--fail-on-profiles --offline-determinism-bag ...`): 下記コメント参照
