### PR TITLE
feat(3dgs): open-loop RGB-D dataset generation (Phase 1)

### DIFF
--- a/docs/research/3dgs-dataset-gen-phase1.md
+++ b/docs/research/3dgs-dataset-gen-phase1.md
@@ -1,0 +1,76 @@
+# 3DGS open-loop データ生成 — Phase 1 (2026-06-15)
+
+3DGS を **sim2real シミュレーション基盤**として開発するトラックの Phase 1。
+Phase 0（`3dgs-sim2real-gap-phase0.md`）で測った**有効視点範囲**の内側で、
+学習済み LiDAR-primed シーンを**ラベル付き RGB-D データセット**に変換する。
+オフラインの知覚モデル学習・評価にそのまま投入できる形が成果物。
+
+ツール: `tools/gaussian_splatting/generate_dataset.py`
+（pure 部 14 ケースを `graph_based_slam/test/test_gaussian_splatting_dataset.py`
+で CPU テスト、ament_flake8 clean）。
+再現: `PLY=... TRANSFORMS=... OUT_DIR=... bash scripts/run_generate_dataset.sh`
+
+## 何を出すか
+
+各参照ビューについて、記録 pose に加えて **jitter pose**（カメラ右 x・下 y
+方向の横ずれ）を `--max-lateral` / `--max-vertical` の箱内から決定論的に
+サンプル（seed 固定 → データセットはバイト再現可能）。各フレームを書き出す:
+
+- `rgb/<stem>.png` — 8-bit RGB レンダ
+- `depth/<stem>.png` — **16-bit metric depth**（既定でミリメートル。
+  gsplat の expected depth = 不透明度重み付きレイ距離。LiDAR-primed なので単位は
+  メートル → 真の range ラベル）
+- `transforms.json` — nerfstudio 互換の intrinsics + 各フレーム camera-to-world
+
+depth は `depth_scale`（uint16 1 単位あたりのメートル、既定 0.001）で量子化し、
+無効サンプル（非有限・負）は 0（= no return）、`--max-depth` と uint16 上限で
+クランプ。`train_gsplat.load_transforms` で読み戻せる convention（OpenCV w2c /
+OpenGL c2w フリップ）で出力するので、生成データを再学習にもそのまま使える。
+
+## なぜ jitter が効くか（Phase 0 との接続）
+
+記録軌跡だけだとデータは 1 本の視点列に縛られる。Phase 0 で「有効視点範囲内なら
+render は破綻せず、LiDAR-primed の正しい幾何が横ずれに対し正しい視差を出す」ことを
+確認済みなので、その範囲内で pose を散らせば**幾何的に妥当な新規視点**を量産できる。
+これが 3DGS をデータ拡張基盤にする差別化点（NeRF/画像合成と違い depth が metric）。
+
+範囲はシーンスケール依存（Phase 0 の結論）。近接屋内ウォークは ~0.2 m、
+開けた走行スケールは ~1.0 m まで。`--max-lateral` をその範囲に収めること。
+
+## 検証（construction クリーン再構築シーン）
+
+RTX 4070 Ti SUPER / gsplat 1.5.3。クリーン再構築済み
+`output/rtkslam_3dgs_clean/gsplat/point_cloud_good.ply`（recon 28.9 dB）。
+
+```
+VIEWS=8 AUG=2 MAX_LATERAL=0.2 MAX_VERTICAL=0.05 SCALE=0.5 MAX_DEPTH=30
+→ 24 RGB-D frames (8 views x 3), 300x220
+→ depth coverage 1.00, median 2.57 m, p95 6.00 m
+```
+
+- **depth は実シーンスケールで妥当**: 屋内マシンホール近接ウォークの被写体距離
+  （中央値 2.5 m、p95 6 m）と一致。uint16 PNG を読み戻すと metric（p50 2.47 m）。
+- **transforms.json は round-trip 健全**: `load_transforms` で 24 frame・
+  300x220 を読み戻せることを確認（再学習・別ツール消費が可能）。
+- データセットは seed 固定で**バイト再現可能**。
+
+## ロードマップ上の位置づけ
+
+```
+Phase 0  外挿安定性測定 (有効視点範囲)         ← 完了
+   ▼
+Phase 1  open-loop RGB-D データ生成            ← 本ノート（有効範囲内で量産、depth metric）
+   ▼
+Phase 2  closed-loop sensor-sim ROS 2 node     ← 完了 (3dgs-sensor-sim-phase2.md)
+   ▼
+Phase 3  dynamic actors + RL
+```
+
+## 限界 / 次アクション
+
+- jitter は静的シーンの視点拡張のみ。動的物体（車両・歩行者）は映らない
+  → Phase 3 の actor compositing で供給し、そこで初めて検出器 gap を exercise できる
+  （Phase 0 で手元 3 シーンとも real 画像で COCO 検出ゼロだった負の結果の解消経路）。
+- depth は expected depth（不透明度重み付き）なので、半透明 Gaussian が多い領域では
+  surface depth よりやや手前寄りに出ることがある。固い面（LiDAR-primed の主成分）では
+  問題にならないが、薄い構造の多いシーンでは median depth で健全性を確認すること。

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -478,6 +478,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_gaussian_splatting_dataset
+    test/test_gaussian_splatting_dataset.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_mid360_robot_preflight
     test/test_mid360_robot_preflight.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_gaussian_splatting_dataset.py
+++ b/graph_based_slam/test/test_gaussian_splatting_dataset.py
@@ -1,0 +1,166 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the Phase 1 dataset-generation pure helpers (CPU, no torch/gsplat)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+
+
+def _load():
+    if str(TOOL_DIR) not in sys.path:
+        sys.path.insert(0, str(TOOL_DIR))
+    import generate_dataset
+
+    return generate_dataset
+
+
+gd = _load()
+
+
+def _viewmat(center, rot=None):
+    rot = np.eye(3) if rot is None else np.asarray(rot, dtype=float)
+    vm = np.eye(4)
+    vm[:3, :3] = rot
+    vm[:3, 3] = -rot @ np.asarray(center, dtype=float)
+    return vm
+
+
+def _center_of(vm):
+    return -vm[:3, :3].T @ vm[:3, 3]
+
+
+def test_depth_quantisation_roundtrips_within_one_unit():
+    depth = np.array([[0.0, 0.5, 1.234], [2.0, 10.0, 0.001]])
+    u16 = gd.depth_to_uint16(depth, depth_scale=0.001)
+    back = gd.uint16_to_depth(u16, depth_scale=0.001)
+    assert u16.dtype == np.uint16
+    assert np.all(np.abs(back - depth) <= 0.001)
+
+
+def test_depth_quantisation_zeroes_invalid_samples():
+    depth = np.array([[np.nan, -1.0, np.inf, 3.0]])
+    u16 = gd.depth_to_uint16(depth, depth_scale=0.001)
+    assert list(u16.ravel()) == [0, 0, 0, 3000]
+
+
+def test_depth_quantisation_clamps_max_depth_and_ceiling():
+    depth = np.array([[5.0, 1000.0]])
+    u16 = gd.depth_to_uint16(depth, depth_scale=0.001, max_depth=2.0)
+    assert u16[0, 0] == 2000 and u16[0, 1] == 2000  # both clipped to 2 m
+    # without max_depth, 1000 m at mm scale saturates the uint16 ceiling
+    u16b = gd.depth_to_uint16(depth, depth_scale=0.001)
+    assert u16b[0, 1] == 65535
+
+
+def test_depth_scale_must_be_positive():
+    with pytest.raises(ValueError):
+        gd.depth_to_uint16(np.zeros((2, 2)), depth_scale=0.0)
+
+
+def test_plan_jitters_first_is_recorded_pose():
+    js = gd.plan_jitters(4, max_lateral=0.5, max_vertical=0.1, seed=1)
+    assert js[0] == (0.0, 0.0)
+    assert len(js) == 5
+
+
+def test_plan_jitters_respects_bounds():
+    js = gd.plan_jitters(50, max_lateral=0.5, max_vertical=0.1, seed=2)
+    for dx, dy in js:
+        assert -0.5 <= dx <= 0.5
+        assert -0.1 <= dy <= 0.1
+
+
+def test_plan_jitters_is_deterministic():
+    a = gd.plan_jitters(8, max_lateral=0.3, max_vertical=0.2, seed=7)
+    b = gd.plan_jitters(8, max_lateral=0.3, max_vertical=0.2, seed=7)
+    assert a == b
+
+
+def test_plan_jitters_zero_aug_is_just_recorded():
+    assert gd.plan_jitters(0, max_lateral=1.0, max_vertical=1.0) == [(0.0, 0.0)]
+
+
+def test_plan_jitters_rejects_negative():
+    with pytest.raises(ValueError):
+        gd.plan_jitters(-1, max_lateral=0.5, max_vertical=0.1)
+
+
+def test_jittered_viewmat_shifts_camera_local_right_and_down():
+    vm = _viewmat([0.0, 0.0, 0.0])  # identity rotation -> local == world
+    moved = gd.jittered_viewmat(vm, 0.5, 0.2)
+    assert np.allclose(_center_of(moved), [0.5, 0.2, 0.0])
+    assert np.allclose(moved[:3, :3], vm[:3, :3])  # heading preserved
+
+
+def test_jittered_viewmat_zero_is_identity():
+    vm = _viewmat([1.0, -2.0, 3.0])
+    assert np.allclose(gd.jittered_viewmat(vm, 0.0, 0.0), vm)
+
+
+def test_c2w_to_opengl_inverts_and_flips():
+    center = [1.0, 2.0, 3.0]
+    vm = _viewmat(center)
+    c2w_gl = gd.c2w_to_opengl(vm)
+    # translation (camera centre) is unchanged by the optical-axis flip
+    assert np.allclose(c2w_gl[:3, 3], center)
+    # the flip negates the y and z basis columns of the identity rotation
+    assert np.allclose(np.diag(c2w_gl[:3, :3]), [1.0, -1.0, -1.0])
+
+
+def test_c2w_to_opengl_roundtrips_through_load_transforms_convention():
+    # load_transforms does: c2w_cv = c2w_gl @ ROS_OPTICAL_TO_OPENGL; vm = inv.
+    import posed_images as pi
+
+    vm = _viewmat([0.4, -0.6, 2.5],
+                  rot=np.array([[0.0, 1.0, 0.0],
+                                [-1.0, 0.0, 0.0],
+                                [0.0, 0.0, 1.0]]))
+    c2w_gl = gd.c2w_to_opengl(vm)
+    c2w_cv = np.asarray(c2w_gl) @ pi.ROS_OPTICAL_TO_OPENGL
+    assert np.allclose(np.linalg.inv(c2w_cv), vm)
+
+
+def test_build_manifest_carries_intrinsics_and_depth_meta():
+    K = np.array([[500.0, 0.0, 320.0], [0.0, 500.0, 240.0], [0.0, 0.0, 1.0]])
+    frames = [{'file_path': 'rgb/a.png'}]
+    m = gd.build_manifest(K, 640, 480, frames, depth_scale=0.001)
+    assert m['w'] == 640 and m['h'] == 480
+    assert m['fl_x'] == 500.0 and m['cx'] == 320.0
+    assert m['depth_scale'] == 0.001
+    assert m['camera_model'] == 'OPENCV'
+    assert m['frames'] == frames

--- a/scripts/run_generate_dataset.sh
+++ b/scripts/run_generate_dataset.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Generate an open-loop RGB-D perception dataset from a trained LiDAR-primed 3DGS
+# scene (Phase 1 of the 3DGS-as-sim2real track). For every reference view it
+# renders the recorded pose plus AUG jittered poses sampled inside the Phase 0
+# valid viewpoint range, writing:
+#   - rgb/<stem>.png    8-bit RGB renders
+#   - depth/<stem>.png  16-bit metric depth (millimetres by default)
+#   - transforms.json   nerfstudio-style intrinsics + per-frame camera-to-world
+# Because the model is LiDAR-primed the depth is metric, so the dataset carries
+# true range labels usable for offline perception training.
+#
+# Keep MAX_LATERAL / MAX_VERTICAL within the scene's valid range (measured by
+# scripts/run_sim2real_gap.sh): ~0.2 m for close indoor walks, up to ~1.0 m for
+# open driving-scale scenes.
+#
+# Requires: a CUDA GPU with torch + gsplat. PLY and TRANSFORMS must be a matched
+# pair (the model trained from exactly that transforms.json).
+#
+# Usage:
+#   PLY=output/rtkslam_3dgs_clean/gsplat/point_cloud_good.ply \
+#   TRANSFORMS=output/rtkslam_3dgs_clean/gsplat/transforms_good.json \
+#   OUT_DIR=output/phase1_dataset \
+#   bash scripts/run_generate_dataset.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+PLY="${PLY:?set PLY to the trained 3DGS .ply}"
+TRANSFORMS="${TRANSFORMS:?set TRANSFORMS to the transforms.json the model trained from}"
+OUT_DIR="${OUT_DIR:-output/phase1_dataset}"
+VIEWS="${VIEWS:-0}"            # 0 = all reference views
+AUG="${AUG:-4}"               # jittered poses per view (within valid range)
+MAX_LATERAL="${MAX_LATERAL:-0.2}"
+MAX_VERTICAL="${MAX_VERTICAL:-0.05}"
+SCALE="${SCALE:-0.5}"
+DEPTH_SCALE="${DEPTH_SCALE:-0.001}"   # metres per uint16 unit (0.001 = mm)
+MAX_DEPTH="${MAX_DEPTH:-0.0}"         # 0 = no clip
+SEED="${SEED:-0}"
+
+python3 tools/gaussian_splatting/generate_dataset.py \
+  --ply "${PLY}" \
+  --transforms "${TRANSFORMS}" \
+  --out "${OUT_DIR}" \
+  --views "${VIEWS}" \
+  --aug "${AUG}" \
+  --max-lateral "${MAX_LATERAL}" \
+  --max-vertical "${MAX_VERTICAL}" \
+  --scale "${SCALE}" \
+  --depth-scale "${DEPTH_SCALE}" \
+  --max-depth "${MAX_DEPTH}" \
+  --seed "${SEED}"

--- a/tools/gaussian_splatting/generate_dataset.py
+++ b/tools/gaussian_splatting/generate_dataset.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Generate an open-loop RGB-D perception dataset from a 3DGS scene (gsplat, Apache-2.0).
+
+Phase 1 of the 3DGS-as-sim2real track. Phase 0 measured the *valid viewpoint
+range* (how far the ego may deviate from the recorded trajectory before the
+render breaks); this tool turns a trained LiDAR-primed scene into a labelled
+RGB-D dataset *within* that range, ready to feed a perception model offline.
+
+For every reference view it renders the recorded pose plus a handful of
+jittered poses (lateral / vertical camera offsets, sampled deterministically
+inside ``--max-lateral`` / ``--max-vertical`` so the augmentation never leaves
+the valid range). Each frame is written as an 8-bit RGB png and a 16-bit depth
+png (millimetres by default), with a nerfstudio-compatible ``transforms.json``
+holding the intrinsics and per-frame camera-to-world pose. Because the model is
+LiDAR-primed the depth is metric, so the dataset carries true range labels.
+
+The pure helpers (depth quantisation, jitter planning, pose offsetting, the
+manifest builder) are numpy-only and unit tested on CPU; rendering needs
+CUDA + torch + gsplat.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Optional, Sequence
+
+import numpy as np
+
+import posed_images as pi
+from render_path import load_gaussian_ply, render_rgbd_frames, scale_intrinsics
+from sim2real_gap import offset_viewmat, select_views
+from train_gsplat import load_transforms
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no torch/CUDA)
+# --------------------------------------------------------------------------- #
+def depth_to_uint16(depth_m: np.ndarray, *, depth_scale: float = 0.001,
+                    max_depth: float = 0.0) -> np.ndarray:
+    """Quantise a metric depth map to uint16 units of ``depth_scale`` metres.
+
+    With the default ``depth_scale`` of 0.001 the stored integers are
+    millimetres (the common RGB-D / KITTI convention). Non-finite and negative
+    samples become 0 (= "no return"); values past ``max_depth`` (when > 0) and
+    past the uint16 ceiling are clamped.
+    """
+    if depth_scale <= 0.0:
+        raise ValueError('depth_scale must be positive')
+    d = np.asarray(depth_m, dtype=np.float64)
+    d = np.where(np.isfinite(d) & (d > 0.0), d, 0.0)
+    if max_depth > 0.0:
+        d = np.minimum(d, max_depth)
+    u = np.rint(d / depth_scale)
+    return np.minimum(u, 65535.0).astype(np.uint16)
+
+
+def uint16_to_depth(u16: np.ndarray, *, depth_scale: float = 0.001) -> np.ndarray:
+    """Inverse of :func:`depth_to_uint16`: uint16 units back to metric depth."""
+    return np.asarray(u16, dtype=np.float64) * depth_scale
+
+
+def plan_jitters(n_aug: int, *, max_lateral: float, max_vertical: float,
+                 seed: int = 0) -> list[tuple[float, float]]:
+    """Deterministic ``(dx_right, dy_down)`` camera offsets, the recorded pose first.
+
+    Always returns ``(0.0, 0.0)`` as the first entry (the recorded view) followed
+    by ``n_aug`` samples drawn uniformly from the box
+    ``[-max_lateral, max_lateral] x [-max_vertical, max_vertical]``. Seeded, so a
+    given ``(n_aug, ranges, seed)`` always yields the same set -- the dataset is
+    reproducible byte-for-byte.
+    """
+    if n_aug < 0:
+        raise ValueError('n_aug must be non-negative')
+    out = [(0.0, 0.0)]
+    if n_aug == 0:
+        return out
+    rng = np.random.default_rng(seed)
+    dx = rng.uniform(-max_lateral, max_lateral, n_aug)
+    dy = rng.uniform(-max_vertical, max_vertical, n_aug)
+    out.extend((float(x), float(y)) for x, y in zip(dx, dy))
+    return out
+
+
+def jittered_viewmat(viewmat: np.ndarray, dx_right: float,
+                     dy_down: float) -> np.ndarray:
+    """Offset a world->camera view along its local right (x) then down (y) axes."""
+    return offset_viewmat(offset_viewmat(viewmat, dx_right, 'x'), dy_down, 'y')
+
+
+def c2w_to_opengl(viewmat: np.ndarray) -> np.ndarray:
+    """Camera-to-world in OpenGL convention (nerfstudio ``transform_matrix``).
+
+    Inverts the gsplat OpenCV world->camera ``viewmat`` and applies the
+    OpenCV->OpenGL optical flip, matching what ``train_gsplat.load_transforms``
+    expects to read back.
+    """
+    c2w_cv = np.linalg.inv(np.asarray(viewmat, dtype=float))
+    return c2w_cv @ pi.ROS_OPTICAL_TO_OPENGL
+
+
+def build_manifest(K: np.ndarray, width: int, height: int,
+                   frames: Sequence[dict], *, depth_scale: float) -> dict:
+    """Assemble a nerfstudio-style ``transforms.json`` dict with depth metadata."""
+    K = np.asarray(K, dtype=float)
+    return {
+        'w': int(width),
+        'h': int(height),
+        'fl_x': float(K[0, 0]),
+        'fl_y': float(K[1, 1]),
+        'cx': float(K[0, 2]),
+        'cy': float(K[1, 2]),
+        'camera_model': 'OPENCV',
+        'depth_scale': float(depth_scale),
+        'depth_unit': 'metres = pixel * depth_scale',
+        'frames': list(frames),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Generation (torch + gsplat; rendering imported lazily by render_rgbd_frames)
+# --------------------------------------------------------------------------- #
+def generate(ply: Path, transforms: Path, out_dir: Path, *,
+             n_views: int, n_aug: int, max_lateral: float, max_vertical: float,
+             scale: float, depth_scale: float, max_depth: float, seed: int,
+             device: str = 'cuda') -> dict:
+    """Render the RGB-D dataset and write rgb/, depth/ and transforms.json."""
+    import imageio.v2 as imageio
+
+    dataset = load_transforms(transforms)
+    gaussians = load_gaussian_ply(ply)
+    K, width, height = scale_intrinsics(dataset['K'], dataset['width'],
+                                        dataset['height'], scale)
+    views = select_views(len(dataset['viewmats']), n_views)
+    jitters = plan_jitters(n_aug, max_lateral=max_lateral,
+                           max_vertical=max_vertical, seed=seed)
+
+    viewmats, records = [], []
+    for gi in views:
+        base = dataset['viewmats'][gi]
+        for ji, (dx, dy) in enumerate(jitters):
+            vm = jittered_viewmat(base, dx, dy)
+            stem = f'view_{gi:04d}_j{ji:02d}'
+            viewmats.append(vm)
+            records.append({'stem': stem, 'view': int(gi), 'jitter': [dx, dy],
+                            'viewmat': vm})
+
+    (out_dir / 'rgb').mkdir(parents=True, exist_ok=True)
+    (out_dir / 'depth').mkdir(parents=True, exist_ok=True)
+    rgb, depth = render_rgbd_frames(gaussians, np.stack(viewmats), K, width,
+                                    height, device=device)
+
+    frames = []
+    for i, rec in enumerate(records):
+        stem = rec['stem']
+        imageio.imwrite(out_dir / 'rgb' / f'{stem}.png', rgb[i])
+        d16 = depth_to_uint16(depth[i], depth_scale=depth_scale,
+                              max_depth=max_depth)
+        imageio.imwrite(out_dir / 'depth' / f'{stem}.png', d16)
+        frames.append({
+            'file_path': f'rgb/{stem}.png',
+            'depth_file_path': f'depth/{stem}.png',
+            'transform_matrix': c2w_to_opengl(rec['viewmat']).tolist(),
+            'source_view': rec['view'],
+            'jitter_rightdown_m': rec['jitter'],
+        })
+
+    manifest = build_manifest(K, width, height, frames, depth_scale=depth_scale)
+    (out_dir / 'transforms.json').write_text(json.dumps(manifest, indent=2))
+    valid = depth[depth > 0.0]
+    return {
+        'frames': len(frames),
+        'views': len(views),
+        'jitters_per_view': len(jitters),
+        'render_size': [width, height],
+        'depth_scale': depth_scale,
+        'depth_coverage': float(np.mean(depth > 0.0)),
+        'depth_p50_m': float(np.median(valid)) if valid.size else 0.0,
+        'depth_p95_m': float(np.percentile(valid, 95)) if valid.size else 0.0,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the CLI argument parser."""
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument('--ply', required=True, help='trained INRIA 3DGS .ply')
+    p.add_argument('--transforms', required=True,
+                   help='transforms.json the model was trained from')
+    p.add_argument('--out', required=True, help='output dataset directory')
+    p.add_argument('--views', type=int, default=0,
+                   help='evenly spaced reference views (0 = all)')
+    p.add_argument('--aug', type=int, default=0,
+                   help='jittered poses per view, inside the valid range '
+                        '(0 = recorded pose only)')
+    p.add_argument('--max-lateral', type=float, default=0.5,
+                   help='max camera-right jitter in metres (keep within the '
+                        'Phase 0 valid viewpoint range for the scene)')
+    p.add_argument('--max-vertical', type=float, default=0.1,
+                   help='max camera-down jitter in metres')
+    p.add_argument('--scale', type=float, default=0.5,
+                   help='render-resolution scale vs the training images')
+    p.add_argument('--depth-scale', type=float, default=0.001,
+                   help='metres per stored uint16 depth unit (0.001 = mm)')
+    p.add_argument('--max-depth', type=float, default=0.0,
+                   help='clip depth to this many metres (0 = no clip)')
+    p.add_argument('--seed', type=int, default=0,
+                   help='jitter RNG seed (dataset is reproducible)')
+    p.add_argument('--device', default='cuda')
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args(argv)
+    stats = generate(Path(args.ply), Path(args.transforms), Path(args.out),
+                     n_views=args.views, n_aug=args.aug,
+                     max_lateral=args.max_lateral, max_vertical=args.max_vertical,
+                     scale=args.scale, depth_scale=args.depth_scale,
+                     max_depth=args.max_depth, seed=args.seed, device=args.device)
+    print(f"wrote {stats['frames']} RGB-D frames "
+          f"({stats['views']} views x {stats['jitters_per_view']}) to {args.out}")
+    print(f"  size {stats['render_size'][0]}x{stats['render_size'][1]}, "
+          f"depth coverage {stats['depth_coverage']:.2f}, "
+          f"median {stats['depth_p50_m']:.2f} m, p95 {stats['depth_p95_m']:.2f} m")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/gaussian_splatting/render_path.py
+++ b/tools/gaussian_splatting/render_path.py
@@ -208,6 +208,53 @@ def render_frames(gaussians: dict, viewmats: np.ndarray, K: np.ndarray,
     return frames
 
 
+def render_rgbd_frames(gaussians: dict, viewmats: np.ndarray, K: np.ndarray,
+                       width: int, height: int, *,
+                       device: str = 'cuda') -> tuple[np.ndarray, np.ndarray]:
+    """Rasterise every w2c view returning RGB and expected depth.
+
+    Returns ``(rgb, depth)`` where ``rgb`` is uint8 ``(F, H, W, 3)`` and
+    ``depth`` is float32 ``(F, H, W)`` of the gsplat *expected* depth (per-pixel
+    opacity-weighted ray distance, in the Gaussian model's coordinate units).
+    For a LiDAR-primed model those units are metric, so the depth is a usable
+    range image for open-loop perception data generation (Phase 1).
+    """
+    import torch
+    import torch.nn.functional as F
+
+    from gsplat import rasterization
+
+    dev = torch.device(device)
+    means = torch.tensor(gaussians['means'], dtype=torch.float32, device=dev)
+    quats = F.normalize(
+        torch.tensor(gaussians['quats'], dtype=torch.float32, device=dev), dim=-1)
+    scales = torch.exp(
+        torch.tensor(gaussians['scales_log'], dtype=torch.float32, device=dev))
+    opac = torch.sigmoid(
+        torch.tensor(gaussians['opacities_logit'], dtype=torch.float32, device=dev))
+    sh_degree = infer_sh_degree(gaussians['sh_rest'])
+    if sh_degree is None:
+        colors = torch.tensor(np.clip(gaussians['colors_rgb'], 0.0, 1.0),
+                              dtype=torch.float32, device=dev)
+    else:
+        sh0 = (gaussians['colors_rgb'] - 0.5) / SH_C0
+        sh = np.concatenate([sh0[:, None, :], gaussians['sh_rest']], axis=1)
+        colors = torch.tensor(sh, dtype=torch.float32, device=dev)
+    kmat = torch.tensor(K, dtype=torch.float32, device=dev)[None]
+    rgb = np.empty((len(viewmats), height, width, 3), dtype=np.uint8)
+    depth = np.empty((len(viewmats), height, width), dtype=np.float32)
+    with torch.no_grad():
+        for i, vm in enumerate(viewmats):
+            vmt = torch.tensor(vm, dtype=torch.float32, device=dev)[None]
+            out, _, _ = rasterization(means, quats, scales, opac, colors, vmt,
+                                      kmat, width, height, sh_degree=sh_degree,
+                                      packed=False, render_mode='RGB+ED')
+            rgb[i] = (out[0, ..., :3].clamp(0.0, 1.0) * 255.0).to(
+                torch.uint8).cpu().numpy()
+            depth[i] = out[0, ..., 3].cpu().numpy()
+    return rgb, depth
+
+
 def write_videos(frames: np.ndarray, order: Sequence[int], *, fps: int,
                  mp4: Optional[Path], gif: Optional[Path], gif_fps: int,
                  gif_scale: float) -> None:


### PR DESCRIPTION
## What

Phase 1 of the 3DGS-as-sim2real track: turn a trained LiDAR-primed 3DGS scene into a labelled **RGB-D dataset** inside the Phase 0 *valid viewpoint range*, ready for offline perception training.

For every reference view it renders the recorded pose plus deterministic **jittered poses** (camera right/down offsets sampled inside `--max-lateral`/`--max-vertical`, kept within the scene's valid range). Each frame is written as:
- `rgb/<stem>.png` — 8-bit RGB
- `depth/<stem>.png` — **16-bit metric depth** (mm by default; LiDAR-primed → metric range labels)
- `transforms.json` — nerfstudio-style intrinsics + per-frame camera-to-world that round-trips through `train_gsplat.load_transforms`

## Changes
- `tools/gaussian_splatting/generate_dataset.py` — the generator (pure helpers numpy-only).
- `render_path.render_rgbd_frames` — gsplat `RGB+ED` render returning metric expected depth.
- 14 CPU tests (depth quantisation, jitter planning, pose offsetting, OpenGL c2w convention, manifest), ament_flake8 clean; registered in CMakeLists.
- runner `scripts/run_generate_dataset.sh`, doc `docs/research/3dgs-dataset-gen-phase1.md`.

## Validation
Clean construction scene (recon 28.9 dB):
```
VIEWS=8 AUG=2 MAX_LATERAL=0.2 MAX_VERTICAL=0.05 SCALE=0.5 MAX_DEPTH=30
→ 24 RGB-D frames, 300x220, depth coverage 1.00, median 2.57 m / p95 6.00 m
```
uint16 depth round-trips to metric (p50 2.47 m); transforms.json reloads cleanly via `load_transforms`.

## Reproduce
```
PLY=output/rtkslam_3dgs_clean/gsplat/point_cloud_good.ply \
TRANSFORMS=output/rtkslam_3dgs_clean/gsplat/transforms_good.json \
OUT_DIR=output/phase1_dataset bash scripts/run_generate_dataset.sh
```