### PR TITLE
feat(quality): map-quality metrics core + deterministic map_quality_report CLI (v0.7 Phase 1)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -251,6 +251,24 @@ if(BUILD_TESTING)
     )
   endif()
   ament_add_gtest(
+    test_adaptive_voxel_plane_extractor
+    test/test_adaptive_voxel_plane_extractor.cpp
+  )
+  if(TARGET test_adaptive_voxel_plane_extractor)
+    target_include_directories(
+      test_adaptive_voxel_plane_extractor PRIVATE include ${EIGEN3_INCLUDE_DIR}
+    )
+  endif()
+  ament_add_gtest(
+    test_map_quality_metrics
+    test/test_map_quality_metrics.cpp
+  )
+  if(TARGET test_map_quality_metrics)
+    target_include_directories(
+      test_map_quality_metrics PRIVATE include ${EIGEN3_INCLUDE_DIR}
+    )
+  endif()
+  ament_add_gtest(
     test_registration_determinism
     test/test_registration_determinism.cpp
   )
@@ -609,6 +627,18 @@ add_executable(graph_based_slam_node
   src/graph_based_slam_node.cpp
 )
 
+add_executable(map_quality_report
+  src/map_quality_report_main.cpp
+)
+
+target_include_directories(map_quality_report PRIVATE include ${EIGEN3_INCLUDE_DIR})
+
+target_compile_features(map_quality_report PRIVATE cxx_std_17)
+
+target_link_libraries(map_quality_report
+  ${PCL_LIBRARIES}
+)
+
 target_link_libraries(graph_based_slam_node
   graph_based_slam_component
 )
@@ -678,6 +708,7 @@ install(TARGETS
 install(TARGETS
   graph_based_slam_node
   graph_slam_offline_runner
+  map_quality_report
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/graph_based_slam/include/graph_based_slam/adaptive_voxel_plane_extractor.hpp
+++ b/graph_based_slam/include/graph_based_slam/adaptive_voxel_plane_extractor.hpp
@@ -1,0 +1,449 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__ADAPTIVE_VOXEL_PLANE_EXTRACTOR_HPP_
+#define GRAPH_BASED_SLAM__ADAPTIVE_VOXEL_PLANE_EXTRACTOR_HPP_
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Eigenvalues>  // NOLINT(build/include_order)
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <vector>
+
+namespace graphslam
+{
+namespace plane_extraction
+{
+
+/// Shared deterministic plane extractor for the v0.7 map-quality metrics
+/// (Phase 1) and plane BA (Phase 2), docs/roadmap/v0.7.md.
+struct PlaneExtractionConfig
+{
+  double root_voxel_size {1.0};
+  int max_octree_depth {3};
+  int min_points_per_plane {20};
+  double max_plane_thickness {0.06};
+  double min_planarity_ratio {6.0};
+  bool enable_quarter_test {true};
+  double quarter_test_tolerance {2.0};
+};
+
+struct PlanarPatch
+{
+  Eigen::Vector3d centroid;
+  Eigen::Vector3d normal;
+  double lambda_min;
+  double lambda_mid;
+  double lambda_max;
+  double thickness_rms;
+  int point_count;
+  int depth;
+};
+
+struct PlaneExtractionResult
+{
+  std::vector<PlanarPatch> patches;
+  std::int64_t total_points {0};
+  std::int64_t planar_points {0};
+  double planar_coverage {0.0};
+};
+
+namespace detail
+{
+
+struct VoxelKey
+{
+  std::int64_t x;
+  std::int64_t y;
+  std::int64_t z;
+};
+
+inline bool operator<(const VoxelKey & lhs, const VoxelKey & rhs)
+{
+  if (lhs.x != rhs.x) {
+    return lhs.x < rhs.x;
+  }
+  if (lhs.y != rhs.y) {
+    return lhs.y < rhs.y;
+  }
+  return lhs.z < rhs.z;
+}
+
+struct NodeBounds
+{
+  Eigen::Vector3d min_corner;
+  double size;
+};
+
+struct NodeStats
+{
+  Eigen::Vector3d centroid;
+  Eigen::Matrix3d covariance;
+  Eigen::Vector3d eigenvalues;
+  Eigen::Matrix3d eigenvectors;
+};
+
+inline std::int64_t floorToLongLong(const double value)
+{
+  return static_cast<std::int64_t>(std::floor(value));
+}
+
+inline VoxelKey makeRootKey(
+  const Eigen::Vector3d & point,
+  const double root_voxel_size)
+{
+  VoxelKey key;
+  key.x = floorToLongLong(point.x() / root_voxel_size);
+  key.y = floorToLongLong(point.y() / root_voxel_size);
+  key.z = floorToLongLong(point.z() / root_voxel_size);
+  return key;
+}
+
+inline Eigen::Vector3d makeMinCorner(
+  const VoxelKey & key,
+  const double root_voxel_size)
+{
+  return Eigen::Vector3d(
+    static_cast<double>(key.x) * root_voxel_size,
+    static_cast<double>(key.y) * root_voxel_size,
+    static_cast<double>(key.z) * root_voxel_size);
+}
+
+inline double clampSmallEigenvalue(const double value)
+{
+  if (value < 0.0 && value > -1.0e-12) {
+    return 0.0;
+  }
+  return value;
+}
+
+inline NodeStats computeNodeStats(
+  const std::vector<Eigen::Vector3d> & points,
+  const std::vector<int> & indices)
+{
+  NodeStats stats;
+  stats.centroid = Eigen::Vector3d::Zero();
+  stats.covariance = Eigen::Matrix3d::Zero();
+
+  for (std::size_t i = 0; i < indices.size(); ++i) {
+    stats.centroid += points[indices[i]];
+  }
+  stats.centroid /= static_cast<double>(indices.size());
+
+  for (std::size_t i = 0; i < indices.size(); ++i) {
+    const Eigen::Vector3d delta = points[indices[i]] - stats.centroid;
+    stats.covariance += delta * delta.transpose();
+  }
+  stats.covariance /= static_cast<double>(indices.size());
+
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(stats.covariance);
+  stats.eigenvalues = solver.eigenvalues();
+  stats.eigenvectors = solver.eigenvectors();
+
+  stats.eigenvalues.x() = clampSmallEigenvalue(stats.eigenvalues.x());
+  stats.eigenvalues.y() = clampSmallEigenvalue(stats.eigenvalues.y());
+  stats.eigenvalues.z() = clampSmallEigenvalue(stats.eigenvalues.z());
+
+  return stats;
+}
+
+inline int largestAbsComponentIndex(const Eigen::Vector3d & vector)
+{
+  const double ax = std::abs(vector.x());
+  const double ay = std::abs(vector.y());
+  const double az = std::abs(vector.z());
+
+  if (ax >= ay && ax >= az) {
+    return 0;
+  }
+  if (ay >= az) {
+    return 1;
+  }
+  return 2;
+}
+
+inline Eigen::Vector3d canonicalizeNormal(const Eigen::Vector3d & normal)
+{
+  Eigen::Vector3d canonical = normal.normalized();
+  const int largest_index = largestAbsComponentIndex(canonical);
+
+  if (canonical(largest_index) < 0.0) {
+    canonical = -canonical;
+  }
+  return canonical;
+}
+
+inline int octantForPoint(
+  const Eigen::Vector3d & point,
+  const Eigen::Vector3d & center)
+{
+  int octant = 0;
+  if (point.x() >= center.x()) {
+    octant |= 1;
+  }
+  if (point.y() >= center.y()) {
+    octant |= 2;
+  }
+  if (point.z() >= center.z()) {
+    octant |= 4;
+  }
+  return octant;
+}
+
+inline NodeBounds childBounds(
+  const NodeBounds & parent,
+  const int octant)
+{
+  NodeBounds child;
+  child.size = parent.size * 0.5;
+  child.min_corner = parent.min_corner;
+
+  if ((octant & 1) != 0) {
+    child.min_corner.x() += child.size;
+  }
+  if ((octant & 2) != 0) {
+    child.min_corner.y() += child.size;
+  }
+  if ((octant & 4) != 0) {
+    child.min_corner.z() += child.size;
+  }
+  return child;
+}
+
+inline bool passesBasicPlaneTest(
+  const NodeStats & stats,
+  const std::size_t point_count,
+  const PlaneExtractionConfig & config)
+{
+  if (point_count < static_cast<std::size_t>(config.min_points_per_plane)) {
+    return false;
+  }
+
+  const double lambda_min = stats.eigenvalues.x();
+  const double lambda_mid = stats.eigenvalues.y();
+  const double thickness_rms = std::sqrt(std::max(0.0, lambda_min));
+
+  if (thickness_rms > config.max_plane_thickness) {
+    return false;
+  }
+  if (lambda_mid < config.min_planarity_ratio * lambda_min) {
+    return false;
+  }
+  return true;
+}
+
+inline bool passesQuarterTest(
+  const std::vector<Eigen::Vector3d> & points,
+  const std::vector<int> & indices,
+  const NodeBounds & bounds,
+  const NodeStats & stats,
+  const PlaneExtractionConfig & config)
+{
+  if (!config.enable_quarter_test) {
+    return true;
+  }
+
+  std::vector<int> octant_indices[8];
+  const Eigen::Vector3d center = bounds.min_corner + Eigen::Vector3d::Constant(bounds.size * 0.5);
+
+  for (std::size_t i = 0; i < indices.size(); ++i) {
+    const int octant = octantForPoint(points[indices[i]], center);
+    octant_indices[octant].push_back(indices[i]);
+  }
+
+  const int min_quarter_points = std::max(config.min_points_per_plane / 4, 5);
+  int populated_octants = 0;
+
+  for (int octant = 0; octant < 8; ++octant) {
+    if (octant_indices[octant].size() >= static_cast<std::size_t>(min_quarter_points)) {
+      ++populated_octants;
+    }
+  }
+
+  if (populated_octants < 2) {
+    return true;
+  }
+
+  const double lambda_limit = config.quarter_test_tolerance * stats.eigenvalues.x() + 1.0e-12;
+  for (int octant = 0; octant < 8; ++octant) {
+    if (octant_indices[octant].size() < static_cast<std::size_t>(min_quarter_points)) {
+      continue;
+    }
+
+    const NodeStats quarter_stats = computeNodeStats(points, octant_indices[octant]);
+    if (quarter_stats.eigenvalues.x() > lambda_limit) {
+      return false;
+    }
+  }
+  return true;
+}
+
+inline PlanarPatch makePatch(
+  const NodeStats & stats,
+  const std::size_t point_count,
+  const int depth)
+{
+  PlanarPatch patch;
+  patch.centroid = stats.centroid;
+  patch.normal = canonicalizeNormal(stats.eigenvectors.col(0));
+  patch.lambda_min = stats.eigenvalues.x();
+  patch.lambda_mid = stats.eigenvalues.y();
+  patch.lambda_max = stats.eigenvalues.z();
+  patch.thickness_rms = std::sqrt(std::max(0.0, patch.lambda_min));
+  patch.point_count = static_cast<int>(point_count);
+  patch.depth = depth;
+  return patch;
+}
+
+inline void extractRecursive(
+  const std::vector<Eigen::Vector3d> & points,
+  const std::vector<int> & indices,
+  const NodeBounds & bounds,
+  const int depth,
+  const PlaneExtractionConfig & config,
+  std::vector<PlanarPatch> * patches)
+{
+  if (indices.empty()) {
+    return;
+  }
+
+  const NodeStats stats = computeNodeStats(points, indices);
+  const bool accepted =
+    passesBasicPlaneTest(stats, indices.size(), config) &&
+    passesQuarterTest(points, indices, bounds, stats, config);
+
+  if (accepted) {
+    patches->push_back(makePatch(stats, indices.size(), depth));
+    return;
+  }
+
+  if (depth >= config.max_octree_depth) {
+    return;
+  }
+  if (indices.size() < static_cast<std::size_t>(2 * config.min_points_per_plane)) {
+    return;
+  }
+
+  std::vector<int> child_indices[8];
+  const Eigen::Vector3d center = bounds.min_corner + Eigen::Vector3d::Constant(bounds.size * 0.5);
+
+  for (std::size_t i = 0; i < indices.size(); ++i) {
+    const int octant = octantForPoint(points[indices[i]], center);
+    child_indices[octant].push_back(indices[i]);
+  }
+
+  for (int octant = 0; octant < 8; ++octant) {
+    if (child_indices[octant].empty()) {
+      continue;
+    }
+
+    const NodeBounds child = childBounds(bounds, octant);
+    extractRecursive(points, child_indices[octant], child, depth + 1, config, patches);
+  }
+}
+
+inline PlaneExtractionConfig sanitizeConfig(const PlaneExtractionConfig & config)
+{
+  PlaneExtractionConfig sanitized = config;
+  if (sanitized.root_voxel_size <= 0.0) {
+    sanitized.root_voxel_size = 1.0;
+  }
+  if (sanitized.max_octree_depth < 0) {
+    sanitized.max_octree_depth = 0;
+  }
+  if (sanitized.min_points_per_plane < 1) {
+    sanitized.min_points_per_plane = 1;
+  }
+  if (sanitized.max_plane_thickness < 0.0) {
+    sanitized.max_plane_thickness = 0.0;
+  }
+  if (sanitized.min_planarity_ratio < 0.0) {
+    sanitized.min_planarity_ratio = 0.0;
+  }
+  if (sanitized.quarter_test_tolerance < 0.0) {
+    sanitized.quarter_test_tolerance = 0.0;
+  }
+  return sanitized;
+}
+
+}  // namespace detail
+
+inline PlaneExtractionResult extractPlanarPatches(
+  const std::vector<Eigen::Vector3d> & points,
+  const PlaneExtractionConfig & config)
+{
+  PlaneExtractionResult result;
+  result.total_points = static_cast<std::int64_t>(points.size());
+
+  if (points.empty()) {
+    return result;
+  }
+
+  const PlaneExtractionConfig sanitized = detail::sanitizeConfig(config);
+  std::map<detail::VoxelKey, std::vector<int>> voxel_indices;
+
+  for (std::size_t i = 0; i < points.size(); ++i) {
+    const detail::VoxelKey key = detail::makeRootKey(points[i], sanitized.root_voxel_size);
+    voxel_indices[key].push_back(static_cast<int>(i));
+  }
+
+  for (std::map<detail::VoxelKey, std::vector<int>>::const_iterator iter = voxel_indices.begin();
+    iter != voxel_indices.end(); ++iter)
+  {
+    detail::NodeBounds bounds;
+    bounds.min_corner = detail::makeMinCorner(iter->first, sanitized.root_voxel_size);
+    bounds.size = sanitized.root_voxel_size;
+
+    detail::extractRecursive(
+      points,
+      iter->second,
+      bounds,
+      0,
+      sanitized,
+      &result.patches);
+  }
+
+  for (std::size_t i = 0; i < result.patches.size(); ++i) {
+    result.planar_points += result.patches[i].point_count;
+  }
+  if (result.total_points > 0) {
+    result.planar_coverage =
+      static_cast<double>(result.planar_points) / static_cast<double>(result.total_points);
+  }
+  return result;
+}
+
+}  // namespace plane_extraction
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__ADAPTIVE_VOXEL_PLANE_EXTRACTOR_HPP_

--- a/graph_based_slam/include/graph_based_slam/map_quality_metrics.hpp
+++ b/graph_based_slam/include/graph_based_slam/map_quality_metrics.hpp
@@ -1,0 +1,348 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__MAP_QUALITY_METRICS_HPP_
+#define GRAPH_BASED_SLAM__MAP_QUALITY_METRICS_HPP_
+
+// Map-quality metrics for the v0.7 quality gates (docs/roadmap/v0.7.md,
+// Phase 1): Mean Map Entropy, plane-thickness statistics over the patches
+// found by adaptive_voxel_plane_extractor.hpp, and density statistics.
+// Every metric carries its support (eligible/valid fractions, planar
+// coverage) so a better score can never silently mean "ignored hard
+// geometry", and scenes below a planarity-coverage floor report an
+// explicit not-meaningful state instead of a number. Deterministic by
+// construction: voxel-hash neighborhoods iterated in sorted key order,
+// fixed-order double accumulation, no wall clock, no randomness — the
+// release gate requires byte-identical reports across runs.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Eigenvalues>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/adaptive_voxel_plane_extractor.hpp"
+
+namespace graphslam
+{
+namespace map_quality
+{
+
+struct MapQualityConfig
+{
+  // Mean Map Entropy: per-point Gaussian entropy of the neighborhood
+  // within mme_radius; points with fewer than mme_min_neighbors
+  // neighbors (self included) are excluded and reported as such.
+  double mme_radius {0.5};
+  int mme_min_neighbors {8};
+  // Optional deterministic voxel-centroid downsample applied before any
+  // metric (0.0 = off). Keeps the metric cost bounded on dense maps.
+  double downsample_voxel_size {0.0};
+  // Plane metrics share the Phase 2 extractor.
+  plane_extraction::PlaneExtractionConfig plane_config;
+  // Below this planar coverage the plane metrics are reported as
+  // not meaningful (expected on vegetation-heavy outdoor maps).
+  double min_meaningful_planar_coverage {0.10};
+};
+
+struct MapQualityReport
+{
+  std::int64_t input_points {0};
+  std::int64_t evaluated_points {0};  // after optional downsample
+  // Mean Map Entropy (nats); lower = crisper.
+  double mean_map_entropy {0.0};
+  std::int64_t mme_valid_points {0};
+  double mme_valid_fraction {0.0};
+  // Plane metrics (support-reported).
+  int plane_patch_count {0};
+  double plane_thickness_rms_mean_m {0.0};  // point-count weighted
+  double plane_thickness_rms_p95_m {0.0};
+  double planar_coverage {0.0};
+  bool plane_metrics_meaningful {false};
+  // Density over occupied root voxels.
+  std::int64_t occupied_root_voxels {0};
+  double density_mean_points_per_voxel {0.0};
+  double density_stddev_points_per_voxel {0.0};
+};
+
+namespace detail
+{
+
+struct VoxelKey
+{
+  std::int64_t x;
+  std::int64_t y;
+  std::int64_t z;
+
+  bool operator<(const VoxelKey & other) const
+  {
+    if (x != other.x) {return x < other.x;}
+    if (y != other.y) {return y < other.y;}
+    return z < other.z;
+  }
+};
+
+inline VoxelKey keyOf(const Eigen::Vector3d & p, double voxel_size)
+{
+  VoxelKey key;
+  key.x = static_cast<std::int64_t>(std::floor(p.x() / voxel_size));
+  key.y = static_cast<std::int64_t>(std::floor(p.y() / voxel_size));
+  key.z = static_cast<std::int64_t>(std::floor(p.z() / voxel_size));
+  return key;
+}
+
+// std::map keeps the bucket iteration order sorted; point indices are
+// appended in ascending input order, so every downstream accumulation
+// has a fixed order.
+inline std::map<VoxelKey, std::vector<int>> bucketize(
+  const std::vector<Eigen::Vector3d> & points, double voxel_size)
+{
+  std::map<VoxelKey, std::vector<int>> buckets;
+  for (int i = 0; i < static_cast<int>(points.size()); ++i) {
+    buckets[keyOf(points[i], voxel_size)].push_back(i);
+  }
+  return buckets;
+}
+
+}  // namespace detail
+
+// Deterministic voxel-centroid downsample (sorted voxel order, ascending
+// index accumulation). Replaces pcl::VoxelGrid here so the metric input
+// is a pure function of the point list.
+inline std::vector<Eigen::Vector3d> downsampleByVoxelCentroid(
+  const std::vector<Eigen::Vector3d> & points, double voxel_size)
+{
+  if (voxel_size <= 0.0) {return points;}
+  const auto buckets = detail::bucketize(points, voxel_size);
+  std::vector<Eigen::Vector3d> result;
+  result.reserve(buckets.size());
+  for (auto it = buckets.begin(); it != buckets.end(); ++it) {
+    Eigen::Vector3d sum = Eigen::Vector3d::Zero();
+    for (size_t j = 0; j < it->second.size(); ++j) {
+      sum += points[it->second[j]];
+    }
+    result.push_back(sum / static_cast<double>(it->second.size()));
+  }
+  return result;
+}
+
+struct MeanMapEntropyResult
+{
+  double mean_entropy {0.0};
+  std::int64_t valid_points {0};
+  std::int64_t total_points {0};
+};
+
+// Mean Map Entropy: h(p) = 0.5 * ln((2*pi*e)^3 * det(Sigma)) over the
+// neighborhood of p (self included); the mean is taken over points with
+// at least min_neighbors neighbors and a positive-definite covariance.
+inline MeanMapEntropyResult computeMeanMapEntropy(
+  const std::vector<Eigen::Vector3d> & points, double radius, int min_neighbors)
+{
+  MeanMapEntropyResult result;
+  result.total_points = static_cast<std::int64_t>(points.size());
+  if (points.empty() || radius <= 0.0) {return result;}
+
+  const auto buckets = detail::bucketize(points, radius);
+  const double radius_sq = radius * radius;
+  // ln((2*pi*e)^3) = 3 * ln(2*pi*e)
+  const double log_two_pi_e_cubed = 3.0 * std::log(2.0 * M_PI * M_E);
+
+  double entropy_sum = 0.0;
+  std::vector<int> neighbors;
+  for (int i = 0; i < static_cast<int>(points.size()); ++i) {
+    neighbors.clear();
+    const detail::VoxelKey center = detail::keyOf(points[i], radius);
+    for (std::int64_t dx = -1; dx <= 1; ++dx) {
+      for (std::int64_t dy = -1; dy <= 1; ++dy) {
+        for (std::int64_t dz = -1; dz <= 1; ++dz) {
+          detail::VoxelKey key;
+          key.x = center.x + dx;
+          key.y = center.y + dy;
+          key.z = center.z + dz;
+          const auto it = buckets.find(key);
+          if (it == buckets.end()) {continue;}
+          for (size_t j = 0; j < it->second.size(); ++j) {
+            const int idx = it->second[j];
+            if ((points[idx] - points[i]).squaredNorm() <= radius_sq) {
+              neighbors.push_back(idx);
+            }
+          }
+        }
+      }
+    }
+    if (static_cast<int>(neighbors.size()) < min_neighbors) {continue;}
+    // Ascending index order keeps the float accumulation fixed.
+    std::sort(neighbors.begin(), neighbors.end());
+    Eigen::Vector3d mean = Eigen::Vector3d::Zero();
+    for (size_t j = 0; j < neighbors.size(); ++j) {
+      mean += points[neighbors[j]];
+    }
+    mean /= static_cast<double>(neighbors.size());
+    Eigen::Matrix3d covariance = Eigen::Matrix3d::Zero();
+    for (size_t j = 0; j < neighbors.size(); ++j) {
+      const Eigen::Vector3d d = points[neighbors[j]] - mean;
+      covariance += d * d.transpose();
+    }
+    covariance /= static_cast<double>(neighbors.size());
+    const double det = covariance.determinant();
+    if (!(det > 0.0)) {continue;}
+    entropy_sum += 0.5 * (log_two_pi_e_cubed + std::log(det));
+    ++result.valid_points;
+  }
+  if (result.valid_points > 0) {
+    result.mean_entropy = entropy_sum / static_cast<double>(result.valid_points);
+  }
+  return result;
+}
+
+inline MapQualityReport computeMapQuality(
+  const std::vector<Eigen::Vector3d> & input_points, const MapQualityConfig & config)
+{
+  MapQualityReport report;
+  report.input_points = static_cast<std::int64_t>(input_points.size());
+
+  const std::vector<Eigen::Vector3d> points =
+    downsampleByVoxelCentroid(input_points, config.downsample_voxel_size);
+  report.evaluated_points = static_cast<std::int64_t>(points.size());
+  if (points.empty()) {return report;}
+
+  const MeanMapEntropyResult mme =
+    computeMeanMapEntropy(points, config.mme_radius, config.mme_min_neighbors);
+  report.mean_map_entropy = mme.mean_entropy;
+  report.mme_valid_points = mme.valid_points;
+  report.mme_valid_fraction =
+    static_cast<double>(mme.valid_points) / static_cast<double>(points.size());
+
+  const plane_extraction::PlaneExtractionResult planes =
+    plane_extraction::extractPlanarPatches(points, config.plane_config);
+  report.plane_patch_count = static_cast<int>(planes.patches.size());
+  report.planar_coverage = planes.planar_coverage;
+  if (!planes.patches.empty()) {
+    double weighted_sum = 0.0;
+    double weight = 0.0;
+    std::vector<double> thicknesses;
+    thicknesses.reserve(planes.patches.size());
+    for (size_t i = 0; i < planes.patches.size(); ++i) {
+      const auto & patch = planes.patches[i];
+      weighted_sum += patch.thickness_rms * static_cast<double>(patch.point_count);
+      weight += static_cast<double>(patch.point_count);
+      thicknesses.push_back(patch.thickness_rms);
+    }
+    report.plane_thickness_rms_mean_m = weighted_sum / weight;
+    std::sort(thicknesses.begin(), thicknesses.end());
+    const size_t p95_index = std::min(
+      thicknesses.size() - 1,
+      static_cast<size_t>(std::ceil(0.95 * static_cast<double>(thicknesses.size())) - 1.0));
+    report.plane_thickness_rms_p95_m = thicknesses[p95_index];
+  }
+  report.plane_metrics_meaningful =
+    report.planar_coverage >= config.min_meaningful_planar_coverage &&
+    report.plane_patch_count > 0;
+
+  // Density over occupied root voxels (same root size as the extractor).
+  const auto buckets = detail::bucketize(points, config.plane_config.root_voxel_size);
+  report.occupied_root_voxels = static_cast<std::int64_t>(buckets.size());
+  double count_sum = 0.0;
+  for (auto it = buckets.begin(); it != buckets.end(); ++it) {
+    count_sum += static_cast<double>(it->second.size());
+  }
+  const double count_mean = count_sum / static_cast<double>(buckets.size());
+  double variance_sum = 0.0;
+  for (auto it = buckets.begin(); it != buckets.end(); ++it) {
+    const double d = static_cast<double>(it->second.size()) - count_mean;
+    variance_sum += d * d;
+  }
+  report.density_mean_points_per_voxel = count_mean;
+  report.density_stddev_points_per_voxel =
+    std::sqrt(variance_sum / static_cast<double>(buckets.size()));
+  return report;
+}
+
+namespace detail
+{
+
+inline std::string formatDouble(double value)
+{
+  char buffer[64];
+  std::snprintf(buffer, sizeof(buffer), "%.9f", value);
+  return std::string(buffer);
+}
+
+}  // namespace detail
+
+// YAML content for map_quality_report.yaml. Fixed key order and fixed
+// formatting: the release gate compares these bytes across runs.
+inline std::vector<std::string> reportYamlLines(
+  const MapQualityReport & report, const MapQualityConfig & config)
+{
+  std::vector<std::string> lines;
+  lines.push_back("map_quality_report:");
+  lines.push_back("  input_points: " + std::to_string(report.input_points));
+  lines.push_back("  evaluated_points: " + std::to_string(report.evaluated_points));
+  lines.push_back(
+    "  downsample_voxel_size_m: " + detail::formatDouble(config.downsample_voxel_size));
+  lines.push_back("  mean_map_entropy:");
+  lines.push_back("    value_nats: " + detail::formatDouble(report.mean_map_entropy));
+  lines.push_back("    radius_m: " + detail::formatDouble(config.mme_radius));
+  lines.push_back("    valid_points: " + std::to_string(report.mme_valid_points));
+  lines.push_back("    valid_fraction: " + detail::formatDouble(report.mme_valid_fraction));
+  lines.push_back("  plane_metrics:");
+  lines.push_back(
+    "    meaningful: " + std::string(report.plane_metrics_meaningful ? "true" : "false"));
+  lines.push_back("    patch_count: " + std::to_string(report.plane_patch_count));
+  lines.push_back(
+    "    thickness_rms_mean_m: " + detail::formatDouble(report.plane_thickness_rms_mean_m));
+  lines.push_back(
+    "    thickness_rms_p95_m: " + detail::formatDouble(report.plane_thickness_rms_p95_m));
+  lines.push_back("    planar_coverage: " + detail::formatDouble(report.planar_coverage));
+  lines.push_back(
+    "    min_meaningful_planar_coverage: " +
+    detail::formatDouble(config.min_meaningful_planar_coverage));
+  lines.push_back("  density:");
+  lines.push_back("    occupied_root_voxels: " + std::to_string(report.occupied_root_voxels));
+  lines.push_back(
+    "    mean_points_per_voxel: " +
+    detail::formatDouble(report.density_mean_points_per_voxel));
+  lines.push_back(
+    "    stddev_points_per_voxel: " +
+    detail::formatDouble(report.density_stddev_points_per_voxel));
+  return lines;
+}
+
+}  // namespace map_quality
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__MAP_QUALITY_METRICS_HPP_

--- a/graph_based_slam/src/map_quality_report_main.cpp
+++ b/graph_based_slam/src/map_quality_report_main.cpp
@@ -1,0 +1,162 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// map_quality_report: deterministic map-quality metrics over a PCD map
+// (docs/roadmap/v0.7.md, Phase 1). Input is a single .pcd file or a
+// directory of .pcd cells (e.g. the Autoware pointcloud_map/ bundle,
+// loaded in sorted filename order); output is map_quality_report.yaml
+// with Mean Map Entropy, plane-thickness statistics (with planar
+// coverage and an explicit not-meaningful state) and density stats.
+// No ROS, no wall clock, no randomness: the same input bytes produce
+// the same report bytes, and the release gate relies on that.
+
+#include <pcl/io/pcd_io.h>  // NOLINT(build/include_order)
+#include <pcl/point_types.h>  // NOLINT(build/include_order)
+
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "graph_based_slam/map_quality_metrics.hpp"
+
+namespace
+{
+
+void printUsage()
+{
+  std::cout <<
+    "usage: map_quality_report --input <map.pcd | pcd_dir> --output-dir <dir>\n"
+    "  [--downsample <m>]            deterministic voxel-centroid downsample (default 0 = off)\n"
+    "  [--mme-radius <m>]            Mean Map Entropy neighborhood radius (default 0.5)\n"
+    "  [--mme-min-neighbors <n>]     minimum neighbors for a valid MME point (default 8)\n"
+    "  [--root-voxel-size <m>]       plane extractor root voxel size (default 1.0)\n"
+    "  [--min-meaningful-coverage <f>] planar coverage floor for meaningful plane metrics\n"
+    "                                  (default 0.10)\n";
+}
+
+bool loadPcdInto(const std::string & path, std::vector<Eigen::Vector3d> & points)
+{
+  pcl::PointCloud<pcl::PointXYZ> cloud;
+  if (pcl::io::loadPCDFile<pcl::PointXYZ>(path, cloud) == -1) {
+    std::cerr << "error: failed to load " << path << std::endl;
+    return false;
+  }
+  points.reserve(points.size() + cloud.size());
+  for (size_t i = 0; i < cloud.size(); ++i) {
+    const auto & p = cloud.points[i];
+    if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {continue;}
+    points.push_back(Eigen::Vector3d(p.x, p.y, p.z));
+  }
+  return true;
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  std::string input;
+  std::string output_dir;
+  graphslam::map_quality::MapQualityConfig config;
+
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    const bool has_value = i + 1 < argc;
+    if (arg == "--input" && has_value) {
+      input = argv[++i];
+    } else if (arg == "--output-dir" && has_value) {
+      output_dir = argv[++i];
+    } else if (arg == "--downsample" && has_value) {
+      config.downsample_voxel_size = std::stod(argv[++i]);
+    } else if (arg == "--mme-radius" && has_value) {
+      config.mme_radius = std::stod(argv[++i]);
+    } else if (arg == "--mme-min-neighbors" && has_value) {
+      config.mme_min_neighbors = std::stoi(argv[++i]);
+    } else if (arg == "--root-voxel-size" && has_value) {
+      config.plane_config.root_voxel_size = std::stod(argv[++i]);
+    } else if (arg == "--min-meaningful-coverage" && has_value) {
+      config.min_meaningful_planar_coverage = std::stod(argv[++i]);
+    } else {
+      printUsage();
+      return arg == "--help" ? 0 : 1;
+    }
+  }
+  if (input.empty() || output_dir.empty()) {
+    printUsage();
+    return 1;
+  }
+
+  std::vector<Eigen::Vector3d> points;
+  if (std::filesystem::is_directory(input)) {
+    std::vector<std::string> pcd_files;
+    for (const auto & entry : std::filesystem::directory_iterator(input)) {
+      if (entry.path().extension() == ".pcd") {
+        pcd_files.push_back(entry.path().string());
+      }
+    }
+    // Sorted filename order: the input point order (and therefore the
+    // report bytes) must not depend on directory iteration order.
+    std::sort(pcd_files.begin(), pcd_files.end());
+    if (pcd_files.empty()) {
+      std::cerr << "error: no .pcd files in " << input << std::endl;
+      return 1;
+    }
+    for (size_t i = 0; i < pcd_files.size(); ++i) {
+      if (!loadPcdInto(pcd_files[i], points)) {return 1;}
+    }
+    std::cout << "loaded " << pcd_files.size() << " pcd cells, " << points.size() <<
+      " finite points" << std::endl;
+  } else {
+    if (!loadPcdInto(input, points)) {return 1;}
+    std::cout << "loaded " << points.size() << " finite points" << std::endl;
+  }
+
+  const graphslam::map_quality::MapQualityReport report =
+    graphslam::map_quality::computeMapQuality(points, config);
+  const std::vector<std::string> lines =
+    graphslam::map_quality::reportYamlLines(report, config);
+
+  std::filesystem::create_directories(output_dir);
+  const std::string yaml_path = output_dir + "/map_quality_report.yaml";
+  std::ofstream yaml(yaml_path, std::ios::binary);
+  if (!yaml) {
+    std::cerr << "error: cannot write " << yaml_path << std::endl;
+    return 1;
+  }
+  for (size_t i = 0; i < lines.size(); ++i) {
+    yaml << lines[i] << "\n";
+    std::cout << lines[i] << "\n";
+  }
+  yaml.close();
+  std::cout << "wrote " << yaml_path << std::endl;
+  return 0;
+}

--- a/graph_based_slam/test/test_adaptive_voxel_plane_extractor.cpp
+++ b/graph_based_slam/test/test_adaptive_voxel_plane_extractor.cpp
@@ -1,0 +1,270 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "graph_based_slam/adaptive_voxel_plane_extractor.hpp"
+
+namespace
+{
+
+using graphslam::plane_extraction::PlaneExtractionConfig;
+using graphslam::plane_extraction::PlaneExtractionResult;
+using graphslam::plane_extraction::PlanarPatch;
+using graphslam::plane_extraction::extractPlanarPatches;
+
+std::vector<Eigen::Vector3d> makeFlatWallGrid()
+{
+  std::vector<Eigen::Vector3d> points;
+  points.reserve(100);
+
+  for (int ix = 0; ix < 10; ++ix) {
+    for (int iy = 0; iy < 10; ++iy) {
+      const double x = 0.08 + 0.08 * static_cast<double>(ix);
+      const double y = 0.10 + 0.07 * static_cast<double>(iy);
+      // Keep the wall strictly inside the root voxel z in [0, 1): a wall
+      // at z = +/-0.0005 would straddle the voxel boundary at z = 0 and
+      // split into two root-voxel patches.
+      const double z = 0.5 + (((ix + iy) % 2 == 0) ? 0.0005 : -0.0005);
+      points.push_back(Eigen::Vector3d(x, y, z));
+    }
+  }
+  return points;
+}
+
+std::vector<Eigen::Vector3d> makeFloorGrid(const double z)
+{
+  std::vector<Eigen::Vector3d> points;
+  points.reserve(64);
+
+  for (int ix = 0; ix < 8; ++ix) {
+    for (int iy = 0; iy < 8; ++iy) {
+      const double x = 0.06 + 0.10 * static_cast<double>(ix);
+      const double y = 0.07 + 0.09 * static_cast<double>(iy);
+      const double dz = ((ix + 2 * iy) % 3 == 0) ? 0.0004 : -0.0004;
+      points.push_back(Eigen::Vector3d(x, y, z + dz));
+    }
+  }
+  return points;
+}
+
+std::vector<Eigen::Vector3d> makeTwoParallelFloors()
+{
+  std::vector<Eigen::Vector3d> points = makeFloorGrid(0.2);
+  const std::vector<Eigen::Vector3d> upper = makeFloorGrid(1.3);
+  points.insert(points.end(), upper.begin(), upper.end());
+  return points;
+}
+
+std::vector<Eigen::Vector3d> makeParaboloid()
+{
+  std::vector<Eigen::Vector3d> points;
+  points.reserve(169);
+
+  for (int ix = -6; ix <= 6; ++ix) {
+    for (int iy = -6; iy <= 6; ++iy) {
+      const double x = 0.5 + 0.07 * static_cast<double>(ix);
+      const double y = 0.5 + 0.07 * static_cast<double>(iy);
+      const double dx = x - 0.5;
+      const double dy = y - 0.5;
+      const double z = 0.03 + 0.65 * (dx * dx + dy * dy);
+      points.push_back(Eigen::Vector3d(x, y, z));
+    }
+  }
+  return points;
+}
+
+std::vector<Eigen::Vector3d> makeVolumetricCloud()
+{
+  std::vector<Eigen::Vector3d> points;
+  points.reserve(160);
+
+  std::mt19937 generator(12345);
+  std::uniform_real_distribution<double> distribution(0.05, 0.95);
+
+  for (int i = 0; i < 160; ++i) {
+    points.push_back(
+      Eigen::Vector3d(
+        distribution(generator),
+        distribution(generator),
+        distribution(generator)));
+  }
+  return points;
+}
+
+PlaneExtractionConfig baseConfig()
+{
+  PlaneExtractionConfig config;
+  config.root_voxel_size = 1.0;
+  config.max_octree_depth = 3;
+  config.min_points_per_plane = 20;
+  config.max_plane_thickness = 0.01;
+  config.min_planarity_ratio = 6.0;
+  config.enable_quarter_test = true;
+  config.quarter_test_tolerance = 2.0;
+  return config;
+}
+
+void expectPatchesBitIdentical(
+  const PlaneExtractionResult & lhs,
+  const PlaneExtractionResult & rhs)
+{
+  ASSERT_EQ(lhs.patches.size(), rhs.patches.size());
+  EXPECT_EQ(lhs.total_points, rhs.total_points);
+  EXPECT_EQ(lhs.planar_points, rhs.planar_points);
+  EXPECT_EQ(lhs.planar_coverage, rhs.planar_coverage);
+
+  for (std::size_t i = 0; i < lhs.patches.size(); ++i) {
+    const PlanarPatch & a = lhs.patches[i];
+    const PlanarPatch & b = rhs.patches[i];
+
+    EXPECT_EQ(0, std::memcmp(a.centroid.data(), b.centroid.data(), 3 * sizeof(double)));
+    EXPECT_EQ(0, std::memcmp(a.normal.data(), b.normal.data(), 3 * sizeof(double)));
+    EXPECT_EQ(a.lambda_min, b.lambda_min);
+    EXPECT_EQ(a.lambda_mid, b.lambda_mid);
+    EXPECT_EQ(a.lambda_max, b.lambda_max);
+    EXPECT_EQ(a.thickness_rms, b.thickness_rms);
+    EXPECT_EQ(a.point_count, b.point_count);
+    EXPECT_EQ(a.depth, b.depth);
+  }
+}
+
+}  // namespace
+
+TEST(AdaptiveVoxelPlaneExtractor, FlatWallGridAcceptsOnePatch)
+{
+  const std::vector<Eigen::Vector3d> points = makeFlatWallGrid();
+  const PlaneExtractionConfig config = baseConfig();
+
+  const PlaneExtractionResult result = extractPlanarPatches(points, config);
+
+  ASSERT_EQ(1u, result.patches.size());
+  EXPECT_EQ(static_cast<std::int64_t>(points.size()), result.total_points);
+  EXPECT_EQ(static_cast<std::int64_t>(points.size()), result.planar_points);
+  EXPECT_NEAR(1.0, result.planar_coverage, 1.0e-12);
+
+  const PlanarPatch & patch = result.patches[0];
+  EXPECT_NEAR(0.0, patch.normal.x(), 1.0e-9);
+  EXPECT_NEAR(0.0, patch.normal.y(), 1.0e-9);
+  EXPECT_NEAR(1.0, patch.normal.z(), 1.0e-9);
+  EXPECT_LT(patch.thickness_rms, 0.001);
+  EXPECT_EQ(0, patch.depth);
+}
+
+TEST(AdaptiveVoxelPlaneExtractor, TwoParallelFloorsProduceTwoOrderedPatches)
+{
+  const std::vector<Eigen::Vector3d> points = makeTwoParallelFloors();
+  const PlaneExtractionConfig config = baseConfig();
+
+  const PlaneExtractionResult result = extractPlanarPatches(points, config);
+
+  ASSERT_EQ(2u, result.patches.size());
+  EXPECT_EQ(static_cast<std::int64_t>(points.size()), result.total_points);
+  EXPECT_EQ(static_cast<std::int64_t>(points.size()), result.planar_points);
+  EXPECT_NEAR(1.0, result.planar_coverage, 1.0e-12);
+
+  EXPECT_LT(result.patches[0].centroid.z(), result.patches[1].centroid.z());
+  EXPECT_NEAR(0.2, result.patches[0].centroid.z(), 0.001);
+  EXPECT_NEAR(1.3, result.patches[1].centroid.z(), 0.001);
+  EXPECT_NEAR(1.0, result.patches[0].normal.z(), 1.0e-9);
+  EXPECT_NEAR(1.0, result.patches[1].normal.z(), 1.0e-9);
+}
+
+TEST(AdaptiveVoxelPlaneExtractor, CurvedSurfaceDoesNotReturnThickPatches)
+{
+  const std::vector<Eigen::Vector3d> points = makeParaboloid();
+  PlaneExtractionConfig config = baseConfig();
+  config.max_plane_thickness = 0.02;
+  config.max_octree_depth = 3;
+
+  const PlaneExtractionResult result = extractPlanarPatches(points, config);
+
+  for (std::size_t i = 0; i < result.patches.size(); ++i) {
+    EXPECT_LE(result.patches[i].thickness_rms, config.max_plane_thickness);
+  }
+  EXPECT_EQ(static_cast<std::int64_t>(points.size()), result.total_points);
+}
+
+TEST(AdaptiveVoxelPlaneExtractor, VolumetricCloudRejectsPlanarity)
+{
+  const std::vector<Eigen::Vector3d> points = makeVolumetricCloud();
+  PlaneExtractionConfig config = baseConfig();
+  config.max_octree_depth = 0;
+  config.max_plane_thickness = 1.0;
+
+  const PlaneExtractionResult result = extractPlanarPatches(points, config);
+
+  EXPECT_TRUE((result.patches.empty()));
+  EXPECT_EQ(static_cast<std::int64_t>(points.size()), result.total_points);
+  EXPECT_EQ(0, result.planar_points);
+  EXPECT_EQ(0.0, result.planar_coverage);
+}
+
+TEST(AdaptiveVoxelPlaneExtractor, SameInputProducesBitIdenticalResults)
+{
+  std::vector<Eigen::Vector3d> points = makeFlatWallGrid();
+  const std::vector<Eigen::Vector3d> floors = makeTwoParallelFloors();
+  points.insert(points.end(), floors.begin(), floors.end());
+
+  std::mt19937 generator(24680);
+  std::shuffle(points.begin(), points.end(), generator);
+
+  const PlaneExtractionConfig config = baseConfig();
+
+  const PlaneExtractionResult first = extractPlanarPatches(points, config);
+  const PlaneExtractionResult second = extractPlanarPatches(points, config);
+
+  expectPatchesBitIdentical(first, second);
+}
+
+TEST(AdaptiveVoxelPlaneExtractor, SparseCloudBelowMinimumIsRejected)
+{
+  std::vector<Eigen::Vector3d> points;
+  points.push_back(Eigen::Vector3d(0.1, 0.1, 0.0));
+  points.push_back(Eigen::Vector3d(0.2, 0.1, 0.0));
+  points.push_back(Eigen::Vector3d(0.1, 0.2, 0.0));
+  points.push_back(Eigen::Vector3d(0.2, 0.2, 0.0));
+
+  PlaneExtractionConfig config = baseConfig();
+  config.min_points_per_plane = 5;
+
+  const PlaneExtractionResult result = extractPlanarPatches(points, config);
+
+  EXPECT_TRUE((result.patches.empty()));
+  EXPECT_EQ(static_cast<std::int64_t>(points.size()), result.total_points);
+  EXPECT_EQ(0, result.planar_points);
+  EXPECT_EQ(0.0, result.planar_coverage);
+}

--- a/graph_based_slam/test/test_map_quality_metrics.cpp
+++ b/graph_based_slam/test/test_map_quality_metrics.cpp
@@ -1,0 +1,203 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "graph_based_slam/map_quality_metrics.hpp"
+
+namespace
+{
+
+using graphslam::map_quality::MapQualityConfig;
+using graphslam::map_quality::MapQualityReport;
+
+std::vector<Eigen::Vector3d> makeNoisyFloor(double noise_sigma, int half_extent)
+{
+  // Deterministic grid floor on z=0 with fixed-seed gaussian z-noise.
+  std::mt19937 rng(12345);
+  std::normal_distribution<double> noise(0.0, noise_sigma);
+  std::vector<Eigen::Vector3d> points;
+  for (int x = -half_extent; x < half_extent; ++x) {
+    for (int y = -half_extent; y < half_extent; ++y) {
+      points.push_back(
+        Eigen::Vector3d(0.05 * x, 0.05 * y, noise(rng)));
+    }
+  }
+  return points;
+}
+
+std::vector<Eigen::Vector3d> makeVolumetricCloud(int count)
+{
+  std::mt19937 rng(6789);
+  std::uniform_real_distribution<double> uniform(-2.0, 2.0);
+  std::vector<Eigen::Vector3d> points;
+  points.reserve(count);
+  for (int i = 0; i < count; ++i) {
+    const double x = uniform(rng);
+    const double y = uniform(rng);
+    const double z = uniform(rng);
+    points.push_back(Eigen::Vector3d(x, y, z));
+  }
+  return points;
+}
+
+MapQualityConfig defaultConfig()
+{
+  MapQualityConfig config;
+  config.mme_radius = 0.5;
+  config.mme_min_neighbors = 8;
+  return config;
+}
+
+TEST(MapQualityMetrics, NoisyFloorIsMeaningfulAndThicknessTracksNoise) {
+  const auto points = makeNoisyFloor(0.01, 30);  // 3m x 3m, sigma 1cm
+  const MapQualityReport report =
+    graphslam::map_quality::computeMapQuality(points, defaultConfig());
+  EXPECT_TRUE(report.plane_metrics_meaningful);
+  EXPECT_GT(report.plane_patch_count, 0);
+  EXPECT_GT(report.planar_coverage, 0.9);
+  // The weighted thickness should track the injected sigma (loose band).
+  EXPECT_GT(report.plane_thickness_rms_mean_m, 0.004);
+  EXPECT_LT(report.plane_thickness_rms_mean_m, 0.02);
+  EXPECT_EQ(report.input_points, static_cast<std::int64_t>(points.size()));
+}
+
+TEST(MapQualityMetrics, VolumetricCloudIsNotMeaningful) {
+  const auto points = makeVolumetricCloud(4000);
+  const MapQualityReport report =
+    graphslam::map_quality::computeMapQuality(points, defaultConfig());
+  EXPECT_FALSE(report.plane_metrics_meaningful);
+  EXPECT_LT(report.planar_coverage, 0.10);
+}
+
+TEST(MapQualityMetrics, CrisperMapHasLowerEntropy) {
+  const auto crisp = makeNoisyFloor(0.005, 30);
+  const auto blurry = makeNoisyFloor(0.05, 30);
+  const auto config = defaultConfig();
+  const MapQualityReport crisp_report =
+    graphslam::map_quality::computeMapQuality(crisp, config);
+  const MapQualityReport blurry_report =
+    graphslam::map_quality::computeMapQuality(blurry, config);
+  EXPECT_GT(crisp_report.mme_valid_points, 0);
+  EXPECT_GT(blurry_report.mme_valid_points, 0);
+  EXPECT_LT(crisp_report.mean_map_entropy, blurry_report.mean_map_entropy);
+}
+
+TEST(MapQualityMetrics, MmeValidFractionReportsSupport) {
+  // A dense floor plus far isolated points: the isolated points must be
+  // excluded from the MME and visible in the valid fraction.
+  auto points = makeNoisyFloor(0.01, 20);
+  const size_t dense_count = points.size();
+  points.push_back(Eigen::Vector3d(100.0, 100.0, 100.0));
+  points.push_back(Eigen::Vector3d(-100.0, 50.0, -3.0));
+  const MapQualityReport report =
+    graphslam::map_quality::computeMapQuality(points, defaultConfig());
+  EXPECT_GT(report.mme_valid_points, 0);
+  EXPECT_LE(report.mme_valid_points, static_cast<std::int64_t>(dense_count));
+  EXPECT_LT(report.mme_valid_fraction, 1.0);
+}
+
+TEST(MapQualityMetrics, DownsampleCollapsesVoxelsToCentroids) {
+  std::vector<Eigen::Vector3d> points;
+  points.push_back(Eigen::Vector3d(0.1, 0.1, 0.1));
+  points.push_back(Eigen::Vector3d(0.3, 0.3, 0.3));   // same 0.5m voxel
+  points.push_back(Eigen::Vector3d(10.0, 10.0, 10.0));
+  const auto result = graphslam::map_quality::downsampleByVoxelCentroid(points, 0.5);
+  ASSERT_EQ(result.size(), 2u);
+  EXPECT_DOUBLE_EQ(result[0].x(), 0.2);
+  EXPECT_DOUBLE_EQ(result[0].y(), 0.2);
+  EXPECT_DOUBLE_EQ(result[0].z(), 0.2);
+}
+
+TEST(MapQualityMetrics, DownsampleOffReturnsInputUnchanged) {
+  const auto points = makeVolumetricCloud(50);
+  const auto result = graphslam::map_quality::downsampleByVoxelCentroid(points, 0.0);
+  ASSERT_EQ(result.size(), points.size());
+  for (size_t i = 0; i < points.size(); ++i) {
+    EXPECT_EQ(0, std::memcmp(points[i].data(), result[i].data(), 3 * sizeof(double)));
+  }
+}
+
+TEST(MapQualityMetrics, ReportBytesAreDeterministic) {
+  const auto points = makeNoisyFloor(0.01, 25);
+  const auto config = defaultConfig();
+  const MapQualityReport first =
+    graphslam::map_quality::computeMapQuality(points, config);
+  const MapQualityReport second =
+    graphslam::map_quality::computeMapQuality(points, config);
+  const auto first_lines = graphslam::map_quality::reportYamlLines(first, config);
+  const auto second_lines = graphslam::map_quality::reportYamlLines(second, config);
+  ASSERT_EQ(first_lines.size(), second_lines.size());
+  for (size_t i = 0; i < first_lines.size(); ++i) {
+    EXPECT_EQ(first_lines[i], second_lines[i]);
+  }
+  // Bitwise determinism on the raw doubles, not just the formatted text.
+  EXPECT_EQ(
+    0,
+    std::memcmp(&first.mean_map_entropy, &second.mean_map_entropy, sizeof(double)));
+  EXPECT_EQ(
+    0,
+    std::memcmp(
+      &first.plane_thickness_rms_mean_m, &second.plane_thickness_rms_mean_m,
+      sizeof(double)));
+}
+
+TEST(MapQualityMetrics, EmptyInputProducesZeroReport) {
+  const std::vector<Eigen::Vector3d> points;
+  const MapQualityReport report =
+    graphslam::map_quality::computeMapQuality(points, defaultConfig());
+  EXPECT_EQ(report.input_points, 0);
+  EXPECT_EQ(report.evaluated_points, 0);
+  EXPECT_FALSE(report.plane_metrics_meaningful);
+  const auto lines =
+    graphslam::map_quality::reportYamlLines(report, defaultConfig());
+  EXPECT_FALSE(lines.empty());
+}
+
+TEST(MapQualityMetrics, YamlHasFixedKeyOrderAndMeaningfulFlag) {
+  const auto points = makeNoisyFloor(0.01, 20);
+  const auto config = defaultConfig();
+  const MapQualityReport report =
+    graphslam::map_quality::computeMapQuality(points, config);
+  const auto lines = graphslam::map_quality::reportYamlLines(report, config);
+  ASSERT_FALSE(lines.empty());
+  EXPECT_EQ(lines[0], "map_quality_report:");
+  bool found_meaningful = false;
+  for (size_t i = 0; i < lines.size(); ++i) {
+    if (lines[i] == "    meaningful: true") {found_meaningful = true;}
+  }
+  EXPECT_TRUE(found_meaningful);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

v0.7 Phase 1 前半(`docs/roadmap/v0.7.md`): マップ品質メトリクスの計測機構。後半(ゲート基盤での baseline 計測 + release gate への report-only 配線 + メトリクス設定の凍結)は次 PR。

- **`adaptive_voxel_plane_extractor.hpp`** — Phase 1 メトリクスと Phase 2 平面 BA が共有する平面抽出器(clean-room、論文のみ参照: `docs/research/map-refinement-clean-room-design.md`)。root voxel 化 → PCA planarity による再帰 octree 分割 + quarter consistency test。決定論: ソート済み voxel key 走査・固定順 accumulation・法線符号正規化
- **`map_quality_metrics.hpp`** — Mean Map Entropy(voxel-hash 近傍 + 昇順 index accumulation)、平面厚 RMS(点数重み付き mean + p95)、planar coverage、密度統計、決定論的 voxel 重心 downsample。**アンチゲーミング設計**: 全メトリクスが support(valid fraction / coverage / patch 数)を併記、planarity coverage が floor 未満のシーンは数値ではなく明示の `meaningful: false`。YAML は固定フォーマット(バイト比較可能)
- **`map_quality_report` CLI** — PCD ファイル / ディレクトリ(ファイル名ソート順)→ `map_quality_report.yaml`。ROS なし・クロックなし・乱数なし
- 新規テスト 15 本(合成 wall/floor/曲面/体積雲、ビット決定論契約、support 報告、YAML バイト一致)

## Verification

- `colcon test --packages-select graph_based_slam`: **1073 tests, 0 failures**(lint 込み)
- CLI スモーク(実 NTU マップ 239,885 点): 2 run で **YAML バイト一致**。同マップは planar_coverage 0.6% で `meaningful: false` 判定 — not-meaningful 状態が現実データで正しく機能
- リリースゲートは未実行: 既存コード経路に変更なし(純追加 + CMake ターゲットのみ)。ゲート配線と baseline は次 PR で実施


