### PR TITLE
fix(3dgs): load the web viewer's .splat under gzip transport

### DIFF
--- a/docs/assets/3dgs-viewer/main.js
+++ b/docs/assets/3dgs-viewer/main.js
@@ -766,7 +766,13 @@ async function main() {
 
     const rowLength = 3 * 4 + 3 * 4 + 4 + 4;
     const reader = req.body.getReader();
-    let splatData = new Uint8Array(req.headers.get("content-length"));
+    // Local modification (lidarslam_ros2): the content-length is unreliable when
+    // the server gzips the response (GitHub Pages reports the COMPRESSED length),
+    // which is both too small and not a multiple of rowLength -- the worker's
+    // Float32Array view over the buffer then threw. Treat it as a hint only,
+    // rounded up to a whole splat, and grow as the decoded stream arrives.
+    const sizeHint = parseInt(req.headers.get("content-length")) || 0;
+    let splatData = new Uint8Array(Math.ceil(sizeHint / rowLength) * rowLength);
 
     const downsample =
         splatData.length / rowLength > 500000 ? 1 : 1 / devicePixelRatio;
@@ -1459,6 +1465,17 @@ async function main() {
         const { done, value } = await reader.read();
         if (done || stopLoading) break;
 
+        // Local modification (lidarslam_ros2): grow the buffer to fit the
+        // decoded stream when the (gzip) content-length hint was too small.
+        // Keep the length a whole number of splats so the worker's Float32Array
+        // view stays 4-byte aligned.
+        if (bytesRead + value.length > splatData.length) {
+            const needed =
+                Math.ceil((bytesRead + value.length) / rowLength) * rowLength;
+            const grown = new Uint8Array(Math.max(needed, splatData.length * 2));
+            grown.set(splatData.subarray(0, bytesRead));
+            splatData = grown;
+        }
         splatData.set(value, bytesRead);
         bytesRead += value.length;
 


### PR DESCRIPTION
## Problem

The interactive 3DGS viewer shipped in #288 fails to load its map **once
deployed to GitHub Pages** — it shows `RangeError` and never renders, even
though it works against the local `python -m http.server` used during review.

Root cause: GitHub Pages serves the `.splat` with `Content-Encoding: gzip`, so
the response `content-length` is the **compressed** size (8,826,330 B vs the
9,600,000 B decoded). The upstream antimatter15 loader preallocates its buffer
from `content-length`, which is:

1. too small for the decoded stream → `RangeError` on buffer write, and
2. not a multiple of the 32-byte splat stride → the worker's `Float32Array`
   view over the buffer throws *"byte length should be a multiple of 4"*.

```
$ curl -sI -H 'Accept-Encoding: gzip' .../koide_lidar_primed.splat
content-encoding: gzip
content-length: 8826330      # compressed; decoded is 9600000
```

## Fix

`docs/assets/3dgs-viewer/main.js` (local mod, tagged with comments): treat
`content-length` as a hint rounded up to a whole splat, and grow the buffer —
staying 32-byte aligned — as the decoded chunks arrive. Content-length is no
longer trusted for sizing.

## Verification

Reproduced Pages' behaviour with a local server that gzips the `.splat` and
advertises the compressed length, driven through headless Chrome (SwiftShader
WebGL2) via CDP:

- **Before:** `RangeError: byte length of Float32Array should be a multiple of 4`,
  blue loader cube forever.
- **After:** console logs `275823 1` then `sort: 5.5 ms / 15.9 ms`; the photoreal
  koide scene renders. The plain (non-gzip) path still renders too — the fix
  doesn't regress normal serving.

`mkdocs build --strict` passes.
