### PR TITLE
feat(refine): default-on in the offline runner + gate map-quality wiring + README claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,9 @@ python3 scripts/simple_lanelet2_generator.py \
 |-----------|------|
 | `run_default_ci_checks.sh` | ローカル CI（ビルド＋テスト）|
 | `run_release_readiness_checks.sh` | リリースゲート（APE 閾値、`--offline-determinism-bag` / `--frontend-determinism-bag` で決定論ハードゲート）|
-| `run_offline_determinism_check.sh` | オフラインバックエンド決定論ゲート（N-run バイト一致 + 任意 APE レポート）|
+| `run_offline_determinism_check.sh` | オフラインバックエンド決定論ゲート（N-run バイト一致 + 任意 APE レポート。`--ape-interpolate` で疎チェックポイント GT、`--save-maps` で refined マップ出力）|
 | `run_frontend_determinism_check.sh` | オフラインフロントエンド決定論ゲート（scanmatcher lockstep、N-run バイト一致）|
-| `run_map_quality_check.sh` | マップ品質メトリクス（MME/平面厚/coverage、N-run バイト一致。release gate の `--map-quality-pcd`）|
+| `run_map_quality_check.sh` | マップ品質メトリクス（MME/平面厚/coverage、N-run バイト一致 + `--profile` で閾値表照合。release gate は `--map-quality-pcd <path>[@<profile>]` / `--offline-determinism-map-quality-profile`）|
 | `run_rko_lio_graph_benchmark.sh` | ベンチマークパイプライン |
 | `run_autoware_quickstart.sh` | NTU VIRAL → Autoware マップ E2E |
 | `download_ntu_viral_tnp01.sh` | NTU VIRAL データダウンロード |

--- a/README.md
+++ b/README.md
@@ -41,11 +41,9 @@ artifacts you need downstream:
   produce *byte-identical* trajectories, loop edges and submaps on every run
   (verified 3-run on MID-360 and NTU VIRAL); the release gate enforces both
   (`--offline-determinism-bag` / `--frontend-determinism-bag`).
-- **Globally refined, quality-gated maps** — offline hierarchical plane
-  bundle adjustment (clean-room, BSD-2) refines submap poses after graph
-  optimization (default on in the offline runner), gated by holdout-validated
-  map-quality thresholds. On every ground-truth substrate it improves
-  trajectory APE *and* map crispness simultaneously, byte-reproducibly
+- **Globally refined, quality-gated maps** — clean-room plane bundle adjustment
+  refines submap poses offline (default on) under holdout-validated quality
+  thresholds; APE and crispness improve together on every GT substrate
   ([evidence](docs/research/map-quality-baseline.md)).
 - **GNSS georeferencing** — optional GNSS constraints and projector metadata for
   real-world coordinates.
@@ -71,12 +69,10 @@ docker run --rm -v "$PWD/lidarslam_output:/lidarslam_ws/output" \
 This pulls the prebuilt image, downloads a public Livox MID-360 driving bag
 (517 MB, [Zenodo](https://zenodo.org/records/14841855), CC-BY 4.0) and runs the
 full RKO-LIO + graph_based_slam pipeline headless — a few minutes later
-`./lidarslam_output/mid360_demo/` holds the Autoware-ready map
-(`map.pcd`, `pointcloud_map/` tiles, `map_projector_info.yaml`) and the
-loop-closed trajectory (`traj_corrected.tum`). Add
-`-v lidarslam_demo_data:/lidarslam_ws/datasets` to cache the bag between runs.
-Any other command works too, e.g.
-`docker run --rm -it ghcr.io/rsasaki0109/lidar_slam_ros2:humble bash`.
+`./lidarslam_output/mid360_demo/` holds the Autoware-ready map bundle and
+the loop-closed trajectory (`traj_corrected.tum`). Add
+`-v lidarslam_demo_data:/lidarslam_ws/datasets` to cache the bag between runs;
+appending `bash` instead drops you into an interactive shell.
 
 ### Build from source
 
@@ -155,14 +151,13 @@ Every release is blocked in CI by these per-dataset thresholds.
 | RTK-SLAM Stadtgarten 1 (outdoor park, ~1 km loop) | Livox MID-360 | total-station checkpoints¹ | **1.666 m** (median 1.511) | report-only² |
 | Newer College `math-hard` (~320 m loop) | Ouster OS0-128 | prism ground truth | reported separately | ≤ 0.10 m |
 
-¹ Surveyed checkpoints from the public RTK-SLAM dataset (CC-BY 4.0); scored on the
-dense odometry trajectory, the same form as the dataset's published baselines.
-² Outdoor profiles soak as report-only before graduating; the former
-cross-validation gate vs GLIM (3.64 m) is also report-only since v0.5. Full
-methodology and caveats: [docs/comparison.md](docs/comparison.md).
+¹ Surveyed checkpoints from the public RTK-SLAM dataset (CC-BY 4.0), scored like
+its published baselines (dense odometry trajectory).
+² Outdoor profiles soak as report-only before graduating; the former GLIM
+cross-validation gate is also report-only since v0.5. Methodology and
+caveats: [docs/comparison.md](docs/comparison.md).
 
 Reproduce locally:
-
 ```bash
 bash scripts/run_rko_lio_graph_benchmark.sh
 bash scripts/run_release_readiness_checks.sh --fail-on-profiles
@@ -208,17 +203,14 @@ Preview the doc site locally: `python3 -m mkdocs serve`.
 | Jazzy  | 24.04 | default workflow build + package tests in CI; Autoware dogfood exercised locally |
 
 `graph_based_slam` is BSD-2-Clause; `RKO-LIO`, `DLIO`, and the optional vendored
-`3D-BBS` are MIT; `FAST_GICP` is BSD-3-Clause; built-in Scan Context is implemented
-locally. The default workflow excludes GPL-only components — `Thirdparty/lio-sam`
-and `Thirdparty/3d_bbs` are gated by `COLCON_IGNORE`.
+`3D-BBS` are MIT; `FAST_GICP` is BSD-3-Clause; built-in Scan Context is local. GPL-only
+components (`Thirdparty/lio-sam`, `Thirdparty/3d_bbs`) are excluded via `COLCON_IGNORE`.
 
 ## Quality gates
 
 ```bash
 bash scripts/run_default_ci_checks.sh
 bash scripts/run_release_readiness_checks.sh --ape-threshold 0.10
-# + map-quality thresholds on the gate-built refined map (v0.7):
-#   --offline-determinism-map-quality-profile configs/map_quality_profiles/indoor_construction.yaml
 ```
 
 Reference commands and parameter pointers live in [docs/workflows.md](docs/workflows.md).

--- a/README.md
+++ b/README.md
@@ -41,13 +41,11 @@ artifacts you need downstream:
   produce *byte-identical* trajectories, loop edges and submaps on every run
   (verified 3-run on MID-360 and NTU VIRAL); the release gate enforces both
   (`--offline-determinism-bag` / `--frontend-determinism-bag`).
-- **Globally refined, quality-gated maps** — an offline hierarchical plane
-  bundle adjustment (clean-room, BSD-2) refines the submap poses after graph
-  optimization (default on in the offline runner) and the result is held to
-  explicit map-quality thresholds (plane thickness, planar coverage, mean map
-  entropy) with holdout-validated per-profile tables. On every ground-truth
-  substrate the refinement improves trajectory APE *and* map crispness
-  simultaneously (NTU −3.2 %, construction −1.5 %/−0.7 %), byte-reproducibly
+- **Globally refined, quality-gated maps** — offline hierarchical plane
+  bundle adjustment (clean-room, BSD-2) refines submap poses after graph
+  optimization (default on in the offline runner), gated by holdout-validated
+  map-quality thresholds. On every ground-truth substrate it improves
+  trajectory APE *and* map crispness simultaneously, byte-reproducibly
   ([evidence](docs/research/map-quality-baseline.md)).
 - **GNSS georeferencing** — optional GNSS constraints and projector metadata for
   real-world coordinates.
@@ -219,8 +217,7 @@ and `Thirdparty/3d_bbs` are gated by `COLCON_IGNORE`.
 ```bash
 bash scripts/run_default_ci_checks.sh
 bash scripts/run_release_readiness_checks.sh --ape-threshold 0.10
-# map-quality thresholds on the gate-produced refined map (v0.7):
-#   --offline-determinism-bag <backend_input> \
+# + map-quality thresholds on the gate-built refined map (v0.7):
 #   --offline-determinism-map-quality-profile configs/map_quality_profiles/indoor_construction.yaml
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ artifacts you need downstream:
   produce *byte-identical* trajectories, loop edges and submaps on every run
   (verified 3-run on MID-360 and NTU VIRAL); the release gate enforces both
   (`--offline-determinism-bag` / `--frontend-determinism-bag`).
+- **Globally refined, quality-gated maps** — an offline hierarchical plane
+  bundle adjustment (clean-room, BSD-2) refines the submap poses after graph
+  optimization (default on in the offline runner) and the result is held to
+  explicit map-quality thresholds (plane thickness, planar coverage, mean map
+  entropy) with holdout-validated per-profile tables. On every ground-truth
+  substrate the refinement improves trajectory APE *and* map crispness
+  simultaneously (NTU −3.2 %, construction −1.5 %/−0.7 %), byte-reproducibly
+  ([evidence](docs/research/map-quality-baseline.md)).
 - **GNSS georeferencing** — optional GNSS constraints and projector metadata for
   real-world coordinates.
 
@@ -211,6 +219,9 @@ and `Thirdparty/3d_bbs` are gated by `COLCON_IGNORE`.
 ```bash
 bash scripts/run_default_ci_checks.sh
 bash scripts/run_release_readiness_checks.sh --ape-threshold 0.10
+# map-quality thresholds on the gate-produced refined map (v0.7):
+#   --offline-determinism-bag <backend_input> \
+#   --offline-determinism-map-quality-profile configs/map_quality_profiles/indoor_construction.yaml
 ```
 
 Reference commands and parameter pointers live in [docs/workflows.md](docs/workflows.md).

--- a/graph_based_slam/src/graph_slam_offline_runner.cpp
+++ b/graph_based_slam/src/graph_slam_offline_runner.cpp
@@ -139,14 +139,17 @@ int main(int argc, char ** argv)
   node->get_parameter_or("submap_distance_threshold", submap_distance_threshold, 1.5);
   node->get_parameter_or("debug_flag", debug_flag, false);
 
-  // v0.7 Phase 2 (docs/roadmap/v0.7.md): optional offline plane-BA
-  // refinement of the optimized submap poses. Off by default; when it
-  // does not improve anything the pose-graph solution is kept unchanged.
-  bool refine = false;
+  // v0.7 (docs/roadmap/v0.7.md): offline plane-BA refinement of the
+  // optimized submap poses. On by default since Phase 3 (holdout-validated
+  // evidence in docs/research/map-quality-baseline.md); when it does not
+  // improve anything the pose-graph solution is kept unchanged, and the
+  // pose-graph artifacts (loop_edges.csv, trajectory_optimized.tum) are
+  // byte-identical either way.
+  bool refine = true;
   double refine_cloud_downsample = 0.10;
   int refine_window_size = 16;
   int refine_window_stride = 8;
-  node->get_parameter_or("refine", refine, false);
+  node->get_parameter_or("refine", refine, true);
   node->get_parameter_or("refine_cloud_downsample", refine_cloud_downsample, 0.10);
   node->get_parameter_or("refine_window_size", refine_window_size, 16);
   node->get_parameter_or("refine_window_stride", refine_window_stride, 8);

--- a/scripts/run_offline_determinism_check.sh
+++ b/scripts/run_offline_determinism_check.sh
@@ -12,7 +12,12 @@ set -euo pipefail
 #     [--params lidarslam/param/lidarslam_mid360_rko_graph.yaml] \
 #     [--runs 3] [--output-dir output/offline_determinism_<timestamp>] \
 #     [--reference-tum output/glim_mid360_reference.tum] \
-#     [--ape-interpolate] [--ape-max-time-diff 0.05]
+#     [--ape-interpolate] [--ape-max-time-diff 0.05] \
+#     [--save-maps]
+#
+# --save-maps forwards refine_save_maps:=true to the runner so each run
+# writes map_optimized.pcd / map_refined.pcd (used by the release gate to
+# run the map-quality profile check on the gate-produced refined map).
 #
 # When --reference-tum is given, each run's trajectory_optimized.tum is also
 # scored with scripts/ape_from_tum.py (report only; the gate is byte
@@ -32,6 +37,7 @@ OUTPUT_DIR="${REPO_ROOT}/output/offline_determinism_$(date +%Y%m%d_%H%M%S)"
 REFERENCE_TUM=""
 APE_INTERPOLATE=false
 APE_MAX_TIME_DIFF="0.05"
+SAVE_MAPS=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -42,6 +48,7 @@ while [[ $# -gt 0 ]]; do
     --reference-tum) REFERENCE_TUM="$2"; shift 2 ;;
     --ape-interpolate) APE_INTERPOLATE=true; shift ;;
     --ape-max-time-diff) APE_MAX_TIME_DIFF="$2"; shift 2 ;;
+    --save-maps) SAVE_MAPS=true; shift ;;
     *) echo "unknown option: $1" >&2; exit 2 ;;
   esac
 done
@@ -70,10 +77,16 @@ for i in $(seq 1 "${RUNS}"); do
   run_dir="${OUTPUT_DIR}/run${i}"
   mkdir -p "${run_dir}"
   echo "--- run ${i}/${RUNS}"
-  ros2 run graph_based_slam graph_slam_offline_runner --ros-args \
-    --params-file "${PARAMS}" \
-    -p bag_path:="${BAG}" \
-    -p output_dir:="${run_dir}" \
+  RUNNER_CMD=(
+    ros2 run graph_based_slam graph_slam_offline_runner --ros-args
+    --params-file "${PARAMS}"
+    -p bag_path:="${BAG}"
+    -p output_dir:="${run_dir}"
+  )
+  if [[ "${SAVE_MAPS}" == "true" ]]; then
+    RUNNER_CMD+=(-p refine_save_maps:=true)
+  fi
+  "${RUNNER_CMD[@]}" \
     > "${run_dir}/runner.log" 2>&1
   md5sum "${run_dir}/loop_edges.csv" "${run_dir}/trajectory_optimized.tum"
   if [[ -n "${REFERENCE_TUM}" ]]; then

--- a/scripts/run_release_readiness_checks.sh
+++ b/scripts/run_release_readiness_checks.sh
@@ -51,6 +51,13 @@ Options:
   --offline-determinism-reference-tum <tum>
                                 Optional reference trajectory; adds per-run APE
                                 to the determinism report (report only)
+  --offline-determinism-map-quality-profile <yaml>
+                                Run the map-quality threshold profile on the
+                                refined map produced BY the determinism gate
+                                itself (v0.7 Phase 3): forwards --save-maps to
+                                the determinism runs and then checks
+                                run1/map_refined.pcd against this profile
+                                (blocking profiles fail the gate on violation)
   --map-quality-pcd <path>[@<profile>]
                                 Run the map-quality metrics stage (v0.7,
                                 docs/roadmap/v0.7.md) on this map PCD file
@@ -144,6 +151,7 @@ OFFLINE_DETERMINISM_BAG=""
 OFFLINE_DETERMINISM_RUNS=""
 OFFLINE_DETERMINISM_PARAMS=""
 OFFLINE_DETERMINISM_REFERENCE_TUM=""
+OFFLINE_DETERMINISM_MAP_QUALITY_PROFILE=""
 MAP_QUALITY_PCDS=()
 MAP_QUALITY_PROFILES=()
 MAP_QUALITY_DOWNSAMPLE=""
@@ -271,6 +279,11 @@ while [[ $# -gt 0 ]]; do
     --offline-determinism-reference-tum)
       [[ $# -ge 2 ]] || usage
       OFFLINE_DETERMINISM_REFERENCE_TUM=$(realpath -m "$2")
+      shift 2
+      ;;
+    --offline-determinism-map-quality-profile)
+      [[ $# -ge 2 ]] || usage
+      OFFLINE_DETERMINISM_MAP_QUALITY_PROFILE=$(realpath -m "$2")
       shift 2
       ;;
     --map-quality-pcd)
@@ -467,7 +480,25 @@ if [[ -n "${OFFLINE_DETERMINISM_BAG}" ]]; then
   if [[ -n "${OFFLINE_DETERMINISM_REFERENCE_TUM}" ]]; then
     OFFLINE_DETERMINISM_CMD+=(--reference-tum "${OFFLINE_DETERMINISM_REFERENCE_TUM}")
   fi
+  if [[ -n "${OFFLINE_DETERMINISM_MAP_QUALITY_PROFILE}" ]]; then
+    OFFLINE_DETERMINISM_CMD+=(--save-maps)
+  fi
   "${OFFLINE_DETERMINISM_CMD[@]}" 2>&1 | tee "${OUT_DIR}/offline_determinism.log"
+
+  if [[ -n "${OFFLINE_DETERMINISM_MAP_QUALITY_PROFILE}" ]]; then
+    echo "==> Checking the gate-produced refined map against the map-quality profile"
+    REFINED_MAP="${OUT_DIR}/offline_determinism/run1/map_refined.pcd"
+    if [[ ! -f "${REFINED_MAP}" ]]; then
+      echo "refined map not found: ${REFINED_MAP}" >&2
+      echo "(the determinism stage must run with refine enabled to produce it)" >&2
+      exit 1
+    fi
+    bash "${REPO_ROOT}/scripts/run_map_quality_check.sh" \
+      --input "${REFINED_MAP}" \
+      --output-dir "${OUT_DIR}/offline_determinism_map_quality" \
+      --profile "${OFFLINE_DETERMINISM_MAP_QUALITY_PROFILE}" \
+      2>&1 | tee "${OUT_DIR}/offline_determinism_map_quality.log"
+  fi
 fi
 
 if [[ -n "${FRONTEND_DETERMINISM_BAG}" ]]; then


### PR DESCRIPTION
## Summary

v0.7 Phase 3 の最終ステップ。リファインメントをオフラインランナーで default on にし、release gate が**自分で生成した refined マップ**を閾値プロファイルでゲートできるようにし、README に narrow なクレームを追加する。

- `graph_slam_offline_runner`: `refine` default true。pose-graph 成果物はどちらでもバイト不変
- `run_offline_determinism_check.sh --save-maps`: gate 実行で `map_optimized.pcd` / `map_refined.pcd` を出力
- `run_release_readiness_checks.sh --offline-determinism-map-quality-profile <yaml>`: `--save-maps` を含意し、gate 自身が生成した `run1/map_refined.pcd` をプロファイル照合(blocking 違反で gate FAIL)。既存成果物ではなく**ゲートが今ビルドしたマップ**を検査する
- README: 「globally refined, quality-gated maps」bullet(per-substrate デルタと holdout 検証付き閾値表へのリンク)+ quality gates セクションに起動例
- live path(component)は不変

## Verification(default flip の実証)

stock params(refine キーなし)の MID-360 backend replay で:

| artifact | md5 | 意味 |
|---|---|---|
| `loop_edges.csv` | `feee9547…` | Phase 0 以来の正準 md5 と一致(**不変**) |
| `trajectory_optimized.tum` | `92676db4…` | 同上(**不変**) |
| `trajectory_refined.tum` | `4cdc4d14…` | Phase 2 evidence と一致(別起動間再現) |

= default flip は既存のバイト一致チェーンを一切動かさず、refined 成果物だけが新たに加わる。