### PR TITLE
docs(roadmap): v0.7 Phase 3 complete — closing gate green with blocking quality thresholds

### DIFF
--- a/docs/roadmap/v0.7.md
+++ b/docs/roadmap/v0.7.md
@@ -170,17 +170,22 @@ gradient/Hessian assembly, LM step) gets one.
 
 ### Phase 3 — gate flip + the claim
 
-> **Status (2026-06-13)**: threshold mechanism merged (#275: per-profile
-> YAML table, blocking/report_only enforcement, gate binding via
-> `--map-quality-pcd <path>@<profile>`). Indoor thresholds calibrated on
-> the construction_seq1 backend replay + Phase 2 NTU evidence and
-> **validated untouched on the held-out construction_seq2 replay — all
-> five rows PASS** (`docs/research/map-quality-baseline.md`
-> §Threshold calibration). Refinement improves APE against real GT on all
-> three GT substrates (NTU −3.2 %, cs1 −0.7 %, cs2 −1.5 %) with byte-
-> identical 3-run replays. Remaining: refine default-on (offline runner +
-> gate map-quality wiring on gate-produced refined maps) and the README
-> claim.
+> **Status (2026-06-13): COMPLETE** (PRs #275 mechanism, #276
+> calibration, #277 default-on). Indoor thresholds calibrated on the
+> construction_seq1 backend replay + Phase 2 NTU evidence and **validated
+> untouched on the held-out construction_seq2 replay — all five rows
+> PASS** (`docs/research/map-quality-baseline.md` §Threshold calibration).
+> Refinement improves APE against real GT on all three GT substrates
+> (NTU −3.2 %, cs1 −0.7 %, cs2 −1.5 %) with byte-identical 3-run replays.
+> Refine defaults on in the offline runner (pose-graph artifacts proven
+> byte-unchanged), the release gate checks the refined map it builds
+> itself via `--offline-determinism-map-quality-profile`, and the README
+> carries the narrow claim. **Closing gate run green** (exit 0,
+> `output/release_readiness_20260613_082619`): both determinism stages
+> byte-identical (backend md5 `feee9547…`/`92676db4…`, frontend
+> `0ca41ec6…`), gate-built refined map passes the blocking indoor profile
+> 5/5 (thickness 0.0441 ≤ 0.085, coverage 0.546 ≥ 0.30, MME −1.62 ≤
+> −0.80).
 - On Phase 2 evidence: refinement defaults on in the offline runner and the
   map-authoring bundle scripts; map-quality metrics get **blocking
   thresholds with an explicit per-profile table** (indoor blocking first,


### PR DESCRIPTION
## Summary

v0.7 Phase 3 の完了スタンプ。クロージング条件「full release gate(両決定論ステージ + 新閾値、holdout 込み)green」を実走で満たした。

## Closing gate evidence(`output/release_readiness_20260613_082619`, exit 0)

- backend determinism: 3-run バイト一致(`loop_edges.csv` `feee9547…` / `trajectory_optimized.tum` `92676db4…` — Phase 0 以来の正準 md5 不変)
- **gate 自身がビルドした refined マップが blocking indoor profile を 5/5 PASS**: thickness 0.0441 ≤ 0.085 / p95 0.1017 ≤ 0.15 / coverage 0.546 ≥ 0.30 / MME −1.62 ≤ −0.80 / valid_fraction 0.953 ≥ 0.90(quality report も 3-run バイト一致)
- frontend determinism: 3-run バイト一致(`0ca41ec6…`、800 poses / 11 submaps)

Phase 0〜3 の全 evidence チェーンは `docs/research/map-quality-baseline.md` と roadmap の各 Status ブロックに記録済み。