### PR TITLE
feat(3dgs): dynamic actor compositing + detector gap (Phase 3)

### DIFF
--- a/docs/research/3dgs-actor-compositing-phase3.md
+++ b/docs/research/3dgs-actor-compositing-phase3.md
@@ -1,0 +1,79 @@
+# 3DGS dynamic actor compositing + 検出器 gap — Phase 3 (2026-06-15)
+
+3DGS を **sim2real シミュレーション基盤**として開発するトラックの Phase 3
+（actor 挿入の部分。RL はスコープ外）。静的 3DGS シーンには動的交通が無く、
+Phase 0 で手元 3 シーンに COCO クラス物体が皆無 → 実画像検出器が render 上で
+一度も発火しなかった（負の結果）。本 Phase はシーンに**動く actor を挿入**し、
+その検出器 gap をようやく exercise する。
+
+ツール: `tools/gaussian_splatting/actor_compositing.py`
+（pure 部 19 ケースを `graph_based_slam/test/test_gaussian_splatting_actor.py`
+で CPU テスト、ament_flake8 clean）。
+再現: `PLY=... TRANSFORMS=... OUT_DIR=... MODE=... bash scripts/run_actor_compositing.sh`
+
+## 仕組み
+
+actor をシーンカメラの前方にステージし、視野を横断させる。各フレームで
+**per-pixel depth test** によりシーン render と actor を合成（actor はシーンより
+手前のピクセルにだけ描かれる）→ 幾何的に正しいオクルージョン。各フレームの
+**ground-truth 2D box** も出力（actor の投影範囲から）。
+
+- **box actor** — Gaussian の合成立体。シーンカメラからラスタライズして
+  depth test 合成（`composite_depth`）。アセット不要、決定論的、移動物体の
+  photoreal-geometry デモ。
+- **sprite actor** — 実写 RGBA カットアウトを billboard 挿入。depth でスケールし
+  シーン depth でオクルージョン（`paste_sprite`）。sprite は実物体なので COCO
+  検出器が発火し得る → これで**検出 gap を実測**する。
+
+## 検証（construction クリーン再構築シーン、recon 28.9 dB）
+
+RTX 4070 Ti SUPER / gsplat 1.5.3 / yolov8n。
+
+### box actor（オクルージョン正当性）
+
+```
+VIEW=40 FRAMES=36 MODE=box BOX_SIZE=0.6,0.6,1.7 DISTANCE=4 LATERAL=2 SCALE=0.5
+→ 36/36 frames に可視 actor ラベル。GT box が x1: 0→201 と視野を横断。
+```
+
+赤い人型 box が床に立ち、**前景の機材に正しく下半身を遮蔽される**（depth test
+が機能）。GT box は移動と遮蔽に追従。
+
+### sprite actor（検出 gap 実測）
+
+bus.jpg の縦長歩行者（504x197、素のクロップは person conf 0.87 で検出）を挿入:
+
+| render scale | 解像度 | detection recall | mean best IoU |
+|---|---|---|---|
+| 1.0 | 600x440 | **0.28** | 0.28 |
+| 0.5 | 300x220 | 0.06 | 0.21 |
+
+**検出 gap は render 解像度とオクルージョンが主因**（物体の見え方ではない）:
+素のクロップは 0.87 で確実に検出されるのに、3DGS render に埋め込むと
+フル解像度でも recall 0.28、半解像度で 0.06 に落ちる。フレーム別に見ると
+**開けた床では検出成立・前景機材の背後を歩くと下半身が遮蔽されて検出失敗**
+（hit frame は視野端、miss frame は遮蔽の濃い中央）と、recall がオクルージョンに
+明瞭に連動する。これが「3DGS をデータ生成・closed-loop に使うときの知覚 gap」の
+最初の定量値。
+
+## 限界 / 次アクション
+
+- **sprite は矩形カットアウト**（セグメンテーション alpha でない）ので GT box に
+  背景マージンが入り、検出が成立しても IoU が伸びにくい（mean ~0.28）。tight な
+  検出 gap には人物セグメント alpha か、actor 自体の 3DGS モデルが要る。
+- **真に photoreal な actor** は実物体の 3DGS モデル（車・人の learned Gaussian）を
+  挿入するのが本命。billboard は単一 depth なので斜めビューで平面感が出る。
+- 検出 gap の改善余地: 解像度を上げる / closed-loop では sensor_sim_node
+  （Phase 2）の出力解像度を上げる。低解像度ほど gap が急拡大するのは
+  運用上の重要知見。
+- RL（動的 actor 群 + 方策学習）は本 Phase のスコープ外。compositing と GT label の
+  基盤は整ったので、actor 軌跡を増やせば multi-agent シナリオに拡張できる。
+
+## ロードマップ上の位置づけ
+
+```
+Phase 0  外挿安定性測定 (有効視点範囲)            ← 完了
+Phase 1  open-loop RGB-D データ生成               ← 完了 (3dgs-dataset-gen-phase1.md)
+Phase 2  closed-loop sensor-sim ROS 2 node        ← 完了 (3dgs-sensor-sim-phase2.md)
+Phase 3  dynamic actors (compositing + 検出 gap)  ← 本ノート（RL は将来）
+```

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -483,6 +483,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_gaussian_splatting_actor
+    test/test_gaussian_splatting_actor.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_mid360_robot_preflight
     test/test_mid360_robot_preflight.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_gaussian_splatting_actor.py
+++ b/graph_based_slam/test/test_gaussian_splatting_actor.py
@@ -1,0 +1,198 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the Phase 3 actor-compositing pure helpers (CPU, no torch/gsplat)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+
+
+def _load():
+    if str(TOOL_DIR) not in sys.path:
+        sys.path.insert(0, str(TOOL_DIR))
+    import actor_compositing
+
+    return actor_compositing
+
+
+ac = _load()
+
+
+def test_make_box_actor_fills_and_rests_on_ground():
+    box = ac.make_box_actor([0.6, 0.6, 1.7], spacing=0.2)
+    means = box['means']
+    assert box['sh_rest'] is None
+    assert means.shape[0] == box['quats'].shape[0] > 0
+    assert np.all(box['quats'][:, 0] == 1.0)  # wxyz identity
+    assert means[:, 2].min() == pytest.approx(0.0)  # base on the ground
+    assert means[:, 2].max() == pytest.approx(1.7, abs=0.2)
+    assert abs(means[:, 0]).max() == pytest.approx(0.3, abs=1e-9)
+
+
+def test_make_box_actor_rejects_bad_dims():
+    with pytest.raises(ValueError):
+        ac.make_box_actor([0.0, 1.0, 1.0])
+
+
+def test_transform_gaussians_translates_means():
+    box = ac.make_box_actor([0.4, 0.4, 1.0], spacing=0.5)
+    t = ac.rigid_from_pos_yaw([10.0, -5.0, 2.0], 0.0)
+    moved = ac.transform_gaussians(box, t)
+    assert np.allclose(moved['means'].mean(axis=0),
+                       box['means'].mean(axis=0) + [10.0, -5.0, 2.0])
+
+
+def test_transform_gaussians_rotates_orientation_quats():
+    box = ac.make_box_actor([0.4, 0.4, 0.4], spacing=0.4)
+    t = ac.rigid_from_pos_yaw([0.0, 0.0, 0.0], np.pi / 2.0)
+    moved = ac.transform_gaussians(box, t)
+    assert not np.allclose(moved['quats'], box['quats'])  # yaw changed heading
+    assert np.allclose(np.linalg.norm(moved['quats'], axis=1), 1.0)
+
+
+def test_rigid_from_pos_yaw_is_rotation_about_up():
+    t = ac.rigid_from_pos_yaw([0.0, 0.0, 0.0], np.pi / 2.0, up_axis=2)
+    # +x (1,0,0) rotates to +y under a +90 deg yaw about z
+    assert np.allclose(t[:3, :3] @ [1.0, 0.0, 0.0], [0.0, 1.0, 0.0], atol=1e-9)
+    assert np.allclose(t[:3, :3] @ [0.0, 0.0, 1.0], [0.0, 0.0, 1.0])  # up fixed
+
+
+def test_actor_world_poses_places_actor_in_front():
+    c2w = np.eye(4)  # camera at origin, +z forward (OpenCV)
+    poses = ac.actor_world_poses(c2w, [-1.0, 0.0, 1.0], distance=5.0, drop=0.8)
+    assert np.allclose(poses[1], [0.0, 0.8, 5.0])  # centred: ahead and below
+    assert poses[0][0] == -1.0 and poses[2][0] == 1.0  # lateral sweep
+
+
+def test_project_points_centre_maps_to_principal_point():
+    K = np.array([[100.0, 0.0, 50.0], [0.0, 100.0, 40.0], [0.0, 0.0, 1.0]])
+    vm = np.eye(4)
+    uv, z = ac.project_points(np.array([[0.0, 0.0, 2.0]]), vm, K)
+    assert np.allclose(uv[0], [50.0, 40.0])  # on-axis point -> principal point
+    assert z[0] == pytest.approx(2.0)
+
+
+def test_points_to_bbox_clips_to_image():
+    uv = np.array([[10.0, 20.0], [60.0, 90.0]])
+    z = np.array([1.0, 1.0])
+    assert ac.points_to_bbox(uv, z, 50, 50) == [10, 20, 50, 50]
+
+
+def test_points_to_bbox_none_when_behind_camera():
+    uv = np.array([[10.0, 10.0]])
+    assert ac.points_to_bbox(uv, np.array([-1.0]), 50, 50) is None
+
+
+def test_composite_depth_actor_in_front_wins():
+    scene = np.zeros((4, 4, 3), dtype=np.uint8)
+    actor = np.full((4, 4, 3), 200, dtype=np.uint8)
+    scene_d = np.full((4, 4), 5.0)
+    actor_d = np.full((4, 4), 2.0)  # nearer everywhere
+    alpha = np.ones((4, 4))
+    out, mask = ac.composite_depth(scene, scene_d, actor, actor_d, alpha)
+    assert mask.all() and (out == 200).all()
+
+
+def test_composite_depth_actor_behind_is_occluded():
+    scene = np.zeros((4, 4, 3), dtype=np.uint8)
+    actor = np.full((4, 4, 3), 200, dtype=np.uint8)
+    scene_d = np.full((4, 4), 1.0)
+    actor_d = np.full((4, 4), 3.0)  # behind the scene
+    alpha = np.ones((4, 4))
+    out, mask = ac.composite_depth(scene, scene_d, actor, actor_d, alpha)
+    assert not mask.any() and (out == 0).all()
+
+
+def test_composite_depth_draws_over_empty_scene():
+    scene = np.zeros((2, 2, 3), dtype=np.uint8)
+    actor = np.full((2, 2, 3), 150, dtype=np.uint8)
+    scene_d = np.zeros((2, 2))  # no scene return
+    actor_d = np.full((2, 2), 4.0)
+    out, mask = ac.composite_depth(scene, scene_d, actor, actor_d, np.ones((2, 2)))
+    assert mask.all() and (out == 150).all()
+
+
+def test_resize_nearest_changes_shape_preserves_values():
+    img = np.array([[[0, 0, 0], [255, 255, 255]]], dtype=np.uint8)  # 1x2
+    out = ac.resize_nearest(img, 4, 2)
+    assert out.shape == (2, 4, 3)
+    assert set(np.unique(out)) <= {0, 255}
+
+
+def test_paste_sprite_blends_opaque_pixels_and_returns_bbox():
+    scene = np.zeros((20, 20, 3), dtype=np.uint8)
+    scene_d = np.full((20, 20), 10.0)
+    sprite = np.zeros((4, 4, 4), dtype=np.uint8)
+    sprite[..., :3] = 200
+    sprite[..., 3] = 255  # fully opaque
+    out, bbox = ac.paste_sprite(scene, scene_d, sprite, [10.0, 10.0], 8, 3.0)
+    assert bbox is not None
+    x1, y1, x2, y2 = bbox
+    assert (out[y1:y2, x1:x2] == 200).any()
+    assert 0 <= x1 < x2 <= 20 and 0 <= y1 < y2 <= 20
+
+
+def test_paste_sprite_occluded_by_nearer_scene():
+    scene = np.zeros((20, 20, 3), dtype=np.uint8)
+    scene_d = np.full((20, 20), 1.0)  # scene nearer than the sprite
+    sprite = np.zeros((4, 4, 4), dtype=np.uint8)
+    sprite[..., 3] = 255
+    out, bbox = ac.paste_sprite(scene, scene_d, sprite, [10.0, 10.0], 8, 5.0)
+    assert bbox is None and (out == 0).all()
+
+
+def test_paste_sprite_off_frame_returns_none():
+    scene = np.zeros((10, 10, 3), dtype=np.uint8)
+    scene_d = np.full((10, 10), 10.0)
+    sprite = np.full((4, 4, 4), 255, dtype=np.uint8)
+    out, bbox = ac.paste_sprite(scene, scene_d, sprite, [-50.0, -50.0], 4, 3.0)
+    assert bbox is None
+
+
+def test_linspace_sym_spans_range():
+    assert ac.linspace_sym(2.0, 1) == [0.0]
+    assert ac.linspace_sym(2.0, 3) == [-2.0, 0.0, 2.0]
+
+
+def test_linspace_sym_rejects_nonpositive_count():
+    with pytest.raises(ValueError):
+        ac.linspace_sym(1.0, 0)
+
+
+def test_logit_sigmoid_roundtrip():
+    for p in (0.1, 0.5, 0.99):
+        assert 1.0 / (1.0 + np.exp(-ac.logit(p))) == pytest.approx(p, abs=1e-6)

--- a/scripts/run_actor_compositing.sh
+++ b/scripts/run_actor_compositing.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Composite a dynamic actor into a trained 3DGS scene with correct occlusion
+# (Phase 3 of the 3DGS-as-sim2real track). The actor is staged in front of a
+# scene camera and swept across the field of view; the scene render and the
+# actor are merged by a per-pixel depth test (the actor is drawn only where it
+# is nearer than the scene), and a per-frame ground-truth 2D box is exported.
+#
+# MODE=box     a synthetic Gaussian solid (geometry/occlusion demo, no asset).
+# MODE=sprite  a real-photo RGBA cutout billboarded in -- a COCO detector can
+#              fire on it, so pass DETECTOR to measure the detection gap (how
+#              reliably a real object is detected once embedded in a 3DGS render).
+#
+# A sprite can be made from any image with a detector, e.g. the tallest portrait
+# person in ultralytics' bundled bus.jpg:
+#   python3 - <<'PY'
+#   import numpy as np, imageio.v2 as imageio, os
+#   from ultralytics import YOLO
+#   m = YOLO('yolov8n.pt')
+#   src = os.path.expanduser('~/.local/lib/python3.12/site-packages/ultralytics/assets/bus.jpg')
+#   img = np.asarray(imageio.imread(src))[..., :3]
+#   res = m.predict(img[..., ::-1], conf=0.4, verbose=False)[0]
+#   best = None
+#   for b in res.boxes:
+#       if int(b.cls.item()) == 0:
+#           x1, y1, x2, y2 = (int(v) for v in b.xyxy[0].tolist())
+#           if y2 - y1 > x2 - x1 and (best is None or y2 - y1 > best[1]):
+#               best = ((x1, y1, x2, y2), y2 - y1)
+#   (x1, y1, x2, y2), _ = best
+#   crop = img[y1:y2, x1:x2]
+#   rgba = np.dstack([crop, np.full(crop.shape[:2], 255, np.uint8)])
+#   os.makedirs('output/assets', exist_ok=True)
+#   imageio.imwrite('output/assets/person_sprite.png', rgba)
+#   PY
+#
+# Requires: a CUDA GPU with torch + gsplat; ultralytics if DETECTOR is set.
+#
+# Usage:
+#   PLY=output/rtkslam_3dgs_clean/gsplat/point_cloud_good.ply \
+#   TRANSFORMS=output/rtkslam_3dgs_clean/gsplat/transforms_good.json \
+#   OUT_DIR=output/phase3_actor MODE=sprite \
+#   SPRITE=output/assets/person_sprite.png DETECTOR=yolov8n.pt \
+#   bash scripts/run_actor_compositing.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+PLY="${PLY:?set PLY to the trained 3DGS scene .ply}"
+TRANSFORMS="${TRANSFORMS:?set TRANSFORMS to the transforms.json the scene trained from}"
+OUT_DIR="${OUT_DIR:-output/phase3_actor}"
+VIEW="${VIEW:-40}"
+FRAMES="${FRAMES:-36}"
+MODE="${MODE:-box}"
+BOX_SIZE="${BOX_SIZE:-0.6,0.6,1.7}"
+SPRITE="${SPRITE:-}"
+DISTANCE="${DISTANCE:-3.5}"
+LATERAL="${LATERAL:-1.5}"
+DROP="${DROP:-0.7}"
+SPRITE_HEIGHT_M="${SPRITE_HEIGHT_M:-1.7}"
+SCALE="${SCALE:-1.0}"
+DETECTOR="${DETECTOR:-}"
+FPS="${FPS:-12}"
+
+ARGS=(--ply "${PLY}" --transforms "${TRANSFORMS}" --out "${OUT_DIR}"
+      --view "${VIEW}" --frames "${FRAMES}" --mode "${MODE}"
+      --box-size "${BOX_SIZE}" --distance "${DISTANCE}" --lateral "${LATERAL}"
+      --drop "${DROP}" --sprite-height-m "${SPRITE_HEIGHT_M}" --scale "${SCALE}"
+      --fps "${FPS}")
+[[ -n "${SPRITE}" ]] && ARGS+=(--sprite "${SPRITE}")
+[[ -n "${DETECTOR}" ]] && ARGS+=(--detector "${DETECTOR}")
+
+python3 tools/gaussian_splatting/actor_compositing.py "${ARGS[@]}"

--- a/tools/gaussian_splatting/actor_compositing.py
+++ b/tools/gaussian_splatting/actor_compositing.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Composite dynamic actors into a 3DGS scene with correct occlusion (gsplat, Apache-2.0).
+
+Phase 3 of the 3DGS-as-sim2real track (the actor-insertion half; RL is out of
+scope here). A static 3DGS scene has no moving traffic, and Phase 0 found that
+the indoor/test-track scenes on hand contain no COCO-class objects at all, so a
+real-image detector never fires on the renders. This tool inserts a moving
+actor into the scene so that gap can finally be exercised:
+
+* **box actor** -- a synthetic solid of Gaussians, rasterised from the scene
+  camera and composited by a per-pixel depth test (the actor is only drawn where
+  it is nearer than the scene), giving geometrically correct occlusion. This is
+  the photoreal-geometry demo of a moving object.
+* **sprite actor** -- a real-photo RGBA cutout billboarded into the scene at a
+  chosen camera-local position, scaled by its depth and occluded by the scene
+  depth. Because the sprite is a real object (e.g. a person cut from a stock
+  image), a COCO detector *can* fire on it, so this drives the detection-gap
+  measurement: how reliably is a real object detected once embedded in a 3DGS
+  render, and how does scene occlusion degrade it.
+
+Either way a per-frame ground-truth 2D box is exported (from the projected actor
+extent), so a detector's output can be scored against a known label.
+
+The pure helpers (actor construction, rigid placement, Gaussian transforms,
+projection, depth-tested compositing, nearest-neighbour sprite resize) are
+numpy-only and unit tested on CPU; rasterising the scene/box needs CUDA + torch
++ gsplat and the optional detector needs ultralytics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Optional, Sequence
+
+import numpy as np
+
+import posed_images as pi
+from render_path import load_gaussian_ply, matrix_to_quat_xyzw, scale_intrinsics
+from train_gsplat import load_transforms
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no torch/CUDA)
+# --------------------------------------------------------------------------- #
+def logit(p: float) -> float:
+    """Inverse sigmoid, clamped away from the asymptotes."""
+    p = min(max(float(p), 1e-6), 1.0 - 1e-6)
+    return float(np.log(p / (1.0 - p)))
+
+
+def make_box_actor(size_xyz: Sequence[float], *, spacing: float = 0.1,
+                   color_rgb: Sequence[float] = (0.85, 0.1, 0.1),
+                   opacity: float = 0.99) -> dict:
+    """Build a solid box of Gaussians centred on x/y, resting on the ground (z in [0, h]).
+
+    Returns a gaussians dict in the same layout as ``load_gaussian_ply`` (band-0
+    colour only, identity ``wxyz`` quats), deterministic for a given size and
+    spacing so the demo and tests are reproducible.
+    """
+    sx, sy, sz = (float(v) for v in size_xyz)
+    if min(sx, sy, sz) <= 0.0 or spacing <= 0.0:
+        raise ValueError('box dimensions and spacing must be positive')
+    xs = np.arange(-sx / 2.0, sx / 2.0 + 1e-9, spacing)
+    ys = np.arange(-sy / 2.0, sy / 2.0 + 1e-9, spacing)
+    zs = np.arange(0.0, sz + 1e-9, spacing)
+    gx, gy, gz = np.meshgrid(xs, ys, zs, indexing='ij')
+    means = np.stack([gx.ravel(), gy.ravel(), gz.ravel()], axis=1)
+    n = means.shape[0]
+    quats = np.tile([1.0, 0.0, 0.0, 0.0], (n, 1))  # wxyz identity
+    scales_log = np.full((n, 3), np.log(spacing * 0.75))
+    return {
+        'means': means.astype(np.float64),
+        'scales_log': scales_log,
+        'quats': quats.astype(np.float64),
+        'opacities_logit': np.full(n, logit(opacity)),
+        'colors_rgb': np.tile(np.asarray(color_rgb, dtype=float), (n, 1)),
+        'sh_rest': None,
+    }
+
+
+def _rotate_quats_wxyz(quats_wxyz: np.ndarray, rot: np.ndarray) -> np.ndarray:
+    """Apply a world rotation ``rot`` to a batch of ``wxyz`` Gaussian quaternions."""
+    out = np.empty_like(np.asarray(quats_wxyz, dtype=float))
+    for i, q in enumerate(quats_wxyz):
+        rq = pi.quat_to_matrix([q[1], q[2], q[3], q[0]])  # wxyz -> xyzw -> R
+        xyzw = matrix_to_quat_xyzw(rot @ rq)
+        out[i] = [xyzw[3], xyzw[0], xyzw[1], xyzw[2]]
+    return out
+
+
+def transform_gaussians(g: dict, transform: np.ndarray) -> dict:
+    """Rigidly move a gaussians dict by a 4x4 ``transform`` (means + orientations)."""
+    t = np.asarray(transform, dtype=float)
+    rot, trans = t[:3, :3], t[:3, 3]
+    out = dict(g)
+    out['means'] = (np.asarray(g['means'], dtype=float) @ rot.T) + trans
+    out['quats'] = _rotate_quats_wxyz(g['quats'], rot)
+    return out
+
+
+def rigid_from_pos_yaw(pos: Sequence[float], yaw: float,
+                       up_axis: int = 2) -> np.ndarray:
+    """4x4 transform: translate to ``pos`` and rotate ``yaw`` rad about ``up_axis``."""
+    c, s = np.cos(yaw), np.sin(yaw)
+    rot = np.eye(3)
+    a, b = [i for i in range(3) if i != up_axis]
+    rot[a, a], rot[a, b] = c, -s
+    rot[b, a], rot[b, b] = s, c
+    t = np.eye(4)
+    t[:3, :3] = rot
+    t[:3, 3] = np.asarray(pos, dtype=float)
+    return t
+
+
+def actor_world_poses(c2w: np.ndarray, laterals: Sequence[float], *,
+                      distance: float, drop: float) -> list[np.ndarray]:
+    """Actor world positions in front of a camera, swept across its local x.
+
+    ``c2w`` is an OpenCV camera-to-world pose; the actor sits ``distance`` m
+    ahead (+z), ``drop`` m below (+y down), and at each lateral offset (+x
+    right). Returns one world position per lateral -- the actor crossing the
+    field of view as it moves.
+    """
+    c2w = np.asarray(c2w, dtype=float)
+    rot, eye = c2w[:3, :3], c2w[:3, 3]
+    out = []
+    for lat in laterals:
+        local = np.array([float(lat), float(drop), float(distance)])
+        out.append(eye + rot @ local)
+    return out
+
+
+def project_points(points_world: np.ndarray, viewmat: np.ndarray,
+                   K: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Project world points to pixels; returns ``(uv (N, 2), z (N,))`` in camera z."""
+    pts = np.asarray(points_world, dtype=float)
+    cam = (np.asarray(viewmat, dtype=float)
+           @ np.concatenate([pts, np.ones((len(pts), 1))], axis=1).T).T[:, :3]
+    z = cam[:, 2]
+    safe = np.where(np.abs(z) < 1e-9, 1e-9, z)
+    uv = (np.asarray(K, dtype=float) @ (cam / safe[:, None]).T).T[:, :2]
+    return uv, z
+
+
+def points_to_bbox(uv: np.ndarray, z: np.ndarray, width: int,
+                   height: int) -> Optional[list[int]]:
+    """Axis-aligned ``[x1, y1, x2, y2]`` of the in-front points, clipped to image.
+
+    Returns ``None`` when nothing projects in front of the camera or the extent
+    falls entirely outside the frame.
+    """
+    front = np.asarray(z) > 1e-6
+    if not np.any(front):
+        return None
+    pix = np.asarray(uv)[front]
+    x1, y1 = pix.min(axis=0)
+    x2, y2 = pix.max(axis=0)
+    x1, x2 = max(0, int(np.floor(x1))), min(width, int(np.ceil(x2)))
+    y1, y2 = max(0, int(np.floor(y1))), min(height, int(np.ceil(y2)))
+    if x2 <= x1 or y2 <= y1:
+        return None
+    return [x1, y1, x2, y2]
+
+
+def composite_depth(scene_rgb: np.ndarray, scene_depth: np.ndarray,
+                    actor_rgb: np.ndarray, actor_depth: np.ndarray,
+                    actor_alpha: np.ndarray, *, alpha_thresh: float = 0.5
+                    ) -> tuple[np.ndarray, np.ndarray]:
+    """Z-tested composite of an actor render over a scene render.
+
+    The actor wins a pixel where its coverage exceeds ``alpha_thresh`` and it is
+    nearer than the scene (or the scene has no return, depth 0). Returns the
+    composited uint8 RGB and the boolean actor mask.
+    """
+    sd = np.asarray(scene_depth, dtype=float)
+    ad = np.asarray(actor_depth, dtype=float)
+    nearer = (ad < sd) | (sd <= 0.0)
+    mask = (np.asarray(actor_alpha) >= alpha_thresh) & (ad > 0.0) & nearer
+    out = np.asarray(scene_rgb).copy()
+    out[mask] = np.asarray(actor_rgb)[mask]
+    return out, mask
+
+
+def resize_nearest(img: np.ndarray, out_w: int, out_h: int) -> np.ndarray:
+    """Nearest-neighbour resize of an ``(H, W, C)`` image (pure numpy, testable)."""
+    if out_w <= 0 or out_h <= 0:
+        raise ValueError('output size must be positive')
+    h, w = img.shape[:2]
+    ys = np.minimum((np.arange(out_h) * h / out_h).astype(int), h - 1)
+    xs = np.minimum((np.arange(out_w) * w / out_w).astype(int), w - 1)
+    return img[ys][:, xs]
+
+
+def paste_sprite(scene_rgb: np.ndarray, scene_depth: np.ndarray,
+                 sprite_rgba: np.ndarray, center_uv: Sequence[float],
+                 height_px: int, actor_depth: float, *, alpha_thresh: int = 128
+                 ) -> tuple[np.ndarray, Optional[list[int]]]:
+    """Billboard an RGBA sprite into the scene at ``center_uv``, scaled and z-tested.
+
+    The sprite is resized to ``height_px`` tall (aspect preserved), centred at
+    ``center_uv``, and blended where its alpha exceeds ``alpha_thresh`` and the
+    scene is farther than ``actor_depth`` (or empty). Returns the composited
+    uint8 RGB and the actor's clipped ``[x1, y1, x2, y2]`` (or ``None`` if the
+    sprite lands fully off-frame).
+    """
+    sh, sw = sprite_rgba.shape[:2]
+    out_h = max(1, int(height_px))
+    out_w = max(1, int(round(sw * out_h / sh)))
+    spr = resize_nearest(sprite_rgba, out_w, out_h)
+    H, W = scene_rgb.shape[:2]
+    cx, cy = float(center_uv[0]), float(center_uv[1])
+    x0, y0 = int(round(cx - out_w / 2.0)), int(round(cy - out_h / 2.0))
+    sx0, sy0 = max(0, -x0), max(0, -y0)
+    dx0, dy0 = max(0, x0), max(0, y0)
+    dx1, dy1 = min(W, x0 + out_w), min(H, y0 + out_h)
+    out = np.asarray(scene_rgb).copy()
+    if dx1 <= dx0 or dy1 <= dy0:
+        return out, None
+    region = spr[sy0:sy0 + (dy1 - dy0), sx0:sx0 + (dx1 - dx0)]
+    sd = np.asarray(scene_depth, dtype=float)[dy0:dy1, dx0:dx1]
+    cover = (region[..., 3] >= alpha_thresh) & ((sd > actor_depth) | (sd <= 0.0))
+    dst = out[dy0:dy1, dx0:dx1]
+    dst[cover] = region[..., :3][cover]
+    out[dy0:dy1, dx0:dx1] = dst
+    if not np.any(cover):
+        return out, None
+    ys, xs = np.where(cover)
+    return out, [dx0 + int(xs.min()), dy0 + int(ys.min()),
+                 dx0 + int(xs.max()) + 1, dy0 + int(ys.max()) + 1]
+
+
+def linspace_sym(half_range: float, count: int) -> list[float]:
+    """``count`` evenly spaced values across ``[-half_range, +half_range]``."""
+    if count < 1:
+        raise ValueError('count must be positive')
+    if count == 1:
+        return [0.0]
+    return [float(v) for v in np.linspace(-half_range, half_range, count)]
+
+
+# --------------------------------------------------------------------------- #
+# Rasterisation (torch + gsplat; imported lazily)
+# --------------------------------------------------------------------------- #
+def rasterize_rgbda(gaussians: dict, viewmat: np.ndarray, K: np.ndarray,
+                    width: int, height: int, *, device: str = 'cuda'
+                    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Rasterise one view returning ``(rgb uint8, depth float32, alpha float32)``."""
+    import torch
+    import torch.nn.functional as F
+
+    from gsplat import rasterization
+    from render_path import infer_sh_degree
+    from train_gsplat import SH_C0
+
+    dev = torch.device(device)
+    means = torch.tensor(gaussians['means'], dtype=torch.float32, device=dev)
+    quats = F.normalize(
+        torch.tensor(gaussians['quats'], dtype=torch.float32, device=dev), dim=-1)
+    scales = torch.exp(
+        torch.tensor(gaussians['scales_log'], dtype=torch.float32, device=dev))
+    opac = torch.sigmoid(
+        torch.tensor(gaussians['opacities_logit'], dtype=torch.float32, device=dev))
+    sh_degree = infer_sh_degree(gaussians['sh_rest'])
+    if sh_degree is None:
+        colors = torch.tensor(np.clip(gaussians['colors_rgb'], 0.0, 1.0),
+                              dtype=torch.float32, device=dev)
+    else:
+        sh0 = (gaussians['colors_rgb'] - 0.5) / SH_C0
+        sh = np.concatenate([sh0[:, None, :], gaussians['sh_rest']], axis=1)
+        colors = torch.tensor(sh, dtype=torch.float32, device=dev)
+    kmat = torch.tensor(K, dtype=torch.float32, device=dev)[None]
+    vmt = torch.tensor(np.asarray(viewmat, dtype=np.float32), device=dev)[None]
+    with torch.no_grad():
+        out, alpha, _ = rasterization(means, quats, scales, opac, colors, vmt,
+                                      kmat, width, height, sh_degree=sh_degree,
+                                      packed=False, render_mode='RGB+ED')
+        rgb = (out[0, ..., :3].clamp(0.0, 1.0) * 255.0).to(torch.uint8).cpu().numpy()
+        depth = out[0, ..., 3].cpu().numpy()
+        acc = alpha[0, ..., 0].cpu().numpy()
+    return rgb, depth, acc
+
+
+# --------------------------------------------------------------------------- #
+# Driver
+# --------------------------------------------------------------------------- #
+def load_sprite(path: Path) -> np.ndarray:
+    """Load an RGBA sprite (adds a fully opaque alpha channel if missing)."""
+    import imageio.v2 as imageio
+
+    img = np.asarray(imageio.imread(path))
+    if img.ndim == 2:
+        img = np.repeat(img[..., None], 3, axis=2)
+    if img.shape[2] == 3:
+        a = np.full(img.shape[:2] + (1,), 255, dtype=img.dtype)
+        img = np.concatenate([img, a], axis=2)
+    return np.ascontiguousarray(img[..., :4], dtype=np.uint8)
+
+
+def run(ply: Path, transforms: Path, out_dir: Path, *, view: int, frames: int,
+        mode: str, box_size: Sequence[float], sprite: Optional[Path],
+        distance: float, lateral: float, drop: float, sprite_height_m: float,
+        scale: float, detector, out_fps: int, device: str = 'cuda') -> dict:
+    """Render the actor crossing one scene view and write video + per-frame labels."""
+    import imageio.v2 as imageio
+
+    from sim2real_gap import box_iou
+
+    dataset = load_transforms(transforms)
+    scene = load_gaussian_ply(ply)
+    K, width, height = scale_intrinsics(dataset['K'], dataset['width'],
+                                        dataset['height'], scale)
+    vm = dataset['viewmats'][view]
+    c2w = np.linalg.inv(vm)
+    laterals = linspace_sym(lateral, frames)
+    poses = actor_world_poses(c2w, laterals, distance=distance, drop=drop)
+
+    scene_rgb, scene_depth, _ = rasterize_rgbda(scene, vm, K, width, height,
+                                                device=device)
+    box = make_box_actor(box_size) if mode == 'box' else None
+    spr = load_sprite(sprite) if mode == 'sprite' else None
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    composited, labels, per_frame = [], [], []
+    for i, pos in enumerate(poses):
+        if mode == 'box':
+            placed = transform_gaussians(box, rigid_from_pos_yaw(pos, 0.0))
+            arb, adp, aac = rasterize_rgbda(placed, vm, K, width, height,
+                                            device=device)
+            frame, mask = composite_depth(scene_rgb, scene_depth, arb, adp, aac)
+            uv, z = project_points(placed['means'], vm, K)
+            gt = points_to_bbox(uv, z, width, height)
+        else:
+            uv, z = project_points(pos[None], vm, K)
+            depth_c = float(z[0])
+            height_px = int(round(K[1, 1] * sprite_height_m / max(depth_c, 1e-3)))
+            frame, gt = paste_sprite(scene_rgb, scene_depth, spr, uv[0],
+                                     height_px, depth_c)
+        composited.append(frame)
+        labels.append(gt)
+        rec = {'frame': i, 'gt_bbox': gt}
+        if detector is not None and gt is not None:
+            dets = detector(frame)
+            best = max((box_iou(gt, d['box']) for d in dets), default=0.0)
+            hit = best >= 0.5
+            rec.update({'n_dets': len(dets), 'best_iou': round(float(best), 3),
+                        'hit': bool(hit)})
+        per_frame.append(rec)
+
+    mp4 = out_dir / 'actor.mp4'
+    with imageio.get_writer(mp4, fps=out_fps, codec='libx264', quality=8,
+                            macro_block_size=2) as wr:
+        for f in composited:
+            wr.append_data(f)
+
+    report = {'ply': str(ply), 'mode': mode, 'view': view, 'frames': frames,
+              'render_size': [width, height], 'per_frame': per_frame}
+    if detector is not None:
+        scored = [r for r in per_frame if 'hit' in r]
+        report['detection_recall'] = (sum(r['hit'] for r in scored) / len(scored)
+                                      if scored else 0.0)
+        report['mean_best_iou'] = (float(np.mean([r['best_iou'] for r in scored]))
+                                   if scored else 0.0)
+    (out_dir / 'actor_labels.json').write_text(json.dumps(report, indent=2))
+    report['mp4'] = str(mp4)
+    return report
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the CLI argument parser."""
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument('--ply', required=True, help='trained INRIA 3DGS scene .ply')
+    p.add_argument('--transforms', required=True,
+                   help='transforms.json the scene was trained from')
+    p.add_argument('--out', required=True, help='output directory')
+    p.add_argument('--view', type=int, default=0,
+                   help='scene camera index to stage the actor in front of')
+    p.add_argument('--frames', type=int, default=48,
+                   help='frames as the actor crosses the view')
+    p.add_argument('--mode', default='box', choices=('box', 'sprite'))
+    p.add_argument('--box-size', default='0.6,0.6,1.7',
+                   help='box actor w,d,h in metres (default a standing person)')
+    p.add_argument('--sprite', default='',
+                   help='RGBA cutout for --mode sprite (real object)')
+    p.add_argument('--distance', type=float, default=4.0,
+                   help='actor distance ahead of the camera (m)')
+    p.add_argument('--lateral', type=float, default=2.0,
+                   help='half-width of the lateral sweep across the view (m)')
+    p.add_argument('--drop', type=float, default=0.8,
+                   help='actor drop below the camera (m, +y down)')
+    p.add_argument('--sprite-height-m', type=float, default=1.7,
+                   help='real-world height the sprite represents (m)')
+    p.add_argument('--scale', type=float, default=0.5,
+                   help='render-resolution scale vs the training images')
+    p.add_argument('--detector', default='',
+                   help="ultralytics weights to score detection (e.g. 'yolov8n.pt')")
+    p.add_argument('--det-conf', type=float, default=0.25)
+    p.add_argument('--fps', type=int, default=12)
+    p.add_argument('--device', default='cuda')
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args(argv)
+    if args.mode == 'sprite' and not args.sprite:
+        raise SystemExit('--mode sprite requires --sprite')
+    detector = None
+    if args.detector:
+        from sim2real_gap import Detector
+
+        detector = Detector(args.detector, conf=args.det_conf)
+    box_size = [float(v) for v in args.box_size.split(',')]
+    report = run(Path(args.ply), Path(args.transforms), Path(args.out),
+                 view=args.view, frames=args.frames, mode=args.mode,
+                 box_size=box_size,
+                 sprite=Path(args.sprite) if args.sprite else None,
+                 distance=args.distance, lateral=args.lateral, drop=args.drop,
+                 sprite_height_m=args.sprite_height_m, scale=args.scale,
+                 detector=detector, out_fps=args.fps, device=args.device)
+    print(f"wrote {report['mp4']} ({report['frames']} frames, mode {report['mode']})")
+    labelled = sum(1 for r in report['per_frame'] if r['gt_bbox'] is not None)
+    print(f"  {labelled}/{report['frames']} frames have a visible actor label")
+    if 'detection_recall' in report:
+        print(f"  detection recall {report['detection_recall']:.2f}, "
+              f"mean best IoU {report['mean_best_iou']:.2f}")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Phase 3 of the 3DGS-as-sim2real track (actor-insertion half; RL out of scope). Inserts a **moving actor** into a trained 3DGS scene so the **detection sim2real gap** can finally be measured — Phase 0 found no COCO-class objects in any scene on hand, so a real-image detector never fired on the bare renders.

The actor is staged in front of a scene camera, swept across the view, and merged by a **per-pixel depth test** (drawn only where nearer than the scene → geometrically correct occlusion). A per-frame **ground-truth 2D box** is exported.

- **box** actor — synthetic Gaussian solid (occlusion demo, no asset, deterministic).
- **sprite** actor — real-photo RGBA cutout billboarded in, depth-scaled and scene-occluded, so a COCO detector *can* fire → drives the gap measurement.

## Changes
- `tools/gaussian_splatting/actor_compositing.py` (pure helpers numpy-only).
- 19 CPU tests (box construction, gaussian transform incl. wxyz quat rotation, projection, depth-tested composite, sprite paste/occlusion, nearest resize), ament_flake8 clean; registered in CMakeLists.
- runner `scripts/run_actor_compositing.sh`, doc `docs/research/3dgs-actor-compositing-phase3.md`.

## Validation (clean construction scene, recon 28.9 dB, yolov8n)
- **box**: 36/36 frames labelled; actor correctly occluded by foreground equipment.
- **sprite** (pedestrian cut from ultralytics bus.jpg, bare-crop detected at conf 0.87):

  | render scale | resolution | detection recall | mean best IoU |
  |---|---|---|---|
  | 1.0 | 600x440 | 0.28 | 0.28 |
  | 0.5 | 300x220 | 0.06 | 0.21 |

  The gap is driven by **render resolution and occlusion, not object appearance** — recall tracks occlusion (open floor detected, behind the foreground machine missed). First quantified perception gap for 3DGS-as-sim2real.

## Reproduce
```
PLY=output/rtkslam_3dgs_clean/gsplat/point_cloud_good.ply \
TRANSFORMS=output/rtkslam_3dgs_clean/gsplat/transforms_good.json \
OUT_DIR=output/phase3_actor MODE=sprite SPRITE=output/assets/person_sprite.png \
DETECTOR=yolov8n.pt bash scripts/run_actor_compositing.sh
```

(Supersedes #295, which auto-closed when its stacked base branch was deleted after #294 merged.)