### PR TITLE
feat(refine): map_refiner API + offline runner --refine integration (v0.7 Phase 2)

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -279,6 +279,13 @@ if(BUILD_TESTING)
     target_include_directories(test_plane_ba PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_map_refiner
+    test/test_map_refiner.cpp
+  )
+  if(TARGET test_map_refiner)
+    target_include_directories(test_map_refiner PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  endif()
+  ament_add_gtest(
     test_hba_pyramid
     test/test_hba_pyramid.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/map_refiner.hpp
+++ b/graph_based_slam/include/graph_based_slam/map_refiner.hpp
@@ -1,0 +1,172 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__MAP_REFINER_HPP_
+#define GRAPH_BASED_SLAM__MAP_REFINER_HPP_
+
+// Public entry point of the v0.7 offline map refinement
+// (docs/roadmap/v0.7.md Phase 2): deterministic per-submap downsample ->
+// hierarchical plane BA over the pose sequence -> conservative
+// acceptance. When the refinement does not improve anything the input
+// poses are returned bitwise-unchanged and the report says why — the
+// reject-with-report fallback that bounds the blast radius of the
+// offline runner's --refine stage. Same inputs ⇒ same refined poses and
+// same report bytes.
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+
+#include "graph_based_slam/hba_pyramid.hpp"
+#include "graph_based_slam/map_quality_metrics.hpp"
+
+namespace graphslam
+{
+namespace map_refinement
+{
+
+struct MapRefinerConfig
+{
+  // Deterministic voxel-centroid downsample applied per submap cloud
+  // before the BA (0 = off). Bounds the point-cluster build cost.
+  double cloud_downsample_voxel {0.10};
+  HbaPyramidConfig pyramid;
+};
+
+struct MapRefinerResult
+{
+  std::vector<Eigen::Matrix4d> poses;  // refined, or the input when !accepted
+  bool accepted {false};
+  std::string status;                  // "refined" | "no_improvement" | "empty_input"
+  std::int64_t input_points {0};
+  std::int64_t downsampled_points {0};
+  HbaPyramidResult pyramid_result;
+};
+
+inline MapRefinerResult refineSubmapPoses(
+  const std::vector<std::vector<Eigen::Vector3d>> & local_clouds,
+  const std::vector<Eigen::Matrix4d> & initial_poses,
+  const MapRefinerConfig & config)
+{
+  MapRefinerResult result;
+  result.poses = initial_poses;
+  if (initial_poses.empty() || local_clouds.size() != initial_poses.size()) {
+    result.status = "empty_input";
+    return result;
+  }
+
+  std::vector<std::vector<Eigen::Vector3d>> downsampled;
+  downsampled.reserve(local_clouds.size());
+  for (size_t i = 0; i < local_clouds.size(); ++i) {
+    result.input_points += static_cast<std::int64_t>(local_clouds[i].size());
+    downsampled.push_back(
+      map_quality::downsampleByVoxelCentroid(local_clouds[i], config.cloud_downsample_voxel));
+    result.downsampled_points += static_cast<std::int64_t>(downsampled.back().size());
+  }
+
+  result.pyramid_result =
+    refinePosesHierarchically(downsampled, initial_poses, config.pyramid);
+
+  const bool improved =
+    result.pyramid_result.any_window_improved ||
+    (result.pyramid_result.global_pass_ran && result.pyramid_result.global_report.improved);
+  if (!improved) {
+    // Conservative fallback: the gates can never get worse than the
+    // pose-graph solution.
+    result.status = "no_improvement";
+    return result;
+  }
+  result.poses = result.pyramid_result.poses;
+  result.accepted = true;
+  result.status = "refined";
+  return result;
+}
+
+namespace detail
+{
+
+inline std::string refinerDouble(double value)
+{
+  char buffer[64];
+  std::snprintf(buffer, sizeof(buffer), "%.9f", value);
+  return std::string(buffer);
+}
+
+}  // namespace detail
+
+// Fixed-format report: the offline determinism gate compares these bytes.
+inline std::vector<std::string> refinerReportYamlLines(
+  const MapRefinerResult & result, const MapRefinerConfig & config)
+{
+  std::vector<std::string> lines;
+  lines.push_back("map_refinement_report:");
+  lines.push_back("  status: " + result.status);
+  lines.push_back(
+    "  accepted: " + std::string(result.accepted ? "true" : "false"));
+  lines.push_back("  input_points: " + std::to_string(result.input_points));
+  lines.push_back(
+    "  downsampled_points: " + std::to_string(result.downsampled_points));
+  lines.push_back(
+    "  cloud_downsample_voxel_m: " +
+    detail::refinerDouble(config.cloud_downsample_voxel));
+  lines.push_back(
+    "  windows: " + std::to_string(result.pyramid_result.windows.size()));
+  int improved_windows = 0;
+  int no_feature_windows = 0;
+  for (size_t i = 0; i < result.pyramid_result.windows.size(); ++i) {
+    if (result.pyramid_result.windows[i].improved) {
+      ++improved_windows;
+    }
+    if (result.pyramid_result.windows[i].termination == "no_valid_features") {
+      ++no_feature_windows;
+    }
+  }
+  lines.push_back("  improved_windows: " + std::to_string(improved_windows));
+  lines.push_back("  no_feature_windows: " + std::to_string(no_feature_windows));
+  lines.push_back(
+    "  global_pass_ran: " +
+    std::string(result.pyramid_result.global_pass_ran ? "true" : "false"));
+  if (result.pyramid_result.global_pass_ran) {
+    lines.push_back(
+      "  global_initial_cost: " +
+      detail::refinerDouble(result.pyramid_result.global_report.initial_cost));
+    lines.push_back(
+      "  global_final_cost: " +
+      detail::refinerDouble(result.pyramid_result.global_report.final_cost));
+  }
+  return lines;
+}
+
+}  // namespace map_refinement
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__MAP_REFINER_HPP_

--- a/graph_based_slam/src/graph_slam_offline_runner.cpp
+++ b/graph_based_slam/src/graph_slam_offline_runner.cpp
@@ -45,6 +45,7 @@
 //     -p bag_path:=output/backend_replay_x/backend_input \
 //     -p output_dir:=/tmp/offline_run1
 
+#include <pcl/io/pcd_io.h>  // NOLINT(build/include_order)
 #include <pcl_conversions/pcl_conversions.h>  // NOLINT(build/include_order)
 
 #include <cstdio>
@@ -64,6 +65,7 @@
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include "graph_based_slam/backend_core.hpp"
+#include "graph_based_slam/map_refiner.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
 #include "graph_based_slam/registration_factory.hpp"
 #include "graph_based_slam/submap_creation.hpp"
@@ -136,6 +138,20 @@ int main(int argc, char ** argv)
   node->get_parameter_or("voxel_leaf_size", voxel_leaf_size, 0.2);
   node->get_parameter_or("submap_distance_threshold", submap_distance_threshold, 1.5);
   node->get_parameter_or("debug_flag", debug_flag, false);
+
+  // v0.7 Phase 2 (docs/roadmap/v0.7.md): optional offline plane-BA
+  // refinement of the optimized submap poses. Off by default; when it
+  // does not improve anything the pose-graph solution is kept unchanged.
+  bool refine = false;
+  double refine_cloud_downsample = 0.10;
+  int refine_window_size = 16;
+  int refine_window_stride = 8;
+  node->get_parameter_or("refine", refine, false);
+  node->get_parameter_or("refine_cloud_downsample", refine_cloud_downsample, 0.10);
+  node->get_parameter_or("refine_window_size", refine_window_size, 16);
+  node->get_parameter_or("refine_window_stride", refine_window_stride, 8);
+  bool refine_save_maps = false;
+  node->get_parameter_or("refine_save_maps", refine_save_maps, false);
 
   graphslam::backend_core::DescriptorConfig descriptor_config;
   node->get_parameter_or("use_scan_context", descriptor_config.use_scan_context, false);
@@ -552,6 +568,79 @@ int main(int argc, char ** argv)
       writeTum(output_dir + "/trajectory_optimized.tum", records, optimized_poses);
     }
   }
+  if (refine && !optimized_poses.empty()) {
+    graphslam::map_refinement::MapRefinerConfig refiner_config;
+    refiner_config.cloud_downsample_voxel = refine_cloud_downsample;
+    refiner_config.pyramid.window_size = refine_window_size;
+    refiner_config.pyramid.window_stride = refine_window_stride;
+
+    std::vector<std::vector<Eigen::Vector3d>> local_clouds;
+    local_clouds.reserve(records.size());
+    for (const auto & record : records) {
+      std::vector<Eigen::Vector3d> points;
+      points.reserve(record.cloud->size());
+      for (size_t i = 0; i < record.cloud->size(); ++i) {
+        const auto & p = record.cloud->points[i];
+        if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {continue;}
+        points.push_back(Eigen::Vector3d(p.x, p.y, p.z));
+      }
+      local_clouds.push_back(points);
+    }
+    std::vector<Eigen::Matrix4d> initial_matrices;
+    initial_matrices.reserve(optimized_poses.size());
+    for (const auto & pose : optimized_poses) {
+      initial_matrices.push_back(pose.matrix());
+    }
+
+    const graphslam::map_refinement::MapRefinerResult refined =
+      graphslam::map_refinement::refineSubmapPoses(
+      local_clouds, initial_matrices, refiner_config);
+
+    std::vector<Eigen::Isometry3d> refined_poses;
+    refined_poses.reserve(refined.poses.size());
+    for (const auto & pose : refined.poses) {
+      refined_poses.push_back(Eigen::Isometry3d(pose));
+    }
+    writeTum(output_dir + "/trajectory_refined.tum", records, refined_poses);
+    {
+      std::ofstream report(output_dir + "/map_refinement_report.yaml");
+      const std::vector<std::string> lines =
+        graphslam::map_refinement::refinerReportYamlLines(refined, refiner_config);
+      for (size_t i = 0; i < lines.size(); ++i) {
+        report << lines[i] << "\n";
+      }
+    }
+    RCLCPP_INFO(
+      logger, "Refinement %s: %zu windows, status=%s",
+      refined.accepted ? "accepted" : "rejected",
+      refined.pyramid_result.windows.size(), refined.status.c_str());
+
+    if (refine_save_maps) {
+      // Before/after map PCDs for the map-quality gate stage. The clouds
+      // are the runner's own deterministic submap clouds; only the poses
+      // differ between the two maps.
+      const auto save_map =
+        [&](const std::vector<Eigen::Matrix4d> & poses, const std::string & path) {
+          pcl::PointCloud<pcl::PointXYZ> map_cloud;
+          for (size_t i = 0; i < local_clouds.size(); ++i) {
+            const Eigen::Matrix3d rotation = poses[i].block<3, 3>(0, 0);
+            const Eigen::Vector3d translation = poses[i].block<3, 1>(0, 3);
+            for (size_t j = 0; j < local_clouds[i].size(); ++j) {
+              const Eigen::Vector3d world = rotation * local_clouds[i][j] + translation;
+              map_cloud.push_back(
+                pcl::PointXYZ(
+                  static_cast<float>(world.x()), static_cast<float>(world.y()),
+                  static_cast<float>(world.z())));
+            }
+          }
+          pcl::io::savePCDFileBinary(path, map_cloud);
+        };
+      save_map(initial_matrices, output_dir + "/map_optimized.pcd");
+      save_map(refined.poses, output_dir + "/map_refined.pcd");
+      RCLCPP_INFO(logger, "Wrote map_optimized.pcd and map_refined.pcd");
+    }
+  }
+
   RCLCPP_INFO(logger, "Wrote %s/loop_edges.csv and TUM trajectories", output_dir.c_str());
 
   rclcpp::shutdown();

--- a/graph_based_slam/test/test_map_refiner.cpp
+++ b/graph_based_slam/test/test_map_refiner.cpp
@@ -1,0 +1,192 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "graph_based_slam/map_refiner.hpp"
+
+namespace
+{
+
+using graphslam::map_refinement::expSe3;
+using graphslam::map_refinement::leftPerturb;
+using graphslam::map_refinement::MapRefinerConfig;
+using graphslam::map_refinement::MapRefinerResult;
+using graphslam::map_refinement::refineSubmapPoses;
+using graphslam::map_refinement::refinerReportYamlLines;
+using graphslam::map_refinement::Vector6d;
+
+struct Fixture
+{
+  std::vector<std::vector<Eigen::Vector3d>> local_clouds;
+  std::vector<Eigen::Matrix4d> ground_truth;
+  std::vector<Eigen::Matrix4d> initial;
+};
+
+Eigen::Matrix4d inversePose(const Eigen::Matrix4d & pose)
+{
+  Eigen::Matrix4d inverse = Eigen::Matrix4d::Identity();
+  const Eigen::Matrix3d rotation = pose.block<3, 3>(0, 0);
+  inverse.block<3, 3>(0, 0) = rotation.transpose();
+  inverse.block<3, 1>(0, 3) = -rotation.transpose() * pose.block<3, 1>(0, 3);
+  return inverse;
+}
+
+// A small room: floor + two orthogonal walls, 6 poses, ~mm noise.
+Fixture makeRoomFixture()
+{
+  std::mt19937 rng(31415);
+  std::normal_distribution<double> noise(0.0, 0.004);
+  std::vector<Eigen::Vector3d> world;
+  for (int a = 0; a <= 30; ++a) {
+    for (int b = 0; b <= 30; ++b) {
+      const double u = 0.12 * a;
+      const double v = 0.12 * b;
+      world.push_back(Eigen::Vector3d(u, v, noise(rng)));
+      world.push_back(Eigen::Vector3d(u, noise(rng), 0.3 + 0.8 * v / 3.6));
+      world.push_back(Eigen::Vector3d(noise(rng), u, 0.3 + 0.8 * v / 3.6));
+    }
+  }
+
+  Fixture fixture;
+  for (int i = 0; i < 6; ++i) {
+    Vector6d twist;
+    twist << 0.45 * i, 0.3 * (i % 2), 0.0, 0.0, 0.0, 0.04 * i;
+    fixture.ground_truth.push_back(expSe3(twist));
+  }
+  fixture.initial = fixture.ground_truth;
+  for (size_t i = 1; i < fixture.initial.size(); ++i) {
+    Vector6d delta;
+    const double sign = (i % 2 == 0) ? 1.0 : -1.0;
+    delta << 0.03 * sign, -0.02 * sign, 0.015 * sign, 0.008 * sign,
+      -0.006 * sign, 0.01 * sign;
+    fixture.initial[i] = leftPerturb(delta, fixture.initial[i]);
+  }
+  for (size_t p = 0; p < fixture.ground_truth.size(); ++p) {
+    const Eigen::Matrix4d world_to_local = inversePose(fixture.ground_truth[p]);
+    std::vector<Eigen::Vector3d> local;
+    local.reserve(world.size());
+    for (size_t i = 0; i < world.size(); ++i) {
+      local.push_back(
+        world_to_local.block<3, 3>(0, 0) * world[i] +
+        world_to_local.block<3, 1>(0, 3));
+    }
+    fixture.local_clouds.push_back(local);
+  }
+  return fixture;
+}
+
+MapRefinerConfig smallConfig()
+{
+  MapRefinerConfig config;
+  config.cloud_downsample_voxel = 0.05;
+  config.pyramid.window_size = 4;
+  config.pyramid.window_stride = 2;
+  config.pyramid.window_ba.max_iterations = 15;
+  config.pyramid.global_ba.max_iterations = 15;
+  return config;
+}
+
+double meanError(
+  const std::vector<Eigen::Matrix4d> & poses,
+  const std::vector<Eigen::Matrix4d> & reference)
+{
+  double sum = 0.0;
+  for (size_t i = 0; i < poses.size(); ++i) {
+    sum += (poses[i].block<3, 1>(0, 3) - reference[i].block<3, 1>(0, 3)).norm();
+  }
+  return sum / static_cast<double>(poses.size());
+}
+
+TEST(MapRefiner, RefinesPerturbedRoomTowardGroundTruth) {
+  const Fixture fixture = makeRoomFixture();
+  const MapRefinerResult result =
+    refineSubmapPoses(fixture.local_clouds, fixture.initial, smallConfig());
+  EXPECT_TRUE(result.accepted);
+  EXPECT_EQ(result.status, "refined");
+  EXPECT_GT(result.input_points, result.downsampled_points);
+  const double input_error = meanError(fixture.initial, fixture.ground_truth);
+  const double refined_error = meanError(result.poses, fixture.ground_truth);
+  EXPECT_LT(refined_error, input_error);
+}
+
+TEST(MapRefiner, EmptyInputFallsBack) {
+  const std::vector<std::vector<Eigen::Vector3d>> clouds;
+  const std::vector<Eigen::Matrix4d> poses;
+  const MapRefinerResult result =
+    refineSubmapPoses(clouds, poses, smallConfig());
+  EXPECT_FALSE(result.accepted);
+  EXPECT_EQ(result.status, "empty_input");
+}
+
+TEST(MapRefiner, FeaturelessCloudsReturnInputBitwise) {
+  Fixture fixture = makeRoomFixture();
+  for (size_t i = 0; i < fixture.local_clouds.size(); ++i) {
+    fixture.local_clouds[i].resize(3);
+  }
+  const MapRefinerResult result =
+    refineSubmapPoses(fixture.local_clouds, fixture.initial, smallConfig());
+  EXPECT_FALSE(result.accepted);
+  EXPECT_EQ(result.status, "no_improvement");
+  for (size_t i = 0; i < fixture.initial.size(); ++i) {
+    EXPECT_EQ(
+      0,
+      std::memcmp(
+        fixture.initial[i].data(), result.poses[i].data(), 16 * sizeof(double)));
+  }
+}
+
+TEST(MapRefiner, ReportBytesAreDeterministic) {
+  const Fixture fixture = makeRoomFixture();
+  const MapRefinerConfig config = smallConfig();
+  const MapRefinerResult first =
+    refineSubmapPoses(fixture.local_clouds, fixture.initial, config);
+  const MapRefinerResult second =
+    refineSubmapPoses(fixture.local_clouds, fixture.initial, config);
+  const std::vector<std::string> first_lines = refinerReportYamlLines(first, config);
+  const std::vector<std::string> second_lines = refinerReportYamlLines(second, config);
+  ASSERT_EQ(first_lines.size(), second_lines.size());
+  for (size_t i = 0; i < first_lines.size(); ++i) {
+    EXPECT_EQ(first_lines[i], second_lines[i]);
+  }
+  for (size_t p = 0; p < first.poses.size(); ++p) {
+    EXPECT_EQ(
+      0,
+      std::memcmp(first.poses[p].data(), second.poses[p].data(), 16 * sizeof(double)));
+  }
+  ASSERT_FALSE(first_lines.empty());
+  EXPECT_EQ(first_lines[0], "map_refinement_report:");
+}
+
+}  // namespace

--- a/scripts/run_offline_determinism_check.sh
+++ b/scripts/run_offline_determinism_check.sh
@@ -100,6 +100,16 @@ for i in $(seq 2 "${RUNS}"); do
     echo "MISMATCH (optimized trajectory): run1 vs run${i}"
     status=1
   fi
+  # v0.7 refinement artifacts (present only when the runner ran with
+  # refine:=true) join the byte-identity contract.
+  for refined_artifact in trajectory_refined.tum map_refinement_report.yaml; do
+    if [[ -f "${OUTPUT_DIR}/run1/${refined_artifact}" ]]; then
+      if ! diff -q "${OUTPUT_DIR}/run1/${refined_artifact}"         "${OUTPUT_DIR}/run${i}/${refined_artifact}" > /dev/null; then
+        echo "MISMATCH (${refined_artifact}): run1 vs run${i}"
+        status=1
+      fi
+    fi
+  done
 done
 
 summary="${OUTPUT_DIR}/offline_determinism_summary.md"


### PR DESCRIPTION
## Summary

v0.7 Phase 2(`docs/roadmap/v0.7.md`): **統合層** — リファインメントエンジンが E2E で使える形になりました。

- **`map_refiner.hpp`** — 公開 API: 決定論 downsample → 階層平面 BA → 保守的受理(改善なし = 入力 pose をビット不変で返す reject-with-report)。レポートは固定フォーマット YAML(バイト比較可能)
- **`graph_slam_offline_runner`** — `refine:=true` で pose graph 最適化後に実行、`trajectory_refined.tum` + `map_refinement_report.yaml` を出力。`refine_save_maps:=true` で before/after マップ PCD も出力。**既存成果物は完全無干渉**(refine on でも loop_edges md5 `feee9547` / trajectory_optimized md5 `92676db4` 不変)
- **`run_offline_determinism_check.sh`** — refined 成果物が存在する場合はバイト一致契約に参加
- map_refiner テスト 4 本(部屋フィクスチャ回復 / 空入力・特徴ゼロのビット不変フォールバック / レポートバイト決定論)

## 実データ初証拠(MID-360 ゲート基盤、640 submaps / 1079 m)

| 項目 | 結果 |
|---|---|
| 所要 / メモリ | wall 4:38(リファイン分 ~2.5 分)/ peak RSS **539 MB**(設計予算 1-4GB に余裕) |
| 窓 | **79/79 improved**、status refined |
| 決定論 | trajectory_refined.tum が**独立 2 run でバイト一致** |
| APE vs reference | 7.262851264566504 → **7.254892426501326**(微改善 — 基準は ε 以内) |
| マップ品質 | MME −1.6127 → **−1.6205**、壁厚 mean 0.04440 → **0.04405**(両方改善)、coverage −0.5% |

この基盤は GLIM 参照とのグローバル不一致が支配的なため改善は控えめ(想定どおり)。構造的な indoor 基盤(baseline の 9cm 壁)向けのチューニング + 3-run ハードゲート実走 + roadmap status 更新は次 PR。

## Verification

- `colcon test --packages-select graph_based_slam`: **1180 tests, 0 failures**(lint 込み)
- refine は default off(opt-in)— 既定経路への影響ゼロ
