### PR TITLE
feat(3dgs): sim2real gap harness — offset-sweep extrapolation measurement

### DIFF
--- a/docs/research/3dgs-sim2real-gap-phase0.md
+++ b/docs/research/3dgs-sim2real-gap-phase0.md
@@ -1,0 +1,81 @@
+# 3DGS sim2real gap — Phase 0 外挿安定性測定 (2026-06-15)
+
+3DGS を **sim2real シミュレーション基盤**として開発するトラックの Phase 0。
+全下流用途（open-loop 知覚データ生成 / closed-loop Autoware-in-the-loop /
+RL 方策学習）の前提となる問いを、丸ごとシミュレータを作る前に安く測る:
+
+> 実データで学習済みのモデルは 3DGS レンダにそのまま通用するか。
+> ego が記録軌跡から横ずれしたとき、どこまで視点を外挿してよいか（**有効視点範囲**）。
+
+ハーネス: `tools/gaussian_splatting/sim2real_gap.py`
+（pure 部 18 ケースを `graph_based_slam/test/test_gaussian_splatting_sim2real_gap.py`
+で CPU テスト、ament_flake8 clean）。
+再現: `PLY=... TRANSFORMS=... OUT_DIR=... bash scripts/run_sim2real_gap.sh`
+
+## 測定内容
+
+各学習視点について 2 つを測る:
+
+1. **再構成忠実度（offset 0）** — 記録 pose でレンダ vs 実画像: PSNR / SSIM、
+   および任意で物体検出器の一致（実画像の検出が render 上で IoU マッチで何割残るか）。
+   これが記録軌跡上での文字どおりの sim2real gap。
+2. **外挿安定性（横オフセットスイープ）** — カメラを camera-local x（右）に
+   ±0.25/0.5/1.0 m スライド（heading 固定 = ego の横ずれ）。各 offset を
+   offset-0 render と比較: 見た目安定性 SSIM、sharpness 比、bright-floater 率
+   （3DGS 特有の破綻 = 白飛び floater の proxy）、検出保持率。
+   これらが崖になる offset が closed-loop でこのシーンを使える**有効視点範囲**。
+
+## 結果（有効視点範囲はシーンスケールで決まる）
+
+RTX 4070 Ti SUPER / gsplat 1.5.3 / scale 0.25–0.5 / 横オフセット x 軸。
+
+| シーン | モデル | recon PSNR/SSIM | ssim_vs_base @±0.25 / ±0.5 / ±1.0 m | floater @±1.0 m |
+|---|---|---|---|---|
+| **koide**（近接ハンドヘルド屋内） | pc_sh1_15k | 22.5 dB / 0.82 | 0.34 / 0.30 / 0.25 | ~0.10 |
+| **isuzu**（屋外・走行スケール） | first150 | 17.3 dB / 0.50 | 0.95 / 0.91 / 0.88 | **~0.000** |
+
+- **走行スケールは外挿に強い（本命の追い風）**: isuzu は ±1.0 m 横ずれでも
+  見た目安定性 0.88、floater ほぼ 0。LiDAR-primed の正しい幾何が深い被写体距離で
+  視差を正しく出すため、±1 m の ego 横ずれが render をほとんど乱さない。
+  これは closed-loop Autoware-in-the-loop が必要とする性質そのもの。
+- **近接シーンは速く崩れる**: koide は ±0.25 m で見た目安定性 0.34 まで落ちる。
+  ただし floater は ~0.10 で穏当なので、低下の主因は破綻でなく**近接被写体の正当な
+  視差**（offset-0 比 SSIM は破綻と視差を区別しない）。被写体距離が短いシーンは
+  有効横範囲 < 0.25 m。先行の `3dgs-trajectory-flythrough-notes.md`（koide は
+  0.4 m 外挿で floater 崩壊）と整合。
+
+## 負の結果 / 限界
+
+- **検出器ベースの知覚 gap は手元データで exercise できなかった**。YOLO-COCO は
+  3 シーンすべてで real 画像でも検出ゼロ: koide=屋内（COCO 物体なし）、isuzu
+  first150=空の試験路（草地・舗装のみ、車/人なし）、construction=データ不整合。
+  layer は実装・動作済み（`--detector yolov8n.pt`）だが、**車両/歩行者が実際に
+  frame に映る走行シーンが必要**。これはコードでなくデータの不足。
+- **construction_seq1 はクリーンに測れなかった**。ディスク上の 3DGS 成果物
+  （`output/rtkslam_3dgs/`）は flythrough 実験で images/ と transforms が何度も
+  再生成され不整合化しており、現行 `transforms_crop.json` から再学習しても
+  **train PSNR 12 dB・MSE 発散気味（収束せず）**。raw rosbag はローカルに無く
+  （`scripts/download_rtk_slam_dataset.py` で都度 DL する設計）、クリーンな数値には
+  extract パイプラインの再実行が必要。Phase 0 の配線検証スコープ外として保留。
+
+## sim2real ロードマップ上の位置づけ
+
+```
+Phase 0  外挿安定性測定         ← 本ノート（走行スケールで ±1m OK を確認）
+   ▼
+Phase 1  open-loop データ生成   ← 有効範囲内で RGB/depth 量産（depth は LiDAR-primed）
+   ▼
+Phase 2  closed-loop sensor-sim ROS 2 node（本命）← ego pose 購読→レンダ→Image 配信
+   ▼
+Phase 3  dynamic actors + RL
+```
+
+## 次アクション
+
+- 検出器 gap を本当に測るには、車両/歩行者が映る走行シーンを用意する
+  （公開運転データセット、または後半 frame に物体が映る isuzu 区間を full-res・
+  低 conf で）。
+- construction の数値が要るなら `download_rtk_slam_dataset.py` → SLAM traj →
+  extract を回してクリーンな `point_cloud.ply` × `transforms` を作り直す。
+- 走行スケールで ±1 m が通ったので、Phase 2 の closed-loop sensor-sim node の
+  レンダリングリアルタイム性検証に進むのが妥当。

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -468,6 +468,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_gaussian_splatting_sim2real_gap
+    test/test_gaussian_splatting_sim2real_gap.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_mid360_robot_preflight
     test/test_mid360_robot_preflight.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_gaussian_splatting_sim2real_gap.py
+++ b/graph_based_slam/test/test_gaussian_splatting_sim2real_gap.py
@@ -1,0 +1,176 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the sim2real gap harness pure helpers (CPU, no torch/gsplat)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+
+
+def _load():
+    if str(TOOL_DIR) not in sys.path:
+        sys.path.insert(0, str(TOOL_DIR))
+    import sim2real_gap
+
+    return sim2real_gap
+
+
+s2r = _load()
+
+
+def _viewmat(center, rot=None):
+    rot = np.eye(3) if rot is None else np.asarray(rot, dtype=float)
+    vm = np.eye(4)
+    vm[:3, :3] = rot
+    vm[:3, 3] = -rot @ np.asarray(center, dtype=float)
+    return vm
+
+
+def _center_of(vm):
+    return -vm[:3, :3].T @ vm[:3, 3]
+
+
+def test_offset_viewmat_moves_camera_along_local_axis():
+    vm = _viewmat([1.0, 2.0, 3.0])  # identity rotation: local == world axes
+    moved = s2r.offset_viewmat(vm, 0.5, 'x')
+    assert np.allclose(_center_of(moved), [1.5, 2.0, 3.0])
+    assert np.allclose(moved[:3, :3], vm[:3, :3])  # rotation untouched
+
+
+def test_offset_viewmat_respects_camera_rotation():
+    # 90 deg yaw about world Z: camera local +x points along world -y here.
+    rot = np.array([[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    vm = _viewmat([0.0, 0.0, 0.0], rot)
+    moved = s2r.offset_viewmat(vm, 1.0, 'x')
+    center = _center_of(moved)
+    assert np.isclose(np.linalg.norm(center), 1.0)
+    assert not np.isclose(center[0], 1.0)  # not a naive world-x shift
+
+
+def test_offset_viewmat_zero_is_identity():
+    vm = _viewmat([0.3, -0.7, 2.0])
+    assert np.allclose(s2r.offset_viewmat(vm, 0.0, 'y'), vm)
+
+
+def test_offset_viewmat_rejects_bad_axis():
+    with pytest.raises(ValueError):
+        s2r.offset_viewmat(np.eye(4), 1.0, 'w')
+
+
+def test_sweep_viewmats_shape_and_values():
+    vms = [_viewmat([0.0, 0.0, 0.0]), _viewmat([1.0, 1.0, 1.0])]
+    out = s2r.sweep_viewmats(vms, 0.25, 'x')
+    assert out.shape == (2, 4, 4)
+    assert np.allclose(_center_of(out[0]), [0.25, 0.0, 0.0])
+    assert np.allclose(_center_of(out[1]), [1.25, 1.0, 1.0])
+
+
+def test_psnr_identical_is_inf():
+    a = np.full((8, 8, 3), 100, dtype=np.uint8)
+    assert s2r.psnr(a, a) == float('inf')
+
+
+def test_psnr_known_value():
+    a = np.zeros((4, 4, 3), dtype=np.uint8)
+    b = np.full((4, 4, 3), 1, dtype=np.uint8)  # mse = 1 -> 20*log10(255)
+    assert s2r.psnr(a, b) == pytest.approx(20.0 * np.log10(255.0), rel=1e-6)
+
+
+def test_ssim_identical_is_one():
+    rng = np.random.default_rng(0)
+    a = rng.integers(0, 256, (32, 32, 3), dtype=np.uint8)
+    assert s2r.ssim(a, a) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_ssim_drops_for_different_images():
+    rng = np.random.default_rng(1)
+    a = rng.integers(0, 256, (32, 32, 3), dtype=np.uint8)
+    b = rng.integers(0, 256, (32, 32, 3), dtype=np.uint8)
+    assert s2r.ssim(a, b) < 0.3
+
+
+def test_box_mean_constant_image():
+    img = np.full((10, 10), 5.0)
+    assert np.allclose(s2r._box_mean(img, 5), 5.0)
+
+
+def test_floater_fraction_counts_bright_pixels():
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    img[:5] = 255  # half the pixels white
+    assert s2r.floater_fraction(img) == pytest.approx(0.5)
+
+
+def test_sharpness_flat_is_zero():
+    assert s2r.sharpness(np.full((8, 8, 3), 128, dtype=np.uint8)) == 0.0
+
+
+def test_box_iou_overlap_and_disjoint():
+    assert s2r.box_iou([0, 0, 2, 2], [0, 0, 2, 2]) == pytest.approx(1.0)
+    assert s2r.box_iou([0, 0, 2, 2], [10, 10, 12, 12]) == 0.0
+    # half overlap: inter 2, union 6
+    assert s2r.box_iou([0, 0, 2, 2], [1, 0, 3, 2]) == pytest.approx(2.0 / 6.0)
+
+
+def test_match_detections_greedy_one_to_one():
+    ref = [{'cls': 0, 'box': [0, 0, 2, 2], 'conf': 0.9},
+           {'cls': 0, 'box': [10, 10, 12, 12], 'conf': 0.8}]
+    qry = [{'cls': 0, 'box': [0, 0, 2, 2], 'conf': 0.7}]  # matches first only
+    assert s2r.match_detections(ref, qry) == 1
+
+
+def test_match_detections_class_must_agree():
+    ref = [{'cls': 0, 'box': [0, 0, 2, 2], 'conf': 0.9}]
+    qry = [{'cls': 1, 'box': [0, 0, 2, 2], 'conf': 0.9}]
+    assert s2r.match_detections(ref, qry) == 0
+
+
+def test_select_views_even_spacing():
+    assert s2r.select_views(10, 0) == list(range(10))
+    assert s2r.select_views(5, 10) == list(range(5))
+    assert s2r.select_views(10, 3) == [0, 4, 9]
+
+
+def test_parse_offsets_includes_zero_and_sorts():
+    assert s2r.parse_offsets('0.5,-0.5,1.0') == [0.0, -0.5, 0.5, 1.0]
+
+
+def test_montage_tiles_grid():
+    a = np.full((4, 4, 3), 10, dtype=np.uint8)
+    b = np.full((4, 4, 3), 20, dtype=np.uint8)
+    sheet = s2r.montage([[a, b]], pad=1)
+    assert sheet.shape == (4 + 2, 4 * 2 + 3, 3)
+    assert (sheet == 10).any() and (sheet == 20).any()

--- a/scripts/run_sim2real_gap.sh
+++ b/scripts/run_sim2real_gap.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Measure the sim2real gap of a trained LiDAR-primed 3DGS scene (Phase 0 of the
+# 3DGS-as-sim2real track). Renders each training view at the recorded pose and
+# at a sweep of lateral camera offsets, then scores:
+#   - reconstruction fidelity at offset 0 (render vs the real image: PSNR/SSIM,
+#     plus optional object-detector agreement), and
+#   - extrapolation stability across offsets (SSIM vs the offset-0 render, a
+#     sharpness ratio, a bright-floater fraction, and detector retention).
+# The offset where stability falls off is the valid viewpoint range for using
+# the scene as a closed-loop simulator.
+#
+# Requires: a CUDA GPU with torch + gsplat; an ultralytics install if --detector
+# is passed. The PLY and TRANSFORMS must be a matched pair (the model trained
+# from exactly that transforms.json) or recon PSNR will be meaningless.
+#
+# Usage:
+#   PLY=output/koide_3dgs_firstlight/gsplat/pc_sh1_15k.ply \
+#   TRANSFORMS=output/koide_3dgs_firstlight/gsplat/transforms.json \
+#   OUT_DIR=output/sim2real_gap/koide \
+#   bash scripts/run_sim2real_gap.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+PLY="${PLY:?set PLY to the trained 3DGS .ply}"
+TRANSFORMS="${TRANSFORMS:?set TRANSFORMS to the transforms.json the model trained from}"
+OUT_DIR="${OUT_DIR:-output/sim2real_gap/run}"
+OFFSETS="${OFFSETS:--1.0,-0.5,-0.25,0.25,0.5,1.0}"
+AXIS="${AXIS:-x}"
+SCALE="${SCALE:-0.5}"
+VIEWS="${VIEWS:-12}"
+DETECTOR="${DETECTOR:-}"   # e.g. yolov8n.pt; empty disables the detector gap
+
+DET_ARG=()
+if [[ -n "${DETECTOR}" ]]; then
+  DET_ARG=(--detector "${DETECTOR}")
+fi
+
+python3 tools/gaussian_splatting/sim2real_gap.py \
+  --ply "${PLY}" \
+  --transforms "${TRANSFORMS}" \
+  --out "${OUT_DIR}" \
+  --offsets="${OFFSETS}" \
+  --axis "${AXIS}" \
+  --scale "${SCALE}" \
+  --views "${VIEWS}" \
+  "${DET_ARG[@]}"

--- a/tools/gaussian_splatting/sim2real_gap.py
+++ b/tools/gaussian_splatting/sim2real_gap.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Measure the sim2real gap of a LiDAR-primed 3DGS scene (gsplat, Apache-2.0).
+
+Phase 0 of the 3DGS-as-sim2real track. The question this answers is the
+prerequisite for every downstream use (open-loop data gen, closed-loop
+Autoware-in-the-loop, RL): *does a model trained on real images still work on
+3DGS renders, and out to what viewpoint offset does it keep working?*
+
+The harness does two things per reference view:
+
+1. **Reconstruction fidelity** at the training pose (offset 0): render vs the
+   real image -> PSNR / SSIM, plus optional object-detector agreement (how many
+   real detections survive on the render, matched by IoU). This is the literal
+   sim2real gap at the recorded trajectory.
+
+2. **Extrapolation degradation** as the camera is stepped sideways off the
+   recorded pose (a lateral ego deviation, the thing a closed-loop sim must
+   survive): each offset render is scored against the offset-0 render
+   (appearance stability via SSIM), plus a sharpness ratio and a bright-floater
+   fraction that flags the characteristic 3DGS blow-up, and -- if a detector is
+   enabled -- detection retention. The offset where these fall off a cliff is
+   the *valid viewpoint range* for using this scene as a simulator.
+
+The pure helpers (pose offset math, PSNR/SSIM, box IoU matching, montage) are
+numpy-only and unit tested on CPU; rendering needs CUDA + torch + gsplat and an
+optional detector needs ``ultralytics``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Optional, Sequence
+
+import numpy as np
+
+from render_path import load_gaussian_ply, render_frames, scale_intrinsics
+from train_gsplat import load_transforms
+
+_AXES = {'x': 0, 'y': 1, 'z': 2}
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no torch/CUDA/detector)
+# --------------------------------------------------------------------------- #
+def offset_viewmat(viewmat: np.ndarray, offset_m: float, axis: str) -> np.ndarray:
+    """Translate the camera along one of its *local* axes by ``offset_m``.
+
+    ``viewmat`` is world->camera ``[R | t]`` (so the camera centre in world is
+    ``C = -R^T t``). Moving the centre by ``d_world`` gives ``t' = t - R d_world``;
+    for a camera-local offset ``o`` (``+x`` = right, ``+y`` = down, ``+z`` =
+    forward in the usual pinhole convention) this collapses to ``t' = t - o``,
+    since ``R d_world = R R^T o = o``. Rotation is untouched, so the camera slides
+    sideways while keeping its heading -- exactly a lateral ego deviation.
+    """
+    if axis not in _AXES:
+        raise ValueError(f'axis must be one of x/y/z, got {axis!r}')
+    out = np.asarray(viewmat, dtype=float).copy()
+    out[_AXES[axis], 3] -= float(offset_m)
+    return out
+
+
+def sweep_viewmats(viewmats: Sequence[np.ndarray], offset_m: float,
+                   axis: str) -> np.ndarray:
+    """Apply ``offset_viewmat`` to every view; returns stacked (N, 4, 4)."""
+    return np.stack([offset_viewmat(vm, offset_m, axis) for vm in viewmats])
+
+
+def to_gray(rgb: np.ndarray) -> np.ndarray:
+    """Rec.601 luma of an (H, W, 3) image as float64 in the input's range."""
+    a = np.asarray(rgb, dtype=np.float64)
+    return a[..., 0] * 0.299 + a[..., 1] * 0.587 + a[..., 2] * 0.114
+
+
+def psnr(a: np.ndarray, b: np.ndarray, *, peak: float = 255.0) -> float:
+    """Peak signal-to-noise ratio between two same-shape uint8/float images."""
+    mse = float(np.mean((np.asarray(a, dtype=np.float64)
+                         - np.asarray(b, dtype=np.float64)) ** 2))
+    if mse <= 0.0:
+        return float('inf')
+    return float(10.0 * np.log10(peak * peak / mse))
+
+
+def _box_mean(img: np.ndarray, win: int) -> np.ndarray:
+    """Separable local mean with a shrinking window at the borders (exact)."""
+    def along(a: np.ndarray, axis: int) -> np.ndarray:
+        a = np.moveaxis(a, axis, -1)
+        n = a.shape[-1]
+        cs = np.concatenate([np.zeros(a.shape[:-1] + (1,)),
+                             np.cumsum(a, axis=-1)], axis=-1)
+        idx = np.arange(n)
+        lo = np.maximum(0, idx - win // 2)
+        hi = np.minimum(n, idx + win // 2 + 1)
+        out = (cs[..., hi] - cs[..., lo]) / (hi - lo)
+        return np.moveaxis(out, -1, axis)
+
+    return along(along(np.asarray(img, dtype=np.float64), -1), -2)
+
+
+def ssim(a: np.ndarray, b: np.ndarray, *, win: int = 7, peak: float = 255.0) -> float:
+    """Mean structural similarity over a uniform window (grayscale)."""
+    ga, gb = to_gray(a), to_gray(b)
+    c1 = (0.01 * peak) ** 2
+    c2 = (0.03 * peak) ** 2
+    mu_a, mu_b = _box_mean(ga, win), _box_mean(gb, win)
+    mu_a2, mu_b2, mu_ab = mu_a * mu_a, mu_b * mu_b, mu_a * mu_b
+    var_a = _box_mean(ga * ga, win) - mu_a2
+    var_b = _box_mean(gb * gb, win) - mu_b2
+    cov = _box_mean(ga * gb, win) - mu_ab
+    smap = (((2 * mu_ab + c1) * (2 * cov + c2))
+            / ((mu_a2 + mu_b2 + c1) * (var_a + var_b + c2)))
+    return float(smap.mean())
+
+
+def sharpness(img: np.ndarray) -> float:
+    """Mean squared gradient magnitude of the luma -- a focus/detail proxy."""
+    g = to_gray(img)
+    gy, gx = np.gradient(g)
+    return float(np.mean(gx * gx + gy * gy))
+
+
+def floater_fraction(img: np.ndarray, *, thresh: float = 250.0) -> float:
+    """Fraction of near-white pixels -- a proxy for 3DGS blow-up under extrapolation."""
+    return float(np.mean(to_gray(img) >= thresh))
+
+
+def box_iou(a: Sequence[float], b: Sequence[float]) -> float:
+    """Intersection-over-union of two ``[x1, y1, x2, y2]`` boxes."""
+    ix1, iy1 = max(a[0], b[0]), max(a[1], b[1])
+    ix2, iy2 = min(a[2], b[2]), min(a[3], b[3])
+    iw, ih = max(0.0, ix2 - ix1), max(0.0, iy2 - iy1)
+    inter = iw * ih
+    area_a = max(0.0, a[2] - a[0]) * max(0.0, a[3] - a[1])
+    area_b = max(0.0, b[2] - b[0]) * max(0.0, b[3] - b[1])
+    union = area_a + area_b - inter
+    return float(inter / union) if union > 0.0 else 0.0
+
+
+def match_detections(ref: Sequence[dict], qry: Sequence[dict], *,
+                     iou_thresh: float = 0.5) -> int:
+    """Greedy one-to-one count of ``qry`` boxes matching a same-class ``ref`` box.
+
+    Each detection is ``{'cls': int, 'box': [x1, y1, x2, y2], 'conf': float}``.
+    Matches are taken highest-IoU first; every ref box is used at most once.
+    """
+    pairs = []
+    for qi, q in enumerate(qry):
+        for ri, r in enumerate(ref):
+            if q['cls'] != r['cls']:
+                continue
+            iou = box_iou(q['box'], r['box'])
+            if iou >= iou_thresh:
+                pairs.append((iou, qi, ri))
+    pairs.sort(reverse=True)
+    used_q: set = set()
+    used_r: set = set()
+    matched = 0
+    for _, qi, ri in pairs:
+        if qi in used_q or ri in used_r:
+            continue
+        used_q.add(qi)
+        used_r.add(ri)
+        matched += 1
+    return matched
+
+
+def montage(rows: Sequence[Sequence[np.ndarray]], *, pad: int = 4,
+            bg: int = 32) -> np.ndarray:
+    """Tile a grid of equal-size uint8 RGB images into one contact sheet."""
+    h, w = rows[0][0].shape[:2]
+    ncol = max(len(r) for r in rows)
+    out_h = len(rows) * h + (len(rows) + 1) * pad
+    out_w = ncol * w + (ncol + 1) * pad
+    sheet = np.full((out_h, out_w, 3), bg, dtype=np.uint8)
+    for ri, row in enumerate(rows):
+        y = pad + ri * (h + pad)
+        for ci, im in enumerate(row):
+            x = pad + ci * (w + pad)
+            sheet[y:y + h, x:x + w] = im
+    return sheet
+
+
+# --------------------------------------------------------------------------- #
+# IO + detector (lazy / optional)
+# --------------------------------------------------------------------------- #
+def load_real_image(path: Path, width: int, height: int) -> np.ndarray:
+    """Read a real image and resize it to the render size (uint8 RGB)."""
+    import imageio.v2 as imageio
+
+    img = np.asarray(imageio.imread(path))
+    if img.ndim == 2:
+        img = np.repeat(img[..., None], 3, axis=2)
+    img = img[..., :3]
+    if img.shape[1] != width or img.shape[0] != height:
+        from PIL import Image
+
+        img = np.asarray(Image.fromarray(img).resize((width, height)))
+    return np.ascontiguousarray(img, dtype=np.uint8)
+
+
+class Detector:
+    """Thin wrapper over an ultralytics YOLO model (lazy, optional)."""
+
+    def __init__(self, weights: str, *, conf: float = 0.25):
+        from ultralytics import YOLO
+
+        self.model = YOLO(weights)
+        self.conf = conf
+
+    def __call__(self, img: np.ndarray) -> list:
+        res = self.model.predict(img[..., ::-1], conf=self.conf, verbose=False)[0]
+        out = []
+        for b in res.boxes:
+            out.append({'cls': int(b.cls.item()),
+                        'box': [float(v) for v in b.xyxy[0].tolist()],
+                        'conf': float(b.conf.item())})
+        return out
+
+
+# --------------------------------------------------------------------------- #
+# Harness
+# --------------------------------------------------------------------------- #
+def select_views(n_total: int, n_want: int) -> list[int]:
+    """Evenly spaced reference-view indices (all of them when n_want <= 0)."""
+    if n_want <= 0 or n_want >= n_total:
+        return list(range(n_total))
+    return [int(round(i)) for i in np.linspace(0, n_total - 1, n_want)]
+
+
+def run(ply: Path, transforms: Path, *, offsets: Sequence[float], axis: str,
+        scale: float, n_views: int, detector: Optional[Detector],
+        out_dir: Path, device: str = 'cuda') -> dict:
+    """Render the offset sweep, score every view, and write artefacts."""
+    dataset = load_transforms(transforms)
+    gaussians = load_gaussian_ply(ply)
+    K, width, height = scale_intrinsics(dataset['K'], dataset['width'],
+                                        dataset['height'], scale)
+    views = select_views(len(dataset['viewmats']), n_views)
+    base_vms = [dataset['viewmats'][i] for i in views]
+    reals = [load_real_image(dataset['image_paths'][i], width, height) for i in views]
+
+    # offset -> (V, H, W, 3) renders, with 0.0 first so it is the reference.
+    ordered = sorted(set(offsets), key=lambda o: (abs(o), o))
+    renders: dict[float, np.ndarray] = {}
+    for off in ordered:
+        renders[off] = render_frames(gaussians, sweep_viewmats(base_vms, off, axis),
+                                     K, width, height, device=device)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    per_view = []
+    for vi, gi in enumerate(views):
+        base = renders[0.0][vi]
+        real = reals[vi]
+        det_real = detector(real) if detector else None
+        det_base = detector(base) if detector else None
+        base_sharp = max(sharpness(base), 1e-9)
+        rec = {'view': int(gi),
+               'recon_psnr': psnr(real, base),
+               'recon_ssim': ssim(real, base)}
+        if det_real is not None:
+            rec['real_dets'] = len(det_real)
+            rec['render_dets'] = len(det_base)
+            rec['recon_det_agree'] = (match_detections(det_real, det_base)
+                                      / max(len(det_real), 1))
+        sweep = {}
+        for off in ordered:
+            r = renders[off][vi]
+            entry = {'ssim_vs_base': ssim(base, r),
+                     'sharpness_ratio': sharpness(r) / base_sharp,
+                     'floater_frac': floater_fraction(r)}
+            if det_real is not None:
+                det_r = detector(r)
+                entry['dets'] = len(det_r)
+                entry['det_retain'] = ((match_detections(det_base, det_r)
+                                        / max(len(det_base), 1)) if off else 1.0)
+            sweep[f'{off:+.2f}'] = entry
+        rec['sweep'] = sweep
+        per_view.append(rec)
+
+        import imageio.v2 as imageio
+        sheet = montage([[real] + [renders[o][vi] for o in ordered]])
+        imageio.imwrite(out_dir / f'view_{gi:03d}.png', sheet)
+
+    summary = _summarise(per_view, ordered)
+    report = {'ply': str(ply), 'transforms': str(transforms), 'axis': axis,
+              'scale': scale, 'render_size': [width, height],
+              'offsets': ordered, 'n_views': len(views),
+              'detector': bool(detector), 'per_view': per_view,
+              'summary': summary}
+    (out_dir / 'metrics.json').write_text(json.dumps(report, indent=2))
+    return report
+
+
+def _summarise(per_view: list[dict], offsets: Sequence[float]) -> dict:
+    """Mean recon fidelity and per-offset degradation across all views."""
+    def mean(key: str, src: list) -> float:
+        vals = [s[key] for s in src if key in s and np.isfinite(s[key])]
+        return float(np.mean(vals)) if vals else float('nan')
+
+    out = {'recon_psnr': mean('recon_psnr', per_view),
+           'recon_ssim': mean('recon_ssim', per_view),
+           'per_offset': {}}
+    if any('recon_det_agree' in v for v in per_view):
+        out['recon_det_agree'] = mean('recon_det_agree', per_view)
+    for off in offsets:
+        key = f'{off:+.2f}'
+        cells = [v['sweep'][key] for v in per_view]
+        row = {'ssim_vs_base': mean('ssim_vs_base', cells),
+               'sharpness_ratio': mean('sharpness_ratio', cells),
+               'floater_frac': mean('floater_frac', cells)}
+        if any('det_retain' in c for c in cells):
+            row['det_retain'] = mean('det_retain', cells)
+        out['per_offset'][key] = row
+    return out
+
+
+def parse_offsets(text: str) -> list[float]:
+    """Parse a comma-separated offset list (metres); 0 is always included."""
+    vals = {0.0}
+    for tok in text.split(','):
+        tok = tok.strip()
+        if tok:
+            vals.add(float(tok))
+    return sorted(vals, key=lambda o: (abs(o), o))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the CLI argument parser."""
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument('--ply', required=True, help='trained INRIA 3DGS .ply')
+    p.add_argument('--transforms', required=True,
+                   help='transforms.json the model was trained from')
+    p.add_argument('--out', required=True, help='output directory')
+    p.add_argument('--offsets', default='-1.0,-0.5,-0.25,0.25,0.5,1.0',
+                   help='comma-separated lateral offsets in metres (0 implied)')
+    p.add_argument('--axis', default='x', choices=('x', 'y', 'z'),
+                   help='camera-local offset axis (x=right, default)')
+    p.add_argument('--scale', type=float, default=0.25,
+                   help='render-resolution scale vs the training images')
+    p.add_argument('--views', type=int, default=0,
+                   help='evenly spaced reference views to score (0 = all)')
+    p.add_argument('--detector', default='',
+                   help='ultralytics weights for the sim2real detection gap '
+                        "(e.g. 'yolov8n.pt'); empty disables it")
+    p.add_argument('--det-conf', type=float, default=0.25,
+                   help='detector confidence threshold')
+    p.add_argument('--device', default='cuda')
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args(argv)
+    det = Detector(args.detector, conf=args.det_conf) if args.detector else None
+    report = run(Path(args.ply), Path(args.transforms),
+                 offsets=parse_offsets(args.offsets), axis=args.axis,
+                 scale=args.scale, n_views=args.views, detector=det,
+                 out_dir=Path(args.out), device=args.device)
+    s = report['summary']
+    print(f"recon: PSNR {s['recon_psnr']:.2f} dB, SSIM {s['recon_ssim']:.3f}"
+          + (f", det-agree {s['recon_det_agree']:.2f}"
+             if 'recon_det_agree' in s else ''))
+    for off, row in s['per_offset'].items():
+        line = (f"  off {off} m: ssim_vs_base {row['ssim_vs_base']:.3f}, "
+                f"sharp {row['sharpness_ratio']:.2f}, "
+                f"floater {row['floater_frac']:.3f}")
+        if 'det_retain' in row:
+            line += f", det-retain {row['det_retain']:.2f}"
+        print(line)
+    print(f'wrote {args.out}/metrics.json + per-view montages')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Phase 0 of the 3DGS-as-sim2real track. Before building a simulator, measure the
prerequisite: does a real-image-trained model work on 3DGS renders, and out to
what lateral ego offset does the render stay usable (the valid viewpoint range)?

`tools/gaussian_splatting/sim2real_gap.py` renders every training view at the
recorded pose and at a sweep of camera-local lateral offsets, scoring:

- **reconstruction fidelity** at offset 0 (render vs the real image: PSNR/SSIM,
  plus optional object-detector agreement), and
- **extrapolation stability** across offsets (SSIM vs the offset-0 render, a
  sharpness ratio, a bright-floater fraction, detector retention).

Reuses the existing `render_path`/`train_gsplat` APIs; outputs `metrics.json` +
per-view montages.

## Finding

The valid viewpoint range scales with the scene (see
`docs/research/3dgs-sim2real-gap-phase0.md`):

| scene | recon | ssim-vs-base ±0.25 / ±1.0 m | floater ±1.0 m |
|---|---|---|---|
| isuzu (driving-scale) | 17.3 dB | 0.95 / **0.88** | **~0.000** |
| koide (close-range handheld) | 22.5 dB | 0.34 / 0.25 | ~0.10 |

Driving-scale scenes tolerate ±1 m lateral deviation with almost no floater
blow-up — the tailwind for closed-loop sensor sim. The detector layer runs but
no on-disk scene has COCO objects in frame to exercise it (data gap, not code).

## Repro

```
PLY=output/koide_3dgs_firstlight/gsplat/pc_sh1_15k.ply \
TRANSFORMS=output/koide_3dgs_firstlight/gsplat/transforms.json \
OUT_DIR=output/sim2real_gap/koide DETECTOR=yolov8n.pt \
bash scripts/run_sim2real_gap.sh
```

## Tests

18 CPU unit tests (offset pose math, PSNR/SSIM, IoU matching, montage),
registered in `graph_based_slam/CMakeLists.txt`; `ament_flake8` clean.