### PR TITLE
feat(3dgs): volumetric photoreal actor (ply mode) (Phase 3 follow-up)

### DIFF
--- a/docs/research/3dgs-actor-compositing-phase3.md
+++ b/docs/research/3dgs-actor-compositing-phase3.md
@@ -78,11 +78,30 @@ per-pixel alpha を尊重するので合成側の変更は不要、sprite 生成
 **それでも recall 0.50 止まり**なのは依然オクルージョン（前景機材の背後で失敗）と
 低解像度が主因で、Phase 3 本体の所見は変わらない。
 
+## 追記: volumetric photoreal actor (ply モード) (2026-06-16)
+
+billboard sprite は単一 depth なので視点が振れると平面に見える。これを解消する
+**volumetric actor**（任意の学習済み 3DGS .ply を actor として読み込む `--mode ply`）を
+追加した。box actor と同じ depth-test ラスタライズ経路に乗り、毎フレーム
+`transform_gaussians` で world pose に置いて `rasterize_rgbda` → `composite_depth`。
+真の Gaussian 幾何なので**正しい視差**を持ち、**per-pixel で前景に部分遮蔽される**
+（単一平面の billboard では原理的に不可能）。
+
+photoreal なデモ素材は外部 COCO アセット（データ依存）に頼らず、
+**シーン自身の Gaussian を AABB で切り出して可動オブジェクト化**する
+（`tools/gaussian_splatting/crop_actor_ply.py`、pure 部 `crop_gaussians`/
+`recenter_gaussians` を CPU テスト）。検証（construction, view40）: シーンから
+10265 Gaussian（1.4x1.4x3.4m）を切り出し → actor として横断 → 実写の塊が床に立ち
+前景機材に部分遮蔽されて合成される（600x440, 36/36 frame ラベル）。
+
+残る素材課題は「**車・人クラスの learned 3DGS モデル**」の調達（コードでなくアセット）。
+machinery（ply 読み込み・配置・parallax・occlusion・GT label）は完成しているので、
+そうした actor モデルを `--actor-ply` に渡せばそのまま COCO 検出 gap も締まる。
+
 ## 限界 / 次アクション
 
-- **真に photoreal な actor**（斜めビューでも平面感が出ない）には actor 自体の
-  3DGS モデルが要る。billboard sprite は単一 depth なので視点が振れると平面に見える。
-  これは学習アセット待ちのデータ依存で、コードでなく素材の問題。
+- **COCO クラスの learned 3DGS actor モデル**（車・歩行者）の調達がデータ依存で残る。
+  公開 object-3DGS データセット or 小規模学習が経路。machinery は ply モードで完成済み。
 - 検出 gap の改善余地: 解像度を上げる / closed-loop では sensor_sim_node
   （Phase 2）の出力解像度を上げる。低解像度ほど gap が急拡大するのは
   運用上の重要知見。

--- a/graph_based_slam/test/test_gaussian_splatting_actor.py
+++ b/graph_based_slam/test/test_gaussian_splatting_actor.py
@@ -196,3 +196,51 @@ def test_linspace_sym_rejects_nonpositive_count():
 def test_logit_sigmoid_roundtrip():
     for p in (0.1, 0.5, 0.99):
         assert 1.0 / (1.0 + np.exp(-ac.logit(p))) == pytest.approx(p, abs=1e-6)
+
+
+def _toy_scene(n=40):
+    rng = np.random.default_rng(0)
+    means = rng.uniform(-5.0, 5.0, (n, 3))
+    return {
+        'means': means,
+        'scales_log': np.full((n, 3), -2.0),
+        'quats': np.tile([1.0, 0.0, 0.0, 0.0], (n, 1)),
+        'opacities_logit': np.zeros(n),
+        'colors_rgb': rng.uniform(0.0, 1.0, (n, 3)),
+        'sh_rest': None,
+    }
+
+
+def test_crop_gaussians_keeps_only_in_box():
+    g = _toy_scene()
+    g['means'][0] = [0.0, 0.0, 0.5]   # inside
+    g['means'][1] = [9.0, 9.0, 0.5]   # outside in x/y
+    out = ac.crop_gaussians(g, [0.0, 0.0], 1.0, [0.0, 2.0])
+    m = out['means']
+    assert np.all(np.abs(m[:, 0]) <= 1.0) and np.all(np.abs(m[:, 1]) <= 1.0)
+    assert np.all((m[:, 2] >= 0.0) & (m[:, 2] <= 2.0))
+    # every per-gaussian array is subset to the same length
+    assert out['colors_rgb'].shape[0] == m.shape[0] == out['quats'].shape[0]
+
+
+def test_crop_gaussians_subsets_sh_rest_when_present():
+    g = _toy_scene(6)
+    g['means'][:] = 0.0  # all inside
+    g['sh_rest'] = np.arange(6 * 3 * 3, dtype=float).reshape(6, 3, 3)
+    out = ac.crop_gaussians(g, [0.0, 0.0], 1.0, [-1.0, 1.0])
+    assert out['sh_rest'].shape == (6, 3, 3)
+
+
+def test_crop_gaussians_raises_on_empty_box():
+    with pytest.raises(ValueError):
+        ac.crop_gaussians(_toy_scene(), [100.0, 100.0], 0.1, [0.0, 1.0])
+
+
+def test_recenter_gaussians_zeroes_xy_centroid_and_grounds_z():
+    g = _toy_scene(2)
+    g['means'] = np.array([[1.0, 2.0, 3.0], [3.0, 4.0, 5.0]], dtype=float)
+    g['quats'] = np.tile([1.0, 0.0, 0.0, 0.0], (2, 1))
+    out = ac.recenter_gaussians(g)
+    assert np.allclose(out['means'][:, :2].mean(axis=0), [0.0, 0.0])
+    assert out['means'][:, 2].min() == pytest.approx(0.0)
+    assert np.allclose(out['quats'], g['quats'])  # pure translation

--- a/scripts/run_actor_compositing.sh
+++ b/scripts/run_actor_compositing.sh
@@ -35,9 +35,11 @@ TRANSFORMS="${TRANSFORMS:?set TRANSFORMS to the transforms.json the scene traine
 OUT_DIR="${OUT_DIR:-output/phase3_actor}"
 VIEW="${VIEW:-40}"
 FRAMES="${FRAMES:-36}"
-MODE="${MODE:-box}"
+MODE="${MODE:-box}"            # box | sprite | ply
 BOX_SIZE="${BOX_SIZE:-0.6,0.6,1.7}"
 SPRITE="${SPRITE:-}"
+ACTOR_PLY="${ACTOR_PLY:-}"     # trained 3DGS .ply for MODE=ply (volumetric actor)
+YAW="${YAW:-0.0}"
 DISTANCE="${DISTANCE:-3.5}"
 LATERAL="${LATERAL:-1.5}"
 DROP="${DROP:-0.7}"
@@ -48,10 +50,11 @@ FPS="${FPS:-12}"
 
 ARGS=(--ply "${PLY}" --transforms "${TRANSFORMS}" --out "${OUT_DIR}"
       --view "${VIEW}" --frames "${FRAMES}" --mode "${MODE}"
-      --box-size "${BOX_SIZE}" --distance "${DISTANCE}" --lateral "${LATERAL}"
-      --drop "${DROP}" --sprite-height-m "${SPRITE_HEIGHT_M}" --scale "${SCALE}"
-      --fps "${FPS}")
+      --box-size "${BOX_SIZE}" --yaw "${YAW}" --distance "${DISTANCE}"
+      --lateral "${LATERAL}" --drop "${DROP}"
+      --sprite-height-m "${SPRITE_HEIGHT_M}" --scale "${SCALE}" --fps "${FPS}")
 [[ -n "${SPRITE}" ]] && ARGS+=(--sprite "${SPRITE}")
+[[ -n "${ACTOR_PLY}" ]] && ARGS+=(--actor-ply "${ACTOR_PLY}")
 [[ -n "${DETECTOR}" ]] && ARGS+=(--detector "${DETECTOR}")
 
 python3 tools/gaussian_splatting/actor_compositing.py "${ARGS[@]}"

--- a/tools/gaussian_splatting/actor_compositing.py
+++ b/tools/gaussian_splatting/actor_compositing.py
@@ -80,6 +80,43 @@ def make_box_actor(size_xyz: Sequence[float], *, spacing: float = 0.1,
     }
 
 
+def crop_gaussians(g: dict, center_xy: Sequence[float], half_extent_xy: float,
+                   z_range: Sequence[float]) -> dict:
+    """Subset a gaussians dict to an axis-aligned box around ``center_xy``.
+
+    Keeps Gaussians whose mean lies within ``half_extent_xy`` of ``center_xy`` in
+    x and y and within ``z_range`` (inclusive). Every per-Gaussian array is
+    indexed the same way (including ``sh_rest`` when present), so the result is a
+    valid standalone model -- used to mint a photoreal volumetric actor by
+    cutting a compact object out of a trained scene.
+    """
+    means = np.asarray(g['means'], dtype=float)
+    cx, cy = float(center_xy[0]), float(center_xy[1])
+    zlo, zhi = float(z_range[0]), float(z_range[1])
+    keep = ((np.abs(means[:, 0] - cx) <= half_extent_xy)
+            & (np.abs(means[:, 1] - cy) <= half_extent_xy)
+            & (means[:, 2] >= zlo) & (means[:, 2] <= zhi))
+    if not np.any(keep):
+        raise ValueError('crop box contains no Gaussians')
+    out = {k: (np.asarray(v)[keep] if k != 'sh_rest' else
+               (None if v is None else np.asarray(v)[keep]))
+           for k, v in g.items()}
+    return out
+
+
+def recenter_gaussians(g: dict) -> dict:
+    """Translate a gaussians dict so its x/y centroid is 0 and it rests on z=0.
+
+    A pure translation (orientations untouched), so an arbitrary actor model can
+    be placed with the same ``rigid_from_pos_yaw`` convention as the box actor.
+    """
+    means = np.asarray(g['means'], dtype=float)
+    shift = np.array([means[:, 0].mean(), means[:, 1].mean(), means[:, 2].min()])
+    out = dict(g)
+    out['means'] = means - shift
+    return out
+
+
 def _rotate_quats_wxyz(quats_wxyz: np.ndarray, rot: np.ndarray) -> np.ndarray:
     """Apply a world rotation ``rot`` to a batch of ``wxyz`` Gaussian quaternions."""
     out = np.empty_like(np.asarray(quats_wxyz, dtype=float))
@@ -300,8 +337,9 @@ def load_sprite(path: Path) -> np.ndarray:
 
 def run(ply: Path, transforms: Path, out_dir: Path, *, view: int, frames: int,
         mode: str, box_size: Sequence[float], sprite: Optional[Path],
-        distance: float, lateral: float, drop: float, sprite_height_m: float,
-        scale: float, detector, out_fps: int, device: str = 'cuda') -> dict:
+        actor_ply: Optional[Path], yaw: float, distance: float, lateral: float,
+        drop: float, sprite_height_m: float, scale: float, detector,
+        out_fps: int, device: str = 'cuda') -> dict:
     """Render the actor crossing one scene view and write video + per-frame labels."""
     import imageio.v2 as imageio
 
@@ -318,14 +356,19 @@ def run(ply: Path, transforms: Path, out_dir: Path, *, view: int, frames: int,
 
     scene_rgb, scene_depth, _ = rasterize_rgbda(scene, vm, K, width, height,
                                                 device=device)
-    box = make_box_actor(box_size) if mode == 'box' else None
+    if mode == 'box':
+        actor_g = make_box_actor(box_size)
+    elif mode == 'ply':
+        actor_g = recenter_gaussians(load_gaussian_ply(actor_ply))
+    else:
+        actor_g = None
     spr = load_sprite(sprite) if mode == 'sprite' else None
 
     out_dir.mkdir(parents=True, exist_ok=True)
     composited, labels, per_frame = [], [], []
     for i, pos in enumerate(poses):
-        if mode == 'box':
-            placed = transform_gaussians(box, rigid_from_pos_yaw(pos, 0.0))
+        if actor_g is not None:  # volumetric actor (box or arbitrary 3DGS ply)
+            placed = transform_gaussians(actor_g, rigid_from_pos_yaw(pos, yaw))
             arb, adp, aac = rasterize_rgbda(placed, vm, K, width, height,
                                             device=device)
             frame, mask = composite_depth(scene_rgb, scene_depth, arb, adp, aac)
@@ -378,11 +421,17 @@ def build_parser() -> argparse.ArgumentParser:
                    help='scene camera index to stage the actor in front of')
     p.add_argument('--frames', type=int, default=48,
                    help='frames as the actor crosses the view')
-    p.add_argument('--mode', default='box', choices=('box', 'sprite'))
+    p.add_argument('--mode', default='box', choices=('box', 'sprite', 'ply'))
     p.add_argument('--box-size', default='0.6,0.6,1.7',
                    help='box actor w,d,h in metres (default a standing person)')
     p.add_argument('--sprite', default='',
                    help='RGBA cutout for --mode sprite (real object)')
+    p.add_argument('--actor-ply', default='',
+                   help='trained 3DGS .ply used as a volumetric actor for '
+                        '--mode ply (e.g. an object cut from a scene with '
+                        'crop_actor_ply.py); recentred onto the ground')
+    p.add_argument('--yaw', type=float, default=0.0,
+                   help='actor heading in radians (volumetric actor modes)')
     p.add_argument('--distance', type=float, default=4.0,
                    help='actor distance ahead of the camera (m)')
     p.add_argument('--lateral', type=float, default=2.0,
@@ -406,6 +455,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = build_parser().parse_args(argv)
     if args.mode == 'sprite' and not args.sprite:
         raise SystemExit('--mode sprite requires --sprite')
+    if args.mode == 'ply' and not args.actor_ply:
+        raise SystemExit('--mode ply requires --actor-ply')
     detector = None
     if args.detector:
         from sim2real_gap import Detector
@@ -416,9 +467,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                  view=args.view, frames=args.frames, mode=args.mode,
                  box_size=box_size,
                  sprite=Path(args.sprite) if args.sprite else None,
-                 distance=args.distance, lateral=args.lateral, drop=args.drop,
-                 sprite_height_m=args.sprite_height_m, scale=args.scale,
-                 detector=detector, out_fps=args.fps, device=args.device)
+                 actor_ply=Path(args.actor_ply) if args.actor_ply else None,
+                 yaw=args.yaw, distance=args.distance, lateral=args.lateral,
+                 drop=args.drop, sprite_height_m=args.sprite_height_m,
+                 scale=args.scale, detector=detector, out_fps=args.fps,
+                 device=args.device)
     print(f"wrote {report['mp4']} ({report['frames']} frames, mode {report['mode']})")
     labelled = sum(1 for r in report['per_frame'] if r['gt_bbox'] is not None)
     print(f"  {labelled}/{report['frames']} frames have a visible actor label")

--- a/tools/gaussian_splatting/crop_actor_ply.py
+++ b/tools/gaussian_splatting/crop_actor_ply.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Cut a compact object out of a trained 3DGS scene as a standalone actor .ply.
+
+Phase 3's sprite actor is a flat billboard -- correct from the recorded heading
+but it reveals its flatness as the viewpoint swings. A *volumetric* actor needs
+real Gaussian geometry. The cheapest source on hand is the scene itself: this
+tool selects the Gaussians inside an axis-aligned box and writes them as their
+own INRIA ``.ply``, which ``actor_compositing.py --mode ply`` then places and
+composites with correct parallax and depth-tested occlusion -- a photoreal,
+genuinely 3D actor without any external asset.
+
+The cropping (``crop_gaussians``) and INRIA IO are reused from
+``actor_compositing`` / ``train_gsplat`` and are unit tested there; this is a
+thin CLI wrapper.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional, Sequence
+
+import numpy as np
+
+from actor_compositing import crop_gaussians
+from render_path import load_gaussian_ply
+from train_gsplat import export_ply
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the CLI argument parser."""
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument('--ply', required=True, help='trained INRIA 3DGS scene .ply')
+    p.add_argument('--out', required=True, help='output actor .ply')
+    p.add_argument('--center', required=True,
+                   help='object centre x,y in the scene/world frame (metres)')
+    p.add_argument('--half-extent', type=float, default=0.6,
+                   help='half-width of the crop box in x and y (metres)')
+    p.add_argument('--z-range', default='-1e9,1e9',
+                   help='z_min,z_max of the crop box (metres)')
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args(argv)
+    center = [float(v) for v in args.center.split(',')]
+    z_range = [float(v) for v in args.z_range.split(',')]
+    scene = load_gaussian_ply(args.ply)
+    actor = crop_gaussians(scene, center, args.half_extent, z_range)
+    out = export_ply(args.out, actor['means'], actor['scales_log'],
+                     actor['quats'], actor['opacities_logit'],
+                     actor['colors_rgb'], actor['sh_rest'])
+    means = np.asarray(actor['means'])
+    extent = means.max(axis=0) - means.min(axis=0)
+    print(f'wrote {out} ({means.shape[0]} gaussians, '
+          f'extent {extent[0]:.2f}x{extent[1]:.2f}x{extent[2]:.2f} m)')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Addresses the last code-side Phase 3 limitation: the sprite actor is a **flat billboard** that betrays its single depth plane as the viewpoint swings. This adds a **volumetric actor** mode — load an arbitrary trained 3DGS `.ply` as the actor — placed each frame on the same depth-tested rasterise+composite path as the box actor. It therefore has **correct parallax** and is **occluded per-pixel by foreground geometry** (impossible for a single-plane billboard).

No external COCO asset is needed for a photoreal demo: a compact object is **cut from the scene itself**.

## Changes
- `actor_compositing.py`: `--mode ply --actor-ply <path>` (+ `--yaw`). Pure helpers `crop_gaussians` (subset to an AABB, incl. `sh_rest`) and `recenter_gaussians` (translate to ground / x-y centroid). box & ply share one volumetric-actor branch.
- `crop_actor_ply.py`: mint a photoreal actor by cropping a compact object out of a trained scene.
- 6 new CPU tests (crop incl. sh_rest subset + empty-box error, recenter), ament_flake8 clean; runner gains `MODE=ply` / `ACTOR_PLY` / `YAW`.

## Validation (clean construction scene, view 40)
Cut a **10265-gaussian object (1.4×1.4×3.4 m)** from the scene, swept it across the view at 600×440 — the photoreal chunk stands on the floor and is **partially occluded by the foreground equipment** (volumetric, not a flat plane); 36/36 frames labelled. `box` mode unchanged (regression-checked).

## Remaining (data, not code)
A curated **COCO-class learned 3DGS actor model** (car/pedestrian) — the ply machinery is ready to place one and would directly tighten the detection gap.

## Reproduce
```
python3 tools/gaussian_splatting/crop_actor_ply.py \
  --ply output/rtkslam_3dgs_clean/gsplat/point_cloud_good.ply \
  --out output/assets/actor_from_scene.ply \
  --center=-34.57,23.9 --half-extent 0.7 --z-range=11.5,16.0
PLY=output/rtkslam_3dgs_clean/gsplat/point_cloud_good.ply \
TRANSFORMS=output/rtkslam_3dgs_clean/gsplat/transforms_good.json \
OUT_DIR=output/phase3_ply MODE=ply ACTOR_PLY=output/assets/actor_from_scene.ply \
DISTANCE=4.0 DROP=1.6 bash scripts/run_actor_compositing.sh
```