### PR TITLE
feat(map-quality): calibrate indoor thresholds, holdout-validated on construction_seq2

### DIFF
--- a/configs/map_quality_profiles/indoor_construction.yaml
+++ b/configs/map_quality_profiles/indoor_construction.yaml
@@ -1,12 +1,22 @@
-# Phase 3 rollout mirrors the v0.5 GT-gate rollout: indoor profiles block first
-# while outdoor profiles remain report-only until calibration evidence lands.
-# Thresholds marked PROVISIONAL are replaced by the Phase 3 calibration PR.
+# v0.7 Phase 3 rollout (docs/roadmap/v0.7.md): indoor profiles block first,
+# outdoor profiles stay report-only — the same shape as the v0.5 GT-gate
+# rollout.
+#
+# Calibration (2026-06-13, docs/research/map-quality-baseline.md §thresholds):
+# values were selected from the TUNING substrates only — the refined
+# construction_seq1 backend replay (thickness 0.0751, coverage 0.394,
+# MME -0.932, valid_fraction 0.977) and the Phase 2 NTU evidence — and then
+# validated untouched on the held-out construction_seq2 replay. The margins
+# are set to admit healthy refined maps and reject the pre-refinement
+# failure regime observed in the Phase 1 baseline (~0.09 m walls, planar
+# coverage collapse on blurred indoor maps).
 map_quality_profile:
   name: indoor_construction
   enforcement: blocking
   require_meaningful_planes: true
   thresholds:
-    # PROVISIONAL values - calibrated in the Phase 3 evidence PR (holdout-validated).
-    thickness_rms_mean_max_m: 0.999
-    planar_coverage_min: 0.001
-    mme_valid_fraction_min: 0.5
+    thickness_rms_mean_max_m: 0.085
+    thickness_rms_p95_max_m: 0.15
+    planar_coverage_min: 0.30
+    mean_map_entropy_max_nats: -0.80
+    mme_valid_fraction_min: 0.90

--- a/configs/map_quality_profiles/outdoor_vegetation.yaml
+++ b/configs/map_quality_profiles/outdoor_vegetation.yaml
@@ -1,11 +1,14 @@
-# Phase 3 rollout mirrors the v0.5 GT-gate rollout: indoor profiles block first
-# while outdoor profiles remain report-only until calibration evidence lands.
-# Thresholds marked PROVISIONAL are replaced by the Phase 3 calibration PR.
+# v0.7 Phase 3 rollout (docs/roadmap/v0.7.md): outdoor maps are vegetation-
+# dominated (Stadtgarten baseline: planar coverage 0.12-0.16), so plane-based
+# thresholds stay REPORT-ONLY here — the rows are informational until outdoor
+# refinement evidence lands (v0.8 candidate). Only the indoor profile blocks.
+# The thickness row uses the same informative reference value as the indoor
+# profile; the coverage row only flags collapse below the meaningfulness
+# floor.
 map_quality_profile:
   name: outdoor_vegetation
   enforcement: report_only
   require_meaningful_planes: false
   thresholds:
-    # PROVISIONAL values - calibrated in the Phase 3 evidence PR (holdout-validated).
-    thickness_rms_mean_max_m: 0.999
-    planar_coverage_min: 0.001
+    thickness_rms_mean_max_m: 0.085
+    planar_coverage_min: 0.05

--- a/docs/research/map-quality-baseline.md
+++ b/docs/research/map-quality-baseline.md
@@ -99,10 +99,67 @@ unchanged with `refine:=true`. Resources: 640 submaps / 1079 m in
 4:38 wall / 539 MB peak RSS (NTU: 1:54 / 367 MB) — inside the design
 note's budget.
 
-## Threshold outlook (for Phase 3, not enforced yet)
+## Indoor construction replay evidence (Phase 3, 2026-06-13)
 
-Per-profile, baseline-relative: a refined map must not regress MME,
-thickness mean, or coverage on its own substrate beyond noise; blocking
-absolute thresholds are deferred until the Phase 2 deltas exist and a
-holdout sequence validates them (`docs/roadmap/v0.7.md` Phase 3,
-threshold hygiene).
+Backend-input bags were recorded for both RTK-SLAM construction sequences
+(`ros2 bag record /rko_lio/odometry /rko_lio/frame` on an isolated domain
+while the exact original benchmark configuration replayed:
+cs1 = `rko_lio_rtk_slam_mid360.yaml`, cs2 =
+`rko_lio_mid360_low_voxel_no_deskew.yaml`, both with
+`lidarslam/param/lidarslam.yaml`; 6301 / 5865 frames captured). Each
+substrate then ran the 3-run offline determinism check with
+`refine: true` + `refine_save_maps: true` — **byte identity passed on
+both, including the refined artifacts**.
+
+APE is scored against the total-station checkpoint GT with
+`ape_from_tum.py --interpolate --max-time-diff 2.0` (checkpoints are taken
+while the platform is stationary, so they fall between submap-rate poses;
+linear interpolation across the stop is exact up to noise; 15 pairs each).
+
+| substrate | metric | optimized (before) | refined (after) | Δ |
+|---|---|---:|---:|---|
+| construction_seq1 (tuning) | APE RMSE (m) | 0.7800603471740267 | **0.7744167604040919** | −0.7 % |
+| | MME (nats) | −0.894974483 | **−0.932375982** | crisper |
+| | thickness mean (m) | 0.077957119 | **0.075093748** | **−3.7 %** |
+| | thickness p95 (m) | 0.120066887 | 0.120291624 | +0.2 % |
+| | planar coverage | 0.377912074 | **0.394277537** | **+4.3 %** |
+| construction_seq2 (holdout) | APE RMSE (m) | 0.8376950131160659 | **0.825250416881328** | **−1.5 %** |
+| | MME (nats) | −0.915227013 | **−0.942085924** | crisper |
+| | thickness mean (m) | 0.082155760 | **0.078891815** | **−4.0 %** |
+| | thickness p95 (m) | 0.124039191 | 0.123056184 | −0.8 % |
+| | planar coverage | 0.423900020 | 0.424767096 | +0.2 % |
+
+With the NTU Phase 2 row, refinement now improves trajectory APE against
+real ground truth on **all three GT substrates** (NTU −3.2 %, cs1 −0.7 %,
+cs2 −1.5 %) while making the maps measurably crisper — never trading one
+for the other.
+
+## Threshold calibration (Phase 3, enforced via profiles)
+
+Selection discipline: thresholds were chosen from the **tuning substrates
+only** (refined cs1 replay above + the Phase 2 NTU evidence), written into
+`configs/map_quality_profiles/indoor_construction.yaml`, and only then was
+the held-out cs2 replay evaluated against them.
+
+| row (indoor_construction, blocking) | limit | tuning basis (cs1 refined) | holdout (cs2 refined) |
+|---|---:|---:|---:|
+| thickness_rms_mean_max_m | 0.085 | 0.075093748 | 0.078891815 PASS |
+| thickness_rms_p95_max_m | 0.15 | 0.120291624 | 0.123056184 PASS |
+| planar_coverage_min | 0.30 | 0.394277537 | 0.424767096 PASS |
+| mean_map_entropy_max_nats | −0.80 | −0.932375982 | −0.942085924 PASS |
+| mme_valid_fraction_min | 0.90 | 0.976671657 | 0.980798880 PASS |
+
+**Holdout verdict: all five rows PASS untouched** (`check_map_quality_thresholds.py`
+exit 0, `violations=0`).
+
+Margin rationale: limits sit between today's healthy refined values and
+the Phase 1 failure regime (~0.09 m walls; planar coverage collapses
+toward the 0.05 meaningfulness floor on blurred indoor maps — the original
+full-session cs2 map measured 0.085). The unrefined replay maps also pass
+these rows today (cs2 optimized thickness 0.0822 < 0.085): the gate
+guards the *deliverable* against the blur/divergence regime, it does not
+force refinement to exist — refinement is defaulted on separately.
+`patch_count_min` is deliberately unused (scales with map extent, not
+quality). The outdoor profile (`outdoor_vegetation.yaml`) stays
+report-only: Stadtgarten coverage baselines are 0.12–0.16, vegetation-
+dominated, and refinement evidence there is a v0.8 item.

--- a/docs/roadmap/v0.7.md
+++ b/docs/roadmap/v0.7.md
@@ -169,6 +169,18 @@ gradient/Hessian assembly, LM step) gets one.
   until Phase 3.
 
 ### Phase 3 — gate flip + the claim
+
+> **Status (2026-06-13)**: threshold mechanism merged (#275: per-profile
+> YAML table, blocking/report_only enforcement, gate binding via
+> `--map-quality-pcd <path>@<profile>`). Indoor thresholds calibrated on
+> the construction_seq1 backend replay + Phase 2 NTU evidence and
+> **validated untouched on the held-out construction_seq2 replay — all
+> five rows PASS** (`docs/research/map-quality-baseline.md`
+> §Threshold calibration). Refinement improves APE against real GT on all
+> three GT substrates (NTU −3.2 %, cs1 −0.7 %, cs2 −1.5 %) with byte-
+> identical 3-run replays. Remaining: refine default-on (offline runner +
+> gate map-quality wiring on gate-produced refined maps) and the README
+> claim.
 - On Phase 2 evidence: refinement defaults on in the offline runner and the
   map-authoring bundle scripts; map-quality metrics get **blocking
   thresholds with an explicit per-profile table** (indoor blocking first,

--- a/scripts/ape_from_tum.py
+++ b/scripts/ape_from_tum.py
@@ -59,6 +59,50 @@ def associate(
     return ref_xyz_matched, est_xyz_matched
 
 
+def interpolate_association(
+    ref: list[tuple[float, tuple[float, float, float]]],
+    est: list[tuple[float, tuple[float, float, float]]],
+    max_edge_diff: float,
+) -> tuple[list[tuple[float, float, float]], list[tuple[float, float, float]]]:
+    """Sample the estimated trajectory at the reference timestamps.
+
+    Linear position interpolation between the two estimated poses that
+    bracket each reference timestamp. Made for sparse checkpoint references
+    (e.g. total-station checkpoints taken while the platform is stationary,
+    which fall into the time gaps of a submap-rate trajectory). Outside the
+    estimated time range the nearest endpoint is used only when it is
+    within max_edge_diff.
+    """
+    est_times = [ts for ts, _ in est]
+    est_xyz = [xyz for _, xyz in est]
+    ref_xyz_matched: list[tuple[float, float, float]] = []
+    est_xyz_matched: list[tuple[float, float, float]] = []
+
+    for ref_ts, ref_xyz in ref:
+        idx = bisect.bisect_left(est_times, ref_ts)
+        if idx == 0:
+            if est_times[0] - ref_ts > max_edge_diff:
+                continue
+            sampled = est_xyz[0]
+        elif idx == len(est_times):
+            if ref_ts - est_times[-1] > max_edge_diff:
+                continue
+            sampled = est_xyz[-1]
+        else:
+            t0, t1 = est_times[idx - 1], est_times[idx]
+            p0, p1 = est_xyz[idx - 1], est_xyz[idx]
+            w = 0.0 if t1 == t0 else (ref_ts - t0) / (t1 - t0)
+            sampled = (
+                p0[0] + w * (p1[0] - p0[0]),
+                p0[1] + w * (p1[1] - p0[1]),
+                p0[2] + w * (p1[2] - p0[2]),
+            )
+        ref_xyz_matched.append(ref_xyz)
+        est_xyz_matched.append(sampled)
+
+    return ref_xyz_matched, est_xyz_matched
+
+
 def align_first_pose(
     ref_xyz: list[tuple[float, float, float]],
     est_xyz: list[tuple[float, float, float]],
@@ -142,6 +186,14 @@ def main() -> int:
     ap.add_argument("--est", required=True, help="Estimated TUM trajectory")
     ap.add_argument("--out", required=True, help="Output report path")
     ap.add_argument("--max-time-diff", type=float, default=0.05, help="Max timestamp association gap in seconds")
+    ap.add_argument(
+        "--interpolate",
+        action="store_true",
+        help="Linearly interpolate the estimated trajectory at the reference "
+        "timestamps instead of nearest-neighbour matching. For sparse "
+        "checkpoint references that fall between submap-rate poses; "
+        "--max-time-diff then only bounds extrapolation at the ends.",
+    )
     args = ap.parse_args()
 
     ref = read_tum(Path(args.ref).expanduser().resolve())
@@ -149,7 +201,10 @@ def main() -> int:
     if not ref or not est:
         return 1
 
-    ref_xyz, est_xyz = associate(ref, est, args.max_time_diff)
+    if args.interpolate:
+        ref_xyz, est_xyz = interpolate_association(ref, est, args.max_time_diff)
+    else:
+        ref_xyz, est_xyz = associate(ref, est, args.max_time_diff)
     if len(ref_xyz) < 2:
         return 1
 

--- a/scripts/run_offline_determinism_check.sh
+++ b/scripts/run_offline_determinism_check.sh
@@ -11,12 +11,16 @@ set -euo pipefail
 #     --bag output/backend_replay_x/backend_input \
 #     [--params lidarslam/param/lidarslam_mid360_rko_graph.yaml] \
 #     [--runs 3] [--output-dir output/offline_determinism_<timestamp>] \
-#     [--reference-tum output/glim_mid360_reference.tum]
+#     [--reference-tum output/glim_mid360_reference.tum] \
+#     [--ape-interpolate] [--ape-max-time-diff 0.05]
 #
 # When --reference-tum is given, each run's trajectory_optimized.tum is also
 # scored with scripts/ape_from_tum.py (report only; the gate is byte
-# identity, not an APE threshold). A markdown summary in the same shape as
-# the legacy backend_replay_summary.md is always written.
+# identity, not an APE threshold). For sparse checkpoint references (e.g.
+# total-station checkpoints recorded while the platform is stationary,
+# which fall between submap-rate poses) pass --ape-interpolate together
+# with a generous --ape-max-time-diff (e.g. 2.0). A markdown summary in the
+# same shape as the legacy backend_replay_summary.md is always written.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -26,6 +30,8 @@ PARAMS="${REPO_ROOT}/lidarslam/param/lidarslam_mid360_rko_graph.yaml"
 RUNS=3
 OUTPUT_DIR="${REPO_ROOT}/output/offline_determinism_$(date +%Y%m%d_%H%M%S)"
 REFERENCE_TUM=""
+APE_INTERPOLATE=false
+APE_MAX_TIME_DIFF="0.05"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -34,6 +40,8 @@ while [[ $# -gt 0 ]]; do
     --runs) RUNS="$2"; shift 2 ;;
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
     --reference-tum) REFERENCE_TUM="$2"; shift 2 ;;
+    --ape-interpolate) APE_INTERPOLATE=true; shift ;;
+    --ape-max-time-diff) APE_MAX_TIME_DIFF="$2"; shift 2 ;;
     *) echo "unknown option: $1" >&2; exit 2 ;;
   esac
 done
@@ -69,10 +77,17 @@ for i in $(seq 1 "${RUNS}"); do
     > "${run_dir}/runner.log" 2>&1
   md5sum "${run_dir}/loop_edges.csv" "${run_dir}/trajectory_optimized.tum"
   if [[ -n "${REFERENCE_TUM}" ]]; then
-    python3 "${SCRIPT_DIR}/ape_from_tum.py" \
-      --ref "${REFERENCE_TUM}" \
-      --est "${run_dir}/trajectory_optimized.tum" \
-      --out "${run_dir}/ape.txt" \
+    APE_CMD=(
+      python3 "${SCRIPT_DIR}/ape_from_tum.py"
+      --ref "${REFERENCE_TUM}"
+      --est "${run_dir}/trajectory_optimized.tum"
+      --out "${run_dir}/ape.txt"
+      --max-time-diff "${APE_MAX_TIME_DIFF}"
+    )
+    if [[ "${APE_INTERPOLATE}" == "true" ]]; then
+      APE_CMD+=(--interpolate)
+    fi
+    "${APE_CMD[@]}" \
       > "${run_dir}/ape_postprocess.log" 2>&1 \
       || echo "WARN: APE post-processing failed in run ${i}; continuing" >&2
   fi


### PR DESCRIPTION
## Summary

v0.7 Phase 3 の閾値較正。**選定は tuning 基盤のみ(cs1 replay + Phase 2 NTU)→ holdout の cs2 replay を未接触で検証 → 全 5 行 PASS**(no training on the test set)。

### 新規 evidence(backend-input bag 2 本を新規収録、3-run バイト一致 PASS)

| substrate | APE RMSE (実 GT) | 壁厚 mean | MME | coverage |
|---|---|---|---|---|
| construction_seq1 (tuning) | 0.7801 → **0.7744** (−0.7%) | **−3.7%** | crisper | **+4.3%** |
| construction_seq2 (**holdout**) | 0.8377 → **0.8253** (−1.5%) | **−4.0%** | crisper | +0.2% |

NTU Phase 2 と合わせ、**実 GT 3 基盤すべてで refinement が軌跡とマップを同時改善**。

### indoor_construction(blocking)確定値

thickness mean ≤ 0.085 / p95 ≤ 0.15 / coverage ≥ 0.30 / MME ≤ −0.80 / valid_fraction ≥ 0.90 — マージンは健全な refined 値と Phase 1 失敗域(壁 ~0.09m・coverage 崩落)の間。`patch_count_min` はマップ規模依存のため不採用。outdoor は report-only 据え置き(植生支配、refinement evidence は v0.8)。

### ape_from_tum.py --interpolate(opt-in、既定挙動不変)

total station チェックポイントは静止時に取られるため submap レート軌跡の時間ギャップに落ち、最近傍照合では 0 ペア。チェックポイント時刻での線形補間を追加(静止区間なので補間は厳密)。`run_offline_determinism_check.sh` に `--ape-interpolate` / `--ape-max-time-diff` を転送。

## Verification

- 3-run determinism: cs1/cs2 とも `DETERMINISM_OK`(refined 成果物込み、loop_edges/trajectory md5 一致)
- holdout: `check_map_quality_thresholds.py` exit 0, violations=0(全行の値は baseline doc の表に記録)
- `--interpolate` は独立実装の参照スコアラと 1e-13 で一致、既定パス(非 interpolate)は挙動不変

## 残り(次 PR)

refine default-on(offline runner)+ gate の map-quality 配線(gate 自身が生成した refined マップへの profile 適用)+ README クレーム