### PR TITLE
docs(3dgs): 2DGS + planar regularization — negative on LiDAR-primed data

### DIFF
--- a/docs/3dgs-map-tutorial.md
+++ b/docs/3dgs-map-tutorial.md
@@ -115,12 +115,14 @@ koide（近接密カラー、30 視点）で 8 つの品質レバーを検証し
 | antialiased (`--antialiased`) | **-0.6dB（逆効果）** | OFF |
 | MCMCStrategy (`--mcmc`) | **-1.3〜-1.5dB（LiDAR-primed と不適合）** | OFF |
 | LiDAR 深度教師 (`--lidar-depth-lambda 0.002`) | **新規視点 深度 21m→0.4m**（PSNR -1dB） | OFF |
+| 2DGS surfel + 平面正則化 | **負（深度教師ありに勝てず・外挿不安定）** | 非採用 |
 
 詳細な ablation:
 [`research/3dgs-koide-first-light.md`](research/3dgs-koide-first-light.md) /
 [`research/3dgs-sh-degree-notes.md`](research/3dgs-sh-degree-notes.md) /
 [`research/3dgs-mcmc-notes.md`](research/3dgs-mcmc-notes.md) /
-[`research/3dgs-depth-supervision-notes.md`](research/3dgs-depth-supervision-notes.md)。
+[`research/3dgs-depth-supervision-notes.md`](research/3dgs-depth-supervision-notes.md) /
+[`research/3dgs-2dgs-notes.md`](research/3dgs-2dgs-notes.md)。
 
 **見た目 ≠ 幾何**: photometric-only は綺麗でも新規視点の深度が約 10 倍ズレる（floater）。
 幾何忠実なマップが要るなら `--lidar-depth-lambda` で LiDAR 実面に整列させる

--- a/docs/research/3dgs-2dgs-notes.md
+++ b/docs/research/3dgs-2dgs-notes.md
@@ -1,0 +1,57 @@
+# 2DGS (surfel) + 平面正則化 — LiDAR-primed では負の結果 (2026-06-13)
+
+[深度教師あり](3dgs-depth-supervision-notes.md)で「位置（深度）」は実面に固定できたが、
+**外挿下の RGB floater は残る**（深度は正しいが視点依存の見えが崩れる）。これを surfel
+primitive と平面正則化で抑えられないか検証した記録。**結論: LiDAR-primed パイプラインでは
+2DGS は 3DGS+深度教師ありに勝てず、productionize しない**（[MCMC](3dgs-mcmc-notes.md) と
+同じ理由）。
+
+## 試したこと
+
+gsplat 1.5.3 はネイティブ 2DGS (`rasterization_2dgs`) を持ち、**既存と同じ
+(means, quats, scales, opacities, colors) コンテナ**をそのまま使える（DefaultStrategy は
+`key_for_gradient='gradient_2dgs'` で対応）。これに 2DGS 標準の 2 正則化を加えた:
+
+- **normal 一貫性**: レンダ法線 `render_normals` を深度勾配由来の `surf_normals` に揃える
+  `(1 - <render_normals, surf_normals>)`。
+- **depth distortion**: `render_distort`（レイ方向の重み分散）を最小化＝floater を潰す狙い。
+
+RTK-SLAM walk (74 train / 19 held-out) で、[外挿 dolly 深度プローブ](3dgs-depth-supervision-notes.md)
+（テスト視点を横へ 0〜0.8m ドリーし render 深度 vs LiDAR 投影深度の MAE）で比較。
+
+## 結果（外挿 dolly 深度 MAE, cm）
+
+| 構成 | 0.0m | 0.2m | 0.4m | 0.8m |
+|------|------|------|------|------|
+| 3DGS base（photometric） | 349 | 330 | 290 | 184 |
+| **3DGS + 深度教師 λ0.02** | **20** | **26** | **30** | **34** |
+| 2DGS + normal + dist | 223 | 117 | 124 | 262 |
+| 2DGS + normal + dist + depth | 41 | 38 | 50 | 320 |
+| 2DGS pure + depth | 35 | 44 | 208 | 44 |
+
+- **全 2DGS 変種が 3DGS+深度教師ありに負ける**。しかも offset により 200〜320cm へ
+  **発散**（surfel レンダは外挿下で不安定）。
+- 2DGS+正則化（深度なし）は base よりマシだが深度教師ありに遠く及ばない（局所 surfel
+  一貫性は**絶対的な実面アンカーにならない**）。
+- RGB を外挿レンダしても floater/霧は 3DGS と同程度かむしろ悪化（grazing 角の surfel が
+  画面空間で霧になる）。
+
+## 洞察
+
+**LiDAR のメトリック深度事前が、2DGS の自己教師な幾何正則化を包含する**。2DGS の
+normal/distortion 損失は「画像だけから面の向きと厚みを一から推定する」ためのもので、
+**ground-truth の LiDAR 深度が既にある本パイプラインでは冗長**。むしろ surfel primitive は
+外挿下で 3D Gaussian より不安定だった。これは [MCMC が負だった理由](3dgs-mcmc-notes.md)
+（LiDAR-primed の強い幾何事前があると、自前で再配置/再発見する手法より素直な手法が優位）
+と一貫する。
+
+**外挿下の RGB floater は依然未解決**だが、その本丸は surfel 化ではなく**視点依存の見え**
+（色・grazing opacity・モーションブラー）のモデル化。photoreal novel-view はキャプチャ品質
+律速（[trajectory-flythrough](3dgs-trajectory-flythrough-notes.md)）という結論は変わらない。
+
+## 注意（フェアネス）
+
+normal 損失の warmup スケジュールや重み・iter 数は網羅的にチューニングしていない（2DGS 論文は
+normal 損失を後半から効かせる）。ただし**判断基準は「深度教師ありに勝てるか」**で、素直な
+3DGS+深度教師ありが既に幾何を解いている以上、2DGS は明確な利得なく大きなコード経路と外挿
+不安定性を持ち込むだけ、と判断した。spike コードは `output/twodgs_spike/spike.py`(gitignore)。


### PR DESCRIPTION
Follow-up to the depth-supervision track (#284/#285/#286). The depth-sup notes left RGB floaters off-trajectory as an open item; this spikes **2DGS surfels + planar regularization** to try to suppress them, and records the **negative result**.

## What was tried

gsplat 1.5.3 has native 2DGS (`rasterization_2dgs`) reusing the same param container (DefaultStrategy with `key_for_gradient='gradient_2dgs'`). Added the standard 2DGS regularizers — **normal consistency** (render vs depth-gradient normals) + **depth distortion** (the floater killer) — with and without LiDAR depth supervision.

## Result (RTK-SLAM walk, extrapolation dolly depth MAE, cm)

| variant | 0.0 m | 0.4 m | 0.8 m |
|---|---|---|---|
| **3DGS + depth-sup λ0.02** | **20** | **30** | **34** |
| 2DGS + normal + dist | 223 | 124 | 262 |
| 2DGS + normal + dist + depth | 41 | 50 | 320 |
| 2DGS pure + depth | 35 | 208 | 44 |

Every 2DGS variant **underperforms plain 3DGS + depth supervision** and **destabilises off-trajectory** (200–320 cm blowups). RGB floaters are not reduced either.

## Insight

The **metric LiDAR depth prior subsumes 2DGS's self-supervised geometric regularization** — the normal/distortion losses exist to *discover* surface orientation/thickness from images, which is redundant when ground-truth LiDAR depth is already supervising geometry. Surfels are also less stable under extrapolation. Same root cause as the [MCMC negative](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/docs/research/3dgs-mcmc-notes.md): a strong LiDAR-primed geometry prior favours the simpler primitive.

**Not productionized** — recorded so it is not re-attempted. Doc-only; `mkdocs build --strict` passes.