### PR TITLE
feat(3dgs): procure a COCO-class volumetric actor (Tanks&Temples truck)

### DIFF
--- a/docs/research/3dgs-coco-actor-procurement.md
+++ b/docs/research/3dgs-coco-actor-procurement.md
@@ -1,0 +1,74 @@
+# COCO クラス volumetric actor の調達 (2026-06-16)
+
+Phase 3（`3dgs-actor-compositing-phase3.md`）で残った「真に photoreal な actor には
+actor 自体の 3DGS モデルが要る（学習アセット待ち）」を埋めるための調達ノート。
+**実在の learned 3DGS COCO クラス物体**を入手し、`--mode ply` の volumetric actor
+として検出可能なことを検証した。
+
+## 調達したアセット
+
+| 項目 | 内容 |
+|---|---|
+| ソース | `Voxel51/gaussian_splatting`（HuggingFace dataset） |
+| ライセンス | **Apache-2.0**（permissive、ローカル評価に支障なし） |
+| シーン | Tanks&Temples **Truck**（旧型ピックアップを 360° 撮影） |
+| ファイル | `FO_dataset/truck/point_cloud/iteration_30000/point_cloud.ply`（2,056,645 Gaussian, sh_degree 3） |
+
+入手:
+```
+curl -sL "https://huggingface.co/datasets/Voxel51/gaussian_splatting/resolve/main/\
+FO_dataset/truck/point_cloud/iteration_30000/point_cloud.ply" -o output/assets/truck_scene.ply
+```
+
+## actor 化（シーン → standalone actor）
+
+`crop_actor_ply.py` でトラックを AABB 切り出し。Tanks&Temples は **y-up** なので
+`--up-axis y` で z-up（actor 規約）に reorient:
+```
+python3 tools/gaussian_splatting/crop_actor_ply.py \
+  --ply output/assets/truck_scene.ply --out output/assets/truck_actor.ply \
+  --center=1.0,-2.5 --half-extent 4.0 --z-range=-4,3 --up-axis y
+# -> 538170 gaussians, extent 7.99 x 7.00 x 3.93 m
+```
+
+## 検証: COCO 検出器が "truck" として発火する
+
+truck_actor を単体レンダ（z-up・接地）して yolov8n にかけると、複数視点で
+**truck として確実に検出**:
+
+| view | 検出 |
+|---|---|
+| 30° | truck **0.78** |
+| 70° | truck 0.49（+ stop sign 誤検出） |
+| 110° | truck **0.73** |
+
+→ 調達物は「3DGS render 上で実画像検出器が発火する COCO クラス volumetric actor」
+として機能する。Phase 3 までは手元 3 シーンに COCO 物体が皆無で exercise 不能
+だった検出 gap の、**物体側ブロッカーが解消**された。
+
+## 性能上の必須修正（million-Gaussian actor）
+
+実シーン由来の actor は ~10^6 Gaussian になる。Phase 3 の `_rotate_quats_wxyz` は
+Python ループで、538k × フレーム数では実質ハングした。
+(1) quat 回転を **Hamilton 積でベクトル化**、(2) heading は sweep 中一定なので
+**回転は 1 回だけ・フレームごとは並進のみ**、に修正して実用速度にした。
+
+## 残課題: シーン規模・品質の整合（data gap）
+
+調達物（実寸 8m トラック）を手元 SLAM シーンに合成する所で**シーン側**が律速:
+
+- **construction**（recon 28.9 dB と高品質だが狭い屋内）: 全 view で前方 depth
+  ~1–4m。8m トラックは壁の奥に置かれ depth-test で完全オクルージョン、近づけると
+  巨大クリップ。**屋内の狭小空間に実寸車両は物理的に入らない**。
+- **isuzu**（屋外・走行スケールで広いが recon 17.3 dB と低品質）: 空間は足りるが
+  washed-out で合成が成立しない。
+
+→ 実寸車両を活かすには **大規模かつ高品質な屋外路上シーン**が要る。これは
+machinery（ply 読み込み・配置・視差・オクルージョン・GT label）でなく、
+**シーン素材の data gap**。machinery と検出可能な COCO actor は揃ったので、
+そうしたシーンが用意できれば `--actor-ply output/assets/truck_actor.ply` を
+渡すだけで検出 gap が締まる。
+
+## 関連
+- 機構: `3dgs-actor-compositing-phase3.md`（box/sprite/ply モード、depth-test 合成）
+- Phase 0 の有効視点範囲・シーンスケール依存の所見と一貫（走行スケール屋外が本命）

--- a/graph_based_slam/test/test_gaussian_splatting_actor.py
+++ b/graph_based_slam/test/test_gaussian_splatting_actor.py
@@ -236,6 +236,26 @@ def test_crop_gaussians_raises_on_empty_box():
         ac.crop_gaussians(_toy_scene(), [100.0, 100.0], 0.1, [0.0, 1.0])
 
 
+def test_reorient_up_to_z_y_up_maps_to_z():
+    g = _toy_scene(1)
+    g['means'] = np.array([[2.0, 3.0, 4.0]])  # y is the scene up axis
+    out = ac.reorient_up_to_z(g, 'y')
+    # the y component (3.0) becomes the new +z height
+    assert out['means'][0, 2] == pytest.approx(3.0)
+    assert np.allclose(np.linalg.norm(out['quats'], axis=1), 1.0)
+
+
+def test_reorient_up_to_z_identity_for_z():
+    g = _toy_scene(3)
+    out = ac.reorient_up_to_z(g, 'z')
+    assert np.allclose(out['means'], g['means'])
+
+
+def test_reorient_up_to_z_rejects_bad_axis():
+    with pytest.raises(ValueError):
+        ac.reorient_up_to_z(_toy_scene(2), 'w')
+
+
 def test_recenter_gaussians_zeroes_xy_centroid_and_grounds_z():
     g = _toy_scene(2)
     g['means'] = np.array([[1.0, 2.0, 3.0], [3.0, 4.0, 5.0]], dtype=float)

--- a/tools/gaussian_splatting/actor_compositing.py
+++ b/tools/gaussian_splatting/actor_compositing.py
@@ -36,7 +36,6 @@ from typing import Optional, Sequence
 
 import numpy as np
 
-import posed_images as pi
 from render_path import load_gaussian_ply, matrix_to_quat_xyzw, scale_intrinsics
 from train_gsplat import load_transforms
 
@@ -104,6 +103,31 @@ def crop_gaussians(g: dict, center_xy: Sequence[float], half_extent_xy: float,
     return out
 
 
+_UP_TO_Z = {
+    'z': np.eye(3),
+    'y': np.array([[1.0, 0.0, 0.0], [0.0, 0.0, -1.0], [0.0, 1.0, 0.0]]),
+    'x': np.array([[0.0, 0.0, -1.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]]),
+}
+
+
+def reorient_up_to_z(g: dict, up_axis: str) -> dict:
+    """Rotate a gaussians dict so the given world up axis maps to +z.
+
+    Assets trained in a different convention (e.g. the y-up Tanks&Temples
+    scenes) must be reoriented before they sit upright under the z-up actor
+    convention (``recenter_gaussians`` grounds on min-z, ``rigid_from_pos_yaw``
+    yaws about z).
+    """
+    if up_axis not in _UP_TO_Z:
+        raise ValueError(f'up_axis must be one of x/y/z, got {up_axis!r}')
+    rot = _UP_TO_Z[up_axis]
+    if up_axis == 'z':
+        return dict(g)
+    t = np.eye(4)
+    t[:3, :3] = rot
+    return transform_gaussians(g, t)
+
+
 def recenter_gaussians(g: dict) -> dict:
     """Translate a gaussians dict so its x/y centroid is 0 and it rests on z=0.
 
@@ -118,12 +142,21 @@ def recenter_gaussians(g: dict) -> dict:
 
 
 def _rotate_quats_wxyz(quats_wxyz: np.ndarray, rot: np.ndarray) -> np.ndarray:
-    """Apply a world rotation ``rot`` to a batch of ``wxyz`` Gaussian quaternions."""
-    out = np.empty_like(np.asarray(quats_wxyz, dtype=float))
-    for i, q in enumerate(quats_wxyz):
-        rq = pi.quat_to_matrix([q[1], q[2], q[3], q[0]])  # wxyz -> xyzw -> R
-        xyzw = matrix_to_quat_xyzw(rot @ rq)
-        out[i] = [xyzw[3], xyzw[0], xyzw[1], xyzw[2]]
+    """Apply a world rotation ``rot`` to a batch of ``wxyz`` Gaussian quaternions.
+
+    Vectorised: the orientation update ``rot @ R_g`` corresponds to the Hamilton
+    product ``q_rot (x) q_g``, computed for all Gaussians at once (a Python loop
+    is far too slow for the ~10^6 Gaussians of a real scene crop).
+    """
+    q = np.asarray(quats_wxyz, dtype=float)
+    rx = matrix_to_quat_xyzw(rot)               # xyzw quaternion of rot
+    rw, rxx, ryy, rzz = rx[3], rx[0], rx[1], rx[2]
+    w, x, y, z = q[:, 0], q[:, 1], q[:, 2], q[:, 3]
+    out = np.empty_like(q)
+    out[:, 0] = rw * w - rxx * x - ryy * y - rzz * z
+    out[:, 1] = rw * x + rxx * w + ryy * z - rzz * y
+    out[:, 2] = rw * y - rxx * z + ryy * w + rzz * x
+    out[:, 3] = rw * z + rxx * y - ryy * x + rzz * w
     return out
 
 
@@ -363,12 +396,18 @@ def run(ply: Path, transforms: Path, out_dir: Path, *, view: int, frames: int,
     else:
         actor_g = None
     spr = load_sprite(sprite) if mode == 'sprite' else None
+    # The heading is fixed across the sweep, so rotate the actor once (a Python
+    # quat loop over ~10^6 Gaussians per frame would be hopeless); each frame
+    # then only translates the means -- cheap even for a full scene crop.
+    actor_rot = (transform_gaussians(actor_g, rigid_from_pos_yaw([0.0, 0.0, 0.0],
+                 yaw)) if actor_g is not None else None)
 
     out_dir.mkdir(parents=True, exist_ok=True)
     composited, labels, per_frame = [], [], []
     for i, pos in enumerate(poses):
-        if actor_g is not None:  # volumetric actor (box or arbitrary 3DGS ply)
-            placed = transform_gaussians(actor_g, rigid_from_pos_yaw(pos, yaw))
+        if actor_rot is not None:  # volumetric actor (box or arbitrary 3DGS ply)
+            placed = dict(actor_rot)
+            placed['means'] = actor_rot['means'] + np.asarray(pos, dtype=float)
             arb, adp, aac = rasterize_rgbda(placed, vm, K, width, height,
                                             device=device)
             frame, mask = composite_depth(scene_rgb, scene_depth, arb, adp, aac)

--- a/tools/gaussian_splatting/crop_actor_ply.py
+++ b/tools/gaussian_splatting/crop_actor_ply.py
@@ -22,7 +22,7 @@ from typing import Optional, Sequence
 
 import numpy as np
 
-from actor_compositing import crop_gaussians
+from actor_compositing import crop_gaussians, reorient_up_to_z
 from render_path import load_gaussian_ply
 from train_gsplat import export_ply
 
@@ -38,6 +38,9 @@ def build_parser() -> argparse.ArgumentParser:
                    help='half-width of the crop box in x and y (metres)')
     p.add_argument('--z-range', default='-1e9,1e9',
                    help='z_min,z_max of the crop box (metres)')
+    p.add_argument('--up-axis', default='z', choices=('x', 'y', 'z'),
+                   help="scene up axis; reoriented to +z so the actor stands "
+                        "upright (y for Tanks&Temples scenes)")
     return p
 
 
@@ -47,7 +50,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     center = [float(v) for v in args.center.split(',')]
     z_range = [float(v) for v in args.z_range.split(',')]
     scene = load_gaussian_ply(args.ply)
-    actor = crop_gaussians(scene, center, args.half_extent, z_range)
+    actor = reorient_up_to_z(crop_gaussians(scene, center, args.half_extent,
+                                            z_range), args.up_axis)
     out = export_ply(args.out, actor['means'], actor['scales_log'],
                      actor['quats'], actor['opacities_logit'],
                      actor['colors_rgb'], actor['sh_rest'])


### PR DESCRIPTION
## What

Fills the last Phase 3 (#298) gap that needed an actor with a **real learned 3DGS appearance**. Procures a permissively-licensed trained 3DGS object and verifies it is a genuine, detectable COCO actor.

| | |
|---|---|
| Source | `Voxel51/gaussian_splatting` (HuggingFace) |
| License | **Apache-2.0** |
| Asset | Tanks&Temples **Truck** (vintage pickup, 2.06M gaussians, SH deg 3) |

Cropped to a standalone actor with `crop_actor_ply.py --up-axis y` (Tanks&Temples is y-up → reoriented to the z-up actor convention) → 538k-gaussian `truck_actor.ply` (8.0×7.0×3.9 m). Rendered alone, **yolov8n detects it as `truck` at conf 0.73–0.78** across views — the object-side blocker of the Phase 3 detection gap is resolved.

## Changes
- `actor_compositing.reorient_up_to_z` + `crop_actor_ply.py --up-axis`: reorient an asset trained in a different up convention to z-up so it stands upright. (3 new CPU tests.)
- **Perf fix**: vectorise `_rotate_quats_wxyz` (Hamilton product) and rotate the actor once per run (heading is fixed; per-frame is translation-only). The old Python quat loop hung on the ~10⁶ gaussians of a real scene crop.
- 48 gsplat CPU tests pass, ament_flake8 clean.

## Honest finding (data, not code)
Compositing a full-size **8 m truck** into the current scene library is blocked by **scene scale/quality**:
- **construction** (28.9 dB but tight indoor, forward depth ~1–4 m) → the truck is occluded/clipped — an 8 m vehicle physically does not fit indoors.
- **isuzu** (open outdoor but 17 dB, washed out) → space is enough, appearance is not.

The machinery (ply load / place / parallax / occlusion / GT label) and a detectable COCO actor are ready; integrating one needs a **large high-quality outdoor road scene**. doc: `docs/research/3dgs-coco-actor-procurement.md`.

## Reproduce
```
curl -sL "https://huggingface.co/datasets/Voxel51/gaussian_splatting/resolve/main/FO_dataset/truck/point_cloud/iteration_30000/point_cloud.ply" -o output/assets/truck_scene.ply
python3 tools/gaussian_splatting/crop_actor_ply.py --ply output/assets/truck_scene.ply \
  --out output/assets/truck_actor.ply --center=1.0,-2.5 --half-extent 4.0 --z-range=-4,3 --up-axis y
```