### PR TITLE
feat(quality): map-quality baseline + frozen metric profile + gate stage (v0.7 Phase 1 complete)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ python3 scripts/simple_lanelet2_generator.py \
 | `run_release_readiness_checks.sh` | リリースゲート（APE 閾値、`--offline-determinism-bag` / `--frontend-determinism-bag` で決定論ハードゲート）|
 | `run_offline_determinism_check.sh` | オフラインバックエンド決定論ゲート（N-run バイト一致 + 任意 APE レポート）|
 | `run_frontend_determinism_check.sh` | オフラインフロントエンド決定論ゲート（scanmatcher lockstep、N-run バイト一致）|
+| `run_map_quality_check.sh` | マップ品質メトリクス（MME/平面厚/coverage、N-run バイト一致。release gate の `--map-quality-pcd`）|
 | `run_rko_lio_graph_benchmark.sh` | ベンチマークパイプライン |
 | `run_autoware_quickstart.sh` | NTU VIRAL → Autoware マップ E2E |
 | `download_ntu_viral_tnp01.sh` | NTU VIRAL データダウンロード |

--- a/docs/research/map-quality-baseline.md
+++ b/docs/research/map-quality-baseline.md
@@ -1,0 +1,71 @@
+# Map-quality baseline (v0.7 Phase 1)
+
+Status: recorded 2026-06-12 on the pre-refinement (v0.6.0-era) maps of the
+five gate substrates. This table is the "before" side of every v0.7 Phase 2
+refinement claim: the refinement gate requires these numbers to improve
+without coverage loss (`docs/roadmap/v0.7.md`).
+
+## Frozen metric extraction profile
+
+The plane extraction profile used by the metrics is **frozen as the
+defaults of `graphslam::map_quality::MapQualityConfig`** as of this
+document. Phase 2 must not change it — the optimizer may not adjust its
+own judge. Values (calibrated below):
+
+| knob | value | rationale |
+|---|---|---|
+| `downsample` (CLI) | 0.10 m | bounds cost; matches the densest substrate leaf |
+| `mme_radius` | 0.50 m | standard MME neighborhood |
+| `mme_min_neighbors` | 8 | excludes isolated points from the entropy mean |
+| `plane: max_plane_thickness` | 0.15 m | must *measure* blurry walls, not exclude them — with the strict 0.06 m default the pre-refinement maps' walls (≈ 9 cm RMS) were invisible and improvement could never register |
+| `plane: min_planarity_ratio` | 4.0 | the binding gate in calibration; 6.0 rejected most real (blurred) planes, 3.0 admitted clutter (cs2 thickness mean jumped to 0.118 m) |
+| `plane: min_points_per_plane` | 10 | admits small wall segments at depth 3–4 |
+| `plane: max_octree_depth` | 4 | one level deeper than the BA-oriented default |
+| `plane: quarter test` | on (tol 2.0) | verified non-binding on all substrates — kept as a clutter guard |
+| `min_meaningful_planar_coverage` | 0.05 | all five substrates sit above it pre-refinement (min: 8.5%) |
+
+Calibration evidence (construction_seq2): with the strict defaults the
+thickness mean pinned at the 0.06 cap (only sneak-under patches accepted,
+coverage 0.2%); thickness sweep saturated at 0.15 (cap no longer binding);
+ratio 6→3 lifted coverage 1.9%→6.6% but degraded the measured population;
+the quarter test changed nothing (binding analysis, not taste).
+
+## Baseline table (pre-refinement maps, `--downsample 0.1`, frozen profile)
+
+| substrate | map | points | MME (nats) ↓ | MME valid | patches | thickness mean (m) ↓ | thickness p95 (m) ↓ | planar coverage ↑ | meaningful |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| construction_seq2 (blocking, APE 0.154) | `output/rtkslam_cs2_run2/map.pcd` | 808,844 | −0.567506873 | 0.905 | 3,595 | 0.091690906 | 0.132638198 | 0.085346600 | true |
+| construction_seq1 (blocking, APE 0.403) | `output/rtkslam_construction_seq1_run/map.pcd` | 946,462 | −0.581225185 | 0.901 | 4,350 | 0.087740857 | 0.131826050 | 0.084639694 | true |
+| stadtgarten_seq2 (report-only, APE 0.835) | `output/rtkslam_stadtgarten_seq2_v1nodd/map.pcd` | 1,037,016 | −0.720378721 | 0.798 | 6,003 | 0.094053898 | 0.134546999 | 0.120050453 | true |
+| stadtgarten_seq1 (report-only, APE 1.666) | `output/rtkslam_stadtgarten_seq1_nodd/map.pcd` | 2,195,507 | −0.773510128 | 0.838 | 16,270 | 0.091641271 | 0.133019576 | 0.163144624 | true |
+| NTU tnp_01 (blocking, APE ≤ 1.00) | `output/bench_ntu_event_driven_live/map.pcd` | 222,367 | −0.989917390 | 0.944 | 2,972 | 0.084936508 | 0.127683566 | 0.312951112 | true |
+
+Determinism: 3 consecutive CLI runs on construction_seq2 produced
+md5-identical `map_quality_report.yaml` (`63a9a9e96cfd…`); the run_* gate
+stage re-checks 3-run byte identity on every invocation.
+
+## Reading the numbers
+
+- **Walls are ≈ 9 cm thick RMS on every substrate.** That is the
+  pre-refinement reality this track exists to change; it also explains why
+  the strict (BA-grade) extraction profile saw almost nothing. The Phase 2
+  plane BA targets exactly this number (and planar coverage, which rises
+  as blurred geometry crosses the acceptance gates).
+- Coverage ordering (NTU 31% > outdoor 12–16% > indoor 8.5%) is **map
+  crispness, not scene structure** — the construction halls are the
+  cluttered, scaffolding-heavy scenes *and* the maps are blurry at the
+  1 m-voxel scale, so fewer voxels pass planarity. Expect indoor coverage
+  to move the most under refinement.
+- MME is not comparable across substrates (density and sensor differ); it
+  is a same-substrate before/after metric only. Lower = crisper.
+- The reproduction command for any row:
+  `map_quality_report --input <map.pcd> --output-dir <dir> --downsample 0.1`
+  (all other knobs are the frozen defaults).
+
+## Threshold outlook (for Phase 3, not enforced yet)
+
+Per-profile, baseline-relative: a refined map must not regress MME,
+thickness mean, or coverage on its own substrate beyond noise; blocking
+absolute thresholds are deferred until the Phase 2 deltas exist and a
+holdout sequence validates them (`docs/roadmap/v0.7.md` Phase 3,
+threshold hygiene).

--- a/docs/roadmap/v0.7.md
+++ b/docs/roadmap/v0.7.md
@@ -88,6 +88,9 @@ gradient/Hessian assembly, LM step) gets one.
   deprecation announced in v0.6.0.
 - **Gate**: package tests + full release gate (both determinism stages)
   green; upgrade note in docs.
+- **Status (2026-06-12)**: done — PR #265. Behavior preservation proven by
+  unchanged determinism md5s/APE on both gate stages and the 20th
+  consecutive bit-identical stadtgarten_seq2 raw 0.835.
 
 ### Phase 1 — map-quality metrics (measure before touching)
 - `map_quality_metrics.hpp` pure header + a `map_quality_report` CLI: Mean
@@ -109,6 +112,13 @@ gradient/Hessian assembly, LM step) gets one.
 - Wire into `run_release_readiness_checks.sh` as a **report-only** stage.
 - **Gate**: written baseline table; metric reports byte-identical across
   3 offline runs.
+- **Status (2026-06-12)**: done — metrics core + CLI in PR #266, baseline
+  + frozen profile + gate stage in the follow-up PR. Baseline:
+  `docs/research/map-quality-baseline.md` (all five substrates, frozen
+  extraction profile in `MapQualityConfig`, 3-run md5-identical reports,
+  `--map-quality-pcd` stage in the release gate). Headline finding: walls
+  are ~9 cm RMS thick on every pre-refinement substrate — the Phase 2
+  target number.
 
 ### Phase 2 — clean-room hierarchical refinement core (the centerpiece)
 - Implementation-ready design note (papers-only):

--- a/graph_based_slam/include/graph_based_slam/map_quality_metrics.hpp
+++ b/graph_based_slam/include/graph_based_slam/map_quality_metrics.hpp
@@ -70,11 +70,23 @@ struct MapQualityConfig
   // Optional deterministic voxel-centroid downsample applied before any
   // metric (0.0 = off). Keeps the metric cost bounded on dense maps.
   double downsample_voxel_size {0.0};
-  // Plane metrics share the Phase 2 extractor.
+  // Plane metrics share the Phase 2 extractor, but with the FROZEN
+  // metric extraction profile below (Phase 1 calibration on the five
+  // gate substrates, docs/research/map-quality-baseline.md). Changing
+  // these values invalidates every recorded baseline; Phase 2 tuning
+  // must not touch them (the optimizer may not adjust its own judge).
   plane_extraction::PlaneExtractionConfig plane_config;
   // Below this planar coverage the plane metrics are reported as
   // not meaningful (expected on vegetation-heavy outdoor maps).
-  double min_meaningful_planar_coverage {0.10};
+  double min_meaningful_planar_coverage {0.05};
+
+  MapQualityConfig()
+  {
+    plane_config.max_plane_thickness = 0.15;
+    plane_config.min_planarity_ratio = 4.0;
+    plane_config.min_points_per_plane = 10;
+    plane_config.max_octree_depth = 4;
+  }
 };
 
 struct MapQualityReport

--- a/graph_based_slam/src/map_quality_report_main.cpp
+++ b/graph_based_slam/src/map_quality_report_main.cpp
@@ -60,6 +60,12 @@ void printUsage()
     "  [--mme-radius <m>]            Mean Map Entropy neighborhood radius (default 0.5)\n"
     "  [--mme-min-neighbors <n>]     minimum neighbors for a valid MME point (default 8)\n"
     "  [--root-voxel-size <m>]       plane extractor root voxel size (default 1.0)\n"
+    "  [--max-plane-thickness <m>]   accept threshold on sqrt(lambda_min) (default 0.06)\n"
+    "  [--min-planarity-ratio <f>]   lambda_mid/lambda_min floor (default 6.0)\n"
+    "  [--min-points-per-plane <n>]  patch support floor (default 20)\n"
+    "  [--max-octree-depth <n>]      root voxel split depth (default 3)\n"
+    "  [--quarter-tolerance <f>]     quarter-test tolerance factor (default 2.0)\n"
+    "  [--no-quarter-test]           disable the quarter consistency test\n"
     "  [--min-meaningful-coverage <f>] planar coverage floor for meaningful plane metrics\n"
     "                                  (default 0.10)\n";
 }
@@ -103,6 +109,18 @@ int main(int argc, char ** argv)
       config.mme_min_neighbors = std::stoi(argv[++i]);
     } else if (arg == "--root-voxel-size" && has_value) {
       config.plane_config.root_voxel_size = std::stod(argv[++i]);
+    } else if (arg == "--max-plane-thickness" && has_value) {
+      config.plane_config.max_plane_thickness = std::stod(argv[++i]);
+    } else if (arg == "--min-planarity-ratio" && has_value) {
+      config.plane_config.min_planarity_ratio = std::stod(argv[++i]);
+    } else if (arg == "--min-points-per-plane" && has_value) {
+      config.plane_config.min_points_per_plane = std::stoi(argv[++i]);
+    } else if (arg == "--max-octree-depth" && has_value) {
+      config.plane_config.max_octree_depth = std::stoi(argv[++i]);
+    } else if (arg == "--quarter-tolerance" && has_value) {
+      config.plane_config.quarter_test_tolerance = std::stod(argv[++i]);
+    } else if (arg == "--no-quarter-test") {
+      config.plane_config.enable_quarter_test = false;
     } else if (arg == "--min-meaningful-coverage" && has_value) {
       config.min_meaningful_planar_coverage = std::stod(argv[++i]);
     } else {

--- a/scripts/run_map_quality_check.sh
+++ b/scripts/run_map_quality_check.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Map-quality report with an N-run byte-identity verdict
+# (v0.7 Phase 1, docs/roadmap/v0.7.md).
+#
+# Usage:
+#   bash scripts/run_map_quality_check.sh \
+#     --input output/rtkslam_cs2_run2/map.pcd \
+#     --output-dir output/map_quality_cs2 \
+#     [--runs 3] [--downsample 0.1]
+#
+# Metric VALUES are report-only (the thresholds come in Phase 3, with a
+# holdout); what this script *enforces* is determinism: every run must
+# produce byte-identical map_quality_report.yaml. The metric extraction
+# profile itself is frozen in MapQualityConfig
+# (docs/research/map-quality-baseline.md) and is deliberately not
+# exposed here.
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+INPUT=""
+OUTPUT_DIR=""
+RUNS=3
+DOWNSAMPLE=0.1
+
+usage() {
+  grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' >&2
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --input)
+      [[ $# -ge 2 ]] || usage
+      INPUT=$(realpath -m "$2")
+      shift 2
+      ;;
+    --output-dir)
+      [[ $# -ge 2 ]] || usage
+      OUTPUT_DIR=$(realpath -m "$2")
+      shift 2
+      ;;
+    --runs)
+      [[ $# -ge 2 ]] || usage
+      RUNS="$2"
+      shift 2
+      ;;
+    --downsample)
+      [[ $# -ge 2 ]] || usage
+      DOWNSAMPLE="$2"
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[ -z "${INPUT}" || -z "${OUTPUT_DIR}" ]]; then
+  echo "--input and --output-dir are required" >&2
+  exit 2
+fi
+if [[ ! -e "${INPUT}" ]]; then
+  echo "input not found: ${INPUT}" >&2
+  exit 2
+fi
+if [[ ! -f "${REPO_ROOT}/install/setup.bash" ]]; then
+  echo "install/setup.bash not found; build the workspace first" >&2
+  exit 2
+fi
+
+# shellcheck disable=SC1091
+set +u
+source "${REPO_ROOT}/install/setup.bash"
+set -u
+
+mkdir -p "${OUTPUT_DIR}"
+echo "input:      ${INPUT}"
+echo "runs:       ${RUNS}"
+echo "downsample: ${DOWNSAMPLE}"
+echo "out:        ${OUTPUT_DIR}"
+
+MD5S=()
+for ((r = 1; r <= RUNS; r++)); do
+  echo "--- run ${r}/${RUNS}"
+  RUN_DIR="${OUTPUT_DIR}/run${r}"
+  ros2 run graph_based_slam map_quality_report \
+    --input "${INPUT}" \
+    --output-dir "${RUN_DIR}" \
+    --downsample "${DOWNSAMPLE}" \
+    > "${OUTPUT_DIR}/run${r}.log" 2>&1
+  md5sum "${RUN_DIR}/map_quality_report.yaml"
+  MD5S+=("$(md5sum "${RUN_DIR}/map_quality_report.yaml" | cut -d' ' -f1)")
+done
+
+IDENTICAL=true
+for md5 in "${MD5S[@]}"; do
+  if [[ "${md5}" != "${MD5S[0]}" ]]; then
+    IDENTICAL=false
+  fi
+done
+
+SUMMARY="${OUTPUT_DIR}/map_quality_summary.md"
+{
+  echo "# Map-quality check"
+  echo
+  echo "- input: \`${INPUT}\`"
+  echo "- runs: ${RUNS}, downsample: ${DOWNSAMPLE} m"
+  echo "- reports_identical: ${IDENTICAL}"
+  echo "- report_md5: \`${MD5S[0]}\`"
+  echo
+  echo '```yaml'
+  cat "${OUTPUT_DIR}/run1/map_quality_report.yaml"
+  echo '```'
+} > "${SUMMARY}"
+
+echo "--- verdict"
+cat "${OUTPUT_DIR}/run1/map_quality_report.yaml"
+if [[ "${IDENTICAL}" == "true" ]]; then
+  echo "MAP_QUALITY_OK: ${RUNS} runs produced byte-identical map_quality_report.yaml"
+else
+  echo "MAP_QUALITY_FAILED: reports differ across runs" >&2
+  exit 1
+fi

--- a/scripts/run_release_readiness_checks.sh
+++ b/scripts/run_release_readiness_checks.sh
@@ -51,6 +51,14 @@ Options:
   --offline-determinism-reference-tum <tum>
                                 Optional reference trajectory; adds per-run APE
                                 to the determinism report (report only)
+  --map-quality-pcd <path>      Run the map-quality metrics stage (v0.7
+                                Phase 1, docs/roadmap/v0.7.md) on this map
+                                PCD file or pointcloud_map directory.
+                                Repeatable. Metric values are report-only,
+                                but a byte-level mismatch across the 3 runs
+                                fails the gate (determinism enforcement)
+  --map-quality-downsample <m>  Downsample for the map-quality stage
+                                (default: 0.1)
   --frontend-determinism-bag <dir>
                                 Run the offline frontend determinism hard gate
                                 (Phase 4, docs/roadmap/v0.6.md) on this raw
@@ -129,6 +137,8 @@ OFFLINE_DETERMINISM_BAG=""
 OFFLINE_DETERMINISM_RUNS=""
 OFFLINE_DETERMINISM_PARAMS=""
 OFFLINE_DETERMINISM_REFERENCE_TUM=""
+MAP_QUALITY_PCDS=()
+MAP_QUALITY_DOWNSAMPLE=""
 FRONTEND_DETERMINISM_BAG=""
 FRONTEND_DETERMINISM_CLOUD_TOPIC=""
 FRONTEND_DETERMINISM_IMU_TOPIC=""
@@ -253,6 +263,16 @@ while [[ $# -gt 0 ]]; do
     --offline-determinism-reference-tum)
       [[ $# -ge 2 ]] || usage
       OFFLINE_DETERMINISM_REFERENCE_TUM=$(realpath -m "$2")
+      shift 2
+      ;;
+    --map-quality-pcd)
+      [[ $# -ge 2 ]] || usage
+      MAP_QUALITY_PCDS+=("$(realpath -m "$2")")
+      shift 2
+      ;;
+    --map-quality-downsample)
+      [[ $# -ge 2 ]] || usage
+      MAP_QUALITY_DOWNSAMPLE="$2"
       shift 2
       ;;
     --frontend-determinism-bag)
@@ -489,6 +509,25 @@ if [[ "${RUN_DOGFOOD}" == "true" ]]; then
     DOGFOOD_CMD+=(--auto-exit-secs "${AUTO_EXIT_SECS}")
   fi
   "${DOGFOOD_CMD[@]}" 2>&1 | tee "${OUT_DIR}/dogfood.log"
+fi
+
+if [[ ${#MAP_QUALITY_PCDS[@]} -gt 0 ]]; then
+  echo "==> Running map-quality metrics stage (report-only values, 3-run byte identity)"
+  MAP_QUALITY_INDEX=0
+  for MAP_QUALITY_PCD in "${MAP_QUALITY_PCDS[@]}"; do
+    MAP_QUALITY_INDEX=$((MAP_QUALITY_INDEX + 1))
+    MAP_QUALITY_NAME=$(basename "$(dirname "${MAP_QUALITY_PCD}")")_$(basename "${MAP_QUALITY_PCD%.*}")
+    MAP_QUALITY_CMD=(
+      bash
+      "${REPO_ROOT}/scripts/run_map_quality_check.sh"
+      --input "${MAP_QUALITY_PCD}"
+      --output-dir "${OUT_DIR}/map_quality/${MAP_QUALITY_INDEX}_${MAP_QUALITY_NAME}"
+    )
+    if [[ -n "${MAP_QUALITY_DOWNSAMPLE}" ]]; then
+      MAP_QUALITY_CMD+=(--downsample "${MAP_QUALITY_DOWNSAMPLE}")
+    fi
+    "${MAP_QUALITY_CMD[@]}" 2>&1 | tee -a "${OUT_DIR}/map_quality.log"
+  done
 fi
 
 echo "==> Release readiness checks completed"


### PR DESCRIPTION
## Summary

v0.7 Phase 1 後半 = **Phase 1 完了**(`docs/roadmap/v0.7.md`): baseline 計測 + メトリクス設定の凍結 + release gate 配線。

- **メトリクス抽出プロファイルを較正して凍結**(`MapQualityConfig` のデフォルト: thickness 0.15 / planarity ratio 4.0 / min points 10 / depth 4 / coverage floor 0.05)。較正は実基盤マップでの**拘束条件分析**(どのゲートが coverage を律速しているかの切り分け): BA 級の厳格デフォルトでは thickness が 0.06 cap に張り付き、リファインメントが直すべき blur が**測定不能**だった。Phase 2 の optimizer 作業前に凍結 = 自分の審判を調整できない(roadmap のアンチゲーミング要件)
- **`docs/research/map-quality-baseline.md`** — 全 5 ゲート基盤の pre-refinement baseline。ヘッドライン: **どの基盤でも壁厚 ~9cm RMS**(indoor coverage 8.5% / NTU 31%)= Phase 2 の「before」数値。較正根拠・再現コマンド・Phase 3 閾値方針込み
- **`scripts/run_map_quality_check.sh`** + release gate ステージ `--map-quality-pcd`(複数指定可)/ `--map-quality-downsample` — メトリクス値は report-only、ただし **3-run バイト不一致はゲート FAIL**(決定論の強制)
- CLI に較正スイープ用の抽出器ノブを追加(`--max-plane-thickness` 等 6 個)
- roadmap に Phase 0/1 の Status 追記、CLAUDE.md スクリプト表更新

## Verification

- `colcon test --packages-select graph_based_slam`: **1073 tests, 0 failures**
- 3-run md5 一致: construction_seq2 単体 + 配線済みステージ経由(NTU マップ)で `MAP_QUALITY_OK`
- `python3 -m mkdocs build --strict`: pass
- 既存 SLAM 経路に変更なし(メトリクスは独立した後処理計測)

## Phase 1 ゲート判定

- ✅ baseline 表が docs/research/ に存在
- ✅ メトリクスレポートが 3-run バイト一致
- ✅ report-only ステージが release gate に配線済み
- ✅ 設定凍結(Phase 2 開始前)
