### PR TITLE
feat(3dgs): closed-loop camera sensor-sim ROS 2 node

### DIFF
--- a/docs/research/3dgs-sensor-sim-phase2.md
+++ b/docs/research/3dgs-sensor-sim-phase2.md
@@ -1,0 +1,57 @@
+# 3DGS closed-loop sensor-sim — Phase 2 ノード骨格 (2026-06-15)
+
+3DGS sim2real トラックの Phase 2。LiDAR-primed 3DGS シーンを **closed-loop に置き**、
+実画像で学習した知覚スタック（例: Autoware perception）を合成ではなく photoreal な
+render に対して走らせるための ROS 2 ノード骨格。Phase 0
+（`docs/research/3dgs-sim2real-gap-phase0.md`）で走行スケールが ±1 m 横ずれに
+耐えると分かったのを受けて着手。
+
+## 成果物
+
+- `tools/gaussian_splatting/gaussian_renderer.py` — `GaussianRenderer`:
+  gaussians を GPU に**常駐**させ `render(viewmat, K, w, h) -> uint8 RGB`。
+  pure な pose 数学 `pose_to_viewmat` / `transform_from_pos_quat` 同梱（CPU テスト）。
+- `tools/gaussian_splatting/sensor_sim_node.py` — rclpy ノード。ego pose
+  (`Odometry` or `PoseStamped`) を購読 → render → `sensor_msgs/Image`(rgb8) +
+  `CameraInfo` を配信。`extrinsic`(base←camera_optical) / `align`
+  (model_world←pose_world) / `scale` をパラメータ化。
+- `tools/gaussian_splatting/pose_player.py` — localiser のスタンドイン。
+  `transforms.json` のカメラ姿勢(=inv viewmat)を `Odometry` で配信し、模型自身の
+  frame でループを閉じる。後で Autoware `kinematic_state` に差し替える部品。
+- runner `scripts/run_sensor_sim_node.sh`、CPU テスト
+  `graph_based_slam/test/test_gaussian_splatting_renderer.py`（12 ケース、ament_flake8
+  clean。pose_player↔node の往復が元 viewmat にバイト整合することも検証）。
+
+## 検証
+
+- **リアルタイム性（本命の成立条件）**: 4070 Ti SUPER / gsplat 1.5.3、
+  毎フレーム GPU 再アップロードする `render_frames` 経由でも
+  isuzu(496k gaussians, 720幅) ~112 FPS、koide(660k, 2448幅フル) 16.8 FPS /
+  1224幅 31.5 FPS。実用解像度で 30+ FPS → **レンダはボトルネックでない**。
+  常駐レンダラはアップロードを 1 回に減らすのでさらに余裕。
+- **正しさ**: `GaussianRenderer.render` の出力は `render_frames` と
+  バイト一致（`np.array_equal` True）。
+- **ROS end-to-end**: ノードを別プロセス起動し `/ego_odom` に `Odometry` を
+  publish → `/sensor_sim/image_raw`(512×612, rgb8, frame=camera_optical) と
+  `/sensor_sim/camera_info`(fx 363.2) を受信できることを確認。
+- **closed-loop デモ**: `pose_player`(koide 軌跡 6Hz) → `sensor_sim_node`
+  (808×676) → image を ROS 経由でキャプチャ → `output/sim2real_gap/
+  closed_loop_koide.mp4`(80 frames)。photoreal な軌跡追従レンダがパイプラインを
+  通って出ることを確認。`pose_topic` を Autoware の localization に差し替えれば
+  そのまま実走 closed-loop になる。
+
+## フレーム規約（重要）
+
+- ego pose = `world<-base_link`。`extrinsic` は `base_link<-camera_optical`
+  で、OpenCV optical frame（+x 右, +y 下, +z 前 = 学習 transforms と同じ）を指すこと。
+- localiser の world frame が 3DGS モデルの frame と違う場合は `align`
+  (`model_world<-pose_world`) を設定。一致するなら identity。
+- camera-in-model = `align @ T_world_base @ T_base_cam`、viewmat はその逆行列。
+
+## 次アクション
+
+- AWSIM×Autoware パイプライン（`docs/awsim-autonomous-driving-tutorial.md`）の
+  localization pose を `pose_topic` に繋ぎ、実シーンの 3DGS（要 align 推定）で
+  perception を回す統合。
+- 動的アクタ（歩行者/車）は vanilla 3DGS では出ないので Phase 3 で compositing。
+- render 結果の exposure/tone を実カメラに寄せる後処理（sim2real gap の更なる縮小）。

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -473,6 +473,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_gaussian_splatting_renderer
+    test/test_gaussian_splatting_renderer.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_mid360_robot_preflight
     test/test_mid360_robot_preflight.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_gaussian_splatting_renderer.py
+++ b/graph_based_slam/test/test_gaussian_splatting_renderer.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the sensor-sim renderer's pure pose maths (CPU, no torch/gsplat)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+
+
+def _load():
+    if str(TOOL_DIR) not in sys.path:
+        sys.path.insert(0, str(TOOL_DIR))
+    import gaussian_renderer
+    import pose_player
+
+    return gaussian_renderer, pose_player
+
+
+gr, pp = _load()
+
+
+def _cam_center(viewmat):
+    return -viewmat[:3, :3].T @ viewmat[:3, 3]
+
+
+def test_transform_identity_quat_is_pure_translation():
+    t = gr.transform_from_pos_quat([1.0, 2.0, 3.0], [0.0, 0.0, 0.0, 1.0])
+    assert np.allclose(t[:3, :3], np.eye(3))
+    assert np.allclose(t[:3, 3], [1.0, 2.0, 3.0])
+    assert np.allclose(t[3], [0.0, 0.0, 0.0, 1.0])
+
+
+def test_transform_quat_rotation():
+    # 90 deg about +z (xyzw): maps +x -> +y.
+    t = gr.transform_from_pos_quat([0.0, 0.0, 0.0],
+                                   [0.0, 0.0, np.sin(np.pi / 4), np.cos(np.pi / 4)])
+    assert np.allclose(t[:3, :3] @ np.array([1.0, 0.0, 0.0]), [0.0, 1.0, 0.0],
+                       atol=1e-9)
+
+
+def test_pose_to_viewmat_is_inverse_of_camera_pose():
+    t_wb = gr.transform_from_pos_quat([2.0, -1.0, 0.5],
+                                      [0.0, 0.0, 0.0, 1.0])
+    t_bc = gr.transform_from_pos_quat([0.1, 0.0, 0.2],
+                                      [0.0, 0.0, 0.0, 1.0])
+    vm = gr.pose_to_viewmat(t_wb, t_bc)
+    assert np.allclose(vm @ (t_wb @ t_bc), np.eye(4), atol=1e-9)
+
+
+def test_pose_to_viewmat_recovers_camera_centre():
+    t_wb = gr.transform_from_pos_quat([5.0, 3.0, 1.0],
+                                      [0.0, 0.0, np.sin(0.3), np.cos(0.3)])
+    t_bc = gr.transform_from_pos_quat([0.0, 0.0, 0.0],
+                                      [0.0, 0.0, 0.0, 1.0])
+    vm = gr.pose_to_viewmat(t_wb, t_bc)
+    assert np.allclose(_cam_center(vm), [5.0, 3.0, 1.0], atol=1e-9)
+
+
+def test_pose_to_viewmat_applies_alignment():
+    t_wb = gr.transform_from_pos_quat([1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0])
+    t_bc = np.eye(4)
+    t_align = gr.transform_from_pos_quat([10.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0])
+    vm = gr.pose_to_viewmat(t_wb, t_bc, t_align)
+    # camera at world x=1, shifted by align +10 -> model-world x=11.
+    assert np.allclose(_cam_center(vm), [11.0, 0.0, 0.0], atol=1e-9)
+
+
+def test_pose_to_viewmat_default_align_is_identity():
+    t_wb = gr.transform_from_pos_quat([0.0, 4.0, 0.0], [0.0, 0.0, 0.0, 1.0])
+    t_bc = np.eye(4)
+    assert np.allclose(gr.pose_to_viewmat(t_wb, t_bc),
+                       gr.pose_to_viewmat(t_wb, t_bc, np.eye(4)))
+
+
+def test_pose_to_viewmat_extrinsic_offsets_camera():
+    t_wb = np.eye(4)
+    t_bc = gr.transform_from_pos_quat([0.0, 0.0, 1.5], [0.0, 0.0, 0.0, 1.0])
+    vm = gr.pose_to_viewmat(t_wb, t_bc)
+    assert np.allclose(_cam_center(vm), [0.0, 0.0, 1.5], atol=1e-9)
+
+
+def _rand_viewmat(seed):
+    rng = np.random.default_rng(seed)
+    axis = rng.normal(size=3)
+    axis /= np.linalg.norm(axis)
+    angle = rng.uniform(-np.pi, np.pi)
+    half = angle / 2.0
+    quat = np.array([*(axis * np.sin(half)), np.cos(half)])
+    c2w = gr.transform_from_pos_quat(rng.normal(size=3) * 3.0, quat)
+    return np.linalg.inv(c2w)
+
+
+@pytest.mark.parametrize('seed', [0, 1, 7, 42])
+def test_pose_player_roundtrips_through_node_math(seed):
+    # pose_player publishes inv(viewmat) as a pose; the node rebuilds the
+    # viewmat with identity extrinsic/align. The pair must be exact inverses.
+    vm = _rand_viewmat(seed)
+    pos, quat = pp.viewmat_to_pos_quat(vm)
+    t_world_base = gr.transform_from_pos_quat(pos, quat)
+    recovered = gr.pose_to_viewmat(t_world_base, np.eye(4), np.eye(4))
+    assert np.allclose(recovered, vm, atol=1e-9)
+
+
+def test_viewmat_to_pos_quat_recovers_centre():
+    vm = _rand_viewmat(3)
+    pos, _ = pp.viewmat_to_pos_quat(vm)
+    assert np.allclose(pos, _cam_center(vm), atol=1e-9)

--- a/scripts/run_sensor_sim_node.sh
+++ b/scripts/run_sensor_sim_node.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Launch the closed-loop 3DGS camera sensor-sim ROS 2 node (Phase 2 of the
+# 3DGS-as-sim2real track). Subscribes to the ego pose, renders a LiDAR-primed
+# 3DGS scene from the matching camera viewpoint with a resident GPU renderer,
+# and publishes sensor_msgs/Image + CameraInfo for a real-image-trained stack
+# (e.g. Autoware perception) to consume in the loop.
+#
+# Requires: a sourced ROS 2 workspace (rclpy, cv_bridge) and a CUDA GPU with
+# torch + gsplat. PLY and TRANSFORMS must be a matched pair. The ego pose must
+# be expressed in the same world frame the 3DGS model was built in; if not, set
+# ALIGN (16 row-major floats, model_world<-pose_world). EXTRINSIC is the static
+# base_link<-camera_optical transform (OpenCV optical frame).
+#
+# Usage:
+#   PLY=output/koide_3dgs_firstlight/gsplat/pc_sh1_15k.ply \
+#   TRANSFORMS=output/koide_3dgs_firstlight/gsplat/transforms.json \
+#   POSE_TOPIC=/localization/kinematic_state \
+#   bash scripts/run_sensor_sim_node.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+PLY="${PLY:?set PLY to the trained 3DGS .ply}"
+TRANSFORMS="${TRANSFORMS:?set TRANSFORMS to the matched transforms.json}"
+SCALE="${SCALE:-0.5}"
+POSE_TOPIC="${POSE_TOPIC:-/localization/kinematic_state}"
+POSE_TYPE="${POSE_TYPE:-odometry}"   # or pose_stamped
+IMAGE_TOPIC="${IMAGE_TOPIC:-/sensor_sim/image_raw}"
+CAMERA_INFO_TOPIC="${CAMERA_INFO_TOPIC:-/sensor_sim/camera_info}"
+FRAME_ID="${FRAME_ID:-camera_optical}"
+
+python3 tools/gaussian_splatting/sensor_sim_node.py --ros-args \
+  -p ply:="${PLY}" \
+  -p transforms:="${TRANSFORMS}" \
+  -p scale:="${SCALE}" \
+  -p pose_topic:="${POSE_TOPIC}" \
+  -p pose_type:="${POSE_TYPE}" \
+  -p image_topic:="${IMAGE_TOPIC}" \
+  -p camera_info_topic:="${CAMERA_INFO_TOPIC}" \
+  -p frame_id:="${FRAME_ID}"

--- a/tools/gaussian_splatting/gaussian_renderer.py
+++ b/tools/gaussian_splatting/gaussian_renderer.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Persistent 3DGS renderer for closed-loop sensor simulation (gsplat, Apache-2.0).
+
+Phase 2 of the 3DGS-as-sim2real track. ``render_path.render_frames`` re-uploads
+every Gaussian to the GPU on each call, which is fine for a one-shot flythrough
+but wasteful in a closed loop. ``GaussianRenderer`` uploads the model once and
+keeps the tensors resident, so each ``render(...)`` is just a rasterisation --
+fast enough for an Autoware-in-the-loop camera (see scripts: 30+ FPS at
+practical resolutions on a 4070 Ti SUPER).
+
+The pose maths (``pose_to_viewmat`` and the camera-frame conventions) are
+numpy-only and unit tested on CPU; the renderer itself needs CUDA + torch +
+gsplat and is exercised by the sensor-sim node / benchmarks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+import posed_images as pi
+from render_path import infer_sh_degree, load_gaussian_ply
+from train_gsplat import SH_C0
+
+
+# --------------------------------------------------------------------------- #
+# Pure pose maths (no torch/CUDA)
+# --------------------------------------------------------------------------- #
+def pose_to_viewmat(t_world_base: np.ndarray, t_base_cam: np.ndarray,
+                    t_align: Optional[np.ndarray] = None) -> np.ndarray:
+    """World->camera matrix (gsplat viewmat) from an ego pose and extrinsics.
+
+    ``t_world_base`` is the ego pose ``world<-base_link`` (as published by a
+    localiser), ``t_base_cam`` the static extrinsic ``base_link<-camera_optical``
+    (OpenCV optical frame: +x right, +y down, +z forward, matching the training
+    ``transforms.json``), and ``t_align`` an optional ``model_world<-pose_world``
+    rigid transform for when the localiser's world frame differs from the frame
+    the 3DGS model was built in (identity when they coincide).
+
+    The camera pose in the model frame is ``T = t_align @ t_world_base @
+    t_base_cam`` and the viewmat the rasteriser wants is its inverse.
+    """
+    t_align = np.eye(4) if t_align is None else np.asarray(t_align, dtype=float)
+    cam_in_world = t_align @ np.asarray(t_world_base, dtype=float) \
+        @ np.asarray(t_base_cam, dtype=float)
+    return np.linalg.inv(cam_in_world)
+
+
+def transform_from_pos_quat(pos, quat_xyzw) -> np.ndarray:
+    """4x4 rigid transform from a translation and an xyzw quaternion (ROS order)."""
+    return pi.make_transform(pos, quat_xyzw)
+
+
+# --------------------------------------------------------------------------- #
+# Resident renderer (torch + gsplat; imported lazily)
+# --------------------------------------------------------------------------- #
+class GaussianRenderer:
+    """Hold a trained 3DGS model resident on the GPU and rasterise novel views."""
+
+    def __init__(self, ply: str | Path, *, device: str = 'cuda'):
+        import torch
+        import torch.nn.functional as F
+
+        self._torch = torch
+        g = load_gaussian_ply(ply)
+        dev = torch.device(device)
+        self.device = dev
+        self.num_gaussians = int(g['means'].shape[0])
+        self._means = torch.tensor(g['means'], dtype=torch.float32, device=dev)
+        self._quats = F.normalize(
+            torch.tensor(g['quats'], dtype=torch.float32, device=dev), dim=-1)
+        self._scales = torch.exp(
+            torch.tensor(g['scales_log'], dtype=torch.float32, device=dev))
+        self._opac = torch.sigmoid(
+            torch.tensor(g['opacities_logit'], dtype=torch.float32, device=dev))
+        self.sh_degree = infer_sh_degree(g['sh_rest'])
+        if self.sh_degree is None:
+            self._colors = torch.tensor(np.clip(g['colors_rgb'], 0.0, 1.0),
+                                        dtype=torch.float32, device=dev)
+        else:
+            sh0 = (g['colors_rgb'] - 0.5) / SH_C0
+            sh = np.concatenate([sh0[:, None, :], g['sh_rest']], axis=1)
+            self._colors = torch.tensor(sh, dtype=torch.float32, device=dev)
+
+    def render(self, viewmat: np.ndarray, K: np.ndarray, width: int,
+               height: int) -> np.ndarray:
+        """Rasterise one world->camera view; returns a uint8 (H, W, 3) RGB image."""
+        torch = self._torch
+        from gsplat import rasterization
+
+        vmt = torch.tensor(np.asarray(viewmat, dtype=np.float32),
+                           device=self.device)[None]
+        kmat = torch.tensor(np.asarray(K, dtype=np.float32),
+                            device=self.device)[None]
+        with torch.no_grad():
+            out, _, _ = rasterization(self._means, self._quats, self._scales,
+                                      self._opac, self._colors, vmt, kmat,
+                                      width, height, sh_degree=self.sh_degree,
+                                      packed=False)
+            frame = (out[0].clamp(0.0, 1.0) * 255.0).to(torch.uint8)
+        return frame.cpu().numpy()

--- a/tools/gaussian_splatting/pose_player.py
+++ b/tools/gaussian_splatting/pose_player.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Replay a camera trajectory as ROS 2 ego poses for the 3DGS sensor sim.
+
+Phase 2 building block: a stand-in for the localiser. It walks the camera poses
+of a ``transforms.json`` (the very trajectory the 3DGS scene was built from) and
+publishes them as ``nav_msgs/Odometry`` on the pose topic the sensor-sim node
+subscribes to. With the node's ``extrinsic`` and ``align`` left at identity this
+closes the loop in the model's own frame, so the rendered stream is a faithful
+trajectory flythrough -- the same path a live Autoware ``kinematic_state`` would
+drive once a real driving scene (3DGS + NDT map + lanelet2 in one frame) is wired
+in its place.
+
+The pose maths (``viewmat_to_pos_quat``: world->camera viewmat to the camera's
+world position + xyzw quaternion) is numpy-only and unit tested on CPU; the node
+itself needs rclpy.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import numpy as np  # noqa: E402
+from render_path import matrix_to_quat_xyzw  # noqa: E402
+from train_gsplat import load_transforms  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Pure pose maths (no rclpy)
+# --------------------------------------------------------------------------- #
+def viewmat_to_pos_quat(viewmat: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Camera world position and xyzw orientation from a world->camera viewmat.
+
+    The camera-to-world pose is ``inv(viewmat)``; its translation is the camera
+    centre in world and its rotation becomes the published orientation. Feeding
+    this back through the sensor-sim node with identity extrinsic/align recovers
+    the original viewmat exactly.
+    """
+    c2w = np.linalg.inv(np.asarray(viewmat, dtype=float))
+    return c2w[:3, 3].copy(), matrix_to_quat_xyzw(c2w[:3, :3])
+
+
+# --------------------------------------------------------------------------- #
+# Replay node (rclpy; imported lazily)
+# --------------------------------------------------------------------------- #
+def _build_node():
+    """Construct the node class lazily (so the module imports without rclpy)."""
+    import rclpy
+    from rclpy.node import Node
+
+    class PosePlayer(Node):
+        """Publish the transforms.json camera poses as Odometry on a timer."""
+
+        def __init__(self):
+            super().__init__('pose_player')
+            self.declare_parameter('transforms', '')
+            self.declare_parameter('topic', '/ego_odom')
+            self.declare_parameter('rate', 10.0)
+            self.declare_parameter('frame_id', 'map')
+            self.declare_parameter('child_frame_id', 'base_link')
+            self.declare_parameter('loop', True)
+
+            transforms = self.get_parameter('transforms').value
+            if not transforms:
+                raise RuntimeError('parameter "transforms" is required')
+            ds = load_transforms(transforms)
+            self.poses = [viewmat_to_pos_quat(vm) for vm in ds['viewmats']]
+            self.frame_id = self.get_parameter('frame_id').value
+            self.child_frame_id = self.get_parameter('child_frame_id').value
+            self.loop = bool(self.get_parameter('loop').value)
+            self.idx = 0
+
+            from nav_msgs.msg import Odometry
+
+            self._odom_cls = Odometry
+            self.pub = self.create_publisher(Odometry, self.get_parameter('topic').value, 1)
+            rate = float(self.get_parameter('rate').value)
+            self.timer = self.create_timer(1.0 / rate, self._tick)
+            self.get_logger().info(
+                f'replaying {len(self.poses)} poses at {rate} Hz '
+                f'(loop={self.loop})')
+
+        def _tick(self):
+            if self.idx >= len(self.poses):
+                if not self.loop:
+                    self.get_logger().info('trajectory finished')
+                    self.timer.cancel()
+                    return
+                self.idx = 0
+            pos, quat = self.poses[self.idx]
+            msg = self._odom_cls()
+            msg.header.stamp = self.get_clock().now().to_msg()
+            msg.header.frame_id = self.frame_id
+            msg.child_frame_id = self.child_frame_id
+            msg.pose.pose.position.x = float(pos[0])
+            msg.pose.pose.position.y = float(pos[1])
+            msg.pose.pose.position.z = float(pos[2])
+            msg.pose.pose.orientation.x = float(quat[0])
+            msg.pose.pose.orientation.y = float(quat[1])
+            msg.pose.pose.orientation.z = float(quat[2])
+            msg.pose.pose.orientation.w = float(quat[3])
+            self.pub.publish(msg)
+            self.idx += 1
+
+    return rclpy, PosePlayer
+
+
+def main(argv=None):
+    """CLI entry point: spin the pose-replay node."""
+    rclpy, PosePlayer = _build_node()
+    rclpy.init(args=argv)
+    node = PosePlayer()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/gaussian_splatting/sensor_sim_node.py
+++ b/tools/gaussian_splatting/sensor_sim_node.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+r"""Closed-loop 3DGS camera sensor simulator as a ROS 2 node (gsplat, Apache-2.0).
+
+Phase 2 of the 3DGS-as-sim2real track: put a LiDAR-primed 3DGS scene in the
+loop so a real-image-trained stack (e.g. Autoware perception) drives against a
+photoreal render instead of a synthetic one. The node subscribes to the ego
+pose, renders the scene from the matching camera viewpoint with a resident
+``GaussianRenderer``, and publishes ``sensor_msgs/Image`` + ``CameraInfo``.
+
+Frames: the ego pose is ``world<-base_link``; the static ``base_link<-camera``
+extrinsic (``extrinsic`` param, 16 row-major floats) must target the OpenCV
+optical frame the model was trained in (+x right, +y down, +z forward). If the
+localiser's world frame differs from the model's, set ``align`` (16 floats,
+``model_world<-pose_world``). Phase 0 found driving-scale scenes tolerate ~±1 m
+lateral deviation before the render degrades -- see
+``docs/research/3dgs-sim2real-gap-phase0.md``.
+
+Run (after sourcing the workspace and with a CUDA GPU):
+    python3 tools/gaussian_splatting/sensor_sim_node.py --ros-args \\
+        -p ply:=output/koide_3dgs_firstlight/gsplat/pc_sh1_15k.ply \\
+        -p transforms:=output/koide_3dgs_firstlight/gsplat/transforms.json \\
+        -p scale:=0.5 -p pose_topic:=/localization/kinematic_state
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gaussian_renderer import (  # noqa: E402
+    GaussianRenderer, pose_to_viewmat, transform_from_pos_quat)
+import numpy as np  # noqa: E402
+from render_path import scale_intrinsics  # noqa: E402
+from train_gsplat import load_transforms  # noqa: E402
+
+
+def _mat4(values, name: str) -> np.ndarray:
+    """Validate a 16-element row-major list into a 4x4 matrix."""
+    arr = np.asarray(values, dtype=float)
+    if arr.size != 16:
+        raise ValueError(f'{name} must have 16 elements, got {arr.size}')
+    return arr.reshape(4, 4)
+
+
+def _camera_info(K: np.ndarray, width: int, height: int, frame_id: str):
+    """Build a plumb_bob CameraInfo with no distortion from intrinsics K."""
+    from sensor_msgs.msg import CameraInfo
+
+    info = CameraInfo()
+    info.width = int(width)
+    info.height = int(height)
+    info.distortion_model = 'plumb_bob'
+    info.d = [0.0, 0.0, 0.0, 0.0, 0.0]
+    info.k = [float(v) for v in K.reshape(-1)]
+    info.r = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]
+    info.p = [K[0, 0], K[0, 1], K[0, 2], 0.0,
+              K[1, 0], K[1, 1], K[1, 2], 0.0,
+              0.0, 0.0, 1.0, 0.0]
+    info.header.frame_id = frame_id
+    return info
+
+
+def _build_node():
+    """Construct the node class lazily (so the module imports without rclpy)."""
+    import rclpy
+    from rclpy.node import Node
+
+    class SensorSimNode(Node):
+        """Render the resident 3DGS scene at each incoming ego pose."""
+
+        def __init__(self):
+            super().__init__('gaussian_sensor_sim')
+            self.declare_parameter('ply', '')
+            self.declare_parameter('transforms', '')
+            self.declare_parameter('scale', 0.5)
+            self.declare_parameter('pose_topic', '/localization/kinematic_state')
+            self.declare_parameter('pose_type', 'odometry')  # or 'pose_stamped'
+            self.declare_parameter('image_topic', '/sensor_sim/image_raw')
+            self.declare_parameter('camera_info_topic', '/sensor_sim/camera_info')
+            self.declare_parameter('frame_id', 'camera_optical')
+            self.declare_parameter('extrinsic', list(np.eye(4).reshape(-1)))
+            self.declare_parameter('align', list(np.eye(4).reshape(-1)))
+
+            ply = self.get_parameter('ply').value
+            transforms = self.get_parameter('transforms').value
+            if not ply or not transforms:
+                raise RuntimeError('parameters "ply" and "transforms" are required')
+            scale = float(self.get_parameter('scale').value)
+            self.frame_id = self.get_parameter('frame_id').value
+            self.t_base_cam = _mat4(self.get_parameter('extrinsic').value, 'extrinsic')
+            self.t_align = _mat4(self.get_parameter('align').value, 'align')
+
+            ds = load_transforms(transforms)
+            self.K, self.width, self.height = scale_intrinsics(
+                ds['K'], ds['width'], ds['height'], scale)
+            self.renderer = GaussianRenderer(ply)
+            self.get_logger().info(
+                f'loaded {self.renderer.num_gaussians} gaussians, rendering '
+                f'{self.width}x{self.height} (sh_degree={self.renderer.sh_degree})')
+
+            from sensor_msgs.msg import CameraInfo, Image
+            from cv_bridge import CvBridge
+
+            self.bridge = CvBridge()
+            self.pub_img = self.create_publisher(
+                Image, self.get_parameter('image_topic').value, 1)
+            self.pub_info = self.create_publisher(
+                CameraInfo, self.get_parameter('camera_info_topic').value, 1)
+
+            topic = self.get_parameter('pose_topic').value
+            if self.get_parameter('pose_type').value == 'pose_stamped':
+                from geometry_msgs.msg import PoseStamped
+
+                self.create_subscription(PoseStamped, topic,
+                                         self._on_pose_stamped, 10)
+            else:
+                from nav_msgs.msg import Odometry
+
+                self.create_subscription(Odometry, topic, self._on_odometry, 10)
+            self.get_logger().info(f'subscribed to {topic}, publishing renders')
+
+        def _on_odometry(self, msg):
+            self._render_and_publish(msg.pose.pose, msg.header.stamp)
+
+        def _on_pose_stamped(self, msg):
+            self._render_and_publish(msg.pose, msg.header.stamp)
+
+        def _render_and_publish(self, pose, stamp):
+            p, q = pose.position, pose.orientation
+            t_world_base = transform_from_pos_quat(
+                [p.x, p.y, p.z], [q.x, q.y, q.z, q.w])
+            viewmat = pose_to_viewmat(t_world_base, self.t_base_cam, self.t_align)
+            rgb = self.renderer.render(viewmat, self.K, self.width, self.height)
+            img = self.bridge.cv2_to_imgmsg(rgb, encoding='rgb8')
+            img.header.stamp = stamp
+            img.header.frame_id = self.frame_id
+            info = _camera_info(self.K, self.width, self.height, self.frame_id)
+            info.header.stamp = stamp
+            self.pub_img.publish(img)
+            self.pub_info.publish(info)
+
+    return rclpy, SensorSimNode
+
+
+def main(argv=None):
+    """CLI entry point: spin the sensor-sim node."""
+    rclpy, SensorSimNode = _build_node()
+    rclpy.init(args=argv)
+    node = SensorSimNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Phase 2 of the 3DGS-as-sim2real track (follow-up to #290). Put a LiDAR-primed
3DGS scene in the loop so a real-image-trained stack (e.g. Autoware perception)
drives against a photoreal render instead of a synthetic one.

- **`gaussian_renderer.py`** — `GaussianRenderer` keeps the model resident on the
  GPU (`render_path` re-uploads every call); `render()` is byte-identical to
  `render_frames`. Pure pose maths (`pose_to_viewmat`) for the ROS frame chain.
- **`sensor_sim_node.py`** — rclpy node subscribing to the ego pose
  (`Odometry`/`PoseStamped`), rendering the matching view and publishing
  `sensor_msgs/Image` + `CameraInfo`. `extrinsic` (base←camera_optical) /
  `align` (model_world←pose_world) / `scale` are parameters.
- **`pose_player.py`** — a localiser stand-in replaying the `transforms.json`
  camera poses as `Odometry`, closing the loop in the model's own frame. This is
  the seam where a live Autoware `kinematic_state` plugs in once a real driving
  scene (3DGS + NDT map + lanelet2 in one frame) is wired in its place.

## Verified

- **Realtime**: rendering is not the bottleneck — 30+ FPS at practical
  resolutions, 16.8 FPS at full 2448×2048 with 660k gaussians.
- **Correctness**: resident renderer output is byte-identical to `render_frames`.
- **ROS end-to-end**: `/ego_odom` `Odometry` → `/sensor_sim/image_raw` (rgb8) +
  `/sensor_sim/camera_info`; a `pose_player → node → capture` flythrough renders
  the koide scene faithfully.

## Frames

ego pose `world←base_link`; `extrinsic` `base_link←camera_optical` (OpenCV
optical: +x right, +y down, +z forward, matching the training transforms);
optional `align` `model_world←pose_world`. viewmat = inv(`align @ T_wb @ T_bc`).

## Tests

12 CPU unit tests including a `pose_player ↔ node` round-trip to byte equality,
registered in `graph_based_slam/CMakeLists.txt`; `ament_flake8` clean.