### PR TITLE
feat(refine): exact eigenvalue plane-cost gradient/Hessian in cluster coordinates (v0.7 Phase 2)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -265,6 +265,13 @@ if(BUILD_TESTING)
     target_include_directories(test_point_cluster PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_scatter_eigen_cost
+    test/test_scatter_eigen_cost.cpp
+  )
+  if(TARGET test_scatter_eigen_cost)
+    target_include_directories(test_scatter_eigen_cost PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  endif()
+  ament_add_gtest(
     test_adaptive_voxel_plane_extractor
     test/test_adaptive_voxel_plane_extractor.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/scatter_eigen_cost.hpp
+++ b/graph_based_slam/include/graph_based_slam/scatter_eigen_cost.hpp
@@ -341,10 +341,10 @@ inline PlaneCostResult evaluatePlaneCost(
       const double hessian_value =
         detail::quadraticForm(second_derivative, u0) +
         detail::eigenvectorCurvatureTerm(
-          row_derivative.a,
-          column_derivative.a,
-          eigenvectors,
-          eigenvalues);
+        row_derivative.a,
+        column_derivative.a,
+        eigenvectors,
+        eigenvalues);
 
       const int row = 6 * row_derivative.pose_index + row_derivative.axis;
       const int column = 6 * column_derivative.pose_index + column_derivative.axis;

--- a/graph_based_slam/include/graph_based_slam/scatter_eigen_cost.hpp
+++ b/graph_based_slam/include/graph_based_slam/scatter_eigen_cost.hpp
@@ -1,0 +1,362 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef GRAPH_BASED_SLAM__SCATTER_EIGEN_COST_HPP_
+#define GRAPH_BASED_SLAM__SCATTER_EIGEN_COST_HPP_
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Eigenvalues>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/point_cluster.hpp"
+#include "graph_based_slam/se3_lie.hpp"
+
+namespace graphslam
+{
+namespace map_refinement
+{
+
+struct PlaneFeatureObservation
+{
+  int pose_index {-1};            // index into the pose vector of the BA problem
+  PointCluster local_cluster;     // points of this feature in that pose's local frame
+};
+
+struct PlaneCostConfig
+{
+  double eigen_gap_min {1e-9};    // require mu_1 - mu_0 > this, else feature invalid
+  double min_total_points {6.0};  // require n >= this
+};
+
+struct PlaneCostResult
+{
+  bool valid {false};
+  double cost {0.0};                       // mu_0 of the combined scatter
+  double normalized_cost {0.0};            // mu_0 / n
+  Eigen::VectorXd gradient;                // size 6 * pose_count (the BA problem's full size)
+  Eigen::MatrixXd hessian;                 // (6 pc) x (6 pc), symmetric
+  Eigen::Vector3d normal {Eigen::Vector3d::Zero()};  // u_0, sign-canonicalized
+  double eigen_gap {0.0};
+};
+
+namespace detail
+{
+
+struct TransformedObservation
+{
+  int pose_index {-1};
+  Eigen::Matrix4d h {Eigen::Matrix4d::Zero()};
+};
+
+struct PlaneDerivativeCache
+{
+  int pose_index {-1};
+  int axis {0};
+  Eigen::Matrix3d a {Eigen::Matrix3d::Zero()};
+  Eigen::Vector3d s {Eigen::Vector3d::Zero()};
+};
+
+inline Eigen::Matrix3d extractQ(const Eigen::Matrix4d & h)
+{
+  return h.block<3, 3>(0, 0);
+}
+
+inline Eigen::Vector3d extractS(const Eigen::Matrix4d & h)
+{
+  return h.block<3, 1>(0, 3);
+}
+
+inline double extractN(const Eigen::Matrix4d & h)
+{
+  return h(3, 3);
+}
+
+inline Eigen::Matrix3d scatterMatrix(
+  const Eigen::Matrix3d & q,
+  const Eigen::Vector3d & s,
+  double n)
+{
+  return q - s * s.transpose() / n;
+}
+
+inline Eigen::Vector3d canonicalNormal(const Eigen::Matrix3d & eigenvectors)
+{
+  Eigen::Vector3d normal = eigenvectors.col(0);
+  int largest_index = 0;
+  double largest_abs = std::abs(normal(0));
+
+  for (int i = 1; i < 3; ++i) {
+    const double component_abs = std::abs(normal(i));
+    if (component_abs > largest_abs) {
+      largest_abs = component_abs;
+      largest_index = i;
+    }
+  }
+
+  if (normal(largest_index) < 0.0) {
+    normal = -normal;
+  }
+
+  return normal;
+}
+
+inline double quadraticForm(
+  const Eigen::Matrix3d & matrix,
+  const Eigen::Vector3d & vector)
+{
+  return vector.dot(matrix * vector);
+}
+
+inline Eigen::Matrix3d firstScatterDerivative(
+  const Eigen::Matrix4d & h_derivative,
+  const Eigen::Vector3d & s,
+  double n,
+  Eigen::Vector3d * s_derivative)
+{
+  const Eigen::Matrix3d q_derivative = extractQ(h_derivative);
+  *s_derivative = extractS(h_derivative);
+  return q_derivative -
+         (*s_derivative * s.transpose() + s * s_derivative->transpose()) / n;
+}
+
+inline Eigen::Matrix3d secondScatterDerivative(
+  const Eigen::Matrix4d & h_derivative,
+  const Eigen::Vector3d & s,
+  double n,
+  const Eigen::Vector3d & s_a,
+  const Eigen::Vector3d & s_b)
+{
+  const Eigen::Matrix3d q_derivative = extractQ(h_derivative);
+  const Eigen::Vector3d s_derivative = extractS(h_derivative);
+  return q_derivative -
+         (s_derivative * s.transpose() + s * s_derivative.transpose() +
+         s_a * s_b.transpose() + s_b * s_a.transpose()) / n;
+}
+
+inline Eigen::Matrix3d mixedPoseScatterDerivative(
+  const Eigen::Vector3d & s_a,
+  const Eigen::Vector3d & s_b,
+  double n)
+{
+  return -(s_a * s_b.transpose() + s_b * s_a.transpose()) / n;
+}
+
+inline double eigenvectorCurvatureTerm(
+  const Eigen::Matrix3d & a,
+  const Eigen::Matrix3d & b,
+  const Eigen::Matrix3d & eigenvectors,
+  const Eigen::Vector3d & eigenvalues)
+{
+  const Eigen::Vector3d u0 = eigenvectors.col(0);
+  double term = 0.0;
+
+  for (int m = 1; m < 3; ++m) {
+    const Eigen::Vector3d um = eigenvectors.col(m);
+    const double a_projection = um.dot(a * u0);
+    const double b_projection = um.dot(b * u0);
+    term += 2.0 * a_projection * b_projection / (eigenvalues(0) - eigenvalues(m));
+  }
+
+  return term;
+}
+
+}  // namespace detail
+
+/// Exact gradient/Hessian of the eliminated plane cost lambda_min(scatter) for
+/// one plane feature observed by multiple poses, in point-cluster coordinates.
+/// This is the v0.7 Phase 2 plane-BA cost layer described by
+/// docs/roadmap/v0.7.md and docs/research/map-refinement-clean-room-design.md.
+/// Accumulation is deterministic: combined clusters are summed in observation
+/// order, then derivatives are assembled in fixed ascending (pose, axis) order.
+/// No robust loss is applied here; rho(mu_0 / n) belongs to the problem layer.
+inline PlaneCostResult evaluatePlaneCost(
+  const std::vector<PlaneFeatureObservation> & observations,
+  const std::vector<Eigen::Matrix4d> & poses,
+  int pose_count,
+  const PlaneCostConfig & config)
+{
+  PlaneCostResult result;
+  const int safe_pose_count = std::max(0, pose_count);
+  const int variable_count = 6 * safe_pose_count;
+  result.gradient = Eigen::VectorXd::Zero(variable_count);
+  result.hessian = Eigen::MatrixXd::Zero(variable_count, variable_count);
+
+  if (pose_count < 0) {
+    return result;
+  }
+
+  Eigen::Matrix4d combined_h = Eigen::Matrix4d::Zero();
+  std::vector<detail::TransformedObservation> transformed_observations;
+  transformed_observations.reserve(observations.size());
+  std::vector<char> pose_observed(static_cast<std::size_t>(pose_count), 0);
+
+  for (std::size_t i = 0; i < observations.size(); ++i) {
+    const int pose_index = observations[i].pose_index;
+    if (pose_index < 0 || pose_index >= pose_count) {
+      return result;
+    }
+
+    const std::size_t pose_offset = static_cast<std::size_t>(pose_index);
+    if (pose_offset >= poses.size()) {
+      return result;
+    }
+
+    const PointCluster transformed_cluster =
+      observations[i].local_cluster.transformed(poses[pose_offset]);
+
+    detail::TransformedObservation transformed_observation;
+    transformed_observation.pose_index = pose_index;
+    transformed_observation.h = transformed_cluster.h;
+    transformed_observations.push_back(transformed_observation);
+
+    combined_h += transformed_observation.h;
+    pose_observed[pose_offset] = 1;
+  }
+
+  const double n = detail::extractN(combined_h);
+  if (n <= 0.0) {
+    return result;
+  }
+
+  const Eigen::Matrix3d q = detail::extractQ(combined_h);
+  const Eigen::Vector3d s = detail::extractS(combined_h);
+  const Eigen::Matrix3d scatter = detail::scatterMatrix(q, s, n);
+
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(scatter);
+  if (solver.info() != Eigen::Success) {
+    return result;
+  }
+
+  const Eigen::Vector3d eigenvalues = solver.eigenvalues();
+  const Eigen::Matrix3d eigenvectors = solver.eigenvectors();
+  const Eigen::Vector3d u0 = eigenvectors.col(0);
+
+  result.cost = eigenvalues(0);
+  result.normalized_cost = result.cost / n;
+  result.normal = detail::canonicalNormal(eigenvectors);
+  result.eigen_gap = eigenvalues(1) - eigenvalues(0);
+
+  if (n < config.min_total_points || result.eigen_gap <= config.eigen_gap_min) {
+    return result;
+  }
+
+  result.valid = true;
+
+  std::vector<int> observed_pose_indices;
+  observed_pose_indices.reserve(static_cast<std::size_t>(pose_count));
+  for (int pose_index = 0; pose_index < pose_count; ++pose_index) {
+    if (pose_observed[static_cast<std::size_t>(pose_index)] != 0) {
+      observed_pose_indices.push_back(pose_index);
+    }
+  }
+
+  std::vector<detail::PlaneDerivativeCache> derivatives;
+  derivatives.reserve(observed_pose_indices.size() * 6U);
+
+  for (std::size_t i = 0; i < observed_pose_indices.size(); ++i) {
+    const int pose_index = observed_pose_indices[i];
+
+    for (int axis = 0; axis < 6; ++axis) {
+      Eigen::Matrix4d h_derivative = Eigen::Matrix4d::Zero();
+
+      for (std::size_t j = 0; j < transformed_observations.size(); ++j) {
+        if (transformed_observations[j].pose_index == pose_index) {
+          h_derivative += clusterFirstDerivative(transformed_observations[j].h, axis);
+        }
+      }
+
+      detail::PlaneDerivativeCache derivative;
+      derivative.pose_index = pose_index;
+      derivative.axis = axis;
+      derivative.a = detail::firstScatterDerivative(h_derivative, s, n, &derivative.s);
+
+      const int variable_index = 6 * pose_index + axis;
+      result.gradient(variable_index) = detail::quadraticForm(derivative.a, u0);
+      derivatives.push_back(derivative);
+    }
+  }
+
+  for (std::size_t i = 0; i < derivatives.size(); ++i) {
+    const detail::PlaneDerivativeCache & row_derivative = derivatives[i];
+
+    for (std::size_t j = i; j < derivatives.size(); ++j) {
+      const detail::PlaneDerivativeCache & column_derivative = derivatives[j];
+      Eigen::Matrix3d second_derivative = Eigen::Matrix3d::Zero();
+
+      if (row_derivative.pose_index == column_derivative.pose_index) {
+        Eigen::Matrix4d h_second_derivative = Eigen::Matrix4d::Zero();
+
+        for (std::size_t k = 0; k < transformed_observations.size(); ++k) {
+          if (transformed_observations[k].pose_index == row_derivative.pose_index) {
+            h_second_derivative += clusterSecondDerivative(
+              transformed_observations[k].h,
+              row_derivative.axis,
+              column_derivative.axis);
+          }
+        }
+
+        second_derivative = detail::secondScatterDerivative(
+          h_second_derivative,
+          s,
+          n,
+          row_derivative.s,
+          column_derivative.s);
+      } else {
+        second_derivative = detail::mixedPoseScatterDerivative(
+          row_derivative.s,
+          column_derivative.s,
+          n);
+      }
+
+      const double hessian_value =
+        detail::quadraticForm(second_derivative, u0) +
+        detail::eigenvectorCurvatureTerm(
+          row_derivative.a,
+          column_derivative.a,
+          eigenvectors,
+          eigenvalues);
+
+      const int row = 6 * row_derivative.pose_index + row_derivative.axis;
+      const int column = 6 * column_derivative.pose_index + column_derivative.axis;
+      result.hessian(row, column) = hessian_value;
+      result.hessian(column, row) = hessian_value;
+    }
+  }
+
+  return result;
+}
+
+}  // namespace map_refinement
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__SCATTER_EIGEN_COST_HPP_

--- a/graph_based_slam/test/test_scatter_eigen_cost.cpp
+++ b/graph_based_slam/test/test_scatter_eigen_cost.cpp
@@ -1,0 +1,383 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstring>
+#include <vector>
+
+#include "graph_based_slam/scatter_eigen_cost.hpp"
+
+namespace
+{
+
+using graphslam::map_refinement::PlaneCostConfig;
+using graphslam::map_refinement::PlaneCostResult;
+using graphslam::map_refinement::PlaneFeatureObservation;
+using graphslam::map_refinement::PointCluster;
+using graphslam::map_refinement::Vector6d;
+using graphslam::map_refinement::evaluatePlaneCost;
+using graphslam::map_refinement::expSe3;
+using graphslam::map_refinement::leftPerturb;
+using graphslam::map_refinement::makeCluster;
+
+struct PlaneFixture
+{
+  std::vector<PlaneFeatureObservation> observations;
+  std::vector<Eigen::Matrix4d> poses;
+};
+
+Eigen::Matrix4d MakePose(
+  const Eigen::Vector3d & translation,
+  const Eigen::Vector3d & rotation)
+{
+  Vector6d delta = Vector6d::Zero();
+  delta.head<3>() = translation;
+  delta.tail<3>() = rotation;
+  return expSe3(delta);
+}
+
+Eigen::Vector3d TransformPoint(
+  const Eigen::Matrix4d & transform,
+  const Eigen::Vector3d & point)
+{
+  Eigen::Vector4d homogeneous;
+  homogeneous << point.x(), point.y(), point.z(), 1.0;
+  return (transform * homogeneous).head<3>();
+}
+
+std::vector<Eigen::Vector3d> TransformPoints(
+  const Eigen::Matrix4d & transform,
+  const std::vector<Eigen::Vector3d> & points)
+{
+  std::vector<Eigen::Vector3d> transformed;
+  transformed.reserve(points.size());
+
+  for (std::size_t i = 0; i < points.size(); ++i) {
+    transformed.push_back(TransformPoint(transform, points[i]));
+  }
+
+  return transformed;
+}
+
+PlaneFeatureObservation MakeObservation(
+  int pose_index,
+  const Eigen::Matrix4d & pose,
+  const std::vector<Eigen::Vector3d> & world_points)
+{
+  PlaneFeatureObservation observation;
+  observation.pose_index = pose_index;
+  observation.local_cluster = makeCluster(
+    TransformPoints(pose.inverse(), world_points));
+  return observation;
+}
+
+std::vector<Eigen::Vector3d> MakeCoplanarPoints()
+{
+  std::vector<Eigen::Vector3d> points;
+  points.push_back(Eigen::Vector3d(-2.0, -1.0, 0.0));
+  points.push_back(Eigen::Vector3d(-1.0, 1.0, 0.0));
+  points.push_back(Eigen::Vector3d(0.0, -1.5, 0.0));
+  points.push_back(Eigen::Vector3d(0.8, 0.4, 0.0));
+  points.push_back(Eigen::Vector3d(1.7, -0.2, 0.0));
+  points.push_back(Eigen::Vector3d(2.2, 1.3, 0.0));
+  return points;
+}
+
+std::vector<Eigen::Vector3d> MakeNoisyPlanePoints()
+{
+  const double xy[][2] = {
+    {-1.5, -0.8},
+    {-0.4, -1.2},
+    {0.7, -0.9},
+    {1.6, -0.4},
+    {-1.2, 0.2},
+    {-0.2, 0.5},
+    {0.9, 0.3},
+    {1.4, 1.0},
+    {-0.8, 1.3},
+    {0.4, 1.5}
+  };
+  const double noise[] = {-0.020, 0.010, 0.000, 0.030, -0.010,
+    0.020, -0.030, 0.010, -0.020, 0.020};
+
+  std::vector<Eigen::Vector3d> points;
+  points.reserve(sizeof(noise) / sizeof(noise[0]));
+
+  for (std::size_t i = 0; i < sizeof(noise) / sizeof(noise[0]); ++i) {
+    const double x = xy[i][0];
+    const double y = xy[i][1];
+    const double z = 0.25 * x - 0.18 * y + 0.4 + noise[i];
+    points.push_back(Eigen::Vector3d(x, y, z));
+  }
+
+  return points;
+}
+
+std::vector<Eigen::Vector3d> MakeLinePoints()
+{
+  std::vector<Eigen::Vector3d> points;
+  for (int i = 0; i < 8; ++i) {
+    const double u = -1.75 + 0.5 * static_cast<double>(i);
+    points.push_back(Eigen::Vector3d(u, 2.0 * u + 1.0, -0.5 * u));
+  }
+  return points;
+}
+
+PlaneFixture MakeNoisyPlaneFixture()
+{
+  const std::vector<Eigen::Vector3d> world_points = MakeNoisyPlanePoints();
+
+  PlaneFixture fixture;
+  fixture.poses.push_back(
+    MakePose(Eigen::Vector3d(0.2, -0.1, 0.3), Eigen::Vector3d(0.04, -0.03, 0.02)));
+  fixture.poses.push_back(
+    MakePose(Eigen::Vector3d(-0.4, 0.3, -0.2), Eigen::Vector3d(-0.02, 0.05, -0.04)));
+
+  fixture.observations.push_back(MakeObservation(0, fixture.poses[0], world_points));
+  fixture.observations.push_back(MakeObservation(1, fixture.poses[1], world_points));
+  return fixture;
+}
+
+PlaneCostResult EvaluateFixture(
+  const PlaneFixture & fixture,
+  const std::vector<Eigen::Matrix4d> & poses)
+{
+  PlaneCostConfig config;
+  return evaluatePlaneCost(
+    fixture.observations,
+    poses,
+    static_cast<int>(poses.size()),
+    config);
+}
+
+std::vector<Eigen::Matrix4d> PerturbPose(
+  const std::vector<Eigen::Matrix4d> & poses,
+  int variable,
+  double step)
+{
+  std::vector<Eigen::Matrix4d> perturbed = poses;
+  Vector6d delta = Vector6d::Zero();
+  const int pose_index = variable / 6;
+  const int axis = variable % 6;
+  delta(axis) = step;
+  perturbed[static_cast<std::size_t>(pose_index)] =
+    leftPerturb(delta, perturbed[static_cast<std::size_t>(pose_index)]);
+  return perturbed;
+}
+
+}  // namespace
+
+TEST(ScatterEigenCostTest, CoplanarTwoPoseFeatureAtIdentityIsFlat)
+{
+  PlaneFixture fixture;
+  const std::vector<Eigen::Vector3d> points = MakeCoplanarPoints();
+  fixture.poses.push_back(Eigen::Matrix4d::Identity());
+  fixture.poses.push_back(Eigen::Matrix4d::Identity());
+  fixture.observations.push_back(MakeObservation(0, fixture.poses[0], points));
+  fixture.observations.push_back(MakeObservation(1, fixture.poses[1], points));
+
+  const PlaneCostResult result = EvaluateFixture(fixture, fixture.poses);
+
+  ASSERT_TRUE(result.valid);
+  EXPECT_NEAR(
+    result.cost,
+    0.0,
+    1e-12);
+  EXPECT_GT(result.eigen_gap, 1e-9);
+  EXPECT_LT(result.gradient.norm(), 1e-9);
+}
+
+TEST(ScatterEigenCostTest, GradientMatchesCentralFiniteDifference)
+{
+  const PlaneFixture fixture = MakeNoisyPlaneFixture();
+  const PlaneCostResult result = EvaluateFixture(fixture, fixture.poses);
+  ASSERT_TRUE(result.valid);
+
+  const double step = 1e-6;
+  const int variable_count = static_cast<int>(result.gradient.size());
+
+  for (int variable = 0; variable < variable_count; ++variable) {
+    const std::vector<Eigen::Matrix4d> plus_poses =
+      PerturbPose(fixture.poses, variable, step);
+    const std::vector<Eigen::Matrix4d> minus_poses =
+      PerturbPose(fixture.poses, variable, -step);
+
+    const PlaneCostResult plus = EvaluateFixture(fixture, plus_poses);
+    const PlaneCostResult minus = EvaluateFixture(fixture, minus_poses);
+    ASSERT_TRUE(plus.valid);
+    ASSERT_TRUE(minus.valid);
+
+    const double finite_difference = (plus.cost - minus.cost) / (2.0 * step);
+    const double tolerance = 1e-5 * std::max(1.0, std::abs(finite_difference));
+
+    EXPECT_NEAR(
+      result.gradient(variable),
+      finite_difference,
+      tolerance) << "variable " << variable;
+  }
+}
+
+TEST(ScatterEigenCostTest, HessianMatchesCentralGradientDifference)
+{
+  const PlaneFixture fixture = MakeNoisyPlaneFixture();
+  const PlaneCostResult result = EvaluateFixture(fixture, fixture.poses);
+  ASSERT_TRUE(result.valid);
+
+  const double step = 1e-6;
+  const int variable_count = static_cast<int>(result.gradient.size());
+
+  for (int column = 0; column < variable_count; ++column) {
+    const std::vector<Eigen::Matrix4d> plus_poses =
+      PerturbPose(fixture.poses, column, step);
+    const std::vector<Eigen::Matrix4d> minus_poses =
+      PerturbPose(fixture.poses, column, -step);
+
+    const PlaneCostResult plus = EvaluateFixture(fixture, plus_poses);
+    const PlaneCostResult minus = EvaluateFixture(fixture, minus_poses);
+    ASSERT_TRUE(plus.valid);
+    ASSERT_TRUE(minus.valid);
+
+    const Eigen::VectorXd finite_difference =
+      (plus.gradient - minus.gradient) / (2.0 * step);
+
+    for (int row = 0; row < variable_count; ++row) {
+      const double expected = finite_difference(row);
+      const double tolerance = 1e-4 * std::max(1.0, std::abs(expected));
+
+      EXPECT_NEAR(
+        result.hessian(row, column),
+        expected,
+        tolerance) << "row " << row << " column " << column;
+    }
+  }
+}
+
+TEST(ScatterEigenCostTest, CommonRigidTransformLeavesCostUnchanged)
+{
+  const PlaneFixture fixture = MakeNoisyPlaneFixture();
+  const PlaneCostResult original = EvaluateFixture(fixture, fixture.poses);
+  ASSERT_TRUE(original.valid);
+
+  const Eigen::Matrix4d common_transform =
+    MakePose(Eigen::Vector3d(0.7, -0.2, 0.5), Eigen::Vector3d(0.2, -0.1, 0.15));
+
+  std::vector<Eigen::Matrix4d> moved_poses = fixture.poses;
+  for (std::size_t i = 0; i < moved_poses.size(); ++i) {
+    moved_poses[i] = common_transform * moved_poses[i];
+  }
+
+  const PlaneCostResult moved = EvaluateFixture(fixture, moved_poses);
+  ASSERT_TRUE(moved.valid);
+
+  EXPECT_NEAR(
+    original.cost,
+    moved.cost,
+    1e-9);
+}
+
+TEST(ScatterEigenCostTest, LineFeatureIsDegenerate)
+{
+  PlaneFixture fixture;
+  const std::vector<Eigen::Vector3d> points = MakeLinePoints();
+  fixture.poses.push_back(Eigen::Matrix4d::Identity());
+  fixture.observations.push_back(MakeObservation(0, fixture.poses[0], points));
+
+  PlaneCostConfig config;
+  const PlaneCostResult result = evaluatePlaneCost(
+    fixture.observations,
+    fixture.poses,
+    1,
+    config);
+
+  EXPECT_FALSE(result.valid);
+}
+
+TEST(ScatterEigenCostTest, TooFewPointsIsInvalid)
+{
+  PlaneFixture fixture;
+  std::vector<Eigen::Vector3d> points = MakeCoplanarPoints();
+  points.resize(5);
+  fixture.poses.push_back(Eigen::Matrix4d::Identity());
+  fixture.observations.push_back(MakeObservation(0, fixture.poses[0], points));
+
+  PlaneCostConfig config;
+  const PlaneCostResult result = evaluatePlaneCost(
+    fixture.observations,
+    fixture.poses,
+    1,
+    config);
+
+  EXPECT_FALSE(result.valid);
+}
+
+TEST(ScatterEigenCostTest, EvaluationIsDeterministic)
+{
+  const PlaneFixture fixture = MakeNoisyPlaneFixture();
+  const PlaneCostResult first = EvaluateFixture(fixture, fixture.poses);
+  const PlaneCostResult second = EvaluateFixture(fixture, fixture.poses);
+  ASSERT_TRUE(first.valid);
+  ASSERT_TRUE(second.valid);
+
+  ASSERT_EQ(first.gradient.size(), second.gradient.size());
+  ASSERT_EQ(first.hessian.rows(), second.hessian.rows());
+  ASSERT_EQ(first.hessian.cols(), second.hessian.cols());
+
+  const std::size_t gradient_bytes =
+    sizeof(double) * static_cast<std::size_t>(first.gradient.size());
+  const std::size_t hessian_bytes =
+    sizeof(double) * static_cast<std::size_t>(first.hessian.size());
+
+  EXPECT_EQ(
+    0,
+    std::memcmp(first.gradient.data(), second.gradient.data(), gradient_bytes));
+  EXPECT_EQ(
+    0,
+    std::memcmp(first.hessian.data(), second.hessian.data(), hessian_bytes));
+}
+
+TEST(ScatterEigenCostTest, DifferentPoseHessianBlockHasCentroidCoupling)
+{
+  const PlaneFixture fixture = MakeNoisyPlaneFixture();
+  const PlaneCostResult result = EvaluateFixture(fixture, fixture.poses);
+  ASSERT_TRUE(result.valid);
+
+  bool has_nonzero = false;
+  for (int row = 0; row < 6; ++row) {
+    for (int column = 6; column < 12; ++column) {
+      if (std::abs(result.hessian(row, column)) > 1e-12) {
+        has_nonzero = true;
+      }
+    }
+  }
+
+  EXPECT_TRUE(has_nonzero);
+}


### PR DESCRIPTION
## Summary

v0.7 Phase 2(`docs/roadmap/v0.7.md`): 平面 BA の数値核 — **消去済み平面コスト λ_min(scatter) の厳密な勾配/ヘッシアン**を point-cluster 座標で組み立てる層。clean-room(設計ノートのみ参照)。

- `evaluatePlaneCost(observations, poses, ...)`: 複数 pose から観測された 1 平面 feature について、結合 scatter の λ_min と、全観測 pose の twist(6 DoF × pose 数)に対する**厳密 1 階・2 階微分**を返す
  - 1 階: `μ_a = u₀ᵀ A_a u₀`
  - 2 階: 固有ベクトル曲率項 `2 Σ_m (u_mᵀ A_a u₀)(u_mᵀ A_b u₀)/(μ₀−μ_m)` 込み。**pose 跨ぎの centroid 結合** `−(s_a s_bᵀ + s_b s_aᵀ)/n`(Q_ab=0 でも残る項)を実装
  - 計算は常に O(poses)(生点に触らない = point-cluster の意義)
- 退化セーフガード(roadmap の v0.7 スコープ要件): eigen-gap floor(近接固有値は数値的崖)+ 最小サポート → `valid=false` で報告
- 決定論: (pose, axis) 固定順 accumulation、A_a キャッシュ、法線符号正規化

## Verification

- **有限差分がオラクル**: 勾配 vs コストの中心差分、ヘッシアン vs 勾配の中心差分が一致(テスト 2/3)
- gauge 不変性(両 pose への共通剛体変換でコスト不変)、直線退化・低サポート棄却、pose 跨ぎヘッシアン結合の非零性、ビット決定論 — 計 8 本
- `colcon test --packages-select graph_based_slam`: **1122 tests, 0 failures**
- 純追加(既存経路に変更なし)

## 次 PR

`ba_problem.hpp`(複数 feature + gauge 固定 + pose prior)+ `lm_solver.hpp`(damped Newton)。合成 GT 回復 + 「動かないのが正解」退化フィクスチャがハードゲート
