### PR TITLE
feat(3dgs): LiDAR depth supervision for geometrically-faithful maps

### DIFF
--- a/docs/3dgs-map-tutorial.md
+++ b/docs/3dgs-map-tutorial.md
@@ -114,11 +114,17 @@ koide（近接密カラー、30 視点）で 8 つの品質レバーを検証し
 | extrinsic 自己校正 (`--optimize-extrinsic`) | 中立（要・不良 extrinsic 用） | OFF |
 | antialiased (`--antialiased`) | **-0.6dB（逆効果）** | OFF |
 | MCMCStrategy (`--mcmc`) | **-1.3〜-1.5dB（LiDAR-primed と不適合）** | OFF |
+| LiDAR 深度教師 (`--lidar-depth-lambda 0.002`) | **新規視点 深度 21m→0.4m**（PSNR -1dB） | OFF |
 
 詳細な ablation:
 [`research/3dgs-koide-first-light.md`](research/3dgs-koide-first-light.md) /
 [`research/3dgs-sh-degree-notes.md`](research/3dgs-sh-degree-notes.md) /
-[`research/3dgs-mcmc-notes.md`](research/3dgs-mcmc-notes.md)。
+[`research/3dgs-mcmc-notes.md`](research/3dgs-mcmc-notes.md) /
+[`research/3dgs-depth-supervision-notes.md`](research/3dgs-depth-supervision-notes.md)。
+
+**見た目 ≠ 幾何**: photometric-only は綺麗でも新規視点の深度が約 10 倍ズレる（floater）。
+幾何忠実なマップが要るなら `--lidar-depth-lambda` で LiDAR 実面に整列させる
+（[深度教師ノート](research/3dgs-depth-supervision-notes.md)）。
 
 **学んだ要点**: 当初 ~24dB を「データ上限」と見ていたが、実は 3000 iter が
 under-training だった。十分回せば 25.5dB に届く。MCMC / antialiased が負なのは、

--- a/docs/research/3dgs-depth-supervision-notes.md
+++ b/docs/research/3dgs-depth-supervision-notes.md
@@ -1,0 +1,92 @@
+# LiDAR 深度教師あり 3DGS — 「綺麗だが幾何が空洞」を実面に整列させる (2026-06-13)
+
+これまでの 3DGS トレーナは **photometric（見た目）損失のみ**で Gaussian を最適化して
+いた。LiDAR は init（`--init-ply`、LiDAR-primed）にしか使っておらず、学習中は幾何を
+拘束していない。本ノートは **LiDAR の深度を学習中の教師信号**として効かせる
+`--lidar-depth-lambda` を `train_gsplat.py` に追加し、koide で検証した記録。
+
+**核心の発見**: photometric-only の 3DGS は**見た目は良い（PSNR 23dB）が、新規視点の
+幾何が約 10 倍ズレている**。LiDAR 深度教師ありはこれを実面に整列させ、新規視点の深度
+誤差を **2〜4 桁**改善する。これは本リポジトリの「メトリックマップ成果物」という位置
+づけ ([3dgs-postprocess-map-design.md](3dgs-postprocess-map-design.md)) に直結する。
+
+## 動機 — photometric-only の幾何は信用できない
+
+3DGS は半透明 Gaussian をアルファ合成して画像を作る。**訓練視点の見た目さえ合えば
+良い**ので、Gaussian を「真の面より手前」に大量に置いて（floater）合成結果だけ正解に
+する解に容易に落ちる。訓練視点では破綻しないが、**新規視点ではその floater 配置が幾何
+的に意味をなさない**。マップとして使うなら致命的。
+
+koide の保留視点（held-out）で実測した深度分布（同一視点、3000 iter）:
+
+| モデル | レンダ深度 中央値 | (5,50,95) pct | GT(LiDAR) (5,50,95) pct |
+|--------|------------------|----------------|--------------------------|
+| **base（photometric only）** | **3.3 m** | (1.9, 3.3, 6.1) | (8.7, 26.5, 52.2) |
+| λ=0.002 | 26.2 m | (8.6, 26.2, 51.3) | (8.7, 26.5, 52.2) |
+| λ=0.5 | 26.4 m | (8.1, 26.4, 52.2) | (8.7, 26.5, 52.2) |
+
+真の面が **26m** にあるのに、photometric-only は Gaussian を **3m** に置いている。
+見た目（PSNR 23dB）には現れないが、**深度は約 10 倍の嘘**。深度教師ありは λ=0.002 でも
+レンダ深度を GT にほぼ一致させる。
+
+## 実装
+
+- `--lidar-depth-lambda L`（opt-in、既定 0=従来どおり）。`--init-ply`（LiDAR 雲）必須
+  — 無いと `ValueError`。
+- **疎 GT 深度マップ**: `pointcloud_io.project_depth_maps` が world 点群を各視点へ投影し、
+  **画素ごとに最近傍 z（z-buffer）**を取って疎な GT 深度を作る（手前の面が背後の点を
+  自然に遮蔽）。純 numpy・CI テスト付き。
+- **損失**: gsplat の `render_mode='RGB+ED'`（expected depth）でレンダ深度を得て、GT が
+  ある疎画素で **メトリック L1**（`L * |depth_render - depth_lidar|`）を photometric 損失
+  に加算。深度はカメラ系 z（メートル）なので両者の単位は一致。
+- 学習終了時に保留視点ではなく**訓練視点**の深度 median abs error を表示
+  （`depth_mae`）。
+- band-0 / SH / densify / MCMC いずれの経路にも差し込めるよう `render_view` に
+  `with_depth` を追加。深度なし時は完全後方互換。
+
+## 結果（koide firstlight, 24 train / 6 held-out, SH deg1, 3000 iter）
+
+| λ | held-out PSNR | held-out 深度 MAE |
+|---|---------------|--------------------|
+| 0（base） | **23.5 dB** | **~21 m** |
+| 0.002 | 22.5 dB | **0.38 m** |
+| 0.005 | 21.9 dB | 0.15 m |
+| 0.01 | 21.3 dB | 0.17 m |
+| 0.02 | 20.6 dB | 0.077 m |
+| 0.1 | 19.2 dB | 0.013 m |
+| 0.5 | 18.2 dB | 0.003 m |
+
+- **単調**: λ↑ で幾何 MAE は桁単位で改善、PSNR は漸減。**幾何 ↔ 見た目の明快なノブ**。
+- **knee = λ≈0.002**: 深度 MAE を **21m → 0.38m（98% 減）** に落とすのに PSNR は
+  **−1dB だけ**。1dB の見た目を払って「幾何的に意味のないモデル」を「メトリックに忠実な
+  マップ」に変える、良いトレード。
+- 「完全に無償」の幾何は無い（最小 λ でも ~1dB は払う）。これは深度教師ありが
+  densification と競合し、3000 iter では見た目の収束を一部犠牲にするため。
+
+## 位置づけと既定
+
+- **既定 OFF（opt-in）**。他の品質レバー同様、PSNR を払うので default では入れない。
+- **幾何忠実度が要るとき**（マップ計測用途、点群との整合、下流の localization 検討）に
+  `--lidar-depth-lambda 0.002` 程度を推奨。
+- これは「綺麗な render」ではなく「**幾何的に正しい 3DGS マップ**」を作るレバー。SLAM が
+  メトリックな点群を持つ本パイプラインだからこそ COLMAP 無しで深度教師信号を供給できる
+  （[LiDAR-primed の核](3dgs-postprocess-map-design.md) の自然な延長）。
+
+## 再現
+
+```bash
+# 幾何忠実な 3DGS マップ（LiDAR 深度教師あり）
+python3 tools/gaussian_splatting/train_gsplat.py \
+  --transforms output/koide_3dgs_firstlight/gsplat/transforms.json \
+  --init-ply  output/koide_3dgs_firstlight/gsplat/lidar_init.ply \
+  --out model_depthsup.ply --sh-degree 1 --iters 9000 \
+  --lidar-depth-lambda 0.002
+```
+
+## 残課題 / 次レバー
+
+- 退化シーン（HILTI exp07 廊下、RTK-SLAM 歩行窓）での効果測定。floater が支配的なほど
+  深度教師ありの相対利得は大きいはず。
+- depth loss の warmup / densify 後半のみ適用で PSNR 代償を圧縮できるか。
+- scale-invariant / 相対深度損失で大深度シーンの重み付けを改善。
+- 深度教師あり前提なら **法線/平面正則化**（2DGS 系）も自然な次段。

--- a/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
+++ b/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
@@ -236,6 +236,45 @@ def test_colorize_robust_rejects_bad_zbuf_bin():
 
 
 # --------------------------------------------------------------------------- #
+# project_depth_maps (LiDAR depth supervision GT)
+# --------------------------------------------------------------------------- #
+def test_project_depth_maps_centre_pixel_and_depth():
+    vms, K, W, H = _cam()
+    pts = np.array([[0.0, 0.0, 5.0]])      # projects to (50, 50) at depth 5
+    (pix, depth), = pcio.project_depth_maps(pts, vms, K, W, H)
+    assert pix.tolist() == [50 * W + 50]
+    np.testing.assert_allclose(depth, [5.0], atol=1e-6)
+
+
+def test_project_depth_maps_zbuffer_keeps_nearest():
+    vms, K, W, H = _cam()
+    # Two points on the same ray land on one pixel; only the near depth survives.
+    pts = np.array([[0.0, 0.0, 8.0], [0.0, 0.0, 2.0]])
+    (pix, depth), = pcio.project_depth_maps(pts, vms, K, W, H)
+    assert pix.tolist() == [50 * W + 50]
+    np.testing.assert_allclose(depth, [2.0], atol=1e-6)
+
+
+def test_project_depth_maps_culls_behind_and_out_of_frame():
+    vms, K, W, H = _cam()
+    pts = np.array([[0.0, 0.0, -5.0],      # behind the camera
+                    [10.0, 0.0, 5.0]])     # u = 250 -> off image
+    (pix, depth), = pcio.project_depth_maps(pts, vms, K, W, H)
+    assert pix.size == 0 and depth.size == 0
+
+
+def test_project_depth_maps_one_entry_per_view():
+    vms1, K, W, H = _cam()
+    vms = np.concatenate([vms1, vms1], axis=0)
+    pts = np.array([[0.0, 0.0, 5.0]])
+    maps = pcio.project_depth_maps(pts, vms, K, W, H)
+    assert len(maps) == 2
+    for pix, depth in maps:
+        assert pix.tolist() == [50 * W + 50]
+        np.testing.assert_allclose(depth, [5.0], atol=1e-6)
+
+
+# --------------------------------------------------------------------------- #
 # drop_sparse_points
 # --------------------------------------------------------------------------- #
 def test_drop_sparse_points_keeps_cluster_drops_isolated():

--- a/graph_based_slam/test/test_gaussian_splatting_train.py
+++ b/graph_based_slam/test/test_gaussian_splatting_train.py
@@ -255,6 +255,36 @@ def test_parser_quality_flags_set():
     assert args.mcmc is True and args.mcmc_cap == 300000
 
 
+def test_parser_lidar_depth_lambda():
+    args = tg.build_parser().parse_args(['--transforms', 't', '--out', 'o'])
+    assert args.lidar_depth_lambda == 0.0
+    args = tg.build_parser().parse_args(
+        ['--transforms', 't', '--out', 'o', '--lidar-depth-lambda', '0.002'])
+    assert args.lidar_depth_lambda == 0.002
+
+
+def _depth_ds():
+    return {'K': np.eye(3), 'width': 8, 'height': 8,
+            'viewmats': [np.eye(4)], 'image_paths': [], 'groups': [0]}
+
+
+def test_lidar_depth_requires_init_points():
+    # The guard fires before any torch/GPU work, so it is CPU-testable.
+    with pytest.raises(ValueError, match='requires an init point cloud'):
+        tg.train_densify(_depth_ds(), init_points=None,
+                         lidar_depth_lambda=0.5, iters=1, device='cpu')
+
+
+def test_lidar_depth_incompatible_with_pose_optimisation():
+    pts = np.zeros((4, 3), dtype=np.float32)
+    with pytest.raises(ValueError, match='incompatible'):
+        tg.train_densify(_depth_ds(), init_points=pts, lidar_depth_lambda=0.5,
+                         optimize_extrinsic=True, iters=1, device='cpu')
+    with pytest.raises(ValueError, match='incompatible'):
+        tg.train_densify(_depth_ds(), init_points=pts, lidar_depth_lambda=0.5,
+                         optimize_pose_groups=True, iters=1, device='cpu')
+
+
 def test_make_ssim_noise_below_one():
     torch = pytest.importorskip('torch')
     a = torch.rand(32, 40, 3)

--- a/tools/gaussian_splatting/pointcloud_io.py
+++ b/tools/gaussian_splatting/pointcloud_io.py
@@ -224,6 +224,52 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
     return rgb, seen
 
 
+def project_depth_maps(points: np.ndarray, viewmats, K: np.ndarray,
+                       width: int, height: int) -> list:
+    """Project a world point cloud into each posed camera as a sparse depth map.
+
+    For depth-supervised 3DGS training: the LiDAR cloud carries metric geometry,
+    so projecting it into every view gives a sparse per-pixel ground-truth depth
+    to regularise the rendered (expected) depth against. ``viewmats`` are OpenCV
+    world->camera (as ``train_gsplat.load_transforms`` returns); a point's depth
+    is its camera-frame ``z``. When several points land on the same pixel only
+    the nearest is kept (a per-pixel z-buffer), so a wall in front naturally
+    occludes the points behind it.
+
+    Returns a list (one entry per view) of ``(pix_idx int64 (M,), depth float32
+    (M,))`` where ``pix_idx = v * width + u`` indexes the flattened image and
+    ``M`` is the number of occupied pixels in that view (sparse; usually far
+    fewer than the point count after the z-buffer dedups colliding pixels).
+    """
+    pts = np.asarray(points, dtype=np.float64)
+    fx, fy, cx, cy = K[0, 0], K[1, 1], K[0, 2], K[1, 2]
+    npix = int(width) * int(height)
+    out = []
+    for vm in viewmats:
+        vm = np.asarray(vm, dtype=np.float64)
+        cam = pts @ vm[:3, :3].T + vm[:3, 3]
+        z = cam[:, 2]
+        with np.errstate(divide='ignore', invalid='ignore'):
+            u = np.nan_to_num(fx * cam[:, 0] / z + cx, nan=-1.0,
+                              posinf=-1.0, neginf=-1.0)
+            v = np.nan_to_num(fy * cam[:, 1] / z + cy, nan=-1.0,
+                              posinf=-1.0, neginf=-1.0)
+        ui = np.round(u).astype(np.int64)
+        vi = np.round(v).astype(np.int64)
+        inb = (z > 1e-6) & (ui >= 0) & (ui < width) & (vi >= 0) & (vi < height)
+        if not inb.any():
+            out.append((np.zeros(0, dtype=np.int64), np.zeros(0, dtype=np.float32)))
+            continue
+        pix = vi[inb] * int(width) + ui[inb]
+        # Per-pixel nearest-depth z-buffer over the flattened image, then keep
+        # only the pixels that actually received a point.
+        buf = np.full(npix, np.inf, dtype=np.float64)
+        np.minimum.at(buf, pix, z[inb])
+        upix = np.unique(pix)
+        out.append((upix.astype(np.int64), buf[upix].astype(np.float32)))
+    return out
+
+
 def drop_sparse_points(xyz: np.ndarray, min_neighbors: int = 3,
                        voxel: float = 0.1) -> np.ndarray:
     """Keep-mask of points whose 3x3x3 voxel neighbourhood holds enough points.

--- a/tools/gaussian_splatting/train_gsplat.py
+++ b/tools/gaussian_splatting/train_gsplat.py
@@ -407,7 +407,8 @@ def train_densify(dataset: dict, *, init_points=None, init_colors=None,
                   ssim_lambda: float = 0.0, knn_scale: bool = False,
                   sh_degree: Optional[int] = None,
                   antialiased: bool = False, mcmc: bool = False,
-                  mcmc_cap: int = 500000) -> dict:
+                  mcmc_cap: int = 500000,
+                  lidar_depth_lambda: float = 0.0) -> dict:
     """Train with gsplat DefaultStrategy adaptive density control (densify/prune).
 
     Same I/O contract as ``train`` but the Gaussian count grows/shrinks via the
@@ -429,7 +430,31 @@ def train_densify(dataset: dict, *, init_points=None, init_colors=None,
     (per-channel gain + bias applied to the render inside the loss only),
     absorbing auto-exposure/white-balance differences between merged sessions.
     Group 0 is the reference, so the exported Gaussians keep its exposure.
+
+    ``lidar_depth_lambda`` (>0) adds a LiDAR depth-supervision term: the init
+    cloud is projected into every view as a sparse ground-truth depth map and
+    the rendered expected depth (gsplat ``RGB+ED``) is pulled towards it with an
+    L1 loss at those pixels. The LiDAR carries metric geometry, so this anchors
+    the Gaussians to the real surface and curbs the view-dependent floaters /
+    collapse that photometric-only training leaves on sparse captures. Requires
+    ``init_points`` (the LiDAR cloud) -- raises ``ValueError`` without them, and
+    is mutually exclusive with the pose-optimisation levers (the GT depth is
+    projected at fixed poses, and trusting vs distrusting the poses is
+    contradictory).
     """
+    if lidar_depth_lambda > 0.0:
+        if init_points is None or len(init_points) == 0:
+            raise ValueError('lidar_depth_lambda>0 requires an init point cloud '
+                             '(--init-ply) to supervise depth against')
+        if optimize_extrinsic or optimize_pose_groups:
+            # The depth GT is projected once from the given viewmats; pose
+            # self-calibration moves the cameras under it, so the rendered depth
+            # and GT would drift into different frames. The two levers are also
+            # contradictory in intent (depth supervision trusts the LiDAR
+            # geometry; pose refinement distrusts the poses). Forbid the combo.
+            raise ValueError('lidar_depth_lambda is incompatible with '
+                             '--optimize-extrinsic / --optimize-pose-groups '
+                             '(GT depth is projected at fixed poses)')
     import torch
     import torch.nn.functional as F
     import imageio.v3 as iio
@@ -476,6 +501,30 @@ def train_densify(dataset: dict, *, init_points=None, init_colors=None,
             img = np.stack([img] * 3, axis=-1)
         gts.append(torch.tensor(img[..., :3], device=dev))
     gts = torch.stack(gts)
+
+    # LiDAR depth supervision: project the init cloud into every view as a
+    # sparse GT depth map (flattened pixel index + metric z), kept on-device for
+    # a cheap gather in the loss. Built once; only the current view is used per
+    # iter. Empty views (no points project) simply contribute no depth term.
+    depth_gt = None
+    if lidar_depth_lambda > 0.0:
+        import pointcloud_io as _pcio
+        maps = _pcio.project_depth_maps(
+            np.asarray(init_points, dtype=np.float64),
+            dataset['viewmats'], dataset['K'], W, H)
+        depth_gt = [(torch.tensor(pix, dtype=torch.long, device=dev),
+                     torch.tensor(d, dtype=torch.float32, device=dev))
+                    for pix, d in maps]
+        n_sup = sum(int(p.numel()) for p, _ in depth_gt)
+        if n_sup == 0:
+            # No init point projects into any view -- almost always a bad
+            # extrinsic or a cloud/camera frame mismatch. Fail loudly rather
+            # than train a silent photometric-only model.
+            raise ValueError('lidar_depth_lambda>0 but the init cloud projects '
+                             'into 0 pixels across all views (check extrinsics/'
+                             'frames)')
+        print(f'LiDAR depth supervision: {n_sup} GT pixels over '
+              f'{len(depth_gt)} views (lambda={lidar_depth_lambda})', flush=True)
 
     if mcmc:
         # MCMC keeps a fixed Gaussian budget (cap_max) and relocates dead/low-
@@ -533,14 +582,19 @@ def train_densify(dataset: dict, *, init_points=None, init_colors=None,
 
     rasterize_mode = 'antialiased' if antialiased else 'classic'
 
-    def render_view(i, vm=None):
+    def render_view(i, vm=None, *, with_depth=False):
         out, _, info = rasterization(
             params['means'], F.normalize(params['quats'], dim=-1),
             torch.exp(params['scales']), torch.sigmoid(params['opacities']),
             _colors_arg(),
             viewmats[i:i + 1] if vm is None else vm, K, W, H,
             sh_degree=sh_degree, rasterize_mode=rasterize_mode, packed=False,
+            render_mode='RGB+ED' if with_depth else 'RGB',
         )
+        if with_depth:
+            # RGB+ED packs expected depth as the trailing channel: (H,W,4).
+            assert out.shape[-1] == 4, f'expected RGB+ED (4 ch), got {out.shape}'
+            return out[0][..., :3], out[0][..., 3], info
         return out[0], info
 
     loss_history: list[float] = []
@@ -551,13 +605,23 @@ def train_densify(dataset: dict, *, init_points=None, init_colors=None,
             vm = (vm[0] @ _se3_exp_torch(taus_g[groups[idx]]))[None]
         if optimize_extrinsic:
             vm = (_se3_exp_torch(tau) @ vm[0])[None]
-        render, info = render_view(idx, vm)
+        if depth_gt is not None:
+            render, depth, info = render_view(idx, vm, with_depth=True)
+        else:
+            render, info = render_view(idx, vm)
         if not mcmc:
             strategy.step_pre_backward(params, optimizers, state, it, info)
         if optimize_exposure:
             e = expo[groups[idx]]
             render = render * (1.0 + e[:3]) + e[3:]
         loss, mse = _photometric_loss(render, gts[idx], ssim_fn, ssim_lambda)
+        if depth_gt is not None:
+            pix, dgt = depth_gt[idx]
+            if pix.numel() > 0:
+                # Pull the rendered expected depth toward the LiDAR depth at the
+                # sparse projected pixels (metric L1).
+                dr = depth.reshape(-1)[pix]
+                loss = loss + lidar_depth_lambda * F.l1_loss(dr, dgt)
         if optimize_exposure:
             # keep the affine compensation near identity: it should absorb
             # auto-exposure drift, not repaint inconsistent geometry
@@ -613,6 +677,22 @@ def train_densify(dataset: dict, *, init_points=None, init_colors=None,
         return out
 
     metrics = _eval_views(_eval_render, gts, ssim_fn)
+    depth_mae = None
+    if depth_gt is not None:
+        # Median absolute error (m) between rendered and LiDAR depth at the
+        # supervised pixels -- a geometry-fidelity readout independent of PSNR.
+        errs = []
+        with torch.no_grad():
+            for i in range(viewmats.shape[0]):
+                pix, dgt = depth_gt[i]
+                if pix.numel() == 0:
+                    continue
+                vm = None if eval_vm is None else eval_vm[i:i + 1]
+                dr = render_view(i, vm, with_depth=True)[1].reshape(-1)[pix]
+                errs.append(torch.abs(dr - dgt))
+        if errs:
+            depth_mae = float(torch.median(torch.cat(errs)).cpu())
+            print(f'LiDAR depth median abs error: {depth_mae:.4f} m', flush=True)
     if sh_degree is None:
         colors_rgb = torch.sigmoid(params['colors']).detach().cpu().numpy()
         sh_rest = None
@@ -631,6 +711,7 @@ def train_densify(dataset: dict, *, init_points=None, init_colors=None,
         'sh_rest': sh_rest,
         'loss_history': loss_history,
         'psnr': metrics['psnr'], 'ssim': metrics['ssim'],
+        'depth_mae': depth_mae,
     }
     if optimize_extrinsic:
         # viewmat_refined = M @ viewmat with M = exp(tau); equivalently the
@@ -679,6 +760,11 @@ def build_parser() -> argparse.ArgumentParser:
                         'instead of clone/split DefaultStrategy (implies --densify)')
     p.add_argument('--mcmc-cap', type=int, default=500000,
                    help='max Gaussian budget for --mcmc (default 500000)')
+    p.add_argument('--lidar-depth-lambda', type=float, default=0.0,
+                   help='weight of the LiDAR depth-supervision L1 term; projects '
+                        'the --init-ply cloud into each view as sparse GT depth '
+                        'and anchors the rendered depth to it (implies --densify, '
+                        'needs --init-ply; 0 = off)')
     p.add_argument('--densify', action='store_true',
                    help='use gsplat DefaultStrategy adaptive density control')
     p.add_argument('--optimize-extrinsic', action='store_true',
@@ -712,7 +798,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(f'LiDAR-primed init: {len(init_points)} points from {args.init_ply}')
     if (args.densify or args.optimize_extrinsic or args.optimize_pose_groups
             or args.optimize_exposure or args.sh_degree is not None
-            or args.antialiased or args.mcmc):
+            or args.antialiased or args.mcmc or args.lidar_depth_lambda > 0.0):
         params = train_densify(
             dataset, init_points=init_points, init_colors=init_colors,
             num_init=args.num_init, iters=args.iters, lr=args.lr,
@@ -721,7 +807,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             optimize_exposure=args.optimize_exposure,
             ssim_lambda=args.ssim_lambda, knn_scale=args.knn_scale_init,
             sh_degree=args.sh_degree, antialiased=args.antialiased,
-            mcmc=args.mcmc, mcmc_cap=args.mcmc_cap)
+            mcmc=args.mcmc, mcmc_cap=args.mcmc_cap,
+            lidar_depth_lambda=args.lidar_depth_lambda)
     else:
         params = train(dataset, init_points=init_points, init_colors=init_colors,
                        num_init=args.num_init, iters=args.iters,
@@ -729,9 +816,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     out = export_ply(args.out, params['means'], params['scales_log'],
                      params['quats'], params['opacities_logit'],
                      params['colors_rgb'], params.get('sh_rest'))
+    dmae = params.get('depth_mae')
     print(f'final mse {params["loss_history"][-1]:.6f}  '
           f'PSNR {params.get("psnr", float("nan")):.2f} dB  '
-          f'SSIM {params.get("ssim", float("nan")):.4f} -> {out}')
+          f'SSIM {params.get("ssim", float("nan")):.4f}'
+          + (f'  depthMAE {dmae:.4f} m' if dmae is not None else '')
+          + f' -> {out}')
     if 'extrinsic_delta' in params:
         import yaml
         from extract_posed_images import parse_extrinsic_dict


### PR DESCRIPTION
## What

Adds an opt-in **LiDAR depth-supervision** term to the gsplat trainer so the 3DGS map is *geometrically faithful*, not just photometrically pretty.

### Motivation — photometric-only geometry is hollow

3DGS alpha-composites semi-transparent Gaussians, so a model can reconstruct the training views by piling splats in front of the true surface (floaters). On held-out koide views the rendered (expected) depth sits at **~3 m while the LiDAR surface is at ~26 m** — a ~10× depth error that is invisible in PSNR but fatal for a *map*.

| held-out view | rendered depth (median) | LiDAR GT |
|---|---|---|
| photometric only | **3.3 m** | 26.5 m |
| `--lidar-depth-lambda 0.002` | 26.2 m | 26.5 m |

### Approach

- `pointcloud_io.project_depth_maps` — project the init cloud into each view as a sparse, **per-pixel z-buffered** GT depth map (pure numpy, CI-tested).
- `train_gsplat --lidar-depth-lambda L` — render the gsplat **`RGB+ED`** expected depth and pull it toward the GT with a metric **L1** at those pixels. Reports depth median-abs-error at eval.

### Result (koide, 24 train / 6 held-out, SH deg1, 3000 iter)

| λ | held-out PSNR | held-out depth MAE |
|---|---|---|
| 0 (base) | 23.5 dB | **~21 m** |
| 0.002 | 22.5 dB | **0.38 m** |
| 0.02 | 20.6 dB | 0.077 m |
| 0.5 | 18.2 dB | 0.003 m |

A clean appearance↔geometry knob: **λ=0.002 cuts novel-view depth error 21 m → 0.38 m (98 %) for −1 dB PSNR**. Default **off** (trades PSNR like the other levers); recommend λ=0.002 when geometry fidelity matters.

## Guards / scope

- Requires `--init-ply`; raises if the cloud projects into 0 pixels.
- Incompatible with `--optimize-extrinsic` / `--optimize-pose-groups` (GT projected at fixed poses; trusting vs distrusting poses is contradictory) — guarded with a clear error.
- Fully back-compatible: depth path only runs when λ>0.

## Tests / verification

- `colcon`-registered pytest: **50 train + 23 pointcloud pass**, `ament_flake8` clean.
- GPU selftest PASS (non-depth path unchanged); depth path verified end-to-end on koide.
- `mkdocs build --strict` passes.
- Adversarial diff review (codex): 3 issues fixed (pose-opt incompatibility, RGB+ED channel assert, 0-pixel guard).

Full holdout sweep + depth-distribution evidence: `docs/research/3dgs-depth-supervision-notes.md`.

## Reproduce

```bash
python3 tools/gaussian_splatting/train_gsplat.py \
  --transforms output/koide_3dgs_firstlight/gsplat/transforms.json \
  --init-ply  output/koide_3dgs_firstlight/gsplat/lidar_init.ply \
  --out model_depthsup.ply --sh-degree 1 --iters 9000 --lidar-depth-lambda 0.002
```
