### PR TITLE
feat(backend)!: remove the legacy wall-clock loop-search timer path (v0.7 Phase 0)

### DIFF
--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -157,7 +157,6 @@ private:
     rclcpp::Publisher < lidarslam_msgs::msg::MapArray > ::SharedPtr modified_map_array_pub_;
     rclcpp::Publisher < nav_msgs::msg::Path > ::SharedPtr modified_path_pub_;
     rclcpp::Publisher < sensor_msgs::msg::PointCloud2 > ::SharedPtr modified_map_pub_;
-    rclcpp::TimerBase::SharedPtr loop_detect_timer_;
     rclcpp::Service < std_srvs::srv::Empty > ::SharedPtr map_save_srv_;
 
     using LoopEdge = backend_core::LoopEdgeSet::Edge;
@@ -171,14 +170,12 @@ private:
       const MapSaveRequestHeader request_header,
       const MapSaveRequest request,
       const MapSaveResponse response);
-    void searchLoop();
     // Event-driven scheduling (docs/roadmap/v0.6.md, Phase 2): drain every
     // submap not yet used as a loop-search query, in arrival order, each
     // against exactly the map state [0..q] so the result is a function of
     // the data, not of how the executor batched arrivals.
     void runEventDrivenLoopSearch();
-    // Per-query loop search body, factored out of searchLoop() so the scheduler
-    // can run it for one (default) or many (deterministic mode) query submaps.
+    // Per-query loop search body shared by the event-driven drain.
     void searchLoopForLatest(
       const lidarslam_msgs::msg::MapArray & map_array_msg,
       LoopEdges & loop_edges,
@@ -190,8 +187,7 @@ private:
       const lidarslam_msgs::msg::MapArray & map_array_msg);
     bool snapshotGraphState(
       lidarslam_msgs::msg::MapArray & map_array_msg,
-      LoopEdges & loop_edges,
-      bool consume_map_update);
+      LoopEdges & loop_edges);
     void snapshotLoopEdges(LoopEdges & loop_edges);
     bool upsertLoopEdge(const LoopEdge & loop_edge);
     void doPoseAdjustment(
@@ -201,7 +197,6 @@ private:
     void publishMapAndPose();
 
     // loop search parameter
-    int loop_detection_period_;
     double threshold_loop_closure_score_;
     double scan_context_loop_closure_score_threshold_ {-1.0};
     double distance_loop_closure_;
@@ -218,14 +213,11 @@ private:
     double loop_max_translation_delta_descriptor_ {-1.0};
     double loop_max_rotation_delta_deg_descriptor_ {-1.0};
     int last_searched_submap_idx_ {-1};
-    // Event-driven loop search (default on since v0.6 Phase 3). When true,
-    // loop search runs once per submap arrival in arrival order (each query
-    // sees exactly the map state up to itself) and the wall timer becomes a
-    // no-op. When false, the legacy wall-clock timer path queries only the
-    // single latest submap per tick (scheduled for removal one release after
-    // the default flip). Subsumes the retired deterministic_loop_scheduling
-    // parameter (v0.4 D1).
-    bool event_driven_loop_search_ {true};
+    // Event-driven loop search (the only scheduling semantics since v0.7
+    // Phase 0): loop search runs once per submap arrival in arrival order,
+    // each query seeing exactly the map state up to itself. The legacy
+    // wall-clock timer path and the retired deterministic_loop_scheduling
+    // parameter (v0.4 D1) are gone.
 
     // pose graph optimization parameter
     int num_adjacent_pose_cnstraints_;
@@ -257,7 +249,6 @@ private:
     double adjacent_edge_info_auto_scale_target_nis_rot_ {3.0};
 
     bool initial_map_array_received_ {false};
-    bool is_map_array_updated_ {false};
     int previous_submaps_num_ {0};
 
     backend_core::LoopEdgeSet loop_edge_set_;

--- a/graph_based_slam/param/graphbasedslam.yaml
+++ b/graph_based_slam/param/graphbasedslam.yaml
@@ -3,14 +3,11 @@ graph_based_slam:
       registration_method: "GICP"
       ndt_resolution: 1.5
       voxel_leaf_size: 0.2
-      loop_detection_period: 3000
-      # Default on (v0.6 Phase 3). true = loop search runs once per submap
-      # arrival in arrival order, so the (query, db) pair set is a pure
-      # function of the input stream instead of wall-clock timer batching.
-      # false = legacy timer path (latest submap only per tick), kept for one
-      # release after the default flip. Replaces the retired
-      # deterministic_loop_scheduling parameter.
-      event_driven_loop_search: true
+      # Loop search runs once per submap arrival, in arrival order, so the
+      # (query, db) pair set is a pure function of the input stream. This is
+      # the only scheduling semantics since v0.7 Phase 0 (the legacy
+      # wall-clock timer path and its event_driven_loop_search /
+      # loop_detection_period knobs were removed).
       threshold_loop_closure_score: 1.5
       scan_context_loop_closure_score_threshold: -1.0
       distance_loop_closure: 30.0

--- a/graph_based_slam/param/graphbasedslam_indoor.yaml
+++ b/graph_based_slam/param/graphbasedslam_indoor.yaml
@@ -3,14 +3,11 @@ graph_based_slam:
       registration_method: "GICP"
       ndt_resolution: 1.5
       voxel_leaf_size: 0.2
-      loop_detection_period: 3000
-      # Default on (v0.6 Phase 3). true = loop search runs once per submap
-      # arrival in arrival order, so the (query, db) pair set is a pure
-      # function of the input stream instead of wall-clock timer batching.
-      # false = legacy timer path (latest submap only per tick), kept for one
-      # release after the default flip. Replaces the retired
-      # deterministic_loop_scheduling parameter.
-      event_driven_loop_search: true
+      # Loop search runs once per submap arrival, in arrival order, so the
+      # (query, db) pair set is a pure function of the input stream. This is
+      # the only scheduling semantics since v0.7 Phase 0 (the legacy
+      # wall-clock timer path and its event_driven_loop_search /
+      # loop_detection_period knobs were removed).
       threshold_loop_closure_score: 1.5
       scan_context_loop_closure_score_threshold: -1.0
       distance_loop_closure: 30.0

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -74,10 +74,6 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   get_parameter("ndt_resolution", ndt_resolution);
   declare_parameter("ndt_num_threads", 0);
   get_parameter("ndt_num_threads", ndt_num_threads);
-  declare_parameter("loop_detection_period", 1000);
-  get_parameter("loop_detection_period", loop_detection_period_);
-  declare_parameter("event_driven_loop_search", true);
-  get_parameter("event_driven_loop_search", event_driven_loop_search_);
   declare_parameter("threshold_loop_closure_score", 1.0);
   get_parameter("threshold_loop_closure_score", threshold_loop_closure_score_);
   declare_parameter("scan_context_loop_closure_score_threshold", -1.0);
@@ -848,7 +844,6 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   std::cout << "voxel_leaf_size[m]:" << voxel_leaf_size << std::endl;
   std::cout << "ndt_resolution[m]:" << ndt_resolution << std::endl;
   std::cout << "ndt_num_threads:" << ndt_num_threads << std::endl;
-  std::cout << "loop_detection_period[Hz]:" << loop_detection_period_ << std::endl;
   std::cout << "threshold_loop_closure_score:" << threshold_loop_closure_score_ << std::endl;
   std::cout << "scan_context_loop_closure_score_threshold:" <<
     scan_context_loop_closure_score_threshold_ << std::endl;
@@ -1136,11 +1131,8 @@ void GraphBasedSlamComponent::initializePubSub()
           }
         }
         initial_map_array_received_ = true;
-        is_map_array_updated_ = true;
       }
-      if (event_driven_loop_search_) {
-        runEventDrivenLoopSearch();
-      }
+      runEventDrivenLoopSearch();
     };
 
   map_array_sub_ =
@@ -1171,12 +1163,6 @@ void GraphBasedSlamComponent::initializePubSub()
     RCLCPP_INFO(
       get_logger(), "Direct odom+cloud input mode enabled (stamp-synced, queue %zu)", sync_depth);
   }
-
-  std::chrono::milliseconds period(loop_detection_period_);
-  loop_detect_timer_ = create_wall_timer(
-    std::chrono::duration_cast<std::chrono::nanoseconds>(period),
-    std::bind(&GraphBasedSlamComponent::searchLoop, this)
-  );
 
   modified_map_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
     "modified_map",
@@ -1225,7 +1211,7 @@ void GraphBasedSlamComponent::handleMapSaveRequest(
   std::cout << "Received an request to save the map" << std::endl;
   lidarslam_msgs::msg::MapArray map_array_msg;
   LoopEdges loop_edges;
-  if (!snapshotGraphState(map_array_msg, loop_edges, false)) {
+  if (!snapshotGraphState(map_array_msg, loop_edges)) {
     std::cout << "initial map is not received" << std::endl;
     return;
   }
@@ -1234,22 +1220,15 @@ void GraphBasedSlamComponent::handleMapSaveRequest(
 
 bool GraphBasedSlamComponent::snapshotGraphState(
   lidarslam_msgs::msg::MapArray & map_array_msg,
-  LoopEdges & loop_edges,
-  bool consume_map_update)
+  LoopEdges & loop_edges)
 {
   std::lock_guard<std::mutex> lock(mtx_);
   if (!initial_map_array_received_) {
     return false;
   }
-  if (consume_map_update && !is_map_array_updated_) {
-    return false;
-  }
 
   map_array_msg = map_array_msg_;
   loop_edges = loop_edge_set_.edges();
-  if (consume_map_update) {
-    is_map_array_updated_ = false;
-  }
   return true;
 }
 
@@ -1306,44 +1285,12 @@ GraphBasedSlamComponent::makeFilteredLocalSubmapProvider(
          };
 }
 
-void GraphBasedSlamComponent::searchLoop()
-{
-  if (event_driven_loop_search_) {
-    // Loop search runs on submap arrival (runEventDrivenLoopSearch); the
-    // wall timer stays registered only as unchanged online pacing.
-    return;
-  }
-  lidarslam_msgs::msg::MapArray map_array_msg;
-  LoopEdges loop_edges;
-  if (!snapshotGraphState(map_array_msg, loop_edges, true)) {return;}
-  if (map_array_msg.submaps.size() < 2) {return;}
-  if (map_array_msg.cloud_coordinate != map_array_msg.LOCAL) {
-    RCLCPP_WARN(get_logger(), "cloud_coordinate should be local, but it's not local.");
-  }
-  int num_submaps = map_array_msg.submaps.size();
-
-  if (debug_flag_) {
-    RCLCPP_INFO(get_logger(), "searching Loop, num_submaps:%d", num_submaps);
-  }
-
-  const auto build_filtered_local_submap = makeFilteredLocalSubmapProvider(map_array_msg);
-
-  // Keep every enabled descriptor database aligned 1:1 with submap indices.
-  backend_core_.ingestDescriptors(num_submaps, build_filtered_local_submap);
-
-  // Legacy (historical) behaviour: query only the single latest submap per
-  // timer tick. The deterministic_loop_scheduling catch-up variant (v0.4 D1)
-  // was retired in v0.6 Phase 3 — event-driven loop search subsumes it by
-  // querying every submap in arrival order.
-  searchLoopForLatest(map_array_msg, loop_edges, num_submaps, num_submaps - 1);
-}
-
 void GraphBasedSlamComponent::runEventDrivenLoopSearch()
 {
   while (rclcpp::ok()) {
     lidarslam_msgs::msg::MapArray map_array_msg;
     LoopEdges loop_edges;
-    if (!snapshotGraphState(map_array_msg, loop_edges, false)) {return;}
+    if (!snapshotGraphState(map_array_msg, loop_edges)) {return;}
     const int num_submaps = static_cast<int>(map_array_msg.submaps.size());
     if (num_submaps < 2) {return;}
     int query_idx = last_searched_submap_idx_ + 1;
@@ -2148,16 +2095,13 @@ void GraphBasedSlamComponent::tryCreateSubmap(
     }
 
     initial_map_array_received_ = true;
-    is_map_array_updated_ = true;
   }
 
   if (n % 50 == 0) {
     RCLCPP_INFO(get_logger(), "Odom input: %d submaps, distance: %.1fm", n, accumulated_distance_);
   }
 
-  if (event_driven_loop_search_) {
-    runEventDrivenLoopSearch();
-  }
+  runEventDrivenLoopSearch();
 }
 
 void GraphBasedSlamComponent::saveSubmapToPCD(

--- a/graph_based_slam/test/test_event_driven_loop_search_defaults.py
+++ b/graph_based_slam/test/test_event_driven_loop_search_defaults.py
@@ -28,16 +28,23 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 """
-Regression tests for the event_driven_loop_search default (v0.6 Phase 3).
+Regression tests for the loop-search scheduling parameter retirements.
 
-event_driven_loop_search runs loop search once per submap arrival in arrival
-order, making the (query, db) pair set a pure function of the input stream
-instead of wall-clock timer batching (the v0.4 D1 nondeterminism root cause).
-It defaults ON since the v0.6 Phase 3 flip; the shipped parameter files must
-document the flag and keep it on so the published behaviour matches the
-determinism evidence (offline 3-run byte-identical loop edges on the MID-360
-and NTU substrates). The retired deterministic_loop_scheduling parameter must
-not reappear.
+Event-driven loop search (one query per submap arrival, in arrival order)
+became the default in v0.6 Phase 3 and the ONLY behaviour in v0.7 Phase 0:
+the legacy wall-clock timer path was removed after its one-release
+deprecation window, together with its parameters. The (query, db) pair set
+is a pure function of the input stream — the property behind the offline
+3-run byte-identical determinism gates (MID-360 and NTU substrates).
+
+These tests pin the retirements so the removed knobs do not silently
+reappear in the shipped parameter files or in the component source:
+
+- ``deterministic_loop_scheduling`` — retired in v0.6 Phase 3 (subsumed).
+- ``event_driven_loop_search`` — retired in v0.7 Phase 0 (now the only
+  semantics, no opt-out).
+- ``loop_detection_period`` — retired in v0.7 Phase 0 (the wall timer it
+  paced no longer exists).
 """
 
 from __future__ import annotations
@@ -49,43 +56,53 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
-PARAM_FILES = [
-    REPO_ROOT / 'graph_based_slam' / 'param' / 'graphbasedslam.yaml',
-    REPO_ROOT / 'graph_based_slam' / 'param' / 'graphbasedslam_indoor.yaml',
-]
+RETIRED_PARAMS = (
+    'deterministic_loop_scheduling',
+    'event_driven_loop_search',
+    'loop_detection_period',
+)
+
+PARAM_FILES = sorted(
+    list((REPO_ROOT / 'graph_based_slam' / 'param').glob('*.yaml')) +
+    list((REPO_ROOT / 'lidarslam' / 'param').glob('*.yaml'))
+)
+
+COMPONENT_CPP = (
+    REPO_ROOT / 'graph_based_slam' / 'src' / 'graph_based_slam_component.cpp'
+)
 
 
-def _load_graph_params(path: Path) -> dict:
-    data = yaml.safe_load(path.read_text(encoding='utf-8'))
-    assert 'graph_based_slam' in data, f'{path} missing graph_based_slam node'
-    params = data['graph_based_slam'].get('ros__parameters')
-    assert params is not None, f'{path} missing ros__parameters'
-    return params
+def _flatten_params(node):
+    """Yield every parameter key in a ROS 2 params yaml, at any nesting."""
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield key
+            yield from _flatten_params(value)
 
 
 @pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
-def test_event_driven_loop_search_present(path):
-    params = _load_graph_params(path)
-    assert 'event_driven_loop_search' in params, (
-        f'{path.name}: event_driven_loop_search must be documented so '
-        'operators can discover the legacy-timer escape hatch'
+def test_param_files_exist(path):
+    assert path.is_file()
+
+
+@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
+@pytest.mark.parametrize('param', RETIRED_PARAMS)
+def test_retired_params_absent_from_param_files(path, param):
+    keys = set(_flatten_params(yaml.safe_load(path.read_text(encoding='utf-8'))))
+    assert param not in keys, (
+        f'{path.name}: {param} was retired (deterministic_loop_scheduling in '
+        'v0.6 Phase 3, the legacy wall-clock timer path and its knobs in v0.7 '
+        'Phase 0) and must not reappear in shipped parameter files'
     )
 
 
-@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
-def test_event_driven_loop_search_defaults_on(path):
-    params = _load_graph_params(path)
-    assert params['event_driven_loop_search'] is True, (
-        f'{path.name}: event_driven_loop_search must stay on so the shipped '
-        'behaviour matches the v0.6 determinism evidence (3-run byte-identical '
-        'loop edges); the legacy timer path is an opt-out, not the default'
-    )
-
-
-@pytest.mark.parametrize('path', PARAM_FILES, ids=lambda p: p.name)
-def test_deterministic_loop_scheduling_is_retired(path):
-    params = _load_graph_params(path)
-    assert 'deterministic_loop_scheduling' not in params, (
-        f'{path.name}: deterministic_loop_scheduling was retired in v0.6 '
-        'Phase 3 (subsumed by event_driven_loop_search) and must not reappear'
+@pytest.mark.parametrize('param', RETIRED_PARAMS)
+def test_retired_params_not_declared_by_component(param):
+    # Historical comments may mention the retired names; only an actual
+    # declare_parameter() would resurrect the knob.
+    source = COMPONENT_CPP.read_text(encoding='utf-8')
+    assert f'declare_parameter("{param}"' not in source, (
+        f'{param} must stay removed — event-driven loop search is the only '
+        'scheduling semantics since v0.7 Phase 0 and the wall timer no '
+        'longer exists'
     )

--- a/lidarslam/param/lidarslam.yaml
+++ b/lidarslam/param/lidarslam.yaml
@@ -37,7 +37,6 @@ graph_based_slam:
       ndt_resolution: 1.0
       ndt_num_threads: 2
       voxel_leaf_size: 0.1
-      loop_detection_period: 3000
       threshold_loop_closure_score: 0.7
       distance_loop_closure: 100.0
       range_of_searching_loop_closure: 20.0

--- a/lidarslam/param/lidarslam_kitti_velodyne.yaml
+++ b/lidarslam/param/lidarslam_kitti_velodyne.yaml
@@ -37,7 +37,6 @@ graph_based_slam:
       ndt_resolution: 1.0
       ndt_num_threads: 2
       voxel_leaf_size: 0.1
-      loop_detection_period: 3000
       threshold_loop_closure_score: 0.7
       distance_loop_closure: 100.0
       range_of_searching_loop_closure: 20.0

--- a/lidarslam/param/lidarslam_lo.yaml
+++ b/lidarslam/param/lidarslam_lo.yaml
@@ -39,7 +39,6 @@ graph_based_slam:
       ndt_resolution: 1.0
       ndt_num_threads: 2
       voxel_leaf_size: 0.1
-      loop_detection_period: 3000
       threshold_loop_closure_score: 0.7
       distance_loop_closure: 100.0
       range_of_searching_loop_closure: 20.0

--- a/lidarslam/param/lidarslam_mid360_imu.yaml
+++ b/lidarslam/param/lidarslam_mid360_imu.yaml
@@ -74,7 +74,6 @@ graph_based_slam:
     ndt_num_threads: 0
     voxel_leaf_size: 0.2
 
-    loop_detection_period: 3000
     threshold_loop_closure_score: 1.0
     distance_loop_closure: 30.0
     range_of_searching_loop_closure: 10.0

--- a/lidarslam/param/lidarslam_mid360_noimu.yaml
+++ b/lidarslam/param/lidarslam_mid360_noimu.yaml
@@ -74,7 +74,6 @@ graph_based_slam:
     ndt_num_threads: 0
     voxel_leaf_size: 0.2
 
-    loop_detection_period: 3000
     threshold_loop_closure_score: 1.0
     distance_loop_closure: 30.0
     range_of_searching_loop_closure: 10.0

--- a/lidarslam/param/lidarslam_mid360_rko_graph.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph.yaml
@@ -5,7 +5,6 @@ graph_based_slam:
     ndt_num_threads: 0
     voxel_leaf_size: 0.2
 
-    loop_detection_period: 1000
     threshold_loop_closure_score: 15.0
     scan_context_loop_closure_score_threshold: -1.0
     distance_loop_closure: 100.0

--- a/lidarslam/param/lidarslam_mid360_rko_graph_3dbbs.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph_3dbbs.yaml
@@ -5,7 +5,6 @@ graph_based_slam:
     ndt_num_threads: 0
     voxel_leaf_size: 0.2
 
-    loop_detection_period: 1000
     threshold_loop_closure_score: 50.0
     # 3D-BBS variant: SCAN_CONTEXT candidates get a separate (looser)
     # NDT fitness gate. 3D-BBS already searched yaw+xyz exhaustively

--- a/lidarslam/param/lidarslam_mid360_rko_graph_strong_loop.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph_strong_loop.yaml
@@ -5,7 +5,6 @@ graph_based_slam:
     ndt_num_threads: 0
     voxel_leaf_size: 0.2
 
-    loop_detection_period: 1000
     # Relaxed from 15.0 to 50.0 to actually fire loop closures on
     # driving_slam_mid360. With the strict 15.0 threshold all 20
     # nearest-revisit candidates (fitness 33-93) are rejected.

--- a/lidarslam/param/lidarslam_mid360_rko_graph_triangle_on.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph_triangle_on.yaml
@@ -5,7 +5,6 @@ graph_based_slam:
     ndt_num_threads: 0
     voxel_leaf_size: 0.2
 
-    loop_detection_period: 1000
     threshold_loop_closure_score: 15.0
     scan_context_loop_closure_score_threshold: -1.0
     distance_loop_closure: 100.0

--- a/lidarslam/param/lidarslam_mid360_rko_graph_v2_sweet.yaml
+++ b/lidarslam/param/lidarslam_mid360_rko_graph_v2_sweet.yaml
@@ -5,7 +5,6 @@ graph_based_slam:
     ndt_num_threads: 0
     voxel_leaf_size: 0.2
 
-    loop_detection_period: 1000
     # v2 "sweet spot": threshold relaxed from default 15.0 to 50.0 so
     # MID-360 narrow-FOV revisits (NDT fitness 30-90) can fire, but not
     # so loose that bad matches (fitness > 50) get accepted.

--- a/lidarslam/param/lidarslam_tukuba.yaml
+++ b/lidarslam/param/lidarslam_tukuba.yaml
@@ -32,7 +32,6 @@ graph_based_slam:
       ndt_resolution: 5.0
       ndt_num_threads: 1
       voxel_leaf_size: 0.2
-      loop_detection_period: 5000
       threshold_loop_closure_score: 2.5
       distance_loop_closure: 100.0
       range_of_searching_loop_closure: 20.0


### PR DESCRIPTION
## Summary

v0.7 Phase 0(`docs/roadmap/v0.7.md`): legacy wall-clock loop-search timer 経路の削除。v0.6.0 で予告した 1 リリース猶予の履行で、event-driven loop search(submap 到着ごと・到着順クエリ)が唯一のスケジューリング意味論になります。

- `searchLoop()`(legacy timer 本体)+ wall timer + `loop_detect_timer_` を削除
- パラメータ `event_driven_loop_search` / `loop_detection_period` を廃止(宣言・メンバ・stdout・全 preset yaml 13 ファイル)
- legacy 専用だった `is_map_array_updated_` 状態と `snapshotGraphState` の `consume_map_update` 引数を削除
- 廃止パラメータ回帰テストを書き換え: 廃止 3 パラメータ(`deterministic_loop_scheduling` / `event_driven_loop_search` / `loop_detection_period`)が全 preset yaml と `declare_parameter` に再出現しないことを固定
- yaml / ヘッダの operator 向けコメントを実態に更新

## Verification

- `colcon test --packages-select graph_based_slam`: **1036 tests, 0 failures**
- フルリリースゲート(`--fail-on-profiles` + 両決定論ステージ)**PASS**:
  - backend 決定論(MID-360): 3-run md5 `feee9547ccaa`/`92676db47106`、APE **7.262851264566504** — v0.6 証拠チェーンと完全同一 = 削除は挙動保存
  - frontend 決定論(NTU 800-cap): 3-run md5 `ba6d6be9cead`/`0ca41ec6183c`、APE **0.4354905815539328** — #262 と完全同一
  - blocking profiles 全 PASS、stadtgarten_seq2 raw **0.835 が 20 回連続ビット一致**

## Notes

- BREAKING: カスタム param ファイルに `event_driven_loop_search` / `loop_detection_period` が残っていても無視されるだけで起動は壊れない(undeclared overrides は無視される)。アップグレードノートは次回リリースノートに記載予定
