### PR TITLE
feat(refine): plane BA problem + deterministic LM solver with degeneracy safeguards (v0.7 Phase 2)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -272,6 +272,13 @@ if(BUILD_TESTING)
     target_include_directories(test_scatter_eigen_cost PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_plane_ba
+    test/test_plane_ba.cpp
+  )
+  if(TARGET test_plane_ba)
+    target_include_directories(test_plane_ba PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  endif()
+  ament_add_gtest(
     test_adaptive_voxel_plane_extractor
     test/test_adaptive_voxel_plane_extractor.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/plane_ba.hpp
+++ b/graph_based_slam/include/graph_based_slam/plane_ba.hpp
@@ -1,0 +1,356 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__PLANE_BA_HPP_
+#define GRAPH_BASED_SLAM__PLANE_BA_HPP_
+
+// Plane bundle-adjustment problem and deterministic damped-Newton (LM)
+// solver over a window of poses (docs/roadmap/v0.7.md Phase 2; design:
+// docs/research/map-refinement-clean-room-design.md). The optimizer-level
+// degeneracy safeguards are first-class v0.7 scope: gauge fixing of the
+// first pose, soft priors of every pose to its input pose (which hold the
+// unconstrained directions of rank-deficient scenes), deterministic
+// whole-vector step limiting, and a reject-with-report fallback when no
+// plane feature is valid. No clocks, no randomness, fixed evaluation
+// order: the same inputs produce bitwise-identical refined poses.
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include <Eigen/Cholesky>  // NOLINT(build/include_order)
+#include <Eigen/Core>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/scatter_eigen_cost.hpp"
+#include "graph_based_slam/se3_lie.hpp"
+
+namespace graphslam
+{
+namespace map_refinement
+{
+
+struct PlaneFeature
+{
+  // Observations are expected in ascending pose_index order.
+  std::vector<PlaneFeatureObservation> observations;
+};
+
+struct PlaneBaConfig
+{
+  PlaneCostConfig cost;
+  int max_iterations {30};
+  double initial_lambda {1e-4};
+  double lambda_up_factor {10.0};
+  double lambda_down_factor {0.3};
+  double max_lambda {1e12};
+  double min_relative_cost_decrease {1e-9};
+  // Per-pose limits; the WHOLE delta is scaled by the worst ratio so the
+  // step direction is preserved deterministically.
+  double max_step_translation {0.25};
+  double max_step_rotation_rad {0.052};
+  // Gauge: hard-fix pose 0 of the window (solve the reduced system).
+  bool fix_first_pose {true};
+  // Soft prior of every pose to its input pose; <= 0 disables priors.
+  // Gauss-Newton with a unit twist Jacobian (exact as the residual -> 0).
+  double prior_translation_sigma {0.30};
+  double prior_rotation_sigma_rad {0.035};
+};
+
+struct PlaneBaResult
+{
+  std::vector<Eigen::Matrix4d> poses;
+  bool converged {false};
+  bool improved {false};
+  int iterations {0};
+  int accepted_steps {0};
+  double initial_cost {0.0};
+  double final_cost {0.0};
+  int valid_features {0};
+  int invalid_features {0};
+  std::string termination;
+};
+
+namespace detail
+{
+
+inline bool priorsEnabled(const PlaneBaConfig & config)
+{
+  return config.prior_translation_sigma > 0.0 && config.prior_rotation_sigma_rad > 0.0;
+}
+
+inline double priorWeight(const PlaneBaConfig & config, int axis)
+{
+  const double sigma =
+    axis < 3 ? config.prior_translation_sigma : config.prior_rotation_sigma_rad;
+  return 1.0 / (sigma * sigma);
+}
+
+// Prior residual twist of pose i against its input pose.
+inline Vector6d priorResidual(
+  const Eigen::Matrix4d & pose, const Eigen::Matrix4d & input_pose)
+{
+  Eigen::Matrix4d input_inverse = Eigen::Matrix4d::Identity();
+  const Eigen::Matrix3d rotation = input_pose.block<3, 3>(0, 0);
+  input_inverse.block<3, 3>(0, 0) = rotation.transpose();
+  input_inverse.block<3, 1>(0, 3) = -rotation.transpose() * input_pose.block<3, 1>(0, 3);
+  return logSe3(pose * input_inverse);
+}
+
+struct CostEvaluation
+{
+  double total_cost {0.0};
+  int valid_features {0};
+  int invalid_features {0};
+};
+
+inline CostEvaluation evaluateTotalCost(
+  const std::vector<PlaneFeature> & features,
+  const std::vector<Eigen::Matrix4d> & poses,
+  const std::vector<Eigen::Matrix4d> & input_poses,
+  const PlaneBaConfig & config)
+{
+  CostEvaluation evaluation;
+  const int pose_count = static_cast<int>(poses.size());
+  for (size_t f = 0; f < features.size(); ++f) {
+    const PlaneCostResult result =
+      evaluatePlaneCost(features[f].observations, poses, pose_count, config.cost);
+    if (!result.valid) {
+      ++evaluation.invalid_features;
+      continue;
+    }
+    ++evaluation.valid_features;
+    evaluation.total_cost += result.cost;
+  }
+  if (priorsEnabled(config)) {
+    const int first = config.fix_first_pose ? 1 : 0;
+    for (int i = first; i < pose_count; ++i) {
+      const Vector6d residual = priorResidual(poses[i], input_poses[i]);
+      for (int axis = 0; axis < 6; ++axis) {
+        evaluation.total_cost +=
+          priorWeight(config, axis) * residual(axis) * residual(axis);
+      }
+    }
+  }
+  return evaluation;
+}
+
+// Accumulate gradient and Hessian of the full problem at the given poses.
+// Returns false when no plane feature is valid.
+inline bool assembleSystem(
+  const std::vector<PlaneFeature> & features,
+  const std::vector<Eigen::Matrix4d> & poses,
+  const std::vector<Eigen::Matrix4d> & input_poses,
+  const PlaneBaConfig & config,
+  Eigen::VectorXd * gradient,
+  Eigen::MatrixXd * hessian)
+{
+  const int pose_count = static_cast<int>(poses.size());
+  const int size = 6 * pose_count;
+  gradient->setZero(size);
+  hessian->setZero(size, size);
+  bool any_valid = false;
+  for (size_t f = 0; f < features.size(); ++f) {
+    const PlaneCostResult result =
+      evaluatePlaneCost(features[f].observations, poses, pose_count, config.cost);
+    if (!result.valid) {
+      continue;
+    }
+    any_valid = true;
+    *gradient += result.gradient;
+    *hessian += result.hessian;
+  }
+  if (!any_valid) {
+    return false;
+  }
+  if (priorsEnabled(config)) {
+    const int first = config.fix_first_pose ? 1 : 0;
+    for (int i = first; i < pose_count; ++i) {
+      const Vector6d residual = priorResidual(poses[i], input_poses[i]);
+      for (int axis = 0; axis < 6; ++axis) {
+        const double weight = priorWeight(config, axis);
+        (*gradient)(6 * i + axis) += 2.0 * weight * residual(axis);
+        (*hessian)(6 * i + axis, 6 * i + axis) += 2.0 * weight;
+      }
+    }
+  }
+  return true;
+}
+
+// Copy the free-variable blocks (everything except pose 0 when fixed)
+// into a reduced system, in ascending variable order.
+inline void reduceSystem(
+  const Eigen::VectorXd & gradient,
+  const Eigen::MatrixXd & hessian,
+  int first_free_variable,
+  Eigen::VectorXd * reduced_gradient,
+  Eigen::MatrixXd * reduced_hessian)
+{
+  const int reduced_size = static_cast<int>(gradient.size()) - first_free_variable;
+  *reduced_gradient = gradient.tail(reduced_size);
+  *reduced_hessian =
+    hessian.block(first_free_variable, first_free_variable, reduced_size, reduced_size);
+}
+
+// Scale the whole step so no pose exceeds the per-pose limits.
+inline void limitStep(
+  const PlaneBaConfig & config, int free_pose_count, Eigen::VectorXd * delta)
+{
+  double worst_ratio = 1.0;
+  for (int p = 0; p < free_pose_count; ++p) {
+    const double translation_norm = delta->segment<3>(6 * p).norm();
+    const double rotation_norm = delta->segment<3>(6 * p + 3).norm();
+    if (translation_norm > config.max_step_translation) {
+      worst_ratio = std::max(worst_ratio, translation_norm / config.max_step_translation);
+    }
+    if (rotation_norm > config.max_step_rotation_rad) {
+      worst_ratio = std::max(worst_ratio, rotation_norm / config.max_step_rotation_rad);
+    }
+  }
+  if (worst_ratio > 1.0) {
+    *delta /= worst_ratio;
+  }
+}
+
+}  // namespace detail
+
+inline PlaneBaResult solvePlaneBa(
+  const std::vector<PlaneFeature> & features,
+  const std::vector<Eigen::Matrix4d> & initial_poses,
+  const PlaneBaConfig & config)
+{
+  PlaneBaResult result;
+  result.poses = initial_poses;
+  const int pose_count = static_cast<int>(initial_poses.size());
+  if (pose_count == 0) {
+    result.termination = "no_valid_features";
+    return result;
+  }
+
+  const detail::CostEvaluation initial_evaluation =
+    detail::evaluateTotalCost(features, result.poses, initial_poses, config);
+  result.initial_cost = initial_evaluation.total_cost;
+  result.final_cost = initial_evaluation.total_cost;
+  result.valid_features = initial_evaluation.valid_features;
+  result.invalid_features = initial_evaluation.invalid_features;
+  if (initial_evaluation.valid_features == 0) {
+    result.termination = "no_valid_features";
+    return result;
+  }
+
+  const int first_free_variable = config.fix_first_pose ? 6 : 0;
+  const int free_pose_count = config.fix_first_pose ? pose_count - 1 : pose_count;
+  if (free_pose_count <= 0) {
+    result.termination = "converged";
+    result.converged = true;
+    return result;
+  }
+
+  double lambda = config.initial_lambda;
+  double current_cost = initial_evaluation.total_cost;
+  result.termination = "max_iterations";
+
+  for (int iteration = 0; iteration < config.max_iterations; ++iteration) {
+    result.iterations = iteration + 1;
+
+    Eigen::VectorXd gradient;
+    Eigen::MatrixXd hessian;
+    if (!detail::assembleSystem(
+        features, result.poses, initial_poses, config, &gradient, &hessian))
+    {
+      result.termination = "no_valid_features";
+      break;
+    }
+    Eigen::VectorXd reduced_gradient;
+    Eigen::MatrixXd reduced_hessian;
+    detail::reduceSystem(
+      gradient, hessian, first_free_variable, &reduced_gradient, &reduced_hessian);
+
+    bool accepted = false;
+    while (lambda <= config.max_lambda) {
+      Eigen::MatrixXd damped = reduced_hessian;
+      for (int i = 0; i < damped.rows(); ++i) {
+        damped(i, i) += lambda * std::max(std::abs(reduced_hessian(i, i)), 1e-12);
+      }
+      Eigen::VectorXd delta = Eigen::LDLT<Eigen::MatrixXd>(damped).solve(-reduced_gradient);
+      if (!delta.allFinite()) {
+        lambda *= config.lambda_up_factor;
+        continue;
+      }
+      detail::limitStep(config, free_pose_count, &delta);
+
+      std::vector<Eigen::Matrix4d> candidate = result.poses;
+      for (int p = 0; p < free_pose_count; ++p) {
+        const Vector6d twist = delta.segment<6>(6 * p);
+        const int pose_index = p + (config.fix_first_pose ? 1 : 0);
+        candidate[pose_index] = leftPerturb(twist, candidate[pose_index]);
+      }
+      const detail::CostEvaluation candidate_evaluation =
+        detail::evaluateTotalCost(features, candidate, initial_poses, config);
+      bool candidate_finite = std::isfinite(candidate_evaluation.total_cost);
+      for (size_t p = 0; p < candidate.size() && candidate_finite; ++p) {
+        candidate_finite = candidate[p].allFinite();
+      }
+      if (candidate_finite && candidate_evaluation.total_cost < current_cost) {
+        const double decrease = current_cost - candidate_evaluation.total_cost;
+        const double relative_decrease =
+          decrease / std::max(std::abs(current_cost), 1e-300);
+        result.poses = candidate;
+        current_cost = candidate_evaluation.total_cost;
+        result.valid_features = candidate_evaluation.valid_features;
+        result.invalid_features = candidate_evaluation.invalid_features;
+        ++result.accepted_steps;
+        lambda = std::max(lambda * config.lambda_down_factor, 1e-12);
+        accepted = true;
+        if (relative_decrease < config.min_relative_cost_decrease) {
+          result.termination = "converged";
+          result.converged = true;
+        }
+        break;
+      }
+      lambda *= config.lambda_up_factor;
+    }
+    if (!accepted) {
+      result.termination = "max_lambda";
+      break;
+    }
+    if (result.converged) {
+      break;
+    }
+  }
+
+  result.final_cost = current_cost;
+  result.improved = result.final_cost < result.initial_cost;
+  return result;
+}
+
+}  // namespace map_refinement
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__PLANE_BA_HPP_

--- a/graph_based_slam/test/test_plane_ba.cpp
+++ b/graph_based_slam/test/test_plane_ba.cpp
@@ -1,0 +1,303 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include "graph_based_slam/plane_ba.hpp"
+
+namespace
+{
+
+using graphslam::map_refinement::leftPerturb;
+using graphslam::map_refinement::logSe3;
+using graphslam::map_refinement::makeCluster;
+using graphslam::map_refinement::PlaneBaConfig;
+using graphslam::map_refinement::PlaneBaResult;
+using graphslam::map_refinement::PlaneFeature;
+using graphslam::map_refinement::PlaneFeatureObservation;
+using graphslam::map_refinement::solvePlaneBa;
+using graphslam::map_refinement::Vector6d;
+
+Eigen::Matrix4d inversePose(const Eigen::Matrix4d & pose)
+{
+  Eigen::Matrix4d inverse = Eigen::Matrix4d::Identity();
+  const Eigen::Matrix3d rotation = pose.block<3, 3>(0, 0);
+  inverse.block<3, 3>(0, 0) = rotation.transpose();
+  inverse.block<3, 1>(0, 3) = -rotation.transpose() * pose.block<3, 1>(0, 3);
+  return inverse;
+}
+
+// World points of three orthogonal noisy planes (z=0, x=2, y=2).
+std::vector<Eigen::Vector3d> makeOrthogonalPlaneWorld(double noise_sigma)
+{
+  std::mt19937 rng(4242);
+  std::normal_distribution<double> noise(0.0, noise_sigma);
+  std::vector<Eigen::Vector3d> points;
+  for (int a = 0; a < 14; ++a) {
+    for (int b = 0; b < 14; ++b) {
+      const double u = 0.15 * a;
+      const double v = 0.15 * b;
+      points.push_back(Eigen::Vector3d(u, v, noise(rng)));
+      points.push_back(Eigen::Vector3d(2.0 + noise(rng), u, v));
+      points.push_back(Eigen::Vector3d(u, 2.0 + noise(rng), v));
+    }
+  }
+  return points;
+}
+
+int planeIdOf(int flat_index)
+{
+  return flat_index % 3;
+}
+
+// Build per-plane features observed by every pose: world points are
+// transformed into each pose's LOCAL frame with the ground-truth poses,
+// so the observations are exactly consistent at the ground truth.
+std::vector<PlaneFeature> makeFeatures(
+  const std::vector<Eigen::Vector3d> & world_points,
+  const std::vector<Eigen::Matrix4d> & ground_truth_poses)
+{
+  std::vector<PlaneFeature> features(3);
+  for (size_t p = 0; p < ground_truth_poses.size(); ++p) {
+    const Eigen::Matrix4d world_to_local = inversePose(ground_truth_poses[p]);
+    std::vector<std::vector<Eigen::Vector3d>> local_points(3);
+    for (size_t i = 0; i < world_points.size(); ++i) {
+      const Eigen::Vector3d local =
+        world_to_local.block<3, 3>(0, 0) * world_points[i] +
+        world_to_local.block<3, 1>(0, 3);
+      local_points[planeIdOf(static_cast<int>(i))].push_back(local);
+    }
+    for (int plane = 0; plane < 3; ++plane) {
+      PlaneFeatureObservation observation;
+      observation.pose_index = static_cast<int>(p);
+      observation.local_cluster = makeCluster(local_points[plane]);
+      features[plane].observations.push_back(observation);
+    }
+  }
+  return features;
+}
+
+std::vector<Eigen::Matrix4d> makeGroundTruthPoses()
+{
+  std::vector<Eigen::Matrix4d> poses(3, Eigen::Matrix4d::Identity());
+  Vector6d twist1;
+  twist1 << 0.4, -0.2, 0.1, 0.02, -0.03, 0.05;
+  Vector6d twist2;
+  twist2 << -0.3, 0.5, -0.1, -0.04, 0.01, -0.02;
+  poses[1] = graphslam::map_refinement::expSe3(twist1);
+  poses[2] = graphslam::map_refinement::expSe3(twist2);
+  return poses;
+}
+
+std::vector<Eigen::Matrix4d> perturbPoses(
+  const std::vector<Eigen::Matrix4d> & poses, double translation, double rotation)
+{
+  std::vector<Eigen::Matrix4d> perturbed = poses;
+  Vector6d twist1;
+  twist1 << translation, -translation, 0.5 * translation, rotation, -rotation,
+    0.5 * rotation;
+  Vector6d twist2;
+  twist2 << -0.5 * translation, translation, -translation, -rotation,
+    0.5 * rotation, rotation;
+  perturbed[1] = leftPerturb(twist1, perturbed[1]);
+  perturbed[2] = leftPerturb(twist2, perturbed[2]);
+  return perturbed;
+}
+
+double poseTranslationError(const Eigen::Matrix4d & a, const Eigen::Matrix4d & b)
+{
+  const Vector6d twist = logSe3(a * inversePose(b));
+  return twist.head<3>().norm();
+}
+
+double poseRotationError(const Eigen::Matrix4d & a, const Eigen::Matrix4d & b)
+{
+  const Vector6d twist = logSe3(a * inversePose(b));
+  return twist.tail<3>().norm();
+}
+
+TEST(PlaneBa, RecoversPerturbedPosesOnOrthogonalPlanes) {
+  const auto world = makeOrthogonalPlaneWorld(0.005);
+  const auto ground_truth = makeGroundTruthPoses();
+  const auto features = makeFeatures(world, ground_truth);
+  const auto initial = perturbPoses(ground_truth, 0.05, 0.017);
+
+  // Controlled test of the plane cost itself: priors are disabled (they
+  // pull toward the perturbed INPUT poses by design; the unobservable
+  // fixture covers their role separately).
+  PlaneBaConfig config;
+  config.prior_translation_sigma = 0.0;
+  const PlaneBaResult result = solvePlaneBa(features, initial, config);
+  ASSERT_EQ(result.poses.size(), 3u);
+  EXPECT_TRUE(result.improved);
+  EXPECT_GE(result.accepted_steps, 1);
+  for (int p = 1; p < 3; ++p) {
+    EXPECT_LT(poseTranslationError(result.poses[p], ground_truth[p]), 0.01);
+    EXPECT_LT(poseRotationError(result.poses[p], ground_truth[p]), 0.005);
+  }
+}
+
+TEST(PlaneBa, AlreadyOptimalInputBarelyMoves) {
+  const auto world = makeOrthogonalPlaneWorld(0.005);
+  const auto ground_truth = makeGroundTruthPoses();
+  const auto features = makeFeatures(world, ground_truth);
+
+  const PlaneBaResult result = solvePlaneBa(features, ground_truth, PlaneBaConfig());
+  EXPECT_LE(result.final_cost, result.initial_cost);
+  for (int p = 1; p < 3; ++p) {
+    EXPECT_LT(poseTranslationError(result.poses[p], ground_truth[p]), 1e-3);
+  }
+}
+
+TEST(PlaneBa, UnobservableFloorOnlySceneIsHeldByPriors) {
+  // A single floor plane: in-plane translation and yaw are unconstrained
+  // by the plane cost. The correct behaviour is "do not move": priors
+  // hold the unconstrained directions and nothing becomes NaN.
+  std::mt19937 rng(99);
+  std::normal_distribution<double> noise(0.0, 0.004);
+  std::vector<Eigen::Vector3d> world;
+  for (int a = 0; a < 20; ++a) {
+    for (int b = 0; b < 20; ++b) {
+      world.push_back(Eigen::Vector3d(0.2 * a, 0.2 * b, noise(rng)));
+    }
+  }
+  std::vector<Eigen::Matrix4d> ground_truth(2, Eigen::Matrix4d::Identity());
+  Vector6d twist;
+  twist << 1.0, 0.5, 0.0, 0.0, 0.0, 0.3;
+  ground_truth[1] = graphslam::map_refinement::expSe3(twist);
+
+  std::vector<PlaneFeature> features(1);
+  for (int p = 0; p < 2; ++p) {
+    const Eigen::Matrix4d world_to_local = inversePose(ground_truth[p]);
+    std::vector<Eigen::Vector3d> local;
+    for (size_t i = 0; i < world.size(); ++i) {
+      local.push_back(
+        world_to_local.block<3, 3>(0, 0) * world[i] +
+        world_to_local.block<3, 1>(0, 3));
+    }
+    PlaneFeatureObservation observation;
+    observation.pose_index = p;
+    observation.local_cluster = makeCluster(local);
+    features[0].observations.push_back(observation);
+  }
+
+  const PlaneBaResult result = solvePlaneBa(features, ground_truth, PlaneBaConfig());
+  ASSERT_EQ(result.poses.size(), 2u);
+  EXPECT_TRUE(result.poses[1].allFinite());
+  EXPECT_LT(poseTranslationError(result.poses[1], ground_truth[1]), 0.02);
+}
+
+TEST(PlaneBa, NoValidFeaturesReturnsInputUnchanged) {
+  std::vector<Eigen::Vector3d> tiny;
+  tiny.push_back(Eigen::Vector3d(0.0, 0.0, 0.0));
+  tiny.push_back(Eigen::Vector3d(1.0, 0.0, 0.0));
+
+  std::vector<PlaneFeature> features(1);
+  PlaneFeatureObservation observation;
+  observation.pose_index = 0;
+  observation.local_cluster = makeCluster(tiny);
+  features[0].observations.push_back(observation);
+
+  std::vector<Eigen::Matrix4d> poses(2, Eigen::Matrix4d::Identity());
+  Vector6d twist;
+  twist << 0.3, 0.1, -0.2, 0.05, 0.0, 0.1;
+  poses[1] = graphslam::map_refinement::expSe3(twist);
+
+  const PlaneBaResult result = solvePlaneBa(features, poses, PlaneBaConfig());
+  EXPECT_EQ(result.termination, "no_valid_features");
+  EXPECT_FALSE(result.improved);
+  for (size_t p = 0; p < poses.size(); ++p) {
+    EXPECT_EQ(
+      0,
+      std::memcmp(poses[p].data(), result.poses[p].data(), 16 * sizeof(double)));
+  }
+}
+
+TEST(PlaneBa, HugePerturbationStaysFiniteAndImproves) {
+  const auto world = makeOrthogonalPlaneWorld(0.005);
+  const auto ground_truth = makeGroundTruthPoses();
+  const auto features = makeFeatures(world, ground_truth);
+  const auto initial = perturbPoses(ground_truth, 0.5, 0.1);
+
+  PlaneBaConfig config;
+  config.max_iterations = 80;
+  config.prior_translation_sigma = 0.0;
+  const PlaneBaResult result = solvePlaneBa(features, initial, config);
+  EXPECT_TRUE(result.improved);
+  for (size_t p = 0; p < result.poses.size(); ++p) {
+    EXPECT_TRUE(result.poses[p].allFinite());
+  }
+}
+
+TEST(PlaneBa, FirstPoseIsBitwiseUnchangedWhenFixed) {
+  const auto world = makeOrthogonalPlaneWorld(0.005);
+  const auto ground_truth = makeGroundTruthPoses();
+  const auto features = makeFeatures(world, ground_truth);
+  const auto initial = perturbPoses(ground_truth, 0.05, 0.017);
+
+  const PlaneBaResult result = solvePlaneBa(features, initial, PlaneBaConfig());
+  EXPECT_EQ(
+    0,
+    std::memcmp(initial[0].data(), result.poses[0].data(), 16 * sizeof(double)));
+}
+
+TEST(PlaneBa, DeterministicAcrossRepeatedSolves) {
+  const auto world = makeOrthogonalPlaneWorld(0.005);
+  const auto ground_truth = makeGroundTruthPoses();
+  const auto features = makeFeatures(world, ground_truth);
+  const auto initial = perturbPoses(ground_truth, 0.05, 0.017);
+
+  const PlaneBaResult first = solvePlaneBa(features, initial, PlaneBaConfig());
+  const PlaneBaResult second = solvePlaneBa(features, initial, PlaneBaConfig());
+  ASSERT_EQ(first.poses.size(), second.poses.size());
+  for (size_t p = 0; p < first.poses.size(); ++p) {
+    EXPECT_EQ(
+      0,
+      std::memcmp(first.poses[p].data(), second.poses[p].data(), 16 * sizeof(double)));
+  }
+  EXPECT_EQ(
+    0, std::memcmp(&first.final_cost, &second.final_cost, sizeof(double)));
+}
+
+TEST(PlaneBa, CostNeverIncreases) {
+  const auto world = makeOrthogonalPlaneWorld(0.005);
+  const auto ground_truth = makeGroundTruthPoses();
+  const auto features = makeFeatures(world, ground_truth);
+  const auto initial = perturbPoses(ground_truth, 0.05, 0.017);
+
+  const PlaneBaResult result = solvePlaneBa(features, initial, PlaneBaConfig());
+  EXPECT_LE(result.final_cost, result.initial_cost);
+  EXPECT_GE(result.accepted_steps, 1);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

v0.7 Phase 2(`docs/roadmap/v0.7.md`): **optimizer 層** — `plane_ba.hpp`。scatter_eigen_cost の厳密 2 階微分の上に、pose 窓 × 複数平面 feature の damped Newton (LM) を実装。clean-room(設計ノートのみ)。

**optimizer レベルの退化セーフガード(roadmap の v0.7 必須スコープ)**:
- gauge 固定: pose 0 をハード固定し**縮約系**を LDLT で解く(ブロック昇順コピー)
- 全 pose の soft prior(入力 pose へ、unit twist Jacobian の GN 近似 = 残差→0 で厳密)— 床のみ/廊下等の rank-deficient シーンで非拘束方向を保持
- 決定論的 whole-vector ステップ制限(per-pose 最悪比でスケール)
- 受理は「有限 かつ 厳密減少」のみ。λ は固定係数で上下。`no_valid_features` は**入力 pose をビット不変で返す** reject-with-report

## Verification(Phase 2 オラクル 2 つを含む 8 テスト)

- **合成 GT 回復**: 直交 3 平面 × 3 pose、摂動 5cm/1° → **回復誤差 < 1cm / < 0.3°**(制御実験として prior 無効 — 設計ノートの規定どおり)
- **「動かないのが正解」退化フィクスチャ**: 床 1 枚のみ(面内並進+yaw が非拘束)→ prior が保持、移動 < 2cm、NaN なし
- 巨大摂動(0.5m)でも有限・改善、gauge pose のビット不変、コスト単調減少、解の 2 回実行ビット一致
- `colcon test`: **1139 tests, 0 failures**(lint 込み)

## Notes

- 次 PR: `hba_pyramid.hpp`(窓→keypose→グローバル融合)+ `map_refiner` 統合
