### PR TITLE
feat(3dgs): detection range via dolly approach (closed-loop relevant)

### DIFF
--- a/docs/research/3dgs-detection-gap-novel-views.md
+++ b/docs/research/3dgs-detection-gap-novel-views.md
@@ -43,6 +43,38 @@ Phase 3 の compositing は隣接する問い（貼り込んだ actor）に答�
   ないため物体シルエットよりやや緩く、検出 box との IoU が 0.5 に届きにくいため。
   代表 hit view（IoU 0.536）では GT box がトラックをよく囲む。
 
+## 追記: 検出レンジ（dolly = ego 前進接近） (2026-06-16)
+
+orbit は全方位だが、closed-loop で効くのは「ego が路側の物体にどこまで近づけば
+検出できるか（**検出レンジ**）」。`--path dolly` は固定方位で far→near にカメラを
+寄せる（ego が前方の物体へ接近）パスで、距離ごとの検出を測る。
+
+Truck シーン、正面方位（azimuth 125°、orbit で hit した向き）、18m→4m、24 step:
+
+```
+--path dolly --azimuth 125 --near 4 --far 18 --frames 24
+→ class-present rate 0.75, recall@IoU0.5 0.42, mean best IoU 0.34
+→ max detection range 15.0 m
+```
+
+距離別（present = truck として検出）:
+
+| 距離 | 検出 | 最良 IoU |
+|---|---|---|
+| >15 m | ✗ | 0（小さすぎ） |
+| 15 → 6.4 m | ✓ | 0.47–**0.63**（9–9.5m がピーク） |
+| <6 m | △ | 0.0–0.01（画面を溢れ文脈喪失） |
+| 4 m | ✗ | 0 |
+
+- **3DGS 再レンダの実トラックは正面接近で 15m から検出でき、7–13m が sweet spot**。
+  近すぎ（<6m、物体が画面を溢れる）と遠すぎ（>15m、小さい）で落ちる典型的な
+  検出器特性が、3DGS render 上でもそのまま出る。
+- **正面方位では class-present 0.75**（全方位 orbit の 0.47 より高い）= viewpoint
+  依存の再確認。closed-loop の ego は前方の車両を canonical 角度で見るので、
+  この sweet-spot レンジが実効的に効く。
+- dolly は recall@IoU0.5 も 0.42 と orbit（0.06）より高い。物体が常に良く framed され
+  GT box と整合するため。
+
 ## 限界 / 次
 
 - tight な IoU/recall には 3D インスタンス mask（学習済み actor の alpha or

--- a/graph_based_slam/test/test_gaussian_splatting_detect.py
+++ b/graph_based_slam/test/test_gaussian_splatting_detect.py
@@ -93,6 +93,26 @@ def test_orbit_viewmats_rejects_bad_inputs():
         dis.orbit_viewmats([0, 0, 0], 5.0, 0.0, 4, up_axis='w')
 
 
+def test_dolly_viewmats_steps_far_to_near_at_fixed_bearing():
+    target = np.array([1.0, 2.0, 3.0])
+    vms = dis.dolly_viewmats(target, 0.0, 4.0, 16.0, 5, up_axis='y')
+    assert vms.shape == (5, 4, 4)
+    cs = np.array([_center_of(vm) for vm in vms])
+    # azimuth 0 about y -> cameras offset along +x; distance shrinks far->near
+    dx = cs[:, 0] - 1.0
+    assert dx[0] == pytest.approx(16.0) and dx[-1] == pytest.approx(4.0)
+    assert np.all(np.diff(dx) < 0)             # monotonically approaching
+    assert np.allclose(cs[:, 1], 2.0)          # constant height (y up)
+    assert np.allclose(cs[:, 2], 3.0)          # on the bearing line
+
+
+def test_dolly_viewmats_rejects_bad_inputs():
+    with pytest.raises(ValueError):
+        dis.dolly_viewmats([0, 0, 0], 0.0, 4.0, 16.0, 0)
+    with pytest.raises(ValueError):
+        dis.dolly_viewmats([0, 0, 0], 0.0, 4.0, 16.0, 4, up_axis='w')
+
+
 def test_subsample_caps_length_and_keeps_endpoints():
     pts = np.arange(30).reshape(10, 3)
     out = dis.subsample(pts, 4)

--- a/tools/gaussian_splatting/detect_in_scene.py
+++ b/tools/gaussian_splatting/detect_in_scene.py
@@ -84,6 +84,37 @@ def orbit_viewmats(target: Sequence[float], radius: float, elevation: float,
     return np.stack(out)
 
 
+def dolly_viewmats(target: Sequence[float], azimuth_deg: float, near: float,
+                   far: float, count: int, *, elevation: float = 0.0,
+                   up_axis: str = 'y') -> np.ndarray:
+    """Synthesise ``count`` views dollying toward ``target`` at a fixed azimuth.
+
+    Cameras sit at a single bearing ``azimuth_deg`` (in the plane perpendicular
+    to ``up_axis``) and step from ``far`` to ``near`` distance, each looking at
+    ``target`` -- the ego approaching a roadside object head-on. The recall as a
+    function of distance is the detector's effective range on a 3DGS object.
+    """
+    if count < 1:
+        raise ValueError('count must be positive')
+    if up_axis not in _UP:
+        raise ValueError(f'up_axis must be one of x/y/z, got {up_axis!r}')
+    target = np.asarray(target, dtype=float)
+    ui = _UP[up_axis]
+    up = np.zeros(3)
+    up[ui] = 1.0
+    h0, h1 = (i for i in range(3) if i != ui)
+    a = np.radians(azimuth_deg)
+    dists = np.linspace(far, near, count) if count > 1 else np.array([near])
+    out = []
+    for d in dists:
+        eye = target.astype(float).copy()
+        eye[h0] += d * np.cos(a)
+        eye[h1] += d * np.sin(a)
+        eye[ui] += elevation
+        out.append(look_at_viewmat(eye, target, up))
+    return np.stack(out)
+
+
 def subsample(points: np.ndarray, limit: int) -> np.ndarray:
     """Evenly stride ``points`` down to at most ``limit`` rows (deterministic)."""
     points = np.asarray(points)
@@ -116,8 +147,9 @@ def run(ply: Path, out_dir: Path, *, center_xy: Sequence[float],
         half_extent: float, z_range: Sequence[float], target_cls: int,
         radius: float, elevation: float, frames: int, up_axis: str,
         arc_deg: float, fx: float, width: int, height: int, detector,
-        out_fps: int, device: str = 'cuda') -> dict:
-    """Orbit the object, render + detect each novel view, score against the box."""
+        out_fps: int, path: str = 'orbit', azimuth_deg: float = 0.0,
+        near: float = 4.0, far: float = 16.0, device: str = 'cuda') -> dict:
+    """Render + detect each novel view along the path, score against the object box."""
     import imageio.v2 as imageio
 
     scene = load_gaussian_ply(ply)
@@ -125,8 +157,14 @@ def run(ply: Path, out_dir: Path, *, center_xy: Sequence[float],
                        0.5 * (z_range[0] + z_range[1])], dtype=float)
     K = np.array([[fx, 0.0, width / 2.0], [0.0, fx, height / 2.0],
                   [0.0, 0.0, 1.0]])
-    vms = orbit_viewmats(target, radius, elevation, frames, up_axis=up_axis,
-                         arc_deg=arc_deg)
+    if path == 'dolly':
+        vms = dolly_viewmats(target, azimuth_deg, near, far, frames,
+                             elevation=elevation, up_axis=up_axis)
+        dists = list(np.linspace(far, near, frames)) if frames > 1 else [near]
+    else:
+        vms = orbit_viewmats(target, radius, elevation, frames, up_axis=up_axis,
+                             arc_deg=arc_deg)
+        dists = [radius] * frames
     # Tight ground truth: project the object's own Gaussian means (subsampled),
     # not the loose AABB corners, so the box hugs the object's silhouette.
     obj_pts = subsample(crop_gaussians(scene, center_xy, half_extent,
@@ -141,26 +179,31 @@ def run(ply: Path, out_dir: Path, *, center_xy: Sequence[float],
         dets = detector(rgb) if detector is not None else []
         best, hit = score_detection(dets, gt, target_cls)
         frames_rgb.append(rgb)
-        per_view.append({'view': i, 'gt_bbox': gt, 'n_dets': len(dets),
+        per_view.append({'view': i, 'distance_m': round(float(dists[i]), 2),
+                         'gt_bbox': gt, 'n_dets': len(dets),
                          'best_iou': round(best, 3), 'hit': hit,
+                         'present': target_cls in {d['cls'] for d in dets},
                          'classes': sorted({d['cls'] for d in dets})})
 
-    mp4 = out_dir / 'orbit.mp4'
+    mp4 = out_dir / f'{path}.mp4'
     with imageio.get_writer(mp4, fps=out_fps, codec='libx264', quality=8,
                             macro_block_size=2) as wr:
         for f in frames_rgb:
             wr.append_data(f)
 
     scored = [v for v in per_view if v['gt_bbox'] is not None]
-    cls_present = sum(1 for v in scored if target_cls in v['classes'])
+    cls_present = sum(1 for v in scored if v['present'])
+    # For a dolly, the farthest distance still detected = the effective range.
+    present_dists = [v['distance_m'] for v in scored if v['present']]
     report = {
-        'ply': str(ply), 'target_cls': target_cls, 'frames': frames,
-        'render_size': [width, height], 'orbit_radius': radius,
+        'ply': str(ply), 'path': path, 'target_cls': target_cls,
+        'frames': frames, 'render_size': [width, height],
         'recall_iou50': (sum(v['hit'] for v in scored) / len(scored)
                          if scored else 0.0),
         'class_present_rate': cls_present / len(scored) if scored else 0.0,
         'mean_best_iou': (float(np.mean([v['best_iou'] for v in scored]))
                           if scored else 0.0),
+        'max_detect_range_m': max(present_dists) if present_dists else 0.0,
         'per_view': per_view,
     }
     (out_dir / 'detect_in_scene.json').write_text(json.dumps(report, indent=2))
@@ -180,8 +223,17 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--z-range', default='-4,3', help='object z_min,z_max (metres)')
     p.add_argument('--class-id', type=int, default=7,
                    help='COCO class to score (7 = truck, 2 = car, 0 = person)')
+    p.add_argument('--path', default='orbit', choices=('orbit', 'dolly'),
+                   help="'orbit' (all-round views) or 'dolly' (approach at a "
+                        'fixed bearing -> detection range)')
     p.add_argument('--radius', type=float, default=9.0,
                    help='orbit radius around the object (metres)')
+    p.add_argument('--azimuth', type=float, default=125.0,
+                   help='dolly bearing in degrees (125 ~ truck front)')
+    p.add_argument('--near', type=float, default=4.0,
+                   help='dolly nearest distance (metres)')
+    p.add_argument('--far', type=float, default=18.0,
+                   help='dolly farthest distance (metres)')
     p.add_argument('--elevation', type=float, default=-2.0,
                    help='camera offset along the up axis (metres)')
     p.add_argument('--frames', type=int, default=36)
@@ -214,11 +266,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                  elevation=args.elevation, frames=args.frames,
                  up_axis=args.up_axis, arc_deg=args.arc, fx=args.fx,
                  width=args.width, height=args.height, detector=detector,
-                 out_fps=args.fps, device=args.device)
-    print(f"wrote {report['mp4']} ({report['frames']} orbit views)")
+                 out_fps=args.fps, path=args.path, azimuth_deg=args.azimuth,
+                 near=args.near, far=args.far, device=args.device)
+    print(f"wrote {report['mp4']} ({report['frames']} {report['path']} views)")
     print(f"  class-present rate {report['class_present_rate']:.2f}, "
           f"recall@IoU0.5 {report['recall_iou50']:.2f}, "
           f"mean best IoU {report['mean_best_iou']:.2f}")
+    if report['path'] == 'dolly':
+        print(f"  max detection range {report['max_detect_range_m']:.1f} m")
     return 0
 
 


### PR DESCRIPTION
## What

Extends `detect_in_scene` (#300) with a **dolly path**: a camera approaching the object head-on at a fixed bearing (the ego nearing a roadside vehicle), measuring **detection as a function of distance** — the detector's effective range on a 3DGS object, which is what a closed-loop ego actually cares about (orbit measured all-round views).

## Changes
- `dolly_viewmats` pure helper (far→near at a fixed azimuth, looking at target); `--path orbit|dolly` with `--azimuth/--near/--far`; per-view `distance_m` + a `max_detect_range_m` summary. 2 new CPU tests (12 total), ament_flake8 clean.

## Result (Truck scene, yolov8n, front bearing 125°, 18→4 m, 24 steps)
```
class-present 0.75, recall@IoU0.5 0.42, mean IoU 0.34, max range 15.0 m
```

| distance | detected | best IoU |
|---|---|---|
| >15 m | ✗ | 0 (too small) |
| 15 → 6.4 m | ✓ | 0.47–**0.63** (peak ~9 m) |
| <6 m | △ | ~0 (overflows frame) |
| 4 m | ✗ | 0 |

A 3DGS-rendered real truck is detected **from 15 m** down the approach, **sweet spot 7–13 m**. Typical detector range behaviour (drops out too far / too near) holds on 3DGS renders. **Front-bearing class-present 0.75 vs 0.47 all-round orbit** reconfirms the viewpoint dependence — favourable for closed-loop, where the ego sees vehicles from canonical front angles in this sweet-spot range.

## Reproduce
```
python3 tools/gaussian_splatting/detect_in_scene.py --ply output/assets/truck_scene.ply \
  --out output/detect_truck_dolly --center=0.75,-2.0 --half-extent 3.0 --z-range=-3,2 \
  --class-id 7 --path dolly --azimuth 125 --near 4 --far 18 --up-axis y --detector yolov8n.pt
```
doc addendum: `docs/research/3dgs-detection-gap-novel-views.md`