### PR TITLE
feat(3dgs): tight segmentation-alpha actor sprites (Phase 3 follow-up)

### DIFF
--- a/docs/research/3dgs-actor-compositing-phase3.md
+++ b/docs/research/3dgs-actor-compositing-phase3.md
@@ -56,13 +56,33 @@ bus.jpg の縦長歩行者（504x197、素のクロップは person conf 0.87 �
 明瞭に連動する。これが「3DGS をデータ生成・closed-loop に使うときの知覚 gap」の
 最初の定量値。
 
+## 追記: セグメント alpha sprite で gap を tight に再測 (2026-06-16)
+
+初回の矩形クロップ sprite は背景マージンを抱え（alpha coverage ~1.0）、
+合成にハローが出て GT box も緩く、検出が成立しても IoU が伸びなかった。
+インスタンスセグメンテーション（`tools/gaussian_splatting/make_actor_sprite.py`、
+ultralytics `*-seg` + `retina_masks`、pure 部 8 ケースを
+`test_gaussian_splatting_sprite.py` で CPU テスト）で**人物シルエットの alpha matte**
+に置き換えると、合成は背景ハローなし・GT box は tight になり、検出 gap が改善した:
+
+| sprite | render scale | recall | mean best IoU |
+|---|---|---|---|
+| 矩形クロップ | 1.0 (600x440) | 0.28 | 0.28 |
+| **セグメント alpha** | 1.0 | **0.50** | **0.38** |
+| 矩形クロップ | 0.5 (300x220) | 0.06 | 0.21 |
+| **セグメント alpha** | 0.5 | **0.33** | **0.31** |
+
+bus.jpg の歩行者 sprite は 194x507・alpha coverage 0.52（= 矩形の約半分が背景だった）。
+背景除去でフル解像度 recall がほぼ倍増（0.28→0.50）。`paste_sprite` は元から
+per-pixel alpha を尊重するので合成側の変更は不要、sprite 生成だけで gap が締まる。
+**それでも recall 0.50 止まり**なのは依然オクルージョン（前景機材の背後で失敗）と
+低解像度が主因で、Phase 3 本体の所見は変わらない。
+
 ## 限界 / 次アクション
 
-- **sprite は矩形カットアウト**（セグメンテーション alpha でない）ので GT box に
-  背景マージンが入り、検出が成立しても IoU が伸びにくい（mean ~0.28）。tight な
-  検出 gap には人物セグメント alpha か、actor 自体の 3DGS モデルが要る。
-- **真に photoreal な actor** は実物体の 3DGS モデル（車・人の learned Gaussian）を
-  挿入するのが本命。billboard は単一 depth なので斜めビューで平面感が出る。
+- **真に photoreal な actor**（斜めビューでも平面感が出ない）には actor 自体の
+  3DGS モデルが要る。billboard sprite は単一 depth なので視点が振れると平面に見える。
+  これは学習アセット待ちのデータ依存で、コードでなく素材の問題。
 - 検出 gap の改善余地: 解像度を上げる / closed-loop では sensor_sim_node
   （Phase 2）の出力解像度を上げる。低解像度ほど gap が急拡大するのは
   運用上の重要知見。

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -488,6 +488,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_gaussian_splatting_sprite
+    test/test_gaussian_splatting_sprite.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_mid360_robot_preflight
     test/test_mid360_robot_preflight.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_gaussian_splatting_sprite.py
+++ b/graph_based_slam/test/test_gaussian_splatting_sprite.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the actor-sprite extraction pure helpers (CPU, no detector)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+
+
+def _load():
+    if str(TOOL_DIR) not in sys.path:
+        sys.path.insert(0, str(TOOL_DIR))
+    import make_actor_sprite
+
+    return make_actor_sprite
+
+
+ms = _load()
+
+
+def test_compose_rgba_alpha_follows_mask():
+    rgb = np.full((4, 4, 3), 100, dtype=np.uint8)
+    mask = np.zeros((4, 4))
+    mask[1:3, 1:3] = 1.0
+    rgba = ms.compose_rgba(rgb, mask)
+    assert rgba.shape == (4, 4, 4) and rgba.dtype == np.uint8
+    assert rgba[1, 1, 3] == 255 and rgba[0, 0, 3] == 0
+    assert np.all(rgba[..., :3] == 100)  # colour untouched
+
+
+def test_compose_rgba_soft_mask_threshold():
+    rgb = np.zeros((1, 3, 3), dtype=np.uint8)
+    mask = np.array([[0.2, 0.5, 0.9]])
+    rgba = ms.compose_rgba(rgb, mask, mask_thresh=0.5)
+    assert list(rgba[0, :, 3]) == [0, 255, 255]
+
+
+def test_compose_rgba_rejects_shape_mismatch():
+    with pytest.raises(ValueError):
+        ms.compose_rgba(np.zeros((4, 4, 3)), np.zeros((3, 3)))
+
+
+def test_tight_crop_removes_transparent_margin():
+    rgba = np.zeros((10, 10, 4), dtype=np.uint8)
+    rgba[3:6, 4:8, 3] = 255  # opaque region 3 tall x 4 wide
+    cropped = ms.tight_crop_rgba(rgba)
+    assert cropped.shape == (3, 4, 4)
+
+
+def test_tight_crop_raises_when_empty():
+    with pytest.raises(ValueError):
+        ms.tight_crop_rgba(np.zeros((5, 5, 4), dtype=np.uint8))
+
+
+def test_alpha_coverage_counts_opaque_fraction():
+    rgba = np.zeros((10, 10, 4), dtype=np.uint8)
+    rgba[:5, :, 3] = 255  # half opaque
+    assert ms.alpha_coverage(rgba) == pytest.approx(0.5)
+
+
+def test_pick_portrait_instance_prefers_tallest_portrait():
+    boxes = [
+        [0, 0, 100, 50],     # person, landscape (wide) -> rejected
+        [0, 0, 30, 60],      # person, portrait, height 60
+        [0, 0, 40, 90],      # person, portrait, height 90 -> winner
+        [0, 0, 20, 200],     # wrong class
+    ]
+    classes = [0, 0, 0, 2]
+    assert ms.pick_portrait_instance(boxes, classes, 0) == 2
+
+
+def test_pick_portrait_instance_none_when_no_match():
+    boxes = [[0, 0, 100, 40]]  # only a landscape person
+    assert ms.pick_portrait_instance(boxes, [0], 0) is None
+    # wrong class only
+    assert ms.pick_portrait_instance([[0, 0, 10, 50]], [5], 0) is None

--- a/scripts/run_actor_compositing.sh
+++ b/scripts/run_actor_compositing.sh
@@ -11,26 +11,11 @@
 #              reliably a real object is detected once embedded in a 3DGS render).
 #
 # A sprite can be made from any image with a detector, e.g. the tallest portrait
-# person in ultralytics' bundled bus.jpg:
-#   python3 - <<'PY'
-#   import numpy as np, imageio.v2 as imageio, os
-#   from ultralytics import YOLO
-#   m = YOLO('yolov8n.pt')
-#   src = os.path.expanduser('~/.local/lib/python3.12/site-packages/ultralytics/assets/bus.jpg')
-#   img = np.asarray(imageio.imread(src))[..., :3]
-#   res = m.predict(img[..., ::-1], conf=0.4, verbose=False)[0]
-#   best = None
-#   for b in res.boxes:
-#       if int(b.cls.item()) == 0:
-#           x1, y1, x2, y2 = (int(v) for v in b.xyxy[0].tolist())
-#           if y2 - y1 > x2 - x1 and (best is None or y2 - y1 > best[1]):
-#               best = ((x1, y1, x2, y2), y2 - y1)
-#   (x1, y1, x2, y2), _ = best
-#   crop = img[y1:y2, x1:x2]
-#   rgba = np.dstack([crop, np.full(crop.shape[:2], 255, np.uint8)])
-#   os.makedirs('output/assets', exist_ok=True)
-#   imageio.imwrite('output/assets/person_sprite.png', rgba)
-#   PY
+# person in ultralytics' bundled bus.jpg. Cut a tight RGBA sprite (segmentation
+# alpha matte, no background halo) with make_actor_sprite.py:
+#   python3 tools/gaussian_splatting/make_actor_sprite.py \
+#     --image "$(python3 -c 'import ultralytics,os;print(os.path.dirname(ultralytics.__file__)+"/assets/bus.jpg")')" \
+#     --out output/assets/person_seg.png --class-id 0
 #
 # Requires: a CUDA GPU with torch + gsplat; ultralytics if DETECTOR is set.
 #

--- a/tools/gaussian_splatting/make_actor_sprite.py
+++ b/tools/gaussian_splatting/make_actor_sprite.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Cut a tight RGBA actor sprite from a real photo via instance segmentation.
+
+Phase 3 of the 3DGS-as-sim2real track used a *rectangular* crop as the sprite,
+so the composited actor carried a halo of source background and the exported
+ground-truth box was loose (detector IoU capped ~0.28). This tool replaces that
+crop with a **segmentation alpha matte**: it runs an instance-segmentation model
+(ultralytics ``*-seg``), takes the largest portrait instance of the requested
+class, and writes an RGBA PNG whose alpha is the object silhouette, tightly
+cropped to it. Fed to ``actor_compositing.py --mode sprite`` it composites with
+no background halo and yields a tight per-frame label, so the detection-gap
+numbers measure the object, not the crop.
+
+The pure helpers (RGBA assembly from a soft mask, tight crop to the alpha
+bounding box, portrait-instance selection) are numpy-only and unit tested on
+CPU; extracting from a photo needs ultralytics + a segmentation model.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional, Sequence
+
+import numpy as np
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no torch/detector)
+# --------------------------------------------------------------------------- #
+def compose_rgba(rgb: np.ndarray, mask: np.ndarray, *,
+                 mask_thresh: float = 0.5) -> np.ndarray:
+    """Stack an ``(H, W, 3)`` image and an ``(H, W)`` soft mask into RGBA uint8.
+
+    Alpha is 255 where the mask meets ``mask_thresh`` and 0 elsewhere, so the
+    sprite carries the object silhouette rather than a rectangle.
+    """
+    rgb = np.asarray(rgb)
+    mask = np.asarray(mask, dtype=float)
+    if mask.shape != rgb.shape[:2]:
+        raise ValueError('mask shape must match the image height/width')
+    alpha = np.where(mask >= mask_thresh, 255, 0).astype(np.uint8)
+    return np.dstack([rgb.astype(np.uint8), alpha])
+
+
+def tight_crop_rgba(rgba: np.ndarray, *, alpha_thresh: int = 1) -> np.ndarray:
+    """Crop an RGBA image to the bounding box of pixels with alpha >= threshold."""
+    a = np.asarray(rgba)
+    ys, xs = np.where(a[..., 3] >= alpha_thresh)
+    if ys.size == 0:
+        raise ValueError('sprite has no opaque pixels')
+    return np.ascontiguousarray(a[ys.min():ys.max() + 1, xs.min():xs.max() + 1])
+
+
+def alpha_coverage(rgba: np.ndarray, *, alpha_thresh: int = 1) -> float:
+    """Fraction of the RGBA tile that is opaque -- a halo/tightness proxy."""
+    a = np.asarray(rgba)[..., 3]
+    return float(np.mean(a >= alpha_thresh))
+
+
+def pick_portrait_instance(boxes: Sequence[Sequence[float]],
+                           classes: Sequence[int], target_cls: int
+                           ) -> Optional[int]:
+    """Index of the tallest taller-than-wide instance of ``target_cls`` (or None).
+
+    Restricting to portrait (height > width) boxes rejects the wide,
+    multi-subject detections that do not look like a single standing object --
+    the trap that produced a non-detectable sprite in the first Phase 3 pass.
+    """
+    best, best_h = None, -1.0
+    for i, (box, cls) in enumerate(zip(boxes, classes)):
+        if int(cls) != target_cls:
+            continue
+        w = float(box[2]) - float(box[0])
+        h = float(box[3]) - float(box[1])
+        if h > w and h > best_h:
+            best, best_h = i, h
+    return best
+
+
+# --------------------------------------------------------------------------- #
+# Extraction (ultralytics; imported lazily)
+# --------------------------------------------------------------------------- #
+def extract_sprite(image: Path, out: Path, *, weights: str, target_cls: int,
+                   conf: float, mask_thresh: float) -> dict:
+    """Segment the largest portrait instance of a class and write a tight RGBA PNG."""
+    import imageio.v2 as imageio
+    from ultralytics import YOLO
+
+    img = np.asarray(imageio.imread(image))[..., :3]
+    res = YOLO(weights).predict(img[..., ::-1], conf=conf, verbose=False,
+                                retina_masks=True)[0]
+    if res.masks is None:
+        raise SystemExit('segmentation model returned no masks')
+    boxes = [b.xyxy[0].tolist() for b in res.boxes]
+    classes = [int(b.cls.item()) for b in res.boxes]
+    idx = pick_portrait_instance(boxes, classes, target_cls)
+    if idx is None:
+        raise SystemExit(f'no portrait instance of class {target_cls} found')
+    mask = res.masks.data[idx].cpu().numpy()
+    rgba = tight_crop_rgba(compose_rgba(img, mask, mask_thresh=mask_thresh))
+    out.parent.mkdir(parents=True, exist_ok=True)
+    imageio.imwrite(out, rgba)
+    return {'out': str(out), 'size_hw': [int(rgba.shape[0]), int(rgba.shape[1])],
+            'alpha_coverage': round(alpha_coverage(rgba), 3),
+            'class': target_cls, 'conf': round(float(res.boxes[idx].conf.item()), 3)}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the CLI argument parser."""
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument('--image', required=True, help='source photo')
+    p.add_argument('--out', required=True, help='output RGBA .png sprite')
+    p.add_argument('--weights', default='yolov8n-seg.pt',
+                   help='ultralytics segmentation weights')
+    p.add_argument('--class-id', type=int, default=0,
+                   help='COCO class to extract (0 = person)')
+    p.add_argument('--conf', type=float, default=0.4,
+                   help='detection confidence threshold')
+    p.add_argument('--mask-thresh', type=float, default=0.5,
+                   help='soft-mask cutoff for the alpha matte')
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args(argv)
+    info = extract_sprite(Path(args.image), Path(args.out), weights=args.weights,
+                          target_cls=args.class_id, conf=args.conf,
+                          mask_thresh=args.mask_thresh)
+    print(f"wrote {info['out']} {info['size_hw'][1]}x{info['size_hw'][0]} "
+          f"(class {info['class']} conf {info['conf']}, "
+          f"alpha coverage {info['alpha_coverage']})")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Closes the documented Phase 3 (#296) limitation: the sprite actor was a **rectangular crop**, so the composited actor carried a background halo and the exported ground-truth box was loose (detector IoU capped ~0.28). This replaces it with an **instance-segmentation alpha matte** — the sprite is now the object silhouette.

- `tools/gaussian_splatting/make_actor_sprite.py` — runs an ultralytics `*-seg` model (`retina_masks`, original resolution), picks the largest **portrait** instance of a class, writes a tight RGBA PNG cropped to the alpha. Pure helpers numpy-only.
- 8 CPU tests, ament_flake8 clean; registered in CMakeLists; runner header points at the new tool.

`actor_compositing.paste_sprite` already honours per-pixel alpha, so **no compositing change is needed** — a tighter sprite tightens both the render and the GT box.

## Re-measurement (clean construction scene, pedestrian from bus.jpg, sprite 194x507, alpha coverage 0.52)

| sprite | render scale | recall | mean best IoU |
|---|---|---|---|
| rectangular crop | 1.0 (600x440) | 0.28 | 0.28 |
| **segmentation alpha** | 1.0 | **0.50** | **0.38** |
| rectangular crop | 0.5 (300x220) | 0.06 | 0.21 |
| **segmentation alpha** | 0.5 | **0.33** | **0.31** |

Background removal nearly doubles full-res recall. Recall still caps at 0.50 because **occlusion and low resolution dominate** — the Phase 3 finding stands.

## Reproduce
```
python3 tools/gaussian_splatting/make_actor_sprite.py \
  --image $(python3 -c 'import ultralytics,os;print(os.path.dirname(ultralytics.__file__)+"/assets/bus.jpg")') \
  --out output/assets/person_seg.png --class-id 0
PLY=output/rtkslam_3dgs_clean/gsplat/point_cloud_good.ply \
TRANSFORMS=output/rtkslam_3dgs_clean/gsplat/transforms_good.json \
OUT_DIR=output/phase3_seg MODE=sprite SPRITE=output/assets/person_seg.png \
DETECTOR=yolov8n.pt bash scripts/run_actor_compositing.sh
```