### PR TITLE
feat(map-quality): per-profile threshold table mechanism (v0.7 Phase 3)

### DIFF
--- a/configs/map_quality_profiles/indoor_construction.yaml
+++ b/configs/map_quality_profiles/indoor_construction.yaml
@@ -1,0 +1,12 @@
+# Phase 3 rollout mirrors the v0.5 GT-gate rollout: indoor profiles block first
+# while outdoor profiles remain report-only until calibration evidence lands.
+# Thresholds marked PROVISIONAL are replaced by the Phase 3 calibration PR.
+map_quality_profile:
+  name: indoor_construction
+  enforcement: blocking
+  require_meaningful_planes: true
+  thresholds:
+    # PROVISIONAL values - calibrated in the Phase 3 evidence PR (holdout-validated).
+    thickness_rms_mean_max_m: 0.999
+    planar_coverage_min: 0.001
+    mme_valid_fraction_min: 0.5

--- a/configs/map_quality_profiles/outdoor_vegetation.yaml
+++ b/configs/map_quality_profiles/outdoor_vegetation.yaml
@@ -1,0 +1,11 @@
+# Phase 3 rollout mirrors the v0.5 GT-gate rollout: indoor profiles block first
+# while outdoor profiles remain report-only until calibration evidence lands.
+# Thresholds marked PROVISIONAL are replaced by the Phase 3 calibration PR.
+map_quality_profile:
+  name: outdoor_vegetation
+  enforcement: report_only
+  require_meaningful_planes: false
+  thresholds:
+    # PROVISIONAL values - calibrated in the Phase 3 evidence PR (holdout-validated).
+    thickness_rms_mean_max_m: 0.999
+    planar_coverage_min: 0.001

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -345,6 +345,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_map_quality_profiles
+    test/test_map_quality_profiles.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_mid360_robot_tools
     test/test_mid360_robot_tools.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_map_quality_profiles.py
+++ b/graph_based_slam/test/test_map_quality_profiles.py
@@ -1,0 +1,281 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Tests for map-quality threshold profiles and comparator CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / 'scripts' / 'check_map_quality_thresholds.py'
+PROFILES_DIR = ROOT / 'configs' / 'map_quality_profiles'
+
+
+def load_comparator_module():
+    """Load the comparator script as an importable module."""
+    spec = importlib.util.spec_from_file_location('check_map_quality_thresholds', SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def base_report(meaningful=True, thickness=0.05, coverage=0.6, valid_fraction=0.99):
+    """Build a synthetic map_quality_report dict in the frozen format."""
+    return {
+        'map_quality_report': {
+            'input_points': 3060570,
+            'evaluated_points': 648113,
+            'downsample_voxel_size_m': 0.1,
+            'mean_map_entropy': {
+                'value_nats': -1.110389903,
+                'radius_m': 0.5,
+                'valid_points': 642003,
+                'valid_fraction': valid_fraction,
+            },
+            'plane_metrics': {
+                'meaningful': meaningful,
+                'patch_count': 7198,
+                'thickness_rms_mean_m': thickness,
+                'thickness_rms_p95_m': 0.11,
+                'planar_coverage': coverage,
+                'min_meaningful_planar_coverage': 0.05,
+            },
+            'density': {
+                'occupied_root_voxels': 9786,
+                'mean_points_per_voxel': 66.228591866,
+                'stddev_points_per_voxel': 97.275177782,
+            },
+        }
+    }
+
+
+def profile(enforcement='blocking', require_meaningful_planes=True, thresholds=None):
+    """Build a synthetic map_quality_profile dict."""
+    return {
+        'map_quality_profile': {
+            'name': 'test_profile',
+            'enforcement': enforcement,
+            'require_meaningful_planes': require_meaningful_planes,
+            'thresholds': thresholds
+            if thresholds is not None
+            else {
+                'thickness_rms_mean_max_m': 0.2,
+                'planar_coverage_min': 0.1,
+                'mme_valid_fraction_min': 0.5,
+            },
+        }
+    }
+
+
+def write_yaml(path, data):
+    """Write a dict as YAML to path."""
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding='utf-8')
+
+
+def run_cli(tmp_path, report_data, profile_data, extra_args=None):
+    """Run the comparator CLI on synthetic report/profile files."""
+    report_path = tmp_path / 'report.yaml'
+    profile_path = tmp_path / 'profile.yaml'
+    write_yaml(report_path, report_data)
+    write_yaml(profile_path, profile_data)
+
+    cmd = [
+        sys.executable,
+        str(SCRIPT),
+        '--report',
+        str(report_path),
+        '--profile',
+        str(profile_path),
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    return subprocess.run(cmd, check=False, capture_output=True, text=True)
+
+
+def test_blocking_profile_all_thresholds_pass(tmp_path):
+    """A blocking profile with satisfied thresholds exits 0 with OK."""
+    completed = run_cli(tmp_path, base_report(), profile())
+
+    assert completed.returncode == 0
+    assert 'MAP_QUALITY_THRESHOLDS_OK' in completed.stdout
+    assert 'violations=0' in completed.stdout
+
+
+def test_blocking_profile_violation_fails(tmp_path):
+    """A blocking violation exits 1 and names the violated key."""
+    completed = run_cli(
+        tmp_path,
+        base_report(thickness=0.5),
+        profile(thresholds={'thickness_rms_mean_max_m': 0.2}),
+    )
+
+    assert completed.returncode == 1
+    assert 'MAP_QUALITY_THRESHOLDS_FAILED' in completed.stdout
+    assert (
+        'THRESHOLD thickness_rms_mean_max_m value=0.500000000 '
+        'limit=0.200000000 verdict=VIOLATION'
+    ) in completed.stdout
+
+
+def test_report_only_profile_violation_exits_zero(tmp_path):
+    """report_only enforcement reports violations but exits 0."""
+    completed = run_cli(
+        tmp_path,
+        base_report(thickness=0.5),
+        profile(
+            enforcement='report_only',
+            require_meaningful_planes=False,
+            thresholds={'thickness_rms_mean_max_m': 0.2},
+        ),
+    )
+
+    assert completed.returncode == 0
+    assert 'MAP_QUALITY_THRESHOLDS_REPORT_ONLY' in completed.stdout
+    assert 'violations=1' in completed.stdout
+
+
+def test_not_meaningful_required_planes_violates_and_skips_plane_thresholds(tmp_path):
+    """meaningful=false violates a require_meaningful_planes gate; plane keys skip."""
+    completed = run_cli(
+        tmp_path,
+        base_report(meaningful=False, valid_fraction=0.75),
+        profile(
+            require_meaningful_planes=True,
+            thresholds={
+                'thickness_rms_mean_max_m': 0.2,
+                'planar_coverage_min': 0.1,
+                'mme_valid_fraction_min': 0.5,
+            },
+        ),
+    )
+
+    assert completed.returncode == 1
+    assert 'MAP_QUALITY_THRESHOLDS_FAILED' in completed.stdout
+    assert 'THRESHOLD thickness_rms_mean_max_m value=NA limit=0.200000000' in completed.stdout
+    assert 'verdict=SKIPPED(not_meaningful)' in completed.stdout
+    assert (
+        'THRESHOLD mme_valid_fraction_min value=0.750000000 '
+        'limit=0.500000000 verdict=PASS'
+    ) in completed.stdout
+
+
+def test_not_meaningful_not_required_with_only_plane_thresholds_passes(tmp_path):
+    """meaningful=false with only plane thresholds and no requirement passes."""
+    completed = run_cli(
+        tmp_path,
+        base_report(meaningful=False),
+        profile(
+            require_meaningful_planes=False,
+            thresholds={
+                'thickness_rms_mean_max_m': 0.2,
+                'planar_coverage_min': 0.1,
+            },
+        ),
+    )
+
+    assert completed.returncode == 0
+    assert 'MAP_QUALITY_THRESHOLDS_OK' in completed.stdout
+    assert completed.stdout.count('SKIPPED(not_meaningful)') == 2
+    assert 'violations=0' in completed.stdout
+
+
+def test_unknown_threshold_key_exits_usage_error(tmp_path):
+    """A typo in a threshold key must fail loudly with exit 2."""
+    completed = run_cli(
+        tmp_path,
+        base_report(),
+        profile(thresholds={'thickness_rms_mean_typo_m': 0.2}),
+    )
+
+    assert completed.returncode == 2
+    assert 'unknown threshold key' in completed.stderr
+
+
+def test_committed_profiles_parse_and_keep_schema_sane():
+    """The committed profile YAMLs parse and keep the required schema."""
+    for path in (
+        PROFILES_DIR / 'indoor_construction.yaml',
+        PROFILES_DIR / 'outdoor_vegetation.yaml',
+    ):
+        with path.open('r', encoding='utf-8') as stream:
+            data = yaml.safe_load(stream)
+
+        assert isinstance(data, dict)
+        body = data['map_quality_profile']
+        assert isinstance(body['name'], str)
+        assert body['enforcement'] in {'blocking', 'report_only'}
+        assert isinstance(body['require_meaningful_planes'], bool)
+        assert isinstance(body['thresholds'], dict)
+
+
+def test_out_verdict_yaml_round_trips(tmp_path):
+    """The --out verdict YAML matches the exit status and checks."""
+    out_path = tmp_path / 'verdict.yaml'
+    completed = run_cli(
+        tmp_path,
+        base_report(thickness=0.5),
+        profile(thresholds={'thickness_rms_mean_max_m': 0.2}),
+        extra_args=['--out', str(out_path)],
+    )
+
+    assert completed.returncode == 1
+    with out_path.open('r', encoding='utf-8') as stream:
+        verdict = yaml.safe_load(stream)
+
+    assert verdict['overall'] == 'FAILED'
+    assert verdict['violations'] == 1
+    assert verdict['enforcement'] == 'blocking'
+    assert verdict['checks'][0]['key'] == 'thickness_rms_mean_max_m'
+    assert verdict['checks'][0]['verdict'] == 'VIOLATION'
+
+
+def test_compare_core_returns_report_only_result():
+    """compare() is callable directly and returns a structured result."""
+    module = load_comparator_module()
+    result = module.compare(
+        base_report(thickness=0.5),
+        profile(
+            enforcement='report_only',
+            require_meaningful_planes=False,
+            thresholds={'thickness_rms_mean_max_m': 0.2},
+        ),
+    )
+
+    assert result.overall == 'REPORT_ONLY'
+    assert result.violations == 1

--- a/graph_based_slam/test/test_map_quality_profiles.py
+++ b/graph_based_slam/test/test_map_quality_profiles.py
@@ -31,9 +31,9 @@
 from __future__ import annotations
 
 import importlib.util
+from pathlib import Path
 import subprocess
 import sys
-from pathlib import Path
 
 import yaml
 

--- a/scripts/check_map_quality_thresholds.py
+++ b/scripts/check_map_quality_thresholds.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Check map-quality report metrics against an explicit threshold profile."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class ThresholdError(Exception):
+    """Raised for user-facing threshold/profile/report errors."""
+
+
+@dataclass(frozen=True)
+class ThresholdSpec:
+    """Where a threshold key reads from the report and how it compares."""
+
+    report_path: tuple[str, ...]
+    comparison: str
+    plane_domain: bool = False
+
+
+@dataclass(frozen=True)
+class ThresholdCheck:
+    """One evaluated threshold row."""
+
+    key: str
+    value: float | int | None
+    limit: float | int
+    verdict: str
+
+
+@dataclass(frozen=True)
+class ThresholdResult:
+    """Deterministic comparison outcome for one report/profile pair."""
+
+    profile: str
+    enforcement: str
+    checks: list[ThresholdCheck]
+    violations: int
+    overall: str
+
+
+THRESHOLD_SPECS: dict[str, ThresholdSpec] = {
+    'mean_map_entropy_max_nats': ThresholdSpec(
+        ('mean_map_entropy', 'value_nats'),
+        'max',
+    ),
+    'mme_valid_fraction_min': ThresholdSpec(
+        ('mean_map_entropy', 'valid_fraction'),
+        'min',
+    ),
+    'thickness_rms_mean_max_m': ThresholdSpec(
+        ('plane_metrics', 'thickness_rms_mean_m'),
+        'max',
+        plane_domain=True,
+    ),
+    'thickness_rms_p95_max_m': ThresholdSpec(
+        ('plane_metrics', 'thickness_rms_p95_m'),
+        'max',
+        plane_domain=True,
+    ),
+    'planar_coverage_min': ThresholdSpec(
+        ('plane_metrics', 'planar_coverage'),
+        'min',
+        plane_domain=True,
+    ),
+    'patch_count_min': ThresholdSpec(
+        ('plane_metrics', 'patch_count'),
+        'min',
+        plane_domain=True,
+    ),
+}
+
+VALID_ENFORCEMENTS = {'blocking', 'report_only'}
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        with path.open('r', encoding='utf-8') as stream:
+            data = yaml.safe_load(stream)
+    except FileNotFoundError as exc:
+        raise ThresholdError(f'missing file: {path}') from exc
+    except OSError as exc:
+        raise ThresholdError(f'cannot read {path}: {exc}') from exc
+    except yaml.YAMLError as exc:
+        raise ThresholdError(f'cannot parse YAML {path}: {exc}') from exc
+
+    if not isinstance(data, dict):
+        raise ThresholdError(f'expected YAML mapping in {path}')
+    return data
+
+
+def _nested_get(data: dict[str, Any], path: tuple[str, ...]) -> Any:
+    current: Any = data
+    for part in path:
+        if not isinstance(current, dict) or part not in current:
+            dotted = '.'.join(path)
+            raise ThresholdError(f'report is missing required metric: {dotted}')
+        current = current[part]
+    return current
+
+
+def _as_number(value: Any, label: str) -> float | int:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ThresholdError(f'{label} must be numeric')
+    return value
+
+
+def _profile_body(profile_dict: dict[str, Any]) -> dict[str, Any]:
+    body = profile_dict.get('map_quality_profile')
+    if not isinstance(body, dict):
+        raise ThresholdError('profile must contain map_quality_profile mapping')
+    return body
+
+
+def _report_body(report_dict: dict[str, Any]) -> dict[str, Any]:
+    body = report_dict.get('map_quality_report')
+    if not isinstance(body, dict):
+        raise ThresholdError('report must contain map_quality_report mapping')
+    return body
+
+
+def _validate_profile(profile: dict[str, Any]) -> tuple[str, str, bool, dict[str, float | int]]:
+    name = profile.get('name')
+    if not isinstance(name, str) or not name:
+        raise ThresholdError('profile field name must be a non-empty string')
+
+    enforcement = profile.get('enforcement')
+    if enforcement not in VALID_ENFORCEMENTS:
+        valid = ', '.join(sorted(VALID_ENFORCEMENTS))
+        raise ThresholdError(f'profile enforcement must be one of: {valid}')
+
+    require_meaningful_planes = profile.get('require_meaningful_planes')
+    if not isinstance(require_meaningful_planes, bool):
+        raise ThresholdError('profile field require_meaningful_planes must be boolean')
+
+    thresholds = profile.get('thresholds')
+    if thresholds is None:
+        thresholds = {}
+    if not isinstance(thresholds, dict):
+        raise ThresholdError('profile field thresholds must be a mapping')
+
+    unknown = sorted(set(thresholds) - set(THRESHOLD_SPECS))
+    if unknown:
+        raise ThresholdError(f"unknown threshold key(s): {', '.join(unknown)}")
+
+    numeric_thresholds: dict[str, float | int] = {}
+    for key, limit in thresholds.items():
+        numeric_thresholds[key] = _as_number(limit, f'threshold {key}')
+
+    return name, enforcement, require_meaningful_planes, numeric_thresholds
+
+
+def _planes_are_meaningful(report: dict[str, Any]) -> bool:
+    plane_metrics = report.get('plane_metrics')
+    if not isinstance(plane_metrics, dict):
+        raise ThresholdError('report is missing required mapping: plane_metrics')
+    meaningful = plane_metrics.get('meaningful')
+    if not isinstance(meaningful, bool):
+        raise ThresholdError('report metric plane_metrics.meaningful must be boolean')
+    return meaningful
+
+
+def _passes(value: float | int, limit: float | int, comparison: str) -> bool:
+    if comparison == 'max':
+        return value <= limit
+    if comparison == 'min':
+        return value >= limit
+    raise ThresholdError(f'internal error: unknown comparison {comparison}')
+
+
+def compare(report_dict: dict[str, Any], profile_dict: dict[str, Any]) -> ThresholdResult:
+    """Compare a report against a profile and return a deterministic verdict."""
+    report = _report_body(report_dict)
+    profile = _profile_body(profile_dict)
+    name, enforcement, require_meaningful_planes, thresholds = _validate_profile(profile)
+    meaningful_planes = _planes_are_meaningful(report)
+
+    checks: list[ThresholdCheck] = []
+    violations = 0
+
+    if require_meaningful_planes and not meaningful_planes:
+        violations += 1
+        checks.append(
+            ThresholdCheck(
+                key='require_meaningful_planes',
+                value=None,
+                limit=1,
+                verdict='VIOLATION',
+            )
+        )
+
+    for key, limit in thresholds.items():
+        spec = THRESHOLD_SPECS[key]
+        if spec.plane_domain and not meaningful_planes:
+            checks.append(
+                ThresholdCheck(
+                    key=key,
+                    value=None,
+                    limit=limit,
+                    verdict='SKIPPED(not_meaningful)',
+                )
+            )
+            continue
+
+        value = _as_number(_nested_get(report, spec.report_path), '.'.join(spec.report_path))
+        verdict = 'PASS' if _passes(value, limit, spec.comparison) else 'VIOLATION'
+        if verdict == 'VIOLATION':
+            violations += 1
+        checks.append(ThresholdCheck(key=key, value=value, limit=limit, verdict=verdict))
+
+    if enforcement == 'report_only':
+        overall = 'REPORT_ONLY'
+    elif violations:
+        overall = 'FAILED'
+    else:
+        overall = 'OK'
+
+    return ThresholdResult(
+        profile=name,
+        enforcement=enforcement,
+        checks=checks,
+        violations=violations,
+        overall=overall,
+    )
+
+
+def _format_value(value: float | int | None) -> str:
+    if value is None:
+        return 'NA'
+    if isinstance(value, int):
+        return str(value)
+    return f'{value:.9f}'
+
+
+def _print_result(result: ThresholdResult) -> None:
+    for check in result.checks:
+        print(
+            'THRESHOLD '
+            f'{check.key} '
+            f'value={_format_value(check.value)} '
+            f'limit={_format_value(check.limit)} '
+            f'verdict={check.verdict}'
+        )
+
+    checked = len(result.checks)
+    if result.overall == 'REPORT_ONLY':
+        print(
+            'MAP_QUALITY_THRESHOLDS_REPORT_ONLY: '
+            f'profile={result.profile} checked={checked} violations={result.violations}'
+        )
+    elif result.overall == 'FAILED':
+        print(
+            'MAP_QUALITY_THRESHOLDS_FAILED: '
+            f'profile={result.profile} enforcement={result.enforcement} '
+            f'checked={checked} violations={result.violations}'
+        )
+    else:
+        print(
+            'MAP_QUALITY_THRESHOLDS_OK: '
+            f'profile={result.profile} enforcement={result.enforcement} '
+            f'checked={checked} violations=0'
+        )
+
+
+def _result_for_yaml(result: ThresholdResult) -> dict[str, Any]:
+    return {
+        'profile': result.profile,
+        'enforcement': result.enforcement,
+        'checks': [
+            {
+                'key': check.key,
+                'value': check.value,
+                'limit': check.limit,
+                'verdict': check.verdict,
+            }
+            for check in result.checks
+        ],
+        'violations': result.violations,
+        'overall': result.overall,
+    }
+
+
+def _write_out(path: Path, result: ThresholdResult) -> None:
+    try:
+        with path.open('w', encoding='utf-8') as stream:
+            yaml.safe_dump(_result_for_yaml(result), stream, sort_keys=False)
+    except OSError as exc:
+        raise ThresholdError(f'cannot write {path}: {exc}') from exc
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--report', required=True, type=Path)
+    parser.add_argument('--profile', required=True, type=Path)
+    parser.add_argument('--out', type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point; returns the process exit code."""
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+
+    try:
+        report = _load_yaml(args.report)
+        profile = _load_yaml(args.profile)
+        result = compare(report, profile)
+        _print_result(result)
+        if args.out is not None:
+            _write_out(args.out, result)
+    except ThresholdError as exc:
+        print(f'ERROR: {exc}', file=sys.stderr)
+        return 2
+
+    if result.overall == 'FAILED':
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/run_map_quality_check.sh
+++ b/scripts/run_map_quality_check.sh
@@ -6,12 +6,17 @@
 #   bash scripts/run_map_quality_check.sh \
 #     --input output/rtkslam_cs2_run2/map.pcd \
 #     --output-dir output/map_quality_cs2 \
-#     [--runs 3] [--downsample 0.1]
+#     [--runs 3] [--downsample 0.1] \
+#     [--profile configs/map_quality_profiles/indoor_construction.yaml]
 #
-# Metric VALUES are report-only (the thresholds come in Phase 3, with a
-# holdout); what this script *enforces* is determinism: every run must
-# produce byte-identical map_quality_report.yaml. The metric extraction
-# profile itself is frozen in MapQualityConfig
+# This script always enforces determinism: every run must produce a
+# byte-identical map_quality_report.yaml. Without --profile the metric
+# VALUES are report-only. With --profile the values are additionally
+# compared against the profile's threshold table
+# (scripts/check_map_quality_thresholds.py); a `blocking` profile turns
+# violations into a non-zero exit, a `report_only` profile prints the
+# verdict rows without failing (v0.7 Phase 3 rollout shape). The metric
+# extraction profile itself is frozen in MapQualityConfig
 # (docs/research/map-quality-baseline.md) and is deliberately not
 # exposed here.
 set -euo pipefail
@@ -21,6 +26,7 @@ INPUT=""
 OUTPUT_DIR=""
 RUNS=3
 DOWNSAMPLE=0.1
+PROFILE=""
 
 usage() {
   grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' >&2
@@ -49,6 +55,11 @@ while [[ $# -gt 0 ]]; do
       DOWNSAMPLE="$2"
       shift 2
       ;;
+    --profile)
+      [[ $# -ge 2 ]] || usage
+      PROFILE=$(realpath -m "$2")
+      shift 2
+      ;;
     *)
       usage
       ;;
@@ -57,6 +68,10 @@ done
 
 if [[ -z "${INPUT}" || -z "${OUTPUT_DIR}" ]]; then
   echo "--input and --output-dir are required" >&2
+  exit 2
+fi
+if [[ -n "${PROFILE}" && ! -f "${PROFILE}" ]]; then
+  echo "profile not found: ${PROFILE}" >&2
   exit 2
 fi
 if [[ ! -e "${INPUT}" ]]; then
@@ -99,6 +114,19 @@ for md5 in "${MD5S[@]}"; do
   fi
 done
 
+THRESHOLD_LOG="${OUTPUT_DIR}/threshold_verdict.txt"
+THRESHOLD_STATUS=0
+if [[ -n "${PROFILE}" ]]; then
+  set +e
+  python3 "${REPO_ROOT}/scripts/check_map_quality_thresholds.py" \
+    --report "${OUTPUT_DIR}/run1/map_quality_report.yaml" \
+    --profile "${PROFILE}" \
+    --out "${OUTPUT_DIR}/threshold_verdict.yaml" \
+    > "${THRESHOLD_LOG}" 2>&1
+  THRESHOLD_STATUS=$?
+  set -e
+fi
+
 SUMMARY="${OUTPUT_DIR}/map_quality_summary.md"
 {
   echo "# Map-quality check"
@@ -107,17 +135,32 @@ SUMMARY="${OUTPUT_DIR}/map_quality_summary.md"
   echo "- runs: ${RUNS}, downsample: ${DOWNSAMPLE} m"
   echo "- reports_identical: ${IDENTICAL}"
   echo "- report_md5: \`${MD5S[0]}\`"
+  if [[ -n "${PROFILE}" ]]; then
+    echo "- threshold_profile: \`${PROFILE}\`"
+  fi
   echo
   echo '```yaml'
   cat "${OUTPUT_DIR}/run1/map_quality_report.yaml"
   echo '```'
+  if [[ -n "${PROFILE}" ]]; then
+    echo
+    echo '```'
+    cat "${THRESHOLD_LOG}"
+    echo '```'
+  fi
 } > "${SUMMARY}"
 
 echo "--- verdict"
 cat "${OUTPUT_DIR}/run1/map_quality_report.yaml"
-if [[ "${IDENTICAL}" == "true" ]]; then
-  echo "MAP_QUALITY_OK: ${RUNS} runs produced byte-identical map_quality_report.yaml"
-else
+if [[ -n "${PROFILE}" ]]; then
+  cat "${THRESHOLD_LOG}"
+fi
+if [[ "${IDENTICAL}" != "true" ]]; then
   echo "MAP_QUALITY_FAILED: reports differ across runs" >&2
   exit 1
 fi
+if [[ "${THRESHOLD_STATUS}" -ne 0 ]]; then
+  echo "MAP_QUALITY_FAILED: threshold check failed (exit ${THRESHOLD_STATUS})" >&2
+  exit "${THRESHOLD_STATUS}"
+fi
+echo "MAP_QUALITY_OK: ${RUNS} runs produced byte-identical map_quality_report.yaml"

--- a/scripts/run_release_readiness_checks.sh
+++ b/scripts/run_release_readiness_checks.sh
@@ -51,12 +51,19 @@ Options:
   --offline-determinism-reference-tum <tum>
                                 Optional reference trajectory; adds per-run APE
                                 to the determinism report (report only)
-  --map-quality-pcd <path>      Run the map-quality metrics stage (v0.7
-                                Phase 1, docs/roadmap/v0.7.md) on this map
-                                PCD file or pointcloud_map directory.
-                                Repeatable. Metric values are report-only,
-                                but a byte-level mismatch across the 3 runs
-                                fails the gate (determinism enforcement)
+  --map-quality-pcd <path>[@<profile>]
+                                Run the map-quality metrics stage (v0.7,
+                                docs/roadmap/v0.7.md) on this map PCD file
+                                or pointcloud_map directory. Repeatable.
+                                A byte-level mismatch across the 3 runs
+                                always fails the gate (determinism
+                                enforcement). With @<profile> the metric
+                                values are additionally checked against
+                                that threshold profile YAML (Phase 3); a
+                                blocking profile fails the gate on
+                                violation, report_only only reports.
+                                Without a profile the values stay
+                                report-only
   --map-quality-downsample <m>  Downsample for the map-quality stage
                                 (default: 0.1)
   --frontend-determinism-bag <dir>
@@ -138,6 +145,7 @@ OFFLINE_DETERMINISM_RUNS=""
 OFFLINE_DETERMINISM_PARAMS=""
 OFFLINE_DETERMINISM_REFERENCE_TUM=""
 MAP_QUALITY_PCDS=()
+MAP_QUALITY_PROFILES=()
 MAP_QUALITY_DOWNSAMPLE=""
 FRONTEND_DETERMINISM_BAG=""
 FRONTEND_DETERMINISM_CLOUD_TOPIC=""
@@ -267,7 +275,13 @@ while [[ $# -gt 0 ]]; do
       ;;
     --map-quality-pcd)
       [[ $# -ge 2 ]] || usage
-      MAP_QUALITY_PCDS+=("$(realpath -m "$2")")
+      if [[ "$2" == *@* ]]; then
+        MAP_QUALITY_PCDS+=("$(realpath -m "${2%@*}")")
+        MAP_QUALITY_PROFILES+=("$(realpath -m "${2##*@}")")
+      else
+        MAP_QUALITY_PCDS+=("$(realpath -m "$2")")
+        MAP_QUALITY_PROFILES+=("")
+      fi
       shift 2
       ;;
     --map-quality-downsample)
@@ -512,9 +526,10 @@ if [[ "${RUN_DOGFOOD}" == "true" ]]; then
 fi
 
 if [[ ${#MAP_QUALITY_PCDS[@]} -gt 0 ]]; then
-  echo "==> Running map-quality metrics stage (report-only values, 3-run byte identity)"
+  echo "==> Running map-quality metrics stage (3-run byte identity + optional threshold profiles)"
   MAP_QUALITY_INDEX=0
   for MAP_QUALITY_PCD in "${MAP_QUALITY_PCDS[@]}"; do
+    MAP_QUALITY_PROFILE="${MAP_QUALITY_PROFILES[$MAP_QUALITY_INDEX]}"
     MAP_QUALITY_INDEX=$((MAP_QUALITY_INDEX + 1))
     MAP_QUALITY_NAME=$(basename "$(dirname "${MAP_QUALITY_PCD}")")_$(basename "${MAP_QUALITY_PCD%.*}")
     MAP_QUALITY_CMD=(
@@ -525,6 +540,9 @@ if [[ ${#MAP_QUALITY_PCDS[@]} -gt 0 ]]; then
     )
     if [[ -n "${MAP_QUALITY_DOWNSAMPLE}" ]]; then
       MAP_QUALITY_CMD+=(--downsample "${MAP_QUALITY_DOWNSAMPLE}")
+    fi
+    if [[ -n "${MAP_QUALITY_PROFILE}" ]]; then
+      MAP_QUALITY_CMD+=(--profile "${MAP_QUALITY_PROFILE}")
     fi
     "${MAP_QUALITY_CMD[@]}" 2>&1 | tee -a "${OUT_DIR}/map_quality.log"
   done


### PR DESCRIPTION
## Summary

v0.7 Phase 3 (docs/roadmap/v0.7.md) の最初のステップ: マップ品質ゲートに **per-profile 閾値表の機構** を導入する。閾値の数値は本 PR では PROVISIONAL プレースホルダのままで、較正 PR(holdout 検証付き)が実数に置き換える。

- `scripts/check_map_quality_thresholds.py`: 凍結フォーマットの `map_quality_report.yaml` をプロファイル閾値表と照合する決定論コンパレータ
  - 未知の閾値キーは exit 2 で即失敗(typo がゲートを静かに無効化できない)
  - 低 planarity シーンでは plane 系閾値を `SKIPPED(not_meaningful)` として明示スキップ
  - `require_meaningful_planes: true` で「planes が成立しないマップ」自体を violation にできる(indoor ゲート用)
  - `blocking` は violation で exit 1、`report_only` は verdict 行のみで exit 0
- `configs/map_quality_profiles/{indoor_construction,outdoor_vegetation}.yaml`: v0.5 GT ゲートと同じ展開形(indoor blocking 先行、outdoor report-only)
- `run_map_quality_check.sh --profile`: N-run バイト一致チェックに閾値 verdict が合流。summary md に verdict ブロックを記録
- `run_release_readiness_checks.sh --map-quality-pcd <path>[@<profile>]`: release gate で基盤ごとにプロファイルを紐付け
- テスト 9 本(exit code 契約 / skip セマンティクス / コミット済みプロファイルのスキーマ検証 / verdict YAML round-trip)

## Verification

- `ctest -R test_map_quality_profiles` green (9 passed)
- E2E スモーク(実マップ PCD): indoor profile で PASS 行 + `MAP_QUALITY_OK` / 厳格 profile で `VIOLATION` → `MAP_QUALITY_FAILED` exit 1
- flake8 (max-line-length 99) clean

## Scope

機構のみ。閾値の実数値・refine default 化・README クレームは後続 PR(roadmap Phase 3 の残り)。