### PR TITLE
feat(refine): plane-feature association — extracted patches to BA problems (v0.7 Phase 2)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -279,6 +279,15 @@ if(BUILD_TESTING)
     target_include_directories(test_plane_ba PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_plane_feature_association
+    test/test_plane_feature_association.cpp
+  )
+  if(TARGET test_plane_feature_association)
+    target_include_directories(
+      test_plane_feature_association PRIVATE include ${EIGEN3_INCLUDE_DIR}
+    )
+  endif()
+  ament_add_gtest(
     test_adaptive_voxel_plane_extractor
     test/test_adaptive_voxel_plane_extractor.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/adaptive_voxel_plane_extractor.hpp
+++ b/graph_based_slam/include/graph_based_slam/adaptive_voxel_plane_extractor.hpp
@@ -56,6 +56,7 @@ struct PlaneExtractionConfig
   double min_planarity_ratio {6.0};
   bool enable_quarter_test {true};
   double quarter_test_tolerance {2.0};
+  bool collect_point_indices {false};
 };
 
 struct PlanarPatch
@@ -73,6 +74,8 @@ struct PlanarPatch
 struct PlaneExtractionResult
 {
   std::vector<PlanarPatch> patches;
+  // parallel to patches when collect_point_indices
+  std::vector<std::vector<int>> patch_point_indices;
   std::int64_t total_points {0};
   std::int64_t planar_points {0};
   double planar_coverage {0.0};
@@ -274,7 +277,8 @@ inline bool passesQuarterTest(
   }
 
   std::vector<int> octant_indices[8];
-  const Eigen::Vector3d center = bounds.min_corner + Eigen::Vector3d::Constant(bounds.size * 0.5);
+  const Eigen::Vector3d center =
+    bounds.min_corner + Eigen::Vector3d::Constant(bounds.size * 0.5);
 
   for (std::size_t i = 0; i < indices.size(); ++i) {
     const int octant = octantForPoint(points[indices[i]], center);
@@ -285,7 +289,9 @@ inline bool passesQuarterTest(
   int populated_octants = 0;
 
   for (int octant = 0; octant < 8; ++octant) {
-    if (octant_indices[octant].size() >= static_cast<std::size_t>(min_quarter_points)) {
+    if (octant_indices[octant].size() >=
+      static_cast<std::size_t>(min_quarter_points))
+    {
       ++populated_octants;
     }
   }
@@ -296,7 +302,9 @@ inline bool passesQuarterTest(
 
   const double lambda_limit = config.quarter_test_tolerance * stats.eigenvalues.x() + 1.0e-12;
   for (int octant = 0; octant < 8; ++octant) {
-    if (octant_indices[octant].size() < static_cast<std::size_t>(min_quarter_points)) {
+    if (octant_indices[octant].size() <
+      static_cast<std::size_t>(min_quarter_points))
+    {
       continue;
     }
 
@@ -331,7 +339,8 @@ inline void extractRecursive(
   const NodeBounds & bounds,
   const int depth,
   const PlaneExtractionConfig & config,
-  std::vector<PlanarPatch> * patches)
+  std::vector<PlanarPatch> * patches,
+  std::vector<std::vector<int>> * patch_point_indices)
 {
   if (indices.empty()) {
     return;
@@ -344,6 +353,9 @@ inline void extractRecursive(
 
   if (accepted) {
     patches->push_back(makePatch(stats, indices.size(), depth));
+    if (patch_point_indices != nullptr) {
+      patch_point_indices->push_back(indices);
+    }
     return;
   }
 
@@ -355,7 +367,8 @@ inline void extractRecursive(
   }
 
   std::vector<int> child_indices[8];
-  const Eigen::Vector3d center = bounds.min_corner + Eigen::Vector3d::Constant(bounds.size * 0.5);
+  const Eigen::Vector3d center =
+    bounds.min_corner + Eigen::Vector3d::Constant(bounds.size * 0.5);
 
   for (std::size_t i = 0; i < indices.size(); ++i) {
     const int octant = octantForPoint(points[indices[i]], center);
@@ -368,7 +381,14 @@ inline void extractRecursive(
     }
 
     const NodeBounds child = childBounds(bounds, octant);
-    extractRecursive(points, child_indices[octant], child, depth + 1, config, patches);
+    extractRecursive(
+      points,
+      child_indices[octant],
+      child,
+      depth + 1,
+      config,
+      patches,
+      patch_point_indices);
   }
 }
 
@@ -410,14 +430,20 @@ inline PlaneExtractionResult extractPlanarPatches(
   }
 
   const PlaneExtractionConfig sanitized = detail::sanitizeConfig(config);
-  std::map<detail::VoxelKey, std::vector<int>> voxel_indices;
+  typedef std::map<detail::VoxelKey, std::vector<int>> VoxelIndexMap;
+  VoxelIndexMap voxel_indices;
 
   for (std::size_t i = 0; i < points.size(); ++i) {
     const detail::VoxelKey key = detail::makeRootKey(points[i], sanitized.root_voxel_size);
     voxel_indices[key].push_back(static_cast<int>(i));
   }
 
-  for (std::map<detail::VoxelKey, std::vector<int>>::const_iterator iter = voxel_indices.begin();
+  std::vector<std::vector<int>> * patch_point_indices = nullptr;
+  if (sanitized.collect_point_indices) {
+    patch_point_indices = &result.patch_point_indices;
+  }
+
+  for (VoxelIndexMap::const_iterator iter = voxel_indices.begin();
     iter != voxel_indices.end(); ++iter)
   {
     detail::NodeBounds bounds;
@@ -430,7 +456,8 @@ inline PlaneExtractionResult extractPlanarPatches(
       bounds,
       0,
       sanitized,
-      &result.patches);
+      &result.patches,
+      patch_point_indices);
   }
 
   for (std::size_t i = 0; i < result.patches.size(); ++i) {

--- a/graph_based_slam/include/graph_based_slam/plane_feature_association.hpp
+++ b/graph_based_slam/include/graph_based_slam/plane_feature_association.hpp
@@ -1,0 +1,203 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__PLANE_FEATURE_ASSOCIATION_HPP_
+#define GRAPH_BASED_SLAM__PLANE_FEATURE_ASSOCIATION_HPP_
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/adaptive_voxel_plane_extractor.hpp"
+#include "graph_based_slam/plane_ba.hpp"
+
+namespace graphslam
+{
+namespace map_refinement
+{
+
+/// Converts world-frame planar patches into the per-(feature, pose) local point
+/// clusters consumed by plane BA (docs/roadmap/v0.7.md Phase 2). Owns the raw
+/// point-to-feature assignment for one BA problem. Deterministic: pose-major
+/// input concatenation, ascending index iteration.
+struct AssociationResult
+{
+  std::vector<PlaneFeature> features;
+  int patches_total {0};
+  int patches_used {0};
+  std::int64_t points_used {0};
+};
+
+struct AssociationConfig
+{
+  plane_extraction::PlaneExtractionConfig extraction;
+  int min_observing_poses {2};
+  int min_points_per_observation {5};
+};
+
+namespace detail
+{
+
+inline Eigen::Vector3d transformPoint(
+  const Eigen::Matrix4d & pose,
+  const Eigen::Vector3d & point)
+{
+  const Eigen::Vector4d homogeneous(
+    point.x(),
+    point.y(),
+    point.z(),
+    1.0);
+  return (pose * homogeneous).head<3>();
+}
+
+inline int sanitizePositiveInt(
+  const int value,
+  const int fallback)
+{
+  if (value < 1) {
+    return fallback;
+  }
+  return value;
+}
+
+}  // namespace detail
+
+inline AssociationResult associatePlaneFeatures(
+  const std::vector<std::vector<Eigen::Vector3d>> & local_clouds,
+  const std::vector<Eigen::Matrix4d> & poses,
+  const AssociationConfig & config)
+{
+  AssociationResult result;
+  if (local_clouds.size() != poses.size()) {
+    return result;
+  }
+
+  plane_extraction::PlaneExtractionConfig extraction_config = config.extraction;
+  extraction_config.collect_point_indices = true;
+
+  const int min_observing_poses =
+    detail::sanitizePositiveInt(config.min_observing_poses, 1);
+  const int min_points_per_observation =
+    detail::sanitizePositiveInt(config.min_points_per_observation, 1);
+
+  std::vector<std::size_t> pose_offsets;
+  pose_offsets.reserve(local_clouds.size() + 1);
+  pose_offsets.push_back(0U);
+
+  for (std::size_t pose_index = 0; pose_index < local_clouds.size(); ++pose_index) {
+    pose_offsets.push_back(pose_offsets.back() + local_clouds[pose_index].size());
+  }
+
+  std::vector<Eigen::Vector3d> world_cloud;
+  world_cloud.reserve(pose_offsets.back());
+
+  for (std::size_t pose_index = 0; pose_index < local_clouds.size(); ++pose_index) {
+    for (std::size_t point_index = 0; point_index < local_clouds[pose_index].size();
+      ++point_index)
+    {
+      world_cloud.push_back(
+        detail::transformPoint(
+          poses[pose_index],
+          local_clouds[pose_index][point_index]));
+    }
+  }
+
+  const plane_extraction::PlaneExtractionResult extraction =
+    plane_extraction::extractPlanarPatches(world_cloud, extraction_config);
+  result.patches_total = static_cast<int>(extraction.patches.size());
+
+  for (std::size_t patch_index = 0; patch_index < extraction.patch_point_indices.size();
+    ++patch_index)
+  {
+    const std::vector<int> & patch_indices = extraction.patch_point_indices[patch_index];
+    std::vector<std::vector<int>> local_indices_by_pose(local_clouds.size());
+
+    std::size_t pose_index = 0;
+    for (std::size_t i = 0; i < patch_indices.size(); ++i) {
+      const int signed_world_index = patch_indices[i];
+      if (signed_world_index < 0) {
+        continue;
+      }
+
+      const std::size_t world_index = static_cast<std::size_t>(signed_world_index);
+      while (pose_index + 1U < pose_offsets.size() &&
+        pose_offsets[pose_index + 1U] <= world_index)
+      {
+        ++pose_index;
+      }
+
+      if (pose_index >= local_clouds.size()) {
+        continue;
+      }
+
+      const std::size_t local_index = world_index - pose_offsets[pose_index];
+      local_indices_by_pose[pose_index].push_back(static_cast<int>(local_index));
+    }
+
+    PlaneFeature feature;
+    std::int64_t feature_points = 0;
+    for (std::size_t observation_pose = 0; observation_pose < local_indices_by_pose.size();
+      ++observation_pose)
+    {
+      const std::vector<int> & local_indices = local_indices_by_pose[observation_pose];
+      if (local_indices.size() < static_cast<std::size_t>(min_points_per_observation)) {
+        continue;
+      }
+
+      PlaneFeatureObservation observation;
+      observation.pose_index = static_cast<int>(observation_pose);
+      for (std::size_t local_index_index = 0; local_index_index < local_indices.size();
+        ++local_index_index)
+      {
+        const int local_index = local_indices[local_index_index];
+        observation.local_cluster.add(
+          local_clouds[observation_pose][static_cast<std::size_t>(local_index)]);
+      }
+
+      feature_points += static_cast<std::int64_t>(local_indices.size());
+      feature.observations.push_back(observation);
+    }
+
+    if (feature.observations.size() >= static_cast<std::size_t>(min_observing_poses)) {
+      result.features.push_back(feature);
+      ++result.patches_used;
+      result.points_used += feature_points;
+    }
+  }
+
+  return result;
+}
+
+}  // namespace map_refinement
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__PLANE_FEATURE_ASSOCIATION_HPP_

--- a/graph_based_slam/test/test_plane_feature_association.cpp
+++ b/graph_based_slam/test/test_plane_feature_association.cpp
@@ -265,8 +265,8 @@ TEST(PlaneFeatureAssociation, SharedNoisyFloorCreatesTwoPoseFeatures)
         feature.observations[observation_index];
       const Eigen::Vector3d world_centroid =
         transformPoint(
-          poses[static_cast<std::size_t>(observation.pose_index)],
-          clusterCentroid(observation.local_cluster));
+        poses[static_cast<std::size_t>(observation.pose_index)],
+        clusterCentroid(observation.local_cluster));
       EXPECT_LT((world_centroid - patch_centroid).norm(), 0.1);
     }
   }
@@ -315,9 +315,9 @@ TEST(PlaneFeatureAssociation, AssociatedFeaturesImprovePlaneBaPose)
 
   const map_refinement::AssociationResult association =
     map_refinement::associatePlaneFeatures(
-      local_clouds,
-      initial_poses,
-      association_config);
+    local_clouds,
+    initial_poses,
+    association_config);
   ASSERT_GE(association.features.size(), 3U);
 
   map_refinement::PlaneBaConfig ba_config;

--- a/graph_based_slam/test/test_plane_feature_association.cpp
+++ b/graph_based_slam/test/test_plane_feature_association.cpp
@@ -1,0 +1,566 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstring>
+#include <random>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Geometry>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/plane_ba.hpp"
+#include "graph_based_slam/plane_feature_association.hpp"
+
+namespace
+{
+
+namespace map_refinement = graphslam::map_refinement;
+namespace plane_extraction = graphslam::plane_extraction;
+
+template<int N>
+struct PriorityTag : PriorityTag<N - 1>
+{
+};
+
+template<>
+struct PriorityTag<0>
+{
+};
+
+Eigen::Matrix4d makePose(
+  const double yaw,
+  const Eigen::Vector3d & translation)
+{
+  Eigen::Matrix4d pose = Eigen::Matrix4d::Identity();
+  pose.block<3, 3>(0, 0) =
+    Eigen::AngleAxisd(yaw, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+  pose.block<3, 1>(0, 3) = translation;
+  return pose;
+}
+
+Eigen::Vector3d transformPoint(
+  const Eigen::Matrix4d & pose,
+  const Eigen::Vector3d & point)
+{
+  const Eigen::Vector4d homogeneous(
+    point.x(),
+    point.y(),
+    point.z(),
+    1.0);
+  return (pose * homogeneous).head<3>();
+}
+
+Eigen::Vector3d inverseTransformPoint(
+  const Eigen::Matrix4d & pose,
+  const Eigen::Vector3d & point)
+{
+  const Eigen::Matrix3d rotation = pose.block<3, 3>(0, 0);
+  const Eigen::Vector3d translation = pose.block<3, 1>(0, 3);
+  return rotation.transpose() * (point - translation);
+}
+
+std::vector<Eigen::Vector3d> toLocalCloud(
+  const std::vector<Eigen::Vector3d> & world_points,
+  const Eigen::Matrix4d & pose)
+{
+  std::vector<Eigen::Vector3d> local_points;
+  local_points.reserve(world_points.size());
+  for (std::size_t i = 0; i < world_points.size(); ++i) {
+    local_points.push_back(inverseTransformPoint(pose, world_points[i]));
+  }
+  return local_points;
+}
+
+std::vector<Eigen::Vector3d> makeFloorPoints(
+  const int side_count,
+  const double spacing,
+  const double z_sigma,
+  std::mt19937 * rng)
+{
+  std::normal_distribution<double> noise(0.0, z_sigma);
+  std::vector<Eigen::Vector3d> points;
+  points.reserve(static_cast<std::size_t>(side_count * side_count));
+
+  for (int y_index = 0; y_index < side_count; ++y_index) {
+    for (int x_index = 0; x_index < side_count; ++x_index) {
+      points.push_back(
+        Eigen::Vector3d(
+          0.25 + spacing * static_cast<double>(x_index),
+          0.25 + spacing * static_cast<double>(y_index),
+          noise(*rng)));
+    }
+  }
+  return points;
+}
+
+std::vector<Eigen::Vector3d> makeXWallPoints(
+  const double x,
+  const int side_count,
+  const double spacing)
+{
+  std::vector<Eigen::Vector3d> points;
+  points.reserve(static_cast<std::size_t>(side_count * side_count));
+
+  for (int z_index = 0; z_index < side_count; ++z_index) {
+    for (int y_index = 0; y_index < side_count; ++y_index) {
+      points.push_back(
+        Eigen::Vector3d(
+          x,
+          0.25 + spacing * static_cast<double>(y_index),
+          0.25 + spacing * static_cast<double>(z_index)));
+    }
+  }
+  return points;
+}
+
+std::vector<Eigen::Vector3d> makeYWallPoints(
+  const double y,
+  const int side_count,
+  const double spacing)
+{
+  std::vector<Eigen::Vector3d> points;
+  points.reserve(static_cast<std::size_t>(side_count * side_count));
+
+  for (int z_index = 0; z_index < side_count; ++z_index) {
+    for (int x_index = 0; x_index < side_count; ++x_index) {
+      points.push_back(
+        Eigen::Vector3d(
+          0.25 + spacing * static_cast<double>(x_index),
+          y,
+          0.25 + spacing * static_cast<double>(z_index)));
+    }
+  }
+  return points;
+}
+
+void appendPoints(
+  const std::vector<Eigen::Vector3d> & source,
+  std::vector<Eigen::Vector3d> * target)
+{
+  target->insert(target->end(), source.begin(), source.end());
+}
+
+std::vector<Eigen::Vector3d> buildWorldCloud(
+  const std::vector<std::vector<Eigen::Vector3d>> & local_clouds,
+  const std::vector<Eigen::Matrix4d> & poses)
+{
+  std::vector<Eigen::Vector3d> world_cloud;
+  for (std::size_t pose_index = 0; pose_index < local_clouds.size(); ++pose_index) {
+    for (std::size_t point_index = 0; point_index < local_clouds[pose_index].size();
+      ++point_index)
+    {
+      world_cloud.push_back(
+        transformPoint(
+          poses[pose_index],
+          local_clouds[pose_index][point_index]));
+    }
+  }
+  return world_cloud;
+}
+
+plane_extraction::PlaneExtractionConfig makeExtractionConfig()
+{
+  plane_extraction::PlaneExtractionConfig config;
+  config.root_voxel_size = 8.0;
+  config.max_octree_depth = 0;
+  config.min_points_per_plane = 20;
+  config.max_plane_thickness = 0.04;
+  config.min_planarity_ratio = 4.0;
+  config.enable_quarter_test = false;
+  return config;
+}
+
+map_refinement::AssociationConfig makeAssociationConfig()
+{
+  map_refinement::AssociationConfig config;
+  config.extraction = makeExtractionConfig();
+  config.min_observing_poses = 2;
+  config.min_points_per_observation = 5;
+  return config;
+}
+
+Eigen::Vector3d clusterCentroid(
+  const map_refinement::PointCluster & cluster)
+{
+  const double count = cluster.h(3, 3);
+  if (count <= 0.0) {
+    return Eigen::Vector3d::Zero();
+  }
+  return cluster.h.block<3, 1>(0, 3) / count;
+}
+
+double relativeTranslationError(
+  const std::vector<Eigen::Matrix4d> & poses,
+  const std::vector<Eigen::Matrix4d> & ground_truth)
+{
+  const Eigen::Matrix4d relative = poses[0].inverse() * poses[1];
+  const Eigen::Matrix4d relative_ground_truth = ground_truth[0].inverse() * ground_truth[1];
+  return (
+    relative.block<3, 1>(0, 3) -
+    relative_ground_truth.block<3, 1>(0, 3)).norm();
+}
+
+template<typename Config>
+auto disablePosePriorsImpl(
+  Config * config,
+  PriorityTag<2>)
+-> decltype(config->use_pose_priors = false, void())
+{
+  config->use_pose_priors = false;
+}
+
+template<typename Config>
+auto disablePosePriorsImpl(
+  Config * config,
+  PriorityTag<1>)
+-> decltype(config->enable_pose_priors = false, void())
+{
+  config->enable_pose_priors = false;
+}
+
+template<typename Config>
+void disablePosePriorsImpl(
+  Config *,
+  PriorityTag<0>)
+{
+}
+
+template<typename Config>
+void disablePosePriors(
+  Config * config)
+{
+  disablePosePriorsImpl(config, PriorityTag<2>());
+}
+
+template<typename Config>
+auto setMaxIterationsImpl(
+  Config * config,
+  PriorityTag<1>)
+-> decltype(config->max_iterations = 30, void())
+{
+  config->max_iterations = 30;
+}
+
+template<typename Config>
+void setMaxIterationsImpl(
+  Config *,
+  PriorityTag<0>)
+{
+}
+
+template<typename Config>
+void setMaxIterations(
+  Config * config)
+{
+  setMaxIterationsImpl(config, PriorityTag<1>());
+}
+
+template<typename PoseVector, typename FeatureVector, typename Config>
+auto runSolvePlaneBaImpl(
+  const PoseVector & poses,
+  const FeatureVector & features,
+  const Config & config,
+  PriorityTag<1>)
+-> decltype(map_refinement::solvePlaneBa(poses, features, config))
+{
+  return map_refinement::solvePlaneBa(poses, features, config);
+}
+
+template<typename PoseVector, typename FeatureVector, typename Config>
+auto runSolvePlaneBaImpl(
+  const PoseVector & poses,
+  const FeatureVector & features,
+  const Config & config,
+  PriorityTag<0>)
+-> decltype(map_refinement::solvePlaneBa(features, poses, config))
+{
+  return map_refinement::solvePlaneBa(features, poses, config);
+}
+
+template<typename PoseVector, typename FeatureVector, typename Config>
+auto runSolvePlaneBa(
+  const PoseVector & poses,
+  const FeatureVector & features,
+  const Config & config)
+-> decltype(runSolvePlaneBaImpl(poses, features, config, PriorityTag<1>()))
+{
+  return runSolvePlaneBaImpl(poses, features, config, PriorityTag<1>());
+}
+
+template<typename Result>
+auto optimizedPosesImpl(
+  const Result & result,
+  PriorityTag<3>)
+-> decltype((result.poses))
+{
+  return result.poses;
+}
+
+template<typename Result>
+auto optimizedPosesImpl(
+  const Result & result,
+  PriorityTag<2>)
+-> decltype((result.optimized_poses))
+{
+  return result.optimized_poses;
+}
+
+template<typename Result>
+auto optimizedPosesImpl(
+  const Result & result,
+  PriorityTag<1>)
+-> decltype((result.refined_poses))
+{
+  return result.refined_poses;
+}
+
+const std::vector<Eigen::Matrix4d> & optimizedPosesImpl(
+  const std::vector<Eigen::Matrix4d> & result,
+  PriorityTag<0>)
+{
+  return result;
+}
+
+template<typename Result>
+const std::vector<Eigen::Matrix4d> & optimizedPoses(
+  const Result & result)
+{
+  return optimizedPosesImpl(result, PriorityTag<3>());
+}
+
+}  // namespace
+
+TEST(PlaneFeatureAssociation, SharedNoisyFloorCreatesTwoPoseFeatures)
+{
+  std::mt19937 rng(7);
+  const std::vector<Eigen::Vector3d> floor_points =
+    makeFloorPoints(12, 0.12, 0.004, &rng);
+
+  std::vector<Eigen::Matrix4d> poses;
+  poses.push_back(makePose(0.0, Eigen::Vector3d::Zero()));
+  poses.push_back(makePose(0.25, Eigen::Vector3d(0.4, -0.15, 0.08)));
+
+  std::vector<std::vector<Eigen::Vector3d>> local_clouds;
+  local_clouds.push_back(toLocalCloud(floor_points, poses[0]));
+  local_clouds.push_back(toLocalCloud(floor_points, poses[1]));
+
+  const map_refinement::AssociationConfig config = makeAssociationConfig();
+  const map_refinement::AssociationResult association =
+    map_refinement::associatePlaneFeatures(local_clouds, poses, config);
+
+  ASSERT_FALSE(association.features.empty());
+  for (std::size_t i = 0; i < association.features.size(); ++i) {
+    EXPECT_EQ(2U, association.features[i].observations.size());
+  }
+
+  plane_extraction::PlaneExtractionConfig extraction_config = config.extraction;
+  extraction_config.collect_point_indices = true;
+  const plane_extraction::PlaneExtractionResult extraction =
+    plane_extraction::extractPlanarPatches(
+      buildWorldCloud(local_clouds, poses),
+      extraction_config);
+
+  ASSERT_GE(extraction.patches.size(), association.features.size());
+  for (std::size_t feature_index = 0; feature_index < association.features.size();
+    ++feature_index)
+  {
+    const Eigen::Vector3d patch_centroid = extraction.patches[feature_index].centroid;
+    const map_refinement::PlaneFeature & feature = association.features[feature_index];
+
+    for (std::size_t observation_index = 0; observation_index < feature.observations.size();
+      ++observation_index)
+    {
+      const map_refinement::PlaneFeatureObservation & observation =
+        feature.observations[observation_index];
+      const Eigen::Vector3d world_centroid =
+        transformPoint(
+          poses[static_cast<std::size_t>(observation.pose_index)],
+          clusterCentroid(observation.local_cluster));
+      EXPECT_LT((world_centroid - patch_centroid).norm(), 0.1);
+    }
+  }
+}
+
+TEST(PlaneFeatureAssociation, SinglePosePatchIsFiltered)
+{
+  std::vector<Eigen::Matrix4d> poses;
+  poses.push_back(Eigen::Matrix4d::Identity());
+  poses.push_back(Eigen::Matrix4d::Identity());
+
+  std::vector<std::vector<Eigen::Vector3d>> local_clouds(2);
+  local_clouds[0] = makeXWallPoints(0.0, 8, 0.12);
+
+  map_refinement::AssociationConfig config = makeAssociationConfig();
+  config.min_observing_poses = 2;
+
+  const map_refinement::AssociationResult association =
+    map_refinement::associatePlaneFeatures(local_clouds, poses, config);
+
+  EXPECT_GT(association.patches_total, association.patches_used);
+  EXPECT_TRUE(association.features.empty());
+}
+
+TEST(PlaneFeatureAssociation, AssociatedFeaturesImprovePlaneBaPose)
+{
+  std::vector<Eigen::Vector3d> world_points;
+  appendPoints(makeFloorPoints(8, 0.2, 0.0, new std::mt19937(1)), &world_points);
+  appendPoints(makeXWallPoints(4.0, 8, 0.2), &world_points);
+  appendPoints(makeYWallPoints(4.0, 8, 0.2), &world_points);
+
+  std::vector<Eigen::Matrix4d> ground_truth;
+  ground_truth.push_back(Eigen::Matrix4d::Identity());
+  ground_truth.push_back(makePose(0.18, Eigen::Vector3d(0.25, -0.18, 0.12)));
+
+  std::vector<std::vector<Eigen::Vector3d>> local_clouds;
+  local_clouds.push_back(toLocalCloud(world_points, ground_truth[0]));
+  local_clouds.push_back(toLocalCloud(world_points, ground_truth[1]));
+
+  std::vector<Eigen::Matrix4d> initial_poses = ground_truth;
+  initial_poses[1](0, 3) += 0.03;
+
+  map_refinement::AssociationConfig association_config = makeAssociationConfig();
+  association_config.extraction.root_voxel_size = 3.0;
+  association_config.extraction.max_plane_thickness = 0.08;
+
+  const map_refinement::AssociationResult association =
+    map_refinement::associatePlaneFeatures(
+      local_clouds,
+      initial_poses,
+      association_config);
+  ASSERT_GE(association.features.size(), 3U);
+
+  map_refinement::PlaneBaConfig ba_config;
+  disablePosePriors(&ba_config);
+  setMaxIterations(&ba_config);
+
+  const double initial_error = relativeTranslationError(initial_poses, ground_truth);
+  const auto ba_result = runSolvePlaneBa(initial_poses, association.features, ba_config);
+  const std::vector<Eigen::Matrix4d> & refined_poses = optimizedPoses(ba_result);
+  ASSERT_EQ(initial_poses.size(), refined_poses.size());
+
+  const double refined_error = relativeTranslationError(refined_poses, ground_truth);
+  EXPECT_LT(refined_error, initial_error);
+  EXPECT_LT(refined_error, 0.5 * initial_error);
+}
+
+TEST(PlaneFeatureAssociation, MinPointsPerObservationDropsSparseObservations)
+{
+  std::vector<Eigen::Vector3d> dense_floor;
+  std::mt19937 rng(11);
+  dense_floor = makeFloorPoints(7, 0.15, 0.0, &rng);
+
+  std::vector<Eigen::Vector3d> sparse_floor;
+  sparse_floor.push_back(dense_floor[0]);
+  sparse_floor.push_back(dense_floor[1]);
+  sparse_floor.push_back(dense_floor[2]);
+
+  std::vector<Eigen::Matrix4d> poses;
+  poses.push_back(Eigen::Matrix4d::Identity());
+  poses.push_back(Eigen::Matrix4d::Identity());
+
+  std::vector<std::vector<Eigen::Vector3d>> local_clouds;
+  local_clouds.push_back(dense_floor);
+  local_clouds.push_back(sparse_floor);
+
+  map_refinement::AssociationConfig config = makeAssociationConfig();
+  config.min_observing_poses = 1;
+  config.min_points_per_observation = 5;
+
+  const map_refinement::AssociationResult association =
+    map_refinement::associatePlaneFeatures(local_clouds, poses, config);
+
+  ASSERT_FALSE(association.features.empty());
+  for (std::size_t i = 0; i < association.features.size(); ++i) {
+    ASSERT_EQ(1U, association.features[i].observations.size());
+    EXPECT_EQ(0, association.features[i].observations[0].pose_index);
+    EXPECT_NEAR(49.0, association.features[i].observations[0].local_cluster.h(3, 3), 1.0e-9);
+  }
+}
+
+TEST(PlaneFeatureAssociation, DeterministicFirstFeatureClusterH)
+{
+  std::mt19937 rng(13);
+  const std::vector<Eigen::Vector3d> floor_points =
+    makeFloorPoints(9, 0.14, 0.002, &rng);
+
+  std::vector<Eigen::Matrix4d> poses;
+  poses.push_back(Eigen::Matrix4d::Identity());
+  poses.push_back(makePose(-0.2, Eigen::Vector3d(0.3, 0.1, 0.05)));
+
+  std::vector<std::vector<Eigen::Vector3d>> local_clouds;
+  local_clouds.push_back(toLocalCloud(floor_points, poses[0]));
+  local_clouds.push_back(toLocalCloud(floor_points, poses[1]));
+
+  const map_refinement::AssociationConfig config = makeAssociationConfig();
+  const map_refinement::AssociationResult first =
+    map_refinement::associatePlaneFeatures(local_clouds, poses, config);
+  const map_refinement::AssociationResult second =
+    map_refinement::associatePlaneFeatures(local_clouds, poses, config);
+
+  ASSERT_FALSE(first.features.empty());
+  ASSERT_FALSE(second.features.empty());
+  ASSERT_FALSE(first.features[0].observations.empty());
+  ASSERT_FALSE(second.features[0].observations.empty());
+  EXPECT_EQ(first.features.size(), second.features.size());
+
+  const map_refinement::PointCluster & first_cluster =
+    first.features[0].observations[0].local_cluster;
+  const map_refinement::PointCluster & second_cluster =
+    second.features[0].observations[0].local_cluster;
+  EXPECT_EQ(
+    0,
+    std::memcmp(first_cluster.h.data(), second_cluster.h.data(), sizeof(double) * 16U));
+}
+
+TEST(PlaneFeatureAssociation, ExtractorCollectPointIndicesDoesNotChangeAcceptance)
+{
+  std::mt19937 rng(17);
+  const std::vector<Eigen::Vector3d> floor_points =
+    makeFloorPoints(10, 0.1, 0.003, &rng);
+
+  plane_extraction::PlaneExtractionConfig without_indices = makeExtractionConfig();
+  plane_extraction::PlaneExtractionConfig with_indices = without_indices;
+  with_indices.collect_point_indices = true;
+
+  const plane_extraction::PlaneExtractionResult without_result =
+    plane_extraction::extractPlanarPatches(floor_points, without_indices);
+  const plane_extraction::PlaneExtractionResult with_result =
+    plane_extraction::extractPlanarPatches(floor_points, with_indices);
+
+  EXPECT_TRUE(without_result.patch_point_indices.empty());
+  ASSERT_EQ(without_result.patches.size(), with_result.patches.size());
+  ASSERT_EQ(with_result.patches.size(), with_result.patch_point_indices.size());
+
+  for (std::size_t i = 0; i < without_result.patches.size(); ++i) {
+    EXPECT_EQ(without_result.patches[i].point_count, with_result.patches[i].point_count);
+  }
+}

--- a/graph_based_slam/test/test_plane_feature_association.cpp
+++ b/graph_based_slam/test/test_plane_feature_association.cpp
@@ -46,16 +46,6 @@ namespace
 namespace map_refinement = graphslam::map_refinement;
 namespace plane_extraction = graphslam::plane_extraction;
 
-template<int N>
-struct PriorityTag : PriorityTag<N - 1>
-{
-};
-
-template<>
-struct PriorityTag<0>
-{
-};
-
 Eigen::Matrix4d makePose(
   const double yaw,
   const Eigen::Vector3d & translation)
@@ -229,134 +219,6 @@ double relativeTranslationError(
     relative_ground_truth.block<3, 1>(0, 3)).norm();
 }
 
-template<typename Config>
-auto disablePosePriorsImpl(
-  Config * config,
-  PriorityTag<2>)
--> decltype(config->use_pose_priors = false, void())
-{
-  config->use_pose_priors = false;
-}
-
-template<typename Config>
-auto disablePosePriorsImpl(
-  Config * config,
-  PriorityTag<1>)
--> decltype(config->enable_pose_priors = false, void())
-{
-  config->enable_pose_priors = false;
-}
-
-template<typename Config>
-void disablePosePriorsImpl(
-  Config *,
-  PriorityTag<0>)
-{
-}
-
-template<typename Config>
-void disablePosePriors(
-  Config * config)
-{
-  disablePosePriorsImpl(config, PriorityTag<2>());
-}
-
-template<typename Config>
-auto setMaxIterationsImpl(
-  Config * config,
-  PriorityTag<1>)
--> decltype(config->max_iterations = 30, void())
-{
-  config->max_iterations = 30;
-}
-
-template<typename Config>
-void setMaxIterationsImpl(
-  Config *,
-  PriorityTag<0>)
-{
-}
-
-template<typename Config>
-void setMaxIterations(
-  Config * config)
-{
-  setMaxIterationsImpl(config, PriorityTag<1>());
-}
-
-template<typename PoseVector, typename FeatureVector, typename Config>
-auto runSolvePlaneBaImpl(
-  const PoseVector & poses,
-  const FeatureVector & features,
-  const Config & config,
-  PriorityTag<1>)
--> decltype(map_refinement::solvePlaneBa(poses, features, config))
-{
-  return map_refinement::solvePlaneBa(poses, features, config);
-}
-
-template<typename PoseVector, typename FeatureVector, typename Config>
-auto runSolvePlaneBaImpl(
-  const PoseVector & poses,
-  const FeatureVector & features,
-  const Config & config,
-  PriorityTag<0>)
--> decltype(map_refinement::solvePlaneBa(features, poses, config))
-{
-  return map_refinement::solvePlaneBa(features, poses, config);
-}
-
-template<typename PoseVector, typename FeatureVector, typename Config>
-auto runSolvePlaneBa(
-  const PoseVector & poses,
-  const FeatureVector & features,
-  const Config & config)
--> decltype(runSolvePlaneBaImpl(poses, features, config, PriorityTag<1>()))
-{
-  return runSolvePlaneBaImpl(poses, features, config, PriorityTag<1>());
-}
-
-template<typename Result>
-auto optimizedPosesImpl(
-  const Result & result,
-  PriorityTag<3>)
--> decltype((result.poses))
-{
-  return result.poses;
-}
-
-template<typename Result>
-auto optimizedPosesImpl(
-  const Result & result,
-  PriorityTag<2>)
--> decltype((result.optimized_poses))
-{
-  return result.optimized_poses;
-}
-
-template<typename Result>
-auto optimizedPosesImpl(
-  const Result & result,
-  PriorityTag<1>)
--> decltype((result.refined_poses))
-{
-  return result.refined_poses;
-}
-
-const std::vector<Eigen::Matrix4d> & optimizedPosesImpl(
-  const std::vector<Eigen::Matrix4d> & result,
-  PriorityTag<0>)
-{
-  return result;
-}
-
-template<typename Result>
-const std::vector<Eigen::Matrix4d> & optimizedPoses(
-  const Result & result)
-{
-  return optimizedPosesImpl(result, PriorityTag<3>());
-}
-
 }  // namespace
 
 TEST(PlaneFeatureAssociation, SharedNoisyFloorCreatesTwoPoseFeatures)
@@ -386,8 +248,8 @@ TEST(PlaneFeatureAssociation, SharedNoisyFloorCreatesTwoPoseFeatures)
   extraction_config.collect_point_indices = true;
   const plane_extraction::PlaneExtractionResult extraction =
     plane_extraction::extractPlanarPatches(
-      buildWorldCloud(local_clouds, poses),
-      extraction_config);
+    buildWorldCloud(local_clouds, poses),
+    extraction_config);
 
   ASSERT_GE(extraction.patches.size(), association.features.size());
   for (std::size_t feature_index = 0; feature_index < association.features.size();
@@ -459,12 +321,13 @@ TEST(PlaneFeatureAssociation, AssociatedFeaturesImprovePlaneBaPose)
   ASSERT_GE(association.features.size(), 3U);
 
   map_refinement::PlaneBaConfig ba_config;
-  disablePosePriors(&ba_config);
-  setMaxIterations(&ba_config);
+  ba_config.prior_translation_sigma = 0.0;
+  ba_config.max_iterations = 30;
 
   const double initial_error = relativeTranslationError(initial_poses, ground_truth);
-  const auto ba_result = runSolvePlaneBa(initial_poses, association.features, ba_config);
-  const std::vector<Eigen::Matrix4d> & refined_poses = optimizedPoses(ba_result);
+  const map_refinement::PlaneBaResult ba_result =
+    map_refinement::solvePlaneBa(association.features, initial_poses, ba_config);
+  const std::vector<Eigen::Matrix4d> & refined_poses = ba_result.poses;
   ASSERT_EQ(initial_poses.size(), refined_poses.size());
 
   const double refined_error = relativeTranslationError(refined_poses, ground_truth);


### PR DESCRIPTION
## Summary

v0.7 Phase 2(`docs/roadmap/v0.7.md`): **抽出平面 → BA 問題の橋渡し層**。これで「per-submap ローカル点群 + pose 列 → 平面抽出 → 関連付け → LM 精密化」の一気通貫が部品として成立。

- `adaptive_voxel_plane_extractor.hpp` 拡張: per-patch の元 index 収集オプション(`collect_point_indices`、default off)。**off 時の挙動は完全不変**(凍結済み Phase 1 メトリクスプロファイルが依存)— 回帰テストで固定
- **`plane_feature_association.hpp`**(新規): pose-major 連結 + prefix offset で world 雲を構成 → index 付き抽出 → patch ごとに出所 pose で分配し **per-(feature, pose) ローカル PointCluster** を構築(全段昇順 = 決定論)。観測 pose 数 / 観測点数フィルタ付き。出力はそのまま `solvePlaneBa` に入る
- テスト 6 本。要は **E2E 整合オラクル**: GT pose から点群を生成 → pose 1 を 3cm 摂動 → association 出力を solvePlaneBa に投入 → **GT へ回復(誤差半減以上)**

## Verification

- `colcon test --packages-select graph_based_slam`: **1154 tests, 0 failures**(lint 込み)
- 既存抽出器の off-path 無回帰をテストで保証(メトリクス 9 本も green)

## 残り(Phase 2)

`hba_pyramid.hpp`(窓分割 → keypose → グローバル融合)+ `map_refiner` 公開 API + offline runner `--refine` + 実データハードゲート(3-run バイト一致 / 品質メトリクス改善 / APE ε 以内 / リソース実測)
