### PR TITLE
docs(roadmap): v0.7 — offline map refinement + map-quality gates

### DIFF
--- a/docs/research/map-refinement-clean-room-design.md
+++ b/docs/research/map-refinement-clean-room-design.md
@@ -1,0 +1,624 @@
+<!-- Design input for docs/roadmap/v0.7.md Phase 2. Drafted 2026-06-12 from the published papers only (clean-room constraint: the GPL reference implementations hku-mars/HBA and hku-mars/BALM must never be read while implementing this). -->
+
+# Design Note: Offline Hierarchical Plane-Based Global Map Refinement
+
+## Scope and Licensing
+
+This is a clean-room design for a BSD-2-compatible implementation. The implementation must be written from the published mathematics and local engineering choices only. Do not inspect, copy, translate, or link GPL source from `hku-mars/HBA`, `hku-mars/BALM`, or related GPL implementations.
+
+Primary paper references used for the design direction:
+
+- BALM2 paper: <https://arxiv.org/abs/2209.08854>
+- HBA paper: <https://arxiv.org/abs/2209.11939>
+- Adaptive plane extraction paper: <https://arxiv.org/abs/2305.00287>
+
+## Goal
+
+Add an offline post-pose-graph refinement stage to `lidarslam-ros2`.
+
+The existing deterministic offline backend runner, `graph_slam_offline_runner`, already replays a recorded odometry bag, creates submaps, performs loop search, runs g2o pose-graph optimization, and writes optimized TUM poses plus submap clouds. The new stage runs after pose-graph optimization and refines the submap poses using plane-feature bundle adjustment. It should improve map surface consistency and, when the environment has stable planes, reduce APE against total-station ground truth.
+
+The stage is offline only. It is allowed to spend minutes, but it must preserve this repository's determinism contract.
+
+## Inputs and Outputs
+
+Inputs:
+
+- `std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr>`: one downsampled cloud per submap, expressed in the submap local frame.
+- `std::vector<Eigen::Isometry3d>`: post-g2o optimized submap poses, mapping submap frame to global/map frame.
+- Refinement config: voxelization, hierarchy, optimizer, robust-loss, and determinism settings.
+
+Outputs:
+
+- Refined `std::vector<Eigen::Isometry3d>` with the same indexing as the input poses.
+- Diagnostics: plane counts, rejected-feature counts, cost history, LM damping history, pose delta stats, determinism hash, and convergence status.
+- Optional refined TUM trajectory and refined submap clouds.
+
+The refiner must not mutate the input clouds or input poses in place. Return a new pose vector.
+
+## Math Core
+
+### Plane Cost Without Explicit Plane Variables
+
+For a candidate plane feature `f`, let its global points be `p_j in R^3`, with count `n`. Define:
+
+```text
+s = sum_j p_j
+Q = sum_j p_j p_j^T
+c = s / n
+A = Q - s s^T / n
+```
+
+`A` is the unnormalized scatter matrix around the centroid.
+
+The point-to-plane least-squares cost after eliminating the plane parameters is:
+
+```text
+E_f = min_{||u||=1, d} sum_j (u^T p_j + d)^2
+    = min_{||u||=1} u^T A u
+    = lambda_min(A)
+```
+
+The minimizing plane normal is the unit eigenvector of `A` associated with the smallest eigenvalue. The offset is `d = -u^T c`. These are analytical transient values, not optimization variables.
+
+Total objective:
+
+```text
+E(T_0 ... T_{N-1}) = sum_f w_f rho(lambda_min(A_f) / n_f)
+                  + pose-prior terms
+```
+
+Use `lambda_min(A_f) / n_f` for scale-normalized robust loss, while keeping the raw scatter form internally for derivatives. Pose-prior terms keep the solution close to the g2o trajectory in weakly constrained regions and fix gauge freedom.
+
+### Point Cluster Coordinates
+
+For each plane feature `f` and observing submap pose `i`, precompute a local homogeneous point cluster:
+
+```text
+C_fi = sum_{x in feature f observed in submap i} [x; 1] [x; 1]^T
+     = [ Q_local  s_local
+         s_local^T n_local ]
+```
+
+where `x` is expressed in submap `i`'s local frame. This is a symmetric `4x4` matrix; only 10 doubles plus count are needed.
+
+For pose `T_i in SE(3)` represented as a homogeneous `4x4` matrix:
+
+```text
+H_fi = T_i C_fi T_i^T
+H_f  = sum_i H_fi
+```
+
+Extract `Q`, `s`, and `n` from `H_f`, then compute `A_f = Q - s s^T / n`.
+
+This makes cost and gradient evaluation independent of raw point count. Per optimizer iteration, the solver enumerates non-empty `(feature, pose)` clusters, not individual points. Hessian assembly is `O(observing_pose_pairs)` per feature, bounded by local window size in the hierarchy.
+
+### Pose Perturbation
+
+Use left perturbations with twist order `[translation, rotation]`:
+
+```text
+T_i(delta) = Exp(delta_hat) T_i
+delta = [rho_x rho_y rho_z phi_x phi_y phi_z]^T
+```
+
+Let `G_r` be the `4x4` Lie algebra generator for component `r`. Translation generators have `e_r` in the top-right column. Rotation generators have the corresponding skew basis in the top-left block.
+
+For the current transformed cluster `H = T C T^T`:
+
+```text
+H_r = G_r H + H G_r^T
+P_rs = 0.5 * (G_r G_s + G_s G_r)
+H_rs = P_rs H + H P_rs^T + G_r H G_s^T + G_s H G_r^T
+```
+
+`H_rs` is only nonzero when both derivatives apply to the same pose cluster. Mixed pose derivatives still enter through centroid subtraction in `A`.
+
+For any derivative `D` of `H`, extract `Q_D` and `s_D`. Then:
+
+```text
+A_a  = Q_a - (s_a s^T + s s_a^T) / n
+
+A_ab = Q_ab
+     - (s_ab s^T + s s_ab^T + s_a s_b^T + s_b s_a^T) / n
+```
+
+For different poses, `Q_ab = 0` and `s_ab = 0`, but the final two centroid terms remain.
+
+### Eigenvalue Gradient and Hessian
+
+Let eigenvalues of `A` be ascending:
+
+```text
+mu_0 <= mu_1 <= mu_2
+```
+
+Let `u_0` be the eigenvector for `mu_0`. For a non-degenerate plane feature, require a minimum eigen-gap:
+
+```text
+mu_1 - mu_0 > eigen_gap_min
+```
+
+The first derivative of the plane cost is:
+
+```text
+d mu_0 / d x_a = u_0^T A_a u_0
+```
+
+The second derivative is:
+
+```text
+d^2 mu_0 / d x_a d x_b =
+    u_0^T A_ab u_0
+  + 2 * sum_{m=1,2}
+      (u_m^T A_a u_0) * (u_m^T A_b u_0) / (mu_0 - mu_m)
+```
+
+For robust normalized cost `rho(z)` with `z = mu_0 / n`:
+
+```text
+g_a = w_f * rho'(z) * (1 / n) * mu_a
+
+H_ab = w_f * [
+    rho'(z)  * (1 / n)   * mu_ab
+  + rho''(z) * (1 / n^2) * mu_a * mu_b
+]
+```
+
+This is the exact second-order expression for the eliminated plane-feature cost under the chosen perturbation. Use it in a damped Newton/LM solver. If the Hessian is indefinite or the step is not a descent step, increase LM damping and retry. A conservative fallback is to use a PSD approximation by dropping the eigenvector-curvature term and adding stronger pose priors, but the first implementation should target the exact Hessian with robust damping.
+
+### Gauge and Priors
+
+Plane-only BA has gauge freedom. For each local BA window:
+
+- Fix the first pose in the window, or equivalently apply a very strong prior to it.
+- Optimize relative poses for the remaining window poses.
+
+For full/global refinement:
+
+- Keep the first submap fixed to preserve the map frame.
+- Add soft priors to every pose against the post-g2o pose:
+  - translation sigma default: `0.15 m` to `0.50 m`
+  - rotation sigma default: `1 deg` to `3 deg`
+- Allow config to disable all-pose priors only for controlled tests.
+
+Priors are also important in vegetation-heavy or corridor-like scenes where plane constraints are rank deficient.
+
+## Adaptive Voxelization for Plane Extraction
+
+### Pipeline
+
+For a BA problem over a set of poses:
+
+1. Transform candidate points into the current anchor/global frame using the current initial poses.
+2. Insert points into deterministic root voxels of size `root_voxel_size`.
+3. Process root voxels in lexicographic integer key order.
+4. For each voxel, run a PCA planarity test.
+5. If planar, keep it as a candidate feature.
+6. If not planar, split into eight octree children and recurse.
+7. Stop on `min_voxel_size`, `max_depth`, or `min_points`.
+8. Reject non-planar terminal leaves.
+9. Merge coplanar leaf planes within the same root voxel.
+10. For each accepted plane group, build per-submap point clusters `C_fi`.
+
+### Planarity Test
+
+For a point set, compute scatter eigenvalues ascending:
+
+```text
+lambda_0 <= lambda_1 <= lambda_2
+```
+
+Accept a candidate plane only if all hold:
+
+```text
+lambda_0 / max(lambda_2, eps) < planarity_ratio
+lambda_1 / max(lambda_2, eps) > min_surface_ratio
+point_count >= min_plane_points
+observing_submap_count >= min_observing_submaps
+```
+
+The second condition rejects line-like features.
+
+Use a quarter-split consistency check for false-positive planes:
+
+1. Let `u_0`, `u_1`, `u_2` be the eigenvectors.
+2. Treat `u_0` as normal and `u_1`, `u_2` as in-plane axes.
+3. Move the split center from the centroid along `u_0` by `normal_split_offset * sqrt(lambda_0 / n)` to avoid splitting a thick plane into two layers.
+4. Split points into four quarters by signs along `u_1` and `u_2`.
+5. Reject if any quarter has fewer than `min_quarter_points`.
+6. Compute each quarter's smallest scatter eigenvalue `lambda_0_q`.
+7. Accept only if quarter thicknesses are consistent:
+
+```text
+max_q(lambda_0_q / n_q) <= quarter_thickness_ratio * max(lambda_0 / n, noise_floor^2)
+```
+
+Default starting parameters:
+
+```text
+root_voxel_size:          4.0 m
+min_voxel_size:           0.5 m
+max_depth:                4
+min_plane_points:         30
+min_quarter_points:       6
+min_observing_submaps:    2, prefer 3
+planarity_ratio:          0.03 to 0.08 local, 0.05 to 0.12 global
+min_surface_ratio:        0.05
+quarter_thickness_ratio:  2.0 to 4.0
+noise_floor:              0.02 m
+```
+
+### Plane Merging
+
+Within one root voxel, sort accepted leaf planes by leaf key. Merge deterministically into groups. Two planes may merge if:
+
+```text
+abs(n_a^T n_b) > cos(merge_angle)
+abs(n_a^T (c_b - c_a)) < merge_distance
+```
+
+Canonicalize normals before comparison by making the largest absolute component positive. After each tentative merge, recompute group scatter and rerun the planarity test. Reject the merge if the combined group becomes non-planar.
+
+Suggested defaults:
+
+```text
+merge_angle:     5 deg
+merge_distance:  0.05 m to 0.15 m
+```
+
+### Degenerate Cases
+
+Reject or downweight:
+
+- Features observed by only one pose. They do not constrain relative pose.
+- Features with unstable eigenvectors: `lambda_1 - lambda_0 <= eigen_gap_min`.
+- Line-like features: `lambda_1 / lambda_2` too small.
+- Volumetric vegetation or clutter: planarity ratio too high after max depth.
+- Very large disconnected planes caused by voxel merging. Keep merging local to one root voxel.
+- Planes dominated by one submap. Require minimum observing-submap count and optionally a max per-submap point fraction.
+- Ground-only windows. They constrain `z`, roll, and pitch, but weakly constrain `x`, `y`, and yaw; rely on priors and pose graph constraints.
+
+## HBA-Style Hierarchy
+
+### Layer Model
+
+Layer 0 is the original submap sequence.
+
+Each upper layer is built from overlapping local BA windows over the previous layer:
+
+```text
+window_size = K
+stride = S
+S < K
+```
+
+For each window:
+
+1. Anchor the first pose.
+2. Extract/adapt plane features inside the window.
+3. Run local plane BA over the `K` poses.
+4. Store optimized relative poses and the local Hessian/information.
+5. Aggregate the optimized window clouds into a keyframe expressed in the anchor frame.
+6. The keyframe becomes one node in the next layer.
+
+Use only accepted planar feature points to construct upper-layer keyframes by default. This reduces upper-layer memory and avoids carrying unstructured clutter into global BA.
+
+### Top-Down Fusion Graph
+
+After bottom-up construction, build a global pose graph that fuses constraints from all layers:
+
+- Bottom-layer nodes: original submap poses.
+- Upper-layer nodes: keyposes generated from local windows.
+- Intra-window BA factors: relative pose constraints from local BA.
+- Inter-layer equality/anchor factors: tie an upper-layer keypose to the corresponding lower-layer anchor pose.
+- Adjacent/keypose factors from upper layers.
+- Optional original g2o trajectory priors or relative factors to prevent degradation in weak geometry.
+
+Solve this graph with the repository's existing deterministic g2o path if possible. Then propagate corrections back to bottom-layer poses. Iterate bottom-up BA and top-down graph for a fixed small number of outer iterations, usually `2`.
+
+First implementation recommendation:
+
+```text
+outer_iterations: 2
+local_lm_iterations: 8 to 15
+top_graph_iterations: existing g2o default, fixed count preferred
+```
+
+### Layer Counts for 100 to 700 Submaps
+
+For submaps, each node already covers more area than a raw scan, so use larger windows than scan-level HBA.
+
+Recommended default:
+
+```text
+K = 16
+S = 8
+```
+
+Approximate layer sizes:
+
+```text
+N = 100:  layer0 100 -> layer1 13 -> top
+N = 300:  layer0 300 -> layer1 38 -> top
+N = 640:  layer0 640 -> layer1 80 -> layer2 10 -> top
+N = 700:  layer0 700 -> layer1 88 -> layer2 11 -> top
+```
+
+Policy:
+
+- `N <= 120`: one global BA or one local layer plus top graph.
+- `120 < N <= 350`: two-level hierarchy, top BA/graph on `~15` to `45` keyposes.
+- `350 < N <= 700`: three-level hierarchy, top BA/graph on `~8` to `15` keyposes.
+- Keep top-layer BA under `~50` poses. If it grows larger, add a layer.
+
+Alternative conservative default:
+
+```text
+K = 20
+S = 10
+```
+
+For `640` submaps this gives `640 -> 64 -> 7`, which is attractive for a 1 km release-gate dataset.
+
+## Optimizer Design
+
+Use a deterministic block solver:
+
+1. Fixed pose ordering by submap index or layer-local index.
+2. Dense block Hessian for local windows.
+3. Sparse block Hessian only for the top fusion graph if needed.
+4. LM solve:
+
+```text
+(H + lambda * diag_clamp(H) + H_prior) delta = -g
+```
+
+5. Apply step using `T <- Exp(delta_hat) T`.
+6. Recompute cost.
+7. Accept only if cost decreases and all pose deltas are finite.
+8. If rejected, increase damping by a fixed factor.
+9. If accepted, decrease damping by a fixed factor.
+
+Suggested defaults:
+
+```text
+initial_lambda:        1e-4
+lambda_up_factor:      10
+lambda_down_factor:    0.3
+max_lambda:            1e12
+min_cost_decrease:     1e-9 relative
+max_step_translation:  0.25 m local, 0.50 m global
+max_step_rotation:     3 deg local, 5 deg global
+```
+
+If a step exceeds max step limits, scale the full update vector deterministically before evaluation.
+
+## Integration
+
+### `graph_slam_offline_runner`
+
+Plug in after g2o pose-graph optimization and before final TUM/submap-cloud export:
+
+```text
+recorded odometry bag
+  -> submap creation
+  -> loop search
+  -> g2o pose-graph optimization
+  -> plane-based map refinement
+  -> refined TUM trajectory
+  -> refined submap clouds
+  -> APE release-gate evaluation
+```
+
+Keep the existing optimized output as a baseline artifact:
+
+```text
+trajectory_g2o.tum
+trajectory_refined.tum
+submaps_g2o/
+submaps_refined/
+map_refinement_diagnostics.yaml
+```
+
+Config flag:
+
+```yaml
+map_refinement:
+  enabled: true
+  mode: hierarchical_plane_ba
+```
+
+If refinement fails validation, the runner should be configurable to either:
+
+- fail the release gate, or
+- emit diagnostics and fall back to the g2o trajectory.
+
+For release gates, compare both g2o APE and refined APE. The default gate should require refined APE to be no worse than g2o by a configured tolerance.
+
+### Standalone CLI
+
+Add a standalone ROS-free CLI, for example:
+
+```text
+map_refiner \
+  --poses input_optimized.tum \
+  --submap_dir submaps_g2o \
+  --output_poses trajectory_refined.tum \
+  --output_submap_dir submaps_refined \
+  --config map_refinement.yaml \
+  --diagnostics map_refinement_diagnostics.yaml
+```
+
+Useful flags:
+
+```text
+--no_hierarchy
+--max_submaps N
+--check_determinism_runs 2
+--write_plane_debug_clouds
+--write_cost_history
+```
+
+The CLI should sort input files by explicit submap index, not filesystem order.
+
+## Determinism Requirements
+
+Byte-identical output across repeated runs is a first-class requirement.
+
+Nondeterminism risks and required controls:
+
+- Filesystem order: never rely on directory iteration order. Parse submap indices and sort.
+- Voxel maps: do not allow `unordered_map` iteration order into results. Store voxel records in a vector and sort by integer key before processing.
+- Floating-point accumulation: accumulate points, clusters, gradients, and Hessians in fixed order. Prefer single-threaded accumulation for v1. If threaded later, use fixed shards and deterministic pairwise reduction.
+- PCL filters: avoid filters whose output depends on hash iteration. If downsampling is needed here, implement deterministic voxel centroid/downsample logic.
+- Eigen decomposition: use `Eigen::SelfAdjointEigenSolver`; sort eigenpairs explicitly; canonicalize eigenvector signs.
+- Plane normal sign: canonicalize by largest absolute component positive before merge tests or debug output.
+- Close eigenvalues: skip features with insufficient eigen-gap. They cause unstable normals and Hessians.
+- Robust loss: no random sampling, no RANSAC, no stochastic trimming.
+- Window processing: process windows in ascending `(layer, window_start)` order. Parallel local BA is allowed only if final graph assembly is sorted and independent.
+- Hessian assembly: fixed block ordering; write symmetric blocks once, then mirror deterministically.
+- Linear solver: use deterministic Eigen dense `LDLT` or `LLT` for local windows. For sparse graph solve, use the repository's deterministic g2o path with fixed ordering.
+- LM control flow: fixed iteration limits, fixed damping update factors, no time-budget termination.
+- Invalid points: filter NaN/Inf in deterministic point-index order and report counts.
+- Output formatting: fixed precision, `C` locale, fixed line endings, sorted YAML keys.
+- CPU/compiler: do not use `-ffast-math`. Disable Eigen internal multithreading for deterministic runs. Byte-identical guarantees are required across runs on the same build and machine; cross-machine byte identity needs separately pinned compiler and CPU flags.
+
+Add a diagnostics hash over:
+
+```text
+config
+input pose bytes after parsing
+submap file names and sizes
+accepted plane feature descriptors
+final refined poses
+```
+
+## Header-Only Module Decomposition
+
+Place ROS-free implementation headers under:
+
+```text
+graph_based_slam/include/graph_based_slam/
+```
+
+Suggested headers:
+
+- `map_refinement_types.hpp`
+  - Config structs, diagnostics structs, result types, aligned pose vector aliases.
+
+- `se3_lie.hpp`
+  - `Exp`, `Log`, left perturbation, generators `G_r`, pose delta limits.
+
+- `point_cluster.hpp`
+  - Homogeneous cluster storage, deterministic accumulation, transform, merge, extraction of `Q/s/n`.
+
+- `scatter_eigen_cost.hpp`
+  - Scatter matrix construction, plane eigen-cost, gradient/Hessian formulas, robust loss application.
+
+- `adaptive_voxel_plane_extractor.hpp`
+  - Deterministic root voxelization, octree split, PCA tests, quarter test, plane merge.
+
+- `plane_feature_association.hpp`
+  - Converts accepted voxel planes into per-pose point clusters. Owns raw point-to-feature assignment for one BA problem.
+
+- `ba_problem.hpp`
+  - Pose blocks, feature blocks, priors, cost/gradient/Hessian assembly.
+
+- `lm_solver.hpp`
+  - Deterministic damped Newton/LM loop, acceptance policy, step limiting.
+
+- `hba_pyramid.hpp`
+  - Layer/window construction, local BA orchestration, keyframe aggregation, top-down factor generation.
+
+- `map_refiner.hpp`
+  - Public pure C++ API:
+    ```cpp
+    MapRefinementResult refineMap(
+        const std::vector<pcl::PointCloud<pcl::PointXYZ>::ConstPtr>& clouds,
+        const AlignedIsometry3dVector& initial_poses,
+        const MapRefinementConfig& config);
+    ```
+
+- `map_refiner_io.hpp`
+  - TUM parsing/writing, PCD loading/writing, deterministic file ordering. Keep ROS-free.
+
+Add only thin `.cpp` files for CLI and runner integration.
+
+## Test Plan
+
+Use gtest characterization tests in `graph_based_slam/test`.
+
+Core math tests:
+
+- Cluster equivalence: point-enumerated scatter and cluster-transformed scatter match within tolerance.
+- Feature elimination: `lambda_min(scatter)` equals explicit least-squares point-to-plane residual using analytical plane.
+- Gradient check: compare analytical gradient to central finite differences on fixed synthetic clusters.
+- Hessian check: compare analytical Hessian to central finite differences of the gradient.
+- Gauge test: applying the same global transform to all poses leaves plane costs unchanged.
+- Degenerate feature tests: single-pose plane has no useful relative constraint; line-like and volumetric features are rejected.
+
+Plane extraction tests:
+
+- Synthetic wall, ground, and corner planes with known labels.
+- Curved surface should split until rejected or become small local planes.
+- Outlier slab/vegetation-like points should fail quarter consistency.
+- Plane merging should merge coplanar leaves and reject perpendicular or offset leaves.
+- Shuffled point order must produce identical accepted plane descriptors.
+
+Optimizer tests:
+
+- Two or more submaps observing one plane: constrained components improve, unconstrained components remain governed by priors.
+- Three orthogonal planes with known perturbed poses: recover poses within tolerance.
+- Multi-window synthetic map: hierarchy result is close to one-shot BA for small `N`.
+- Rejection path: deliberately bad initial pose should increase LM damping and not emit NaNs.
+
+Determinism contract tests:
+
+- Run the same refiner twice and compare serialized refined poses byte-for-byte.
+- Insert voxels/features in different orders and verify identical output.
+- Shuffle input PCD file listing and verify identical output after index sorting.
+- Run with `Eigen::setNbThreads(1)` and verify diagnostics hash stability.
+
+Integration tests:
+
+- Small offline-runner fixture with generated submaps and a known loop correction.
+- Verify files are emitted:
+  - g2o trajectory
+  - refined trajectory
+  - diagnostics YAML
+- Verify fallback behavior when refinement has too few valid planes.
+
+## Expected Impact for 640 Submaps / 1 km
+
+Assumptions:
+
+- Post-g2o trajectory is already close enough for voxel plane associations.
+- Downsampled submaps contain stable man-made or ground/wall plane structure.
+- `N ~= 640`, `K = 16`, `S = 8`, hierarchy `640 -> 80 -> 10`.
+
+Expected accuracy:
+
+- Translation APE RMSE improvement: typically `5%` to `25%` when stable planes are abundant.
+- Map plane thickness improvement: often more visible than APE, roughly `10%` to `40%` on walls/ground.
+- Little or no improvement in vegetation-heavy or weakly planar areas.
+- Possible APE regression if false plane associations dominate, so release gates must compare refined APE against the g2o baseline.
+
+Expected compute:
+
+- Plane extraction dominates when clouds are large.
+- For `640` submaps with `5k` to `20k` downsampled points each, expect roughly `3M` to `13M` points.
+- Deterministic single-thread v1 target: about `5` to `25` minutes on a desktop CPU, depending on point count and plane density.
+- Memory target: `1` to `4 GB`, mostly raw/downsampled points, feature assignment, and cluster storage.
+- Local BA windows are small: `K=16` gives `96` pose DoF per local dense solve before anchoring. This is tractable.
+
+## Main Risks
+
+- Few stable planes: outdoor vegetation, open roads, and sparse scenes may not constrain enough DoF.
+- Wrong associations: if post-g2o error exceeds voxel size or local geometry repeats, BA can polish the wrong map.
+- Degenerate geometry: ground-only or corridor-only windows need priors and pose-graph constraints.
+- Dynamic objects: cars, pedestrians, and moving vegetation can create false planes.
+- Memory pressure: storing raw points for reclustering plus cluster descriptors can grow quickly.
+- Convergence: exact Hessian can be indefinite; LM damping and step limits are mandatory.
+- Determinism erosion: unordered containers, parallel reductions, PCL internals, and filesystem order are the most likely causes.
+- Metric mismatch: optimizing map consistency can slightly worsen total-station APE if the total-station frame/noise and LiDAR surface model disagree. Keep the g2o result and require gate-based acceptance.

--- a/docs/roadmap/v0.7.md
+++ b/docs/roadmap/v0.7.md
@@ -1,0 +1,230 @@
+# lidarslam-ros2 v0.7 roadmap — offline map refinement + map-quality gates
+
+> Status: **draft 2026-06-12**, direction approved. v0.7 carries the first two
+> pillars of the "map-authoring SOTA" strategy — a clean-room hierarchical
+> plane-based refinement engine and map-quality metrics as release gates —
+> plus the legacy-timer removal deferred from v0.6. The remaining approved
+> pillars (degeneracy handling, multi-session mapping, per-scan dynamic
+> removal, intensity, HILTI substrate) are v0.8 candidates, listed in §6.
+>
+> Successor to v0.6 (deterministic core/shell refactor, completed 2026-06-12,
+> PRs #237–#263).
+
+## 0. Why this exists (the strategy)
+
+We are not going to out-odometry the FAST-LIO / KISS lineages — that race is
+crowded and the frontend here is RKO-LIO (Thirdparty) by design. The winnable
+SOTA axis for this project is **map authoring quality × reproducibility ×
+verifiability**: deep, accurate maps whose quality is *provable*. v0.6
+delivered the reproducibility leg (same bag ⇒ byte-identical map, gate
+enforced). Two gaps remain between that and a defensible "best maps you can
+generate with an OSS tool" claim:
+
+1. **Nothing measures the map.** Every gate scores a *trajectory* (APE vs
+   GT). Map crispness — the thing an Autoware user actually consumes for NDT
+   localization — is unmeasured. A claim nobody can verify is not a claim.
+2. **Pose-graph optimization is our last accuracy stage.** State-of-the-art
+   mapping systems (HBA, BALM2, Voxel-SLAM) add a global plane-feature bundle
+   adjustment *after* the pose graph and tighten maps well beyond
+   pose-graph-only results — visibly thinner walls/floors, lower APE. We
+   stop where they start.
+
+v0.7 closes both gaps in the measurement-first discipline that worked for
+v0.6: metrics first (Phase 1), then the refinement engine (Phase 2), then
+gate enforcement and defaults on evidence (Phase 3).
+
+**License constraint:** the reference implementations (hku-mars HBA, BALM)
+are GPL-2 — unusable on our BSD-2 default path. The engine is a **clean-room
+implementation from the published papers** (BALM2's eigenvalue point-to-plane
+formulation, HBA's hierarchy), the same pattern already proven with the
+STD/BTC-style triangle descriptor. GPL sources are not to be read during
+this work, and each PR states so.
+
+## 1. Target architecture
+
+```
+graph_slam_offline_runner (v0.6, deterministic)
+   bag → submaps → BackendCore loop search → pose-graph optimization
+                                   │  optimized submap poses + clouds
+[NEW] map refinement core (ROS-free, single-threaded, deterministic)
+   adaptive planar voxelization → plane BA over pose windows
+   → hierarchical fusion (windows → keyposes → global)
+                                   │  refined submap poses
+                                   ▼
+   map save (existing map_saver path)  +  [NEW] map-quality report
+   (MME, plane-thickness RMS, density)    → release-gate thresholds
+```
+
+- Refinement is an **additive offline post-stage**: default off until Phase 3
+  evidence, the live path is untouched, and acceptance is **multi-criteria**
+  — a falling plane cost is necessary but not sufficient (lower plane cost
+  can still bend weakly constrained regions or overfit pseudo-planes); the
+  refined solution is kept only if quality metrics improve *without coverage
+  loss* and APE stays within ε of the unrefined baseline wherever GT exists.
+  On rejection the stage returns the pose-graph solution unchanged and says
+  why in the report.
+- The v0.6 determinism contract extends through the new stage: same bag +
+  same config ⇒ byte-identical refined trajectory *and* byte-identical
+  quality report. The refinement core inherits the BackendCore rules —
+  no wall clock, no unordered iteration into results, fixed-order
+  accumulation, single-threaded (or provably deterministic reductions).
+
+## 2. Testing strategy (unchanged discipline)
+
+The four v0.6 layers continue: characterization before extraction, unit tests
+per pure header, determinism contract tests ("same input twice ⇒ bitwise
+identical"), replay/gate harness per PR. New for v0.7, because refinement has
+*synthetic ground truth available*: generated plane-world fixtures (known
+planes, known poses, known perturbations) where tests assert the optimizer
+**recovers the true poses** to tolerance — a stronger oracle than
+characterization. Every numeric kernel (voxel split, eigenvalue cost,
+gradient/Hessian assembly, LM step) gets one.
+
+## 3. Phases and gates
+
+### Phase 0 — v0.6 leftovers (cleanup)
+- Remove the legacy wall-clock loop-search path (`event_driven_loop_search:
+  false` branch, the timer, and the param), completing the one-release
+  deprecation announced in v0.6.0.
+- **Gate**: package tests + full release gate (both determinism stages)
+  green; upgrade note in docs.
+
+### Phase 1 — map-quality metrics (measure before touching)
+- `map_quality_metrics.hpp` pure header + a `map_quality_report` CLI: Mean
+  Map Entropy (MME), plane-thickness RMS over detected planar patches
+  (reusing the adaptive voxelization from Phase 2's design, extraction-only),
+  point-density statistics. Deterministic by the same rules as everything
+  else.
+- **Anti-gaming design**: every metric reports its support alongside the
+  score (eligible-point ratio, planar-coverage fraction, rejected-point
+  counts) so "thinner planes" can never mean "ignored hard geometry"; scenes
+  below a planarity-coverage floor get an explicit *metric-not-meaningful*
+  state instead of a number (this is the expected outcome on vegetation-heavy
+  outdoor data). The metric extraction config is **frozen at the end of
+  Phase 1**, before any optimizer work, so Phase 2 cannot tune its own judge.
+- Baseline **all** gate substrates (RTK-SLAM ×4, NTU tnp_01, MID-360 replay)
+  and write the table to `docs/research/map-quality-baseline.md` — including
+  metric variance across the deterministic runner (should be zero) and the
+  live runner (won't be), so thresholds are set on data.
+- Wire into `run_release_readiness_checks.sh` as a **report-only** stage.
+- **Gate**: written baseline table; metric reports byte-identical across
+  3 offline runs.
+
+### Phase 2 — clean-room hierarchical refinement core (the centerpiece)
+- Implementation-ready design note (papers-only):
+  `docs/research/map-refinement-clean-room-design.md` — math core (BALM2
+  eigenvalue cost + point clusters), adaptive voxelization, hierarchy
+  sizing, determinism control list, module/test plan.
+- Pure headers, ROS-free, in the established pattern:
+  - `plane_voxelization.hpp` — adaptive octree split on planarity, the shared
+    plane extractor for Phase 1 metrics and the BA;
+  - `plane_ba_cost.hpp` — BALM2-style point-to-plane cost as the minimum
+    eigenvalue of the per-voxel scatter matrix, with the point-cluster
+    aggregation that makes cost/gradient/Hessian O(poses), not O(points);
+  - `hierarchical_refinement.hpp` — bottom-layer sliding windows of K poses
+    with local BA → downsampled keyposes per layer → top-layer global fusion
+    back onto all submap poses.
+- **Optimizer-level degeneracy safeguards are v0.7 scope** (distinct from
+  v0.8's registration-level degeneracy work, which can wait — optimizer
+  safety cannot): gauge fixing, eigen-gap / condition-number checks before a
+  window is trusted, per-window plane-diversity requirements, pose-graph
+  priors as regularization on weakly constrained poses, and
+  reject-with-report fallback. Test fixtures include the *unobservable*
+  cases (corridor, single plane, rank-deficient voxels, near-equal
+  eigenvalues) where the correct behavior is "detect degeneracy and do not
+  move", plus gradient/Hessian finite-difference agreement near degeneracy —
+  synthetic-GT *recovery* alone is not a sufficient oracle.
+- Integration: `--refine` flag on `graph_slam_offline_runner` + a standalone
+  `map_refiner` tool (input: submap clouds + TUM/poses; output: refined
+  poses) so existing maps can be re-polished without re-running SLAM.
+  `map_refiner` must have bounded memory behavior (not "load everything").
+- **Gate (hard)**: synthetic-GT recovery *and* degeneracy-fixture tests
+  pass; on the MID-360 and NTU substrates 3 runs of the refined pipeline
+  are byte-identical; map-quality metrics (Phase 1) improve **without
+  coverage loss** on at least the indoor/structured substrates; **APE stays
+  within ε of the v0.6 per-sequence baseline** (baseline-relative — merely
+  staying under a loose blocking threshold is not a pass); resource budget
+  (peak RSS + wall time on the 640-submap / 1 km case) measured and
+  documented.
+
+### Phase 3 — gate flip + the claim
+- On Phase 2 evidence: refinement defaults on in the offline runner and the
+  map-authoring bundle scripts; map-quality metrics get **blocking
+  thresholds with an explicit per-profile table** (indoor blocking first,
+  outdoor report-only / not-meaningful — the same rollout shape as the v0.5
+  GT gates; APE and each quality metric get their own row).
+- **Threshold hygiene**: threshold selection is separated from release
+  validation — at least one sequence is held out from tuning and only used
+  to validate the chosen thresholds (no training on the test set).
+- The claim stays narrow and evidenced: *globally refined, quality-gated,
+  byte-reproducible maps* — backed by refined-vs-pose-graph-only deltas per
+  substrate, not a vague "best maps" superlative. Supporting (stretch): one
+  downstream-facing check — map-to-GT surface error or NDT relocalization
+  residual — so the quality gates provably track map *usefulness*, not just
+  prettiness.
+- **Gate**: full release gate including both determinism stages and the new
+  quality thresholds green (holdout included); docs updated; live path
+  still untouched.
+
+### Phase 4 — stretch (pull in only if Phases 0–3 land healthy)
+- HILTI 2022/2023 dataset as an external mm-GT evaluation substrate
+  (construction environments = the MID-360 use case; the 2026 challenge
+  moved to visual-inertial, so this is an evaluation substrate, not a
+  competition entry).
+- 発信 prep: determinism + refinement technical writeup (feeds the
+  1000-star campaign track; not gated by this roadmap).
+
+## 4. Risks
+
+- **Clean-room discipline** — GPL repos must not be read; design from the
+  papers via `docs/research/map-refinement-clean-room-design.md`; every
+  refinement PR carries the clean-room statement. This is a hard
+  constraint, not a preference.
+- **Outdoor plane scarcity** (Stadtgarten vegetation) — plane BA may help
+  little where there are few planes. Mitigation: per-substrate evidence in
+  Phase 2, the no-worse acceptance check, and metrics thresholds set per
+  profile (indoor blocking first, outdoor report-only — same rollout shape
+  as the v0.5 GT gates).
+- **Determinism of the numeric core** — the byte-identity claim is scoped
+  the same way as v0.6: **same build + same machine** (cross-machine byte
+  identity would require pinned compiler/CPU flags and is not claimed).
+  Rules: single-threaded core with sorted voxel iteration, fixed
+  accumulation order, no `-ffast-math`, Eigen threading disabled,
+  canonicalized eigenvector signs, eigen-gap floor before a plane is
+  accepted (near-equal eigenvalues are a numerical cliff, skip them);
+  parallelism, if ever needed, must be fixed-partition deterministic and
+  proven by the contract tests. Full control list:
+  `docs/research/map-refinement-clean-room-design.md`.
+- **Compute/memory at scale** (640 submaps × clouds, 1 km) — hierarchy
+  exists precisely for this; per-submap clouds are downsampled before BA;
+  offline minutes are acceptable (offline is the point). Budget measured in
+  Phase 2, stated in docs.
+- **Convergence** — LM with cost-decrease acceptance; on failure the stage
+  returns the pose-graph solution unchanged (and says so in the report), so
+  the gates can never get worse than v0.6 behavior.
+
+## 5. Out of scope
+
+Frontend/odometry changes; learning-based place recognition; rosdistro
+(bloom) release work (`docs/rosdistro-release.md`, tracked separately);
+everything in §6 until v0.8.
+
+## 6. v0.8 candidate backlog (direction approved 2026-06-12, not scheduled)
+
+- **Degeneracy-aware registration** — localizability eigen-analysis of the
+  registration Hessian, constraint switching / prior fallback in degenerate
+  directions, degeneracy report in the map bundle.
+- **Multi-session mapping** — relocalize into an existing map, anchor the new
+  session's graph, deterministic merge ("extend last week's map without
+  re-driving it") for the Autoware map-update workflow.
+- **Per-scan dynamic object removal** — visibility/occupancy-based offline
+  cleaning stage (license check required before any reference is consulted),
+  upgrading the current save-time filter.
+- **Intensity utilization** — intensity-augmented registration and loop
+  verification.
+
+---
+
+(Related: `docs/roadmap/v0.6.md` — the determinism foundation this builds
+on; `docs/research/determinism-variance-attribution.md`;
+`docs/releases/v0.6.0.md`.)

--- a/plan.md
+++ b/plan.md
@@ -21,15 +21,23 @@ total-station GT 化（§11）— 4/4 sequence 計測済み、indoor 2 profile �
 バージョン 0.5.0 整列 + rosdistro (bloom) バイナリリリース prep。README の見せ物は
 実カメラ色のマップフライスルー GIF（§12、PR #229/#230/#231）。
 
-次の主要アクション: **v0.6 決定論 core/shell リファクタリング**
-（[`docs/roadmap/v0.6.md`](docs/roadmap/v0.6.md)、スコープ確定: backend +
-scanmatcher、テスト充実を一級要件化）、bloom リリース実行（ndt_omp_ros2 fork
-先行、`docs/rosdistro-release.md` のランブック、maintainer の GitHub 操作）、
-発信（P2-8、ユーザー本人）。D1 8-vs-16 ベンチは 2026-06-11 実施済み —
-`deterministic_loop_scheduling` は default off 維持で D1 完全クローズ（§1.2）。
-D1 の負の結果が v0.6 の直接の動機: スケジュールの決定論化ではアウトカムは
-決定論にならない = 問題はアーキテクチャ（wall-clock 結合 + データ競合 +
-順序未定義マージ）。
+**v0.6 完了（2026-06-12, PR #237–#263, tag v0.6.0）**: 決定論 core/shell
+リファクタリング完遂。same bag ⇒ byte-identical map（backend +
+scanmatcher frontend の両オフラインランナー、リリースゲートで強制）、
+event-driven loop search default 化、実バグ修正（~6% 入力ドロップ /
+IMU/GNSS 誤ブロック重み / tie-break 欠落 / GNSS yaw 整合 = 初の
+georeferenced マップ）、god object 分解（純ヘッダ 19+4 本、テスト 1100 超）。
+
+次の主要アクション: **v0.7 オフラインマップリファインメント + マップ品質
+ゲート**（[`docs/roadmap/v0.7.md`](docs/roadmap/v0.7.md)、方向性承認
+2026-06-12）。SOTA 戦略 = raw odometry では戦わず「マップ品質 × 再現性 ×
+検証可能性」（map authoring の SOTA）を取る: Phase 0 legacy timer 削除 →
+Phase 1 マップ品質メトリクス（MME/平面厚）baseline → Phase 2 clean-room
+（BSD-2、論文ベース、GPL 参照禁止）の HBA/BALM2 風 階層平面 BA → Phase 3
+ゲート昇格 + クレーム。v0.8 候補 = 退化検出 / マルチセッション / 動的除去 /
+intensity / HILTI 基盤。並行: bloom リリース実行（ndt_omp_ros2 fork 先行、
+`docs/rosdistro-release.md`、maintainer の GitHub 操作）、発信（P2-8、
+v0.6.0 の決定論クレームが素材）。
 
 ---
 
@@ -326,7 +334,8 @@ indoor で 0.15–0.40m（真 GT, agreement でなく accuracy）。outdoor の�
 | 0a | ~~v0.5 outdoor config 調整 → stadtgarten 再 run~~ | ✅ 2026-06-11 解決。`double_downsample: false` で 3.903→0.835m、outdoor preset 化（§11.8 A） |
 | 0b | ~~v0.5 indoor pair を blocking 昇格 + mid360_vs_glim 降格~~ | ✅ PR #228。4/4 seq 計測、indoor blocking、glim は report-only canary（§11.8 C） |
 | 0c | **bloom リリース実行（P2-7 後半）** | repo 側 prep 完了（0.5.0 整列 + ランブック `docs/rosdistro-release.md`）。残り = ndt_omp_ros2 fork PR #11 マージ（整備 PR 作成済み）→ 先行 bloom → 本体 bloom → ros/rosdistro PR（maintainer の GitHub 操作が必要、§13） |
-| 0f | **v0.6 決定論 core/shell リファクタリング** | スコープ確定（2026-06-11、backend + scanmatcher）。Phase 0 変動帰属測定 → Phase 1 競合除去+分割 → Phase 2 BackendCore+オフライン決定論ランナー（ループエッジ集合 3-run 完全一致がハードゲート）→ Phase 3 default 切替 → Phase 4 scanmatcher。テスト 4 層（characterization / unit / 決定論契約 / リプレイ回帰）を各フェーズのゲートに。詳細 [`docs/roadmap/v0.6.md`](docs/roadmap/v0.6.md) |
+| 0f | ~~v0.6 決定論 core/shell リファクタリング~~ | ✅ 2026-06-12 完遂（PR #237–#263、tag v0.6.0 + pre-release）。全フェーズゲート PASS: 両基盤 3-run バイト一致（backend + frontend）、event-driven default 化、純ヘッダ 19+4 本。詳細 [`docs/roadmap/v0.6.md`](docs/roadmap/v0.6.md)、[`docs/releases/v0.6.0.md`](docs/releases/v0.6.0.md) |
+| 0g | **v0.7 マップリファインメント + 品質ゲート** | 方向性承認（2026-06-12）。Phase 0 legacy timer 削除 → Phase 1 マップ品質メトリクス baseline（MME/平面厚、report-only）→ Phase 2 clean-room 階層平面 BA（BSD-2、論文ベース; 合成 GT 回復 + 3-run バイト一致 + APE 無回帰がハードゲート）→ Phase 3 default 化 + blocking 閾値。詳細 [`docs/roadmap/v0.7.md`](docs/roadmap/v0.7.md) |
 | 0d | ~~D1 8-vs-16 再現性ベンチ~~ | ✅ 2026-06-11 実施（GLIM MID-360 bag、3 run × {off/16, on/16, on/8}）。on/16 は APE 実質無回帰（差 0.06m ≪ noise 0.40m）だが分散縮小なし（σ 0.066→0.259）、on/8 arm の 2 実行で loop 試行ゼロ。mp8 の系統的 regression 署名は消滅し乱高下に置換（スケジューリング主要因子と整合、根本原因の証明ではない）。**default off 維持で D1 完全クローズ**（§1.2、research summary） |
 | 0e | **発信（P2-8）** | ghcr ワンコマンド + lanelet2 完全バンドル + 実 GT 数値が揃い、発信material は完成状態。ROS Discourse / Reddit / X はユーザー本人が実施。事前に B2 social preview 設定（Web UI 1 分） |
 | 1 | **GNSS odom→ENU yaw 整合の実装** | 初検証（2026-06-12）で制約形成 ✅・LocalCartesian projector ✅ まで実証済み。残るは yaw 整合（ENU トラックとの 2D 最小二乗 → アンカー回転 or vertex-0 gauge 解放）。これが入ると GNSS georeferencing が実用になる。`docs/research/gnss-constraint-first-validation.md` |


### PR DESCRIPTION
## Summary

v0.7 ロードマップの起草(方向性は 2026-06-12 に承認済み)。SOTA 戦略 = raw odometry では戦わず、**マップ品質 × 再現性 × 検証可能性**(map authoring の SOTA)を取る。v0.6 の決定論オフラインランナーの直接の続編。

- `docs/roadmap/v0.7.md` — フェーズ構成:
  - **Phase 0**: legacy wall-clock loop-search 経路の削除(v0.6.0 で予告済みの 1 リリース猶予の履行)
  - **Phase 1**: マップ品質メトリクス baseline(MME / 平面厚 RMS、support/coverage 併記のアンチゲーミング設計、メトリクス設定は Phase 2 前に凍結、低 planarity シーンは "not meaningful" 状態)
  - **Phase 2**: clean-room 階層平面 BA(**BSD-2、論文のみ参照、GPL 実装は読まない** — triangle descriptor で実証済みのパターン)。optimizer レベルの退化セーフガード(gauge 固定 / eigen-gap / 平面多様性 / reject-with-report)を v0.7 スコープに内包。ハードゲート = 合成 GT 回復 + 退化フィクスチャ + 3-run バイト一致 + **APE は v0.6 比 ε 以内**(blocking 閾値通過だけでは不合格)+ リソース実測
  - **Phase 3**: per-profile 表で品質ゲート昇格(indoor blocking 先行 / outdoor report-only、v0.5 GT ゲートと同じ展開形)、閾値選定と検証の分離(holdout)
  - §6: v0.8 候補(退化対応 registration / マルチセッション / 動的除去 / intensity)
- `docs/research/map-refinement-clean-room-design.md` — 実装可能レベルの clean-room 設計ノート(BALM2 [arXiv:2209.08854] の固有値コスト + point cluster、HBA [arXiv:2209.11939] の階層、[arXiv:2305.00287] の適応 voxel 平面抽出。引用 3 本とも実在確認済み)。決定論コントロール一覧・ヘッダ分解案・テスト計画・640 submaps/1km のリソース見積もり込み
- `plan.md` — v0.6 完了を同期、アクション表に 0g 行追加

## Verification

- `python3 -m mkdocs build --strict`: pass(docs のみの変更、コード変更なし)
- 引用 arXiv ID 3 本の実在・対応を確認済み

## Notes

- ロードマップはドラフト宣言(実装 PR で随時更新)
- ライセンス制約(GPL 参照禁止)は roadmap §0/§4 と設計ノート冒頭に明文化
