### PR TITLE
feat(refine): HBA-style hierarchical refinement over pose windows (v0.7 Phase 2)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -279,6 +279,13 @@ if(BUILD_TESTING)
     target_include_directories(test_plane_ba PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_hba_pyramid
+    test/test_hba_pyramid.cpp
+  )
+  if(TARGET test_hba_pyramid)
+    target_include_directories(test_hba_pyramid PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  endif()
+  ament_add_gtest(
     test_plane_feature_association
     test/test_plane_feature_association.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/hba_pyramid.hpp
+++ b/graph_based_slam/include/graph_based_slam/hba_pyramid.hpp
@@ -189,9 +189,9 @@ inline HbaPyramidResult refinePosesHierarchically(
 
     const std::vector<std::vector<Eigen::Vector3d>> window_clouds =
       detail::copyCloudWindow(
-        local_clouds,
-        start_index,
-        window_pose_count);
+      local_clouds,
+      start_index,
+      window_pose_count);
     std::vector<Eigen::Matrix4d> window_poses = detail::copyPoseWindow(
       poses,
       start_index,

--- a/graph_based_slam/include/graph_based_slam/hba_pyramid.hpp
+++ b/graph_based_slam/include/graph_based_slam/hba_pyramid.hpp
@@ -1,0 +1,279 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__HBA_PYRAMID_HPP_
+#define GRAPH_BASED_SLAM__HBA_PYRAMID_HPP_
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include <Eigen/Dense>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/plane_ba.hpp"
+#include "graph_based_slam/plane_feature_association.hpp"
+#include "graph_based_slam/se3_lie.hpp"
+
+namespace graphslam
+{
+namespace map_refinement
+{
+
+/// Hierarchical (HBA-style) plane-BA refinement over a full pose sequence.
+///
+/// This is the v0.7 Phase 2 orchestration layer from docs/roadmap/v0.7.md and
+/// the design note: overlapping bottom-layer windows are refined by local plane
+/// BA, corrections are propagated through the pose chain, and an optional global
+/// polish pass removes residual long-wavelength error for small sequences.
+///
+/// Determinism is intentional: windows are processed in ascending start index,
+/// the supplied configs are fixed, and no clocks or randomness are used. In an
+/// overlap, later windows overwrite earlier estimates and the last write wins.
+/// This deliberately avoids averaging overlapping SE(3) poses. Upper hierarchy
+/// layers and graph fusion are left for later; large sequences skip the global
+/// polish pass when they exceed global_pass_max_poses.
+struct HbaPyramidConfig
+{
+  AssociationConfig association;
+  PlaneBaConfig window_ba;
+  int window_size {16};
+  int window_stride {8};
+  bool run_global_pass {true};
+  int global_pass_max_poses {64};
+  PlaneBaConfig global_ba;
+};
+
+struct WindowReport
+{
+  int start_index {0};
+  int pose_count {0};
+  int features {0};
+  bool improved {false};
+  std::string termination;
+  double initial_cost {0.0};
+  double final_cost {0.0};
+};
+
+struct HbaPyramidResult
+{
+  std::vector<Eigen::Matrix4d> poses;
+  std::vector<WindowReport> windows;
+  bool any_window_improved {false};
+  bool global_pass_ran {false};
+  WindowReport global_report;
+};
+
+namespace detail
+{
+
+inline std::vector<int> makeWindowStarts(
+  const int pose_count,
+  const int requested_window_size,
+  const int requested_stride)
+{
+  std::vector<int> starts;
+  if (pose_count <= 0) {
+    return starts;
+  }
+
+  const int window_size = std::max(1, requested_window_size);
+  const int stride = std::max(1, requested_stride);
+  int next_start = 0;
+
+  while (next_start < pose_count) {
+    int start_index = next_start;
+    if (start_index + window_size >= pose_count) {
+      start_index = std::max(0, pose_count - window_size);
+    }
+
+    if (starts.empty() || starts.back() != start_index) {
+      starts.push_back(start_index);
+    }
+
+    if (start_index + window_size >= pose_count) {
+      break;
+    }
+    next_start += stride;
+  }
+
+  return starts;
+}
+
+inline std::vector<std::vector<Eigen::Vector3d>> copyCloudWindow(
+  const std::vector<std::vector<Eigen::Vector3d>> & local_clouds,
+  const int start_index,
+  const int pose_count)
+{
+  const auto first = local_clouds.begin() + start_index;
+  const auto last = first + pose_count;
+  return std::vector<std::vector<Eigen::Vector3d>>(first, last);
+}
+
+inline std::vector<Eigen::Matrix4d> copyPoseWindow(
+  const std::vector<Eigen::Matrix4d> & poses,
+  const int start_index,
+  const int pose_count)
+{
+  const auto first = poses.begin() + start_index;
+  const auto last = first + pose_count;
+  return std::vector<Eigen::Matrix4d>(first, last);
+}
+
+inline void fillReportFromBa(
+  const PlaneBaResult & ba_result,
+  WindowReport * report)
+{
+  report->improved = ba_result.improved;
+  report->termination = ba_result.termination;
+  report->initial_cost = ba_result.initial_cost;
+  report->final_cost = ba_result.final_cost;
+}
+
+}  // namespace detail
+
+inline HbaPyramidResult refinePosesHierarchically(
+  const std::vector<std::vector<Eigen::Vector3d>> & local_clouds,
+  const std::vector<Eigen::Matrix4d> & initial_poses,
+  const HbaPyramidConfig & config)
+{
+  HbaPyramidResult result;
+  result.poses = initial_poses;
+
+  if (initial_poses.empty() || local_clouds.size() != initial_poses.size()) {
+    return result;
+  }
+
+  std::vector<Eigen::Matrix4d> poses = initial_poses;
+  const int pose_count = static_cast<int>(poses.size());
+  const int window_size = std::max(1, config.window_size);
+  const std::vector<int> starts = detail::makeWindowStarts(
+    pose_count,
+    window_size,
+    config.window_stride);
+
+  for (std::size_t start_i = 0; start_i < starts.size(); ++start_i) {
+    const int start_index = starts[start_i];
+    const int end_index = std::min(pose_count, start_index + window_size);
+    const int window_pose_count = end_index - start_index;
+
+    WindowReport report;
+    report.start_index = start_index;
+    report.pose_count = window_pose_count;
+
+    const std::vector<std::vector<Eigen::Vector3d>> window_clouds =
+      detail::copyCloudWindow(
+        local_clouds,
+        start_index,
+        window_pose_count);
+    std::vector<Eigen::Matrix4d> window_poses = detail::copyPoseWindow(
+      poses,
+      start_index,
+      window_pose_count);
+
+    const AssociationResult association = associatePlaneFeatures(
+      window_clouds,
+      window_poses,
+      config.association);
+    report.features = static_cast<int>(association.features.size());
+
+    if (association.features.empty()) {
+      report.termination = "no_valid_features";
+      result.windows.push_back(report);
+      continue;
+    }
+
+    PlaneBaConfig window_config = config.window_ba;
+    window_config.fix_first_pose = true;
+
+    const PlaneBaResult ba_result = solvePlaneBa(
+      association.features,
+      window_poses,
+      window_config);
+    detail::fillReportFromBa(ba_result, &report);
+    result.any_window_improved = result.any_window_improved ||
+      ba_result.improved;
+
+    const std::size_t write_count = std::min(
+      ba_result.poses.size(),
+      window_poses.size());
+    for (std::size_t pose_i = 1; pose_i < write_count; ++pose_i) {
+      poses[start_index + static_cast<int>(pose_i)] = ba_result.poses[pose_i];
+    }
+
+    poses.front() = initial_poses.front();
+    result.windows.push_back(report);
+  }
+
+  if (config.run_global_pass && pose_count <= config.global_pass_max_poses) {
+    result.global_pass_ran = true;
+
+    WindowReport report;
+    report.start_index = 0;
+    report.pose_count = pose_count;
+
+    const AssociationResult association = associatePlaneFeatures(
+      local_clouds,
+      poses,
+      config.association);
+    report.features = static_cast<int>(association.features.size());
+
+    if (association.features.empty()) {
+      report.termination = "no_valid_features";
+    } else {
+      PlaneBaConfig global_config = config.global_ba;
+      global_config.fix_first_pose = true;
+
+      const PlaneBaResult ba_result = solvePlaneBa(
+        association.features,
+        poses,
+        global_config);
+      detail::fillReportFromBa(ba_result, &report);
+
+      const std::size_t write_count = std::min(
+        ba_result.poses.size(),
+        poses.size());
+      for (std::size_t pose_i = 0; pose_i < write_count; ++pose_i) {
+        poses[pose_i] = ba_result.poses[pose_i];
+      }
+      poses.front() = initial_poses.front();
+    }
+
+    result.global_report = report;
+  }
+
+  poses.front() = initial_poses.front();
+  result.poses = poses;
+  return result;
+}
+
+}  // namespace map_refinement
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__HBA_PYRAMID_HPP_

--- a/graph_based_slam/test/test_hba_pyramid.cpp
+++ b/graph_based_slam/test/test_hba_pyramid.cpp
@@ -1,0 +1,356 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+#include <Eigen/Dense>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/hba_pyramid.hpp"
+#include "graph_based_slam/se3_lie.hpp"
+
+namespace graphslam
+{
+namespace map_refinement
+{
+namespace
+{
+
+constexpr int kPoseCount = 12;
+constexpr double kSpacing = 0.8;
+
+struct CorridorFixture
+{
+  std::vector<Eigen::Matrix4d> ground_truth;
+  std::vector<Eigen::Matrix4d> initial;
+  std::vector<std::vector<Eigen::Vector3d>> local_clouds;
+};
+
+std::vector<Eigen::Vector3d> makeCorridorWorld()
+{
+  std::vector<Eigen::Vector3d> points;
+  points.reserve(1500);
+
+  for (int ix = 0; ix <= 44; ++ix) {
+    const double x = 0.25 * static_cast<double>(ix);
+
+    for (int iy = 0; iy <= 12; ++iy) {
+      const double y = 0.25 * static_cast<double>(iy);
+      points.push_back(Eigen::Vector3d(x, y, 0.0));
+    }
+
+    for (int iz = 1; iz <= 9; ++iz) {
+      const double z = 0.25 * static_cast<double>(iz);
+      points.push_back(Eigen::Vector3d(x, 0.0, z));
+      points.push_back(Eigen::Vector3d(x, 3.0, z));
+    }
+  }
+
+  // Transverse doorframe walls every 2.0 m: without them a corridor of
+  // floor + two parallel walls leaves translation along x unobservable
+  // (the classic degenerate scene) and the priors-off recovery test
+  // would have no data to recover x from.
+  const double doorframe_x[6] = {0.0, 1.7, 3.9, 6.3, 8.2, 10.6};
+  for (int iw = 0; iw <= 5; ++iw) {
+    const double x = doorframe_x[iw];
+    for (int iy = 0; iy <= 12; ++iy) {
+      const double y = 0.25 * static_cast<double>(iy);
+      for (int iz = 1; iz <= 9; ++iz) {
+        const double z = 0.25 * static_cast<double>(iz);
+        if (y > 0.75 && y < 2.25 && z < 2.0) {
+          continue;  // door opening
+        }
+        points.push_back(Eigen::Vector3d(x, y, z));
+      }
+    }
+  }
+
+  return points;
+}
+
+Eigen::Matrix4d makeGroundTruthPose(const int index)
+{
+  Vector6d yaw_delta = Vector6d::Zero();
+  yaw_delta(5) = 0.015 * std::sin(0.4 * static_cast<double>(index));
+
+  Eigen::Matrix4d pose = expSe3(yaw_delta);
+  pose(0, 3) = kSpacing * static_cast<double>(index);
+  pose(1, 3) = 1.5;
+  pose(2, 3) = 1.0;
+  return pose;
+}
+
+Eigen::Matrix4d perturbPose(
+  const Eigen::Matrix4d & pose,
+  const int index)
+{
+  if (index == 0) {
+    return pose;
+  }
+
+  const double even_sign = (index % 2 == 0) ? 1.0 : -1.0;
+  const double third_sign = (index % 3 == 0) ? -1.0 : 1.0;
+
+  Vector6d translation_delta = Vector6d::Zero();
+  translation_delta(1) = even_sign * (0.024 + 0.001 * index);
+  translation_delta(2) = third_sign * 0.018;
+
+  Eigen::Matrix4d moved = leftPerturb(translation_delta, pose);
+
+  Vector6d rotation_delta = Vector6d::Zero();
+  rotation_delta(3) = even_sign * 0.004;
+  rotation_delta(4) = third_sign * 0.003;
+  rotation_delta(5) = -even_sign * 0.006;
+
+  return moved * expSe3(rotation_delta);
+}
+
+std::vector<std::vector<Eigen::Vector3d>> makeLocalClouds(
+  const std::vector<Eigen::Vector3d> & world_points,
+  const std::vector<Eigen::Matrix4d> & ground_truth)
+{
+  std::vector<std::vector<Eigen::Vector3d>> local_clouds;
+  local_clouds.reserve(ground_truth.size());
+
+  for (const Eigen::Matrix4d & pose : ground_truth) {
+    std::vector<Eigen::Vector3d> local_points;
+    const double pose_x = pose(0, 3);
+    const Eigen::Matrix3d rotation = pose.block<3, 3>(0, 0);
+    const Eigen::Vector3d translation = pose.block<3, 1>(0, 3);
+
+    for (const Eigen::Vector3d & point : world_points) {
+      if (std::fabs(point.x() - pose_x) > 2.5) {
+        continue;
+      }
+      local_points.push_back(rotation.transpose() * (point - translation));
+    }
+
+    local_clouds.push_back(local_points);
+  }
+
+  return local_clouds;
+}
+
+CorridorFixture makeCorridorFixture()
+{
+  CorridorFixture fixture;
+  fixture.ground_truth.reserve(kPoseCount);
+
+  for (int i = 0; i < kPoseCount; ++i) {
+    fixture.ground_truth.push_back(makeGroundTruthPose(i));
+  }
+
+  fixture.initial = fixture.ground_truth;
+  for (std::size_t i = 1; i < fixture.initial.size(); ++i) {
+    fixture.initial[i] = perturbPose(fixture.ground_truth[i], static_cast<int>(i));
+  }
+
+  const std::vector<Eigen::Vector3d> world_points = makeCorridorWorld();
+  fixture.local_clouds = makeLocalClouds(world_points, fixture.ground_truth);
+  return fixture;
+}
+
+HbaPyramidConfig makeConfig(const bool run_global_pass)
+{
+  HbaPyramidConfig config;
+  config.window_size = 6;
+  config.window_stride = 3;
+  config.run_global_pass = run_global_pass;
+  config.global_pass_max_poses = 64;
+  config.association.min_observing_poses = 2;
+  config.association.min_points_per_observation = 5;
+  config.window_ba.max_iterations = 15;
+  // Production defaults keep the soft priors ON: they are what prevents
+  // the optimizer from jumping to a repeated-geometry false minimum
+  // (the design note's "polish the wrong map" failure).
+  config.global_ba = config.window_ba;
+  config.global_ba.max_iterations = 15;
+  return config;
+}
+
+double translationError(
+  const Eigen::Matrix4d & pose,
+  const Eigen::Matrix4d & ground_truth)
+{
+  const Eigen::Vector3d pose_t = pose.block<3, 1>(0, 3);
+  const Eigen::Vector3d truth_t = ground_truth.block<3, 1>(0, 3);
+  return (pose_t - truth_t).norm();
+}
+
+double meanTranslationError(
+  const std::vector<Eigen::Matrix4d> & poses,
+  const std::vector<Eigen::Matrix4d> & ground_truth)
+{
+  if (poses.empty()) {
+    return 0.0;
+  }
+
+  double sum = 0.0;
+  for (std::size_t i = 0; i < poses.size(); ++i) {
+    sum += translationError(poses[i], ground_truth[i]);
+  }
+  return sum / static_cast<double>(poses.size());
+}
+
+bool matricesBitwiseEqual(
+  const Eigen::Matrix4d & lhs,
+  const Eigen::Matrix4d & rhs)
+{
+  return std::memcmp(lhs.data(), rhs.data(), 16 * sizeof(double)) == 0;
+}
+
+}  // namespace
+
+TEST(HbaPyramidTest, RecoversTrajectoryAndReportsCoverage)
+{
+  const CorridorFixture fixture = makeCorridorFixture();
+  const HbaPyramidConfig config = makeConfig(true);
+
+  const HbaPyramidResult result = refinePosesHierarchically(
+    fixture.local_clouds,
+    fixture.initial,
+    config);
+
+  ASSERT_EQ(fixture.ground_truth.size(), result.poses.size());
+
+  const double input_mean = meanTranslationError(
+    fixture.initial,
+    fixture.ground_truth);
+  const double refined_mean = meanTranslationError(
+    result.poses,
+    fixture.ground_truth);
+
+  for (std::size_t i = 0; i < result.poses.size(); ++i) {
+    const double input_error = translationError(
+      fixture.initial[i],
+      fixture.ground_truth[i]);
+    const double refined_error = translationError(
+      result.poses[i],
+      fixture.ground_truth[i]);
+    // Aggregate improvement is the oracle (mean at least halves below);
+    // individual poses may trade a few mm against the gauge anchor and
+    // the soft priors.
+    EXPECT_LE(refined_error, input_error + 0.01) << "pose " << i;
+  }
+
+  EXPECT_LT(refined_mean, 0.5 * input_mean);
+  EXPECT_GE(result.windows.size(), static_cast<std::size_t>(3));
+  ASSERT_FALSE(result.windows.empty());
+
+  const WindowReport & last_window = result.windows.back();
+  const int expected_end = static_cast<int>(fixture.ground_truth.size());
+  EXPECT_EQ(expected_end, last_window.start_index + last_window.pose_count);
+  EXPECT_TRUE(matricesBitwiseEqual(result.poses.front(), fixture.initial.front()));
+  EXPECT_TRUE(result.global_pass_ran);
+}
+
+TEST(HbaPyramidTest, IsDeterministic)
+{
+  const CorridorFixture fixture = makeCorridorFixture();
+  const HbaPyramidConfig config = makeConfig(true);
+
+  const HbaPyramidResult first = refinePosesHierarchically(
+    fixture.local_clouds,
+    fixture.initial,
+    config);
+  const HbaPyramidResult second = refinePosesHierarchically(
+    fixture.local_clouds,
+    fixture.initial,
+    config);
+
+  ASSERT_EQ(first.poses.size(), second.poses.size());
+
+  for (std::size_t i = 0; i < first.poses.size(); ++i) {
+    const bool same = matricesBitwiseEqual(first.poses[i], second.poses[i]);
+    EXPECT_TRUE(same) << "pose " << i;
+  }
+}
+
+TEST(HbaPyramidTest, HandlesZeroFeatureCloudsWithoutChangingPoses)
+{
+  const CorridorFixture fixture = makeCorridorFixture();
+  const HbaPyramidConfig config = makeConfig(true);
+
+  std::vector<std::vector<Eigen::Vector3d>> small_clouds(fixture.initial.size());
+  for (std::size_t i = 0; i < small_clouds.size(); ++i) {
+    small_clouds[i].push_back(Eigen::Vector3d(0.0, 0.0, 0.0));
+    small_clouds[i].push_back(Eigen::Vector3d(0.2, 0.0, 0.1));
+    small_clouds[i].push_back(Eigen::Vector3d(0.0, 0.2, 0.1));
+  }
+
+  const HbaPyramidResult result = refinePosesHierarchically(
+    small_clouds,
+    fixture.initial,
+    config);
+
+  ASSERT_EQ(fixture.initial.size(), result.poses.size());
+  ASSERT_FALSE(result.windows.empty());
+
+  for (const WindowReport & report : result.windows) {
+    EXPECT_EQ("no_valid_features", report.termination);
+    EXPECT_EQ(0, report.features);
+    EXPECT_FALSE(report.improved);
+  }
+
+  for (std::size_t i = 0; i < result.poses.size(); ++i) {
+    const bool same = matricesBitwiseEqual(result.poses[i], fixture.initial[i]);
+    EXPECT_TRUE(same) << "pose " << i;
+  }
+
+  EXPECT_FALSE(result.any_window_improved);
+  EXPECT_TRUE(result.global_pass_ran);
+  EXPECT_EQ("no_valid_features", result.global_report.termination);
+}
+
+TEST(HbaPyramidTest, WindowOnlyRunSkipsGlobalPassAndStillImproves)
+{
+  const CorridorFixture fixture = makeCorridorFixture();
+  const HbaPyramidConfig config = makeConfig(false);
+
+  const HbaPyramidResult result = refinePosesHierarchically(
+    fixture.local_clouds,
+    fixture.initial,
+    config);
+
+  const double input_mean = meanTranslationError(
+    fixture.initial,
+    fixture.ground_truth);
+  const double refined_mean = meanTranslationError(
+    result.poses,
+    fixture.ground_truth);
+
+  EXPECT_FALSE(result.global_pass_ran);
+  EXPECT_LT(refined_mean, input_mean);
+}
+
+}  // namespace map_refinement
+}  // namespace graphslam


### PR DESCRIPTION
## Summary

v0.7 Phase 2(`docs/roadmap/v0.7.md`): **階層リファインメントのオーケストレーション層** `hba_pyramid.hpp`。オーバーラップ窓(K/S)を昇順に局所 BA → 共有アンカー pose 経由でチェーン伝播 → 小規模列にはグローバル磨き上げパス。clean-room。

- 窓ごと: スライス上で associate → 先頭 pose を gauge 固定して `solvePlaneBa`(先頭は前窓で精密化済み = チェーン整合)。オーバーラップは last-write-wins(決定論的。平均化は SE(3) 構造を壊す)
- 特徴ゼロ窓は `no_valid_features` 報告 + pose 不変。列の pose 0 はビット不変
- テスト 4 本: 軌跡回復 + 窓カバレッジ + gauge + global pass / ビット決定論 / 特徴ゼロ頑健性 / 窓のみ改善

## 開発中に実証された設計ノートの警告(重要な知見)

廊下フィクスチャで **「repeated geometry では BA が間違ったマップを磨く」**故障がそのまま再現: prior 無効 + 2.0m 周期ドア枠 → 窓が隣の枠に飛びつき 1.2m 発散。**production 既定の soft prior(σ=0.30m)を有効にすると物理的に偽極小へ飛べなくなり**、不等間隔幾何で平均誤差半減を回復。→ 実データでも prior は切らないのが正(テストにコメントで明文化)

## Verification

- `colcon test --packages-select graph_based_slam`: **1167 tests, 0 failures**(lint 込み)
- 純追加

## 残り(Phase 2)

`map_refiner` 公開 API(+ submap 入力グルー)→ offline runner `--refine` + 単体 CLI → 実データハードゲート(3-run バイト一致 / メトリクス改善 / APE ε / リソース実測)
