### PR TITLE
feat(refine): SE(3) Lie utilities + point-cluster coordinates (v0.7 Phase 2 math foundations)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -251,6 +251,20 @@ if(BUILD_TESTING)
     )
   endif()
   ament_add_gtest(
+    test_se3_lie
+    test/test_se3_lie.cpp
+  )
+  if(TARGET test_se3_lie)
+    target_include_directories(test_se3_lie PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  endif()
+  ament_add_gtest(
+    test_point_cluster
+    test/test_point_cluster.cpp
+  )
+  if(TARGET test_point_cluster)
+    target_include_directories(test_point_cluster PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  endif()
+  ament_add_gtest(
     test_adaptive_voxel_plane_extractor
     test/test_adaptive_voxel_plane_extractor.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/point_cluster.hpp
+++ b/graph_based_slam/include/graph_based_slam/point_cluster.hpp
@@ -1,0 +1,165 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__POINT_CLUSTER_HPP_
+#define GRAPH_BASED_SLAM__POINT_CLUSTER_HPP_
+
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Eigenvalues>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/se3_lie.hpp"
+
+namespace graphslam
+{
+namespace map_refinement
+{
+
+/**
+ * @brief Homogeneous point-cluster coordinates for the plane BA.
+ *
+ * Encodes all raw points of one (feature, pose) pair as a symmetric 4x4
+ * matrix so cost, gradient, and Hessian work over observing poses instead of
+ * raw points. The eliminated plane cost is E_f = lambda_min(scatter), where
+ * scatter is the unnormalized centroid scatter matrix.
+ */
+struct PointCluster
+{
+  Eigen::Matrix4d h {Eigen::Matrix4d::Zero()};  // sum [x;1][x;1]^T
+  std::int64_t count {0};
+
+  void add(const Eigen::Vector3d & p)
+  {
+    Eigen::Vector4d homogeneous;
+    homogeneous << p, 1.0;
+    h += homogeneous * homogeneous.transpose();
+    ++count;
+  }
+
+  void merge(const PointCluster & other)
+  {
+    h += other.h;
+    count += other.count;
+  }
+
+  PointCluster transformed(const Eigen::Matrix4d & pose) const
+  {
+    PointCluster result;
+    result.h = pose * h * pose.transpose();
+    result.count = count;
+    return result;
+  }
+
+  Eigen::Matrix3d q() const
+  {
+    return h.topLeftCorner<3, 3>();
+  }
+
+  Eigen::Vector3d s() const
+  {
+    return h.topRightCorner<3, 1>();
+  }
+
+  double n() const
+  {
+    return h(3, 3);
+  }
+
+  Eigen::Vector3d centroid() const
+  {
+    assert(n() > 0.0);
+    return s() / n();
+  }
+
+  Eigen::Matrix3d scatter() const
+  {
+    assert(n() > 0.0);
+    const Eigen::Vector3d sum = s();
+    return q() - (sum * sum.transpose()) / n();
+  }
+
+  Eigen::Matrix3d covariance() const
+  {
+    assert(n() > 0.0);
+    return scatter() / n();
+  }
+};
+
+/**
+ * @brief Returns lambda_min(scatter), not lambda_min(covariance).
+ *
+ * The v0.7 design keeps the raw scatter form internally; normalized robust
+ * loss layers divide by n separately.
+ */
+inline double minEigenvalueOfScatter(const PointCluster & cluster)
+{
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(cluster.scatter());
+  assert(solver.info() == Eigen::Success);
+  return solver.eigenvalues()(0);
+}
+
+inline PointCluster makeCluster(const std::vector<Eigen::Vector3d> & points)
+{
+  PointCluster cluster;
+  for (std::size_t i = 0; i < points.size(); ++i) {
+    cluster.add(points[i]);
+  }
+  return cluster;
+}
+
+inline Eigen::Matrix4d clusterFirstDerivative(
+  const Eigen::Matrix4d & h,
+  int r)
+{
+  const Eigen::Matrix4d & g_r = generator(r);
+  return g_r * h + h * g_r.transpose();
+}
+
+inline Eigen::Matrix4d clusterSecondDerivative(
+  const Eigen::Matrix4d & h,
+  int r,
+  int s)
+{
+  const int first = r <= s ? r : s;
+  const int second = r <= s ? s : r;
+  const Eigen::Matrix4d & g_r = generator(first);
+  const Eigen::Matrix4d & g_s = generator(second);
+  const Eigen::Matrix4d p_rs = 0.5 * (g_r * g_s + g_s * g_r);
+
+  return p_rs * h + h * p_rs.transpose() +
+         g_r * h * g_s.transpose() + g_s * h * g_r.transpose();
+}
+
+}  // namespace map_refinement
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__POINT_CLUSTER_HPP_

--- a/graph_based_slam/include/graph_based_slam/se3_lie.hpp
+++ b/graph_based_slam/include/graph_based_slam/se3_lie.hpp
@@ -1,0 +1,209 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__SE3_LIE_HPP_
+#define GRAPH_BASED_SLAM__SE3_LIE_HPP_
+
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+
+namespace graphslam
+{
+namespace map_refinement
+{
+
+using Vector6d = Eigen::Matrix<double, 6, 1>;
+
+/**
+ * @brief SE(3) utilities for the v0.7 plane BA.
+ *
+ * Math foundation for docs/roadmap/v0.7.md Phase 2 and
+ * docs/research/map-refinement-clean-room-design.md. Twists use the order
+ * [translation, rotation]. Pose increments are left perturbations:
+ * T(delta) = Exp(delta) * T.
+ */
+namespace detail
+{
+
+constexpr double kSmallAngle = 1.0e-9;
+
+inline Eigen::Vector3d vee(const Eigen::Matrix3d & matrix)
+{
+  Eigen::Vector3d vector;
+  vector << matrix(2, 1), matrix(0, 2), matrix(1, 0);
+  return vector;
+}
+
+}  // namespace detail
+
+inline Eigen::Matrix3d skew(const Eigen::Vector3d & vector)
+{
+  Eigen::Matrix3d matrix;
+  matrix << 0.0, -vector.z(), vector.y(),
+    vector.z(), 0.0, -vector.x(),
+    -vector.y(), vector.x(), 0.0;
+  return matrix;
+}
+
+namespace detail
+{
+
+inline std::array<Eigen::Matrix4d, 6> makeGenerators()
+{
+  std::array<Eigen::Matrix4d, 6> generators;
+  for (std::size_t i = 0; i < generators.size(); ++i) {
+    generators[i].setZero();
+  }
+
+  generators[0](0, 3) = 1.0;
+  generators[1](1, 3) = 1.0;
+  generators[2](2, 3) = 1.0;
+
+  generators[3].topLeftCorner<3, 3>() = skew(Eigen::Vector3d::UnitX());
+  generators[4].topLeftCorner<3, 3>() = skew(Eigen::Vector3d::UnitY());
+  generators[5].topLeftCorner<3, 3>() = skew(Eigen::Vector3d::UnitZ());
+
+  return generators;
+}
+
+}  // namespace detail
+
+inline Eigen::Matrix4d expSe3(const Vector6d & twist)
+{
+  const Eigen::Vector3d rho = twist.head<3>();
+  const Eigen::Vector3d phi = twist.tail<3>();
+  const double theta_squared = phi.squaredNorm();
+  const double theta = std::sqrt(theta_squared);
+
+  const Eigen::Matrix3d phi_hat = skew(phi);
+  const Eigen::Matrix3d phi_hat_squared = phi_hat * phi_hat;
+
+  double a = 0.0;
+  double b = 0.0;
+  double c = 0.0;
+
+  if (theta < detail::kSmallAngle) {
+    const double theta_fourth = theta_squared * theta_squared;
+    a = 1.0 - theta_squared / 6.0 + theta_fourth / 120.0;
+    b = 0.5 - theta_squared / 24.0 + theta_fourth / 720.0;
+    c = 1.0 / 6.0 - theta_squared / 120.0 + theta_fourth / 5040.0;
+  } else {
+    a = std::sin(theta) / theta;
+    b = (1.0 - std::cos(theta)) / theta_squared;
+    c = (theta - std::sin(theta)) / (theta_squared * theta);
+  }
+
+  const Eigen::Matrix3d identity3 = Eigen::Matrix3d::Identity();
+  const Eigen::Matrix3d rotation =
+    identity3 + a * phi_hat + b * phi_hat_squared;
+  const Eigen::Matrix3d v_matrix =
+    identity3 + b * phi_hat + c * phi_hat_squared;
+
+  Eigen::Matrix4d transform = Eigen::Matrix4d::Identity();
+  transform.topLeftCorner<3, 3>() = rotation;
+  transform.topRightCorner<3, 1>() = v_matrix * rho;
+  return transform;
+}
+
+inline Vector6d logSe3(const Eigen::Matrix4d & transform)
+{
+  const Eigen::Matrix3d rotation = transform.topLeftCorner<3, 3>();
+  const Eigen::Vector3d translation = transform.topRightCorner<3, 1>();
+
+  double cos_theta = 0.5 * (rotation.trace() - 1.0);
+  if (cos_theta > 1.0) {
+    cos_theta = 1.0;
+  } else if (cos_theta < -1.0) {
+    cos_theta = -1.0;
+  }
+
+  const double theta = std::acos(cos_theta);
+
+  Eigen::Matrix3d phi_hat_from_rotation;
+  if (theta < detail::kSmallAngle) {
+    phi_hat_from_rotation = 0.5 * (rotation - rotation.transpose());
+  } else {
+    const double sin_theta = std::sin(theta);
+    phi_hat_from_rotation =
+      (theta / (2.0 * sin_theta)) * (rotation - rotation.transpose());
+  }
+
+  const Eigen::Vector3d phi = detail::vee(phi_hat_from_rotation);
+  const Eigen::Matrix3d phi_hat = skew(phi);
+  const Eigen::Matrix3d phi_hat_squared = phi_hat * phi_hat;
+  const double phi_theta_squared = phi.squaredNorm();
+  const double phi_theta = std::sqrt(phi_theta_squared);
+
+  Eigen::Matrix3d v_inverse;
+  if (phi_theta < detail::kSmallAngle) {
+    v_inverse = Eigen::Matrix3d::Identity() - 0.5 * phi_hat +
+      (1.0 / 12.0) * phi_hat_squared;
+  } else {
+    const double coefficient =
+      (1.0 / phi_theta_squared) -
+      ((1.0 + std::cos(phi_theta)) /
+      (2.0 * phi_theta * std::sin(phi_theta)));
+    v_inverse = Eigen::Matrix3d::Identity() - 0.5 * phi_hat +
+      coefficient * phi_hat_squared;
+  }
+
+  Vector6d twist;
+  twist.head<3>() = v_inverse * translation;
+  twist.tail<3>() = phi;
+  return twist;
+}
+
+inline const Eigen::Matrix4d & generator(int r)
+{
+  static const std::array<Eigen::Matrix4d, 6> generators =
+    detail::makeGenerators();
+
+  assert(r >= 0);
+  assert(r < static_cast<int>(generators.size()));
+
+  return generators[static_cast<std::size_t>(r)];
+}
+
+inline Eigen::Matrix4d leftPerturb(
+  const Vector6d & delta,
+  const Eigen::Matrix4d & pose)
+{
+  return expSe3(delta) * pose;
+}
+
+}  // namespace map_refinement
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__SE3_LIE_HPP_

--- a/graph_based_slam/test/test_point_cluster.cpp
+++ b/graph_based_slam/test/test_point_cluster.cpp
@@ -156,7 +156,8 @@ TEST(PointClusterTest, MinEigenvalueOfCoplanarScatterIsNearZero)
   std::vector<Eigen::Vector3d> points;
   for (int x = -3; x <= 3; ++x) {
     for (int y = -2; y <= 2; ++y) {
-      points.push_back(Eigen::Vector3d(
+      points.push_back(
+        Eigen::Vector3d(
           static_cast<double>(x),
           static_cast<double>(y),
           0.0));
@@ -176,7 +177,8 @@ TEST(PointClusterTest, MinEigenvalueOfNoisyPlaneMatchesExpectedScatter)
   std::vector<Eigen::Vector3d> points;
   for (int x = 0; x < 25; ++x) {
     for (int y = 0; y < 25; ++y) {
-      points.push_back(Eigen::Vector3d(
+      points.push_back(
+        Eigen::Vector3d(
           0.2 * static_cast<double>(x - 12),
           0.15 * static_cast<double>(y - 12),
           noise(rng)));

--- a/graph_based_slam/test/test_point_cluster.cpp
+++ b/graph_based_slam/test/test_point_cluster.cpp
@@ -1,0 +1,268 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "graph_based_slam/point_cluster.hpp"
+
+namespace
+{
+
+using graphslam::map_refinement::PointCluster;
+using graphslam::map_refinement::Vector6d;
+using graphslam::map_refinement::clusterFirstDerivative;
+using graphslam::map_refinement::clusterSecondDerivative;
+using graphslam::map_refinement::expSe3;
+using graphslam::map_refinement::makeCluster;
+using graphslam::map_refinement::minEigenvalueOfScatter;
+
+std::vector<Eigen::Vector3d> fixedPoints()
+{
+  std::vector<Eigen::Vector3d> points;
+  points.push_back(Eigen::Vector3d(-1.0, 0.0, 0.25));
+  points.push_back(Eigen::Vector3d(-0.3, 0.8, -0.4));
+  points.push_back(Eigen::Vector3d(0.2, -0.7, 0.9));
+  points.push_back(Eigen::Vector3d(1.4, 0.5, -0.2));
+  points.push_back(Eigen::Vector3d(0.6, 1.1, 0.3));
+  points.push_back(Eigen::Vector3d(-0.8, -1.2, -0.6));
+  points.push_back(Eigen::Vector3d(1.1, -0.4, 0.7));
+  return points;
+}
+
+Eigen::Matrix4d testPose()
+{
+  Vector6d twist = Vector6d::Zero();
+  twist << 0.7, -1.2, 0.4, 0.3, -0.2, 0.5;
+  return expSe3(twist);
+}
+
+bool matrix4BitwiseEqual(
+  const Eigen::Matrix4d & lhs,
+  const Eigen::Matrix4d & rhs)
+{
+  return std::memcmp(lhs.data(), rhs.data(), 16U * sizeof(double)) == 0;
+}
+
+void expectMatrix4Near(
+  const Eigen::Matrix4d & actual,
+  const Eigen::Matrix4d & expected,
+  double tolerance)
+{
+  for (int row = 0; row < 4; ++row) {
+    for (int col = 0; col < 4; ++col) {
+      EXPECT_NEAR(actual(row, col), expected(row, col), tolerance);
+    }
+  }
+}
+
+void expectMatrix3Near(
+  const Eigen::Matrix3d & actual,
+  const Eigen::Matrix3d & expected,
+  double tolerance)
+{
+  for (int row = 0; row < 3; ++row) {
+    for (int col = 0; col < 3; ++col) {
+      EXPECT_NEAR(actual(row, col), expected(row, col), tolerance);
+    }
+  }
+}
+
+void expectVector3Near(
+  const Eigen::Vector3d & actual,
+  const Eigen::Vector3d & expected,
+  double tolerance)
+{
+  for (int row = 0; row < 3; ++row) {
+    EXPECT_NEAR(actual(row), expected(row), tolerance);
+  }
+}
+
+}  // namespace
+
+TEST(PointClusterTest, TransformedClusterMatchesExplicitTransformedPoints)
+{
+  const std::vector<Eigen::Vector3d> points = fixedPoints();
+  const Eigen::Matrix4d pose = testPose();
+
+  const PointCluster local_cluster = makeCluster(points);
+  const PointCluster transformed_cluster = local_cluster.transformed(pose);
+
+  std::vector<Eigen::Vector3d> transformed_points;
+  for (std::size_t i = 0; i < points.size(); ++i) {
+    Eigen::Vector4d homogeneous;
+    homogeneous << points[i], 1.0;
+    transformed_points.push_back((pose * homogeneous).head<3>());
+  }
+
+  const PointCluster explicit_cluster = makeCluster(transformed_points);
+  expectMatrix4Near(transformed_cluster.h, explicit_cluster.h, 1.0e-9);
+  EXPECT_EQ(transformed_cluster.count, explicit_cluster.count);
+}
+
+TEST(PointClusterTest, ScatterAndCentroidMatchTwoPassComputation)
+{
+  const std::vector<Eigen::Vector3d> points = fixedPoints();
+  const PointCluster cluster = makeCluster(points);
+
+  Eigen::Vector3d centroid = Eigen::Vector3d::Zero();
+  for (std::size_t i = 0; i < points.size(); ++i) {
+    centroid += points[i];
+  }
+  centroid /= static_cast<double>(points.size());
+
+  Eigen::Matrix3d scatter = Eigen::Matrix3d::Zero();
+  for (std::size_t i = 0; i < points.size(); ++i) {
+    const Eigen::Vector3d offset = points[i] - centroid;
+    scatter += offset * offset.transpose();
+  }
+
+  expectVector3Near(cluster.centroid(), centroid, 1.0e-12);
+  expectMatrix3Near(cluster.scatter(), scatter, 1.0e-12);
+}
+
+TEST(PointClusterTest, MinEigenvalueOfCoplanarScatterIsNearZero)
+{
+  std::vector<Eigen::Vector3d> points;
+  for (int x = -3; x <= 3; ++x) {
+    for (int y = -2; y <= 2; ++y) {
+      points.push_back(Eigen::Vector3d(
+          static_cast<double>(x),
+          static_cast<double>(y),
+          0.0));
+    }
+  }
+
+  const PointCluster cluster = makeCluster(points);
+  EXPECT_LT(minEigenvalueOfScatter(cluster), 1.0e-18);
+}
+
+TEST(PointClusterTest, MinEigenvalueOfNoisyPlaneMatchesExpectedScatter)
+{
+  const double sigma = 0.01;
+  std::mt19937 rng(12345U);
+  std::normal_distribution<double> noise(0.0, sigma);
+
+  std::vector<Eigen::Vector3d> points;
+  for (int x = 0; x < 25; ++x) {
+    for (int y = 0; y < 25; ++y) {
+      points.push_back(Eigen::Vector3d(
+          0.2 * static_cast<double>(x - 12),
+          0.15 * static_cast<double>(y - 12),
+          noise(rng)));
+    }
+  }
+
+  const PointCluster cluster = makeCluster(points);
+  const double expected = static_cast<double>(points.size()) * sigma * sigma;
+  EXPECT_NEAR(minEigenvalueOfScatter(cluster), expected, 0.3 * expected);
+}
+
+TEST(PointClusterTest, MergeMatchesConcatenatedPointList)
+{
+  const std::vector<Eigen::Vector3d> points = fixedPoints();
+
+  std::vector<Eigen::Vector3d> first_half;
+  std::vector<Eigen::Vector3d> second_half;
+  for (std::size_t i = 0; i < points.size(); ++i) {
+    if (i < points.size() / 2U) {
+      first_half.push_back(points[i]);
+    } else {
+      second_half.push_back(points[i]);
+    }
+  }
+
+  PointCluster merged = makeCluster(first_half);
+  merged.merge(makeCluster(second_half));
+
+  const PointCluster concatenated = makeCluster(points);
+  expectMatrix4Near(merged.h, concatenated.h, 1.0e-12);
+  EXPECT_EQ(merged.count, static_cast<std::int64_t>(points.size()));
+}
+
+TEST(PointClusterTest, FirstDerivativeMatchesCentralFiniteDifference)
+{
+  const std::vector<Eigen::Vector3d> points = fixedPoints();
+  const PointCluster local_cluster = makeCluster(points);
+  const Eigen::Matrix4d pose = testPose();
+  const Eigen::Matrix4d current_h = local_cluster.transformed(pose).h;
+  const double step = 1.0e-7;
+
+  for (int r = 0; r < 6; ++r) {
+    Vector6d delta = Vector6d::Zero();
+    delta(r) = step;
+
+    const Eigen::Matrix4d plus =
+      local_cluster.transformed(expSe3(delta) * pose).h;
+    const Eigen::Matrix4d minus =
+      local_cluster.transformed(expSe3(-delta) * pose).h;
+    const Eigen::Matrix4d finite_difference = (plus - minus) / (2.0 * step);
+    const Eigen::Matrix4d analytic = clusterFirstDerivative(current_h, r);
+
+    for (int row = 0; row < 4; ++row) {
+      for (int col = 0; col < 4; ++col) {
+        double scale = std::fabs(analytic(row, col));
+        if (scale < 1.0) {
+          scale = 1.0;
+        }
+        EXPECT_NEAR(
+          finite_difference(row, col), analytic(row, col), 1.0e-5 * scale);
+      }
+    }
+  }
+}
+
+TEST(PointClusterTest, SecondDerivativeIsSymmetricBitwise)
+{
+  const PointCluster cluster = makeCluster(fixedPoints());
+  const Eigen::Matrix4d h = cluster.transformed(testPose()).h;
+
+  for (int r = 0; r < 6; ++r) {
+    for (int s = 0; s < 6; ++s) {
+      const Eigen::Matrix4d first = clusterSecondDerivative(h, r, s);
+      const Eigen::Matrix4d second = clusterSecondDerivative(h, s, r);
+      EXPECT_TRUE(matrix4BitwiseEqual(first, second));
+    }
+  }
+}
+
+TEST(PointClusterTest, MakeClusterIsDeterministicBitwise)
+{
+  const std::vector<Eigen::Vector3d> points = fixedPoints();
+
+  const PointCluster first = makeCluster(points);
+  const PointCluster second = makeCluster(points);
+
+  EXPECT_TRUE(matrix4BitwiseEqual(first.h, second.h));
+  EXPECT_EQ(first.count, second.count);
+}

--- a/graph_based_slam/test/test_se3_lie.cpp
+++ b/graph_based_slam/test/test_se3_lie.cpp
@@ -1,0 +1,141 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+#include <cstring>
+
+#include "graph_based_slam/se3_lie.hpp"
+
+namespace
+{
+
+using graphslam::map_refinement::Vector6d;
+using graphslam::map_refinement::expSe3;
+using graphslam::map_refinement::generator;
+using graphslam::map_refinement::leftPerturb;
+using graphslam::map_refinement::logSe3;
+
+bool matrixBitwiseEqual(
+  const Eigen::Matrix4d & lhs,
+  const Eigen::Matrix4d & rhs)
+{
+  return std::memcmp(lhs.data(), rhs.data(), 16U * sizeof(double)) == 0;
+}
+
+void expectRoundTrip(const Vector6d & twist)
+{
+  const Vector6d round_trip = logSe3(expSe3(twist));
+  EXPECT_TRUE((round_trip.isApprox(twist, 1.0e-9)));
+}
+
+}  // namespace
+
+TEST(Se3LieTest, ExpLogRoundTripForFixedTwists)
+{
+  Vector6d zero = Vector6d::Zero();
+  expectRoundTrip(zero);
+
+  Vector6d pure_translation = Vector6d::Zero();
+  pure_translation << 1.25, -0.5, 2.0, 0.0, 0.0, 0.0;
+  expectRoundTrip(pure_translation);
+
+  Vector6d small_rotation = Vector6d::Zero();
+  small_rotation << 0.2, -0.1, 0.05, 1.0e-10, -2.0e-10, 3.0e-10;
+  expectRoundTrip(small_rotation);
+
+  Vector6d large_rotation = Vector6d::Zero();
+  large_rotation << -0.3, 0.8, 1.2, 1.9, -1.1, 0.7;
+  expectRoundTrip(large_rotation);
+}
+
+TEST(Se3LieTest, ExpOfZeroIsExactlyIdentity)
+{
+  const Eigen::Matrix4d actual = expSe3(Vector6d::Zero());
+  const Eigen::Matrix4d expected = Eigen::Matrix4d::Identity();
+
+  EXPECT_TRUE(matrixBitwiseEqual(actual, expected));
+}
+
+TEST(Se3LieTest, GeneratorMatchesFiniteDifferenceAtIdentity)
+{
+  const double step = 1.0e-7;
+
+  for (int r = 0; r < 6; ++r) {
+    Vector6d delta = Vector6d::Zero();
+    delta(r) = step;
+
+    const Eigen::Matrix4d finite_difference =
+      (expSe3(delta) - expSe3(-delta)) / (2.0 * step);
+    const Eigen::Matrix4d & analytic = generator(r);
+
+    for (int row = 0; row < 4; ++row) {
+      for (int col = 0; col < 4; ++col) {
+        EXPECT_NEAR(finite_difference(row, col), analytic(row, col), 1.0e-6);
+      }
+    }
+  }
+}
+
+TEST(Se3LieTest, LeftPerturbMatchesExplicitCompositionBitwise)
+{
+  Vector6d pose_twist = Vector6d::Zero();
+  pose_twist << 1.0, -0.4, 0.7, 0.2, -0.3, 0.1;
+
+  Vector6d delta = Vector6d::Zero();
+  delta << 0.03, -0.02, 0.01, -0.04, 0.05, -0.02;
+
+  const Eigen::Matrix4d pose = expSe3(pose_twist);
+  const Eigen::Matrix4d actual = leftPerturb(delta, pose);
+  const Eigen::Matrix4d expected = expSe3(delta) * pose;
+
+  EXPECT_TRUE(matrixBitwiseEqual(actual, expected));
+}
+
+TEST(Se3LieTest, ExpRotationBlockIsOrthonormal)
+{
+  Vector6d twist = Vector6d::Zero();
+  twist << 0.5, -1.0, 0.25, 0.7, -0.4, 0.9;
+
+  const Eigen::Matrix3d rotation = expSe3(twist).topLeftCorner<3, 3>();
+  const Eigen::Matrix3d should_be_identity =
+    rotation.transpose() * rotation;
+
+  EXPECT_TRUE((should_be_identity.isApprox(Eigen::Matrix3d::Identity(), 1.0e-12)));
+}
+
+TEST(Se3LieTest, ExpIsDeterministicBitwise)
+{
+  Vector6d twist = Vector6d::Zero();
+  twist << -0.8, 0.6, 1.1, -0.2, 0.35, -0.45;
+
+  const Eigen::Matrix4d first = expSe3(twist);
+  const Eigen::Matrix4d second = expSe3(twist);
+
+  EXPECT_TRUE(matrixBitwiseEqual(first, second));
+}


### PR DESCRIPTION
## Summary

v0.7 Phase 2 第 1 弾(`docs/roadmap/v0.7.md`): 平面 BA の数学基盤層。clean-room(設計ノート `docs/research/map-refinement-clean-room-design.md` の BALM2 point-cluster 定式化のみ参照、GPL 実装は不参照)。

- **`se3_lie.hpp`** — SE(3) Exp/Log(twist 順序 [translation, rotation]、左摂動)、Lie 代数生成子 G_0..G_5(決定論的 static 初期化)、Rodrigues 閉形式 + 微小角級数フォールバック
- **`point_cluster.hpp`** — 同次 point-cluster 座標: (feature, pose) ペアの全生点を対称 4×4 行列 1 個に集約 → コスト/勾配/ヘッシアンが **O(points) ではなく O(poses)**。scatter/centroid/covariance 抽出、λ_min 平面コスト、次 PR の BA コスト層が使う 1 階・2 階クラスタ微分(G_r H + H G_rᵀ / 対称化 2 階形)
- テスト 14 本: Exp/Log 往復、生成子の有限差分検証、クラスタ変換 vs 明示変換点の等価、coplanar λ_min=0 / ノイズ平面 λ_min=nσ²、微分の有限差分一致、2 階微分の対称性、ビット決定論契約

## Verification

- `colcon test --packages-select graph_based_slam`: **1105 tests, 0 failures**(lint 込み)
- 純追加(既存コード経路に変更なし)

## 次 PR

`scatter_eigen_cost.hpp`(固有値コストの勾配/ヘッシアン組み立て)+ `ba_problem.hpp` / `lm_solver.hpp`(合成 GT 回復 + 退化フィクスチャがハードゲート)
