### PR TITLE
feat(3dgs): LiDAR-primed sim2real detection gap on a real outdoor scene

### DIFF
--- a/docs/research/3dgs-lidar-primed-detection-gap.md
+++ b/docs/research/3dgs-lidar-primed-detection-gap.md
@@ -1,0 +1,63 @@
+# LiDAR-primed sim2real 検出 gap — 実屋外シーン (2026-06-16)
+
+sim2real トラックの知覚スレッドを、**自前の LiDAR-primed シーン**で締める。
+Phase 0 は検出器レイヤ（`sim2real_gap.py --detector`、実画像の検出が 3DGS render 上で
+何割生き残るか = recon_det_agree）を**手元シーンに COCO 物体が皆無で exercise できなかった**。
+RTK-SLAM の **stadtgarten_seq2**（屋外・市民公園、CC-BY 4.0）は駐輪自転車・歩行者が
+映るので、ここでついに直接測れる。
+
+パイプライン（既存ツールのみ、新規コードなし）:
+rosbag2 + RKO-LIO 軌跡 → posed images → **LiDAR-primed gsplat** →
+`sim2real_gap.py --detector`。再現: `scripts/run_stadtgarten_detection_gap.sh`。
+（カメラ timeshift t_imu = t_cam − 0.0206s → `--time-offset -0.020638`。frontend raw
+軌跡を dense pose に使用。窓 225–290s に**駐輪自転車**＝静的が含まれる。）
+
+## 結果（stadtgarten_seq2, 窓 225–290s, yolov8n, 30 view）
+
+```
+recon PSNR 18.9 dB, det-agree 0.27
+offset sweep: ±0.25m で det-retain ~0（sharp 比 70–1800 = floater 爆発）
+```
+
+集計 det-agree 0.27 は低いが、**静的/動的で完全に分かれる**のが本質:
+
+| 物体 | 種別 | 実画像 | 3DGS render | agree |
+|---|---|---|---|---|
+| 駐輪自転車 (view 18–80) | **静的** | bicycle 0.72–0.77 | **bicycle 0.75–0.78** | **~1.0** |
+| 歩行者 (view 9, 89, 98, 107) | **動的** | person 0.77 | **(なし)** | **~0.0** |
+
+- **静的 COCO 物体は LiDAR-primed 3DGS render 上でほぼそのまま検出される**。駐輪自転車は
+  実画像 conf 0.77 → render 0.75 と**ほぼ同一**（render の方が高い view もある）。連続 view
+  18–80 で agree 1.0 を維持＝静的物体の sim2real 検出 gap はほぼゼロ。
+- **動的 COCO 物体は静的前提の 3DGS で ghosting し、render から消える**（agree 0）。歩行者は
+  実画像で検出されても render では smear して未検出。
+- 集計 0.27 は窓内の静的/動的検出の混在比を反映しているだけで、gap の本質は**物体の運動**。
+
+これが Phase 0 で data 不足だった問いへの答え: **実画像の検出器は LiDAR-primed 3DGS
+render 上の実 COCO 物体に発火する — 静的物体には高忠実に（gap ≈ 0）、動的物体には
+dynamic-3DGS 手法が要る**。先行の Truck シーン（SfM, orbit/dolly, class-present 0.47–0.75,
+検出レンジ 15m）の所見—「検出可能だが viewpoint/距離依存」—と整合し、初期化が LiDAR でも
+SfM でも検出器側の挙動は一貫することを示す。
+
+## 限界 / 次
+
+- recon 18.9 dB と低めなのは屋外＋frontend raw 軌跡のドリフト＋動的物体の不整合。backend
+  corrected 軌跡は 278 pose と疎で camera 補間に不足。**dense かつ backend 精度の軌跡**が
+  あれば recon は上がる（construction clean は 28.9 dB）。
+- 有効視点範囲は近接屋外＋ドリフトで < 0.25m（offset で floater 爆発）。Phase 0 の
+  「有効範囲はシーンスケール依存」と整合。
+- **動的物体の検出 gap には dynamic/4D-3DGS**（時間変形 or per-frame actor）が必要。
+  本リポジトリの actor compositing（`3dgs-actor-compositing-phase3.md`）は静的シーンに
+  動的 actor を別途差し込む補完経路。
+
+## ロードマップ上の位置づけ
+
+```
+Phase 0  外挿安定性 / 有効視点範囲                         ← 完了
+Phase 1  open-loop RGB-D データ生成                        ← 完了
+Phase 2  closed-loop sensor-sim ROS 2 node                 ← 完了
+Phase 3  dynamic actors (box/sprite/ply, 検出 gap)         ← 完了
+  └ COCO actor 調達 (Tanks&Temples truck)                  ← 完了
+  └ 実物体 × novel view / 検出レンジ (orbit/dolly)          ← 完了
+  └ LiDAR-primed 実屋外シーンの検出 gap (静的≈1.0/動的≈0)  ← 本ノート
+```

--- a/scripts/run_stadtgarten_detection_gap.sh
+++ b/scripts/run_stadtgarten_detection_gap.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# LiDAR-primed sim2real DETECTION gap on a real outdoor scene with COCO objects
+# (RTK-SLAM stadtgarten_seq2). Phase 0 could not exercise the detector layer --
+# the LiDAR-primed scenes on hand had no COCO objects. stadtgarten is an outdoor
+# city-park sequence that does (parked bicycles, pedestrians), so this closes
+# that loop: rosbag2 + RKO-LIO trajectory -> posed images -> LiDAR-primed gsplat
+# -> sim2real_gap.py --detector (real-image detections surviving on the render).
+#
+# Window 225-290 s holds a PARKED bicycle (static -> reconstructs cleanly) plus
+# walking pedestrians (dynamic -> ghosted by static 3DGS); the result separates
+# the two. Camera timeshift t_imu = t_cam - 0.0206 s -> --time-offset -0.020638.
+#
+# Requires: a CUDA GPU with torch + gsplat + ultralytics, the RTK-SLAM
+# stadtgarten_seq2 rosbag2 (scripts/download_rtk_slam_dataset.py, CC-BY 4.0) and
+# a SLAM trajectory TUM (world<-imu) for it.
+#
+# Usage:
+#   BAG=datasets/rtk_slam/ros2/stadtgarten_seq2 \
+#   TRAJ=output/rtkslam_stadtgarten_seq2_run/traj_raw.tum \
+#   OUT_DIR=output/stadt_3dgs bash scripts/run_stadtgarten_detection_gap.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+BAG="${BAG:?set BAG to the stadtgarten_seq2 rosbag2 directory}"
+TRAJ="${TRAJ:?set TRAJ to the SLAM trajectory TUM file (world<-imu)}"
+OUT_DIR="${OUT_DIR:-output/stadt_3dgs}"
+START="${START:-225}"
+END="${END:-290}"
+STRIDE="${STRIDE:-5}"
+ITERS="${ITERS:-12000}"
+DETECTOR="${DETECTOR:-yolov8n.pt}"
+
+echo "== [1/4] extract posed images (CompressedImage, undistort) =="
+python3 tools/gaussian_splatting/extract_posed_images.py \
+  --bag "${BAG}" --traj "${TRAJ}" \
+  --camera-topic /camera/image_raw/compressed \
+  --intrinsics-yaml configs/gaussian_splatting/rtk_slam_cam0_intrinsics.yaml \
+  --extrinsic configs/gaussian_splatting/rtk_slam_cam0_extrinsic.yaml \
+  --undistort --time-offset -0.020638 \
+  --start-time "${START}" --end-time "${END}" --stride "${STRIDE}" \
+  --max-extrapolation 0.2 \
+  --out "${OUT_DIR}/gsplat"
+
+echo "== [2/4] LiDAR-primed init cloud =="
+python3 tools/gaussian_splatting/build_lidar_init.py \
+  --bag "${BAG}" --traj "${TRAJ}" --points-topic /livox/points \
+  --start-time "${START}" --end-time "${END}" \
+  --voxel 0.05 --min-range 1.5 --max-range 60 --max-points 400000 \
+  --out "${OUT_DIR}/gsplat/lidar_init.ply"
+
+echo "== [3/4] half-res + vignette crop, then train gsplat =="
+python3 - "$OUT_DIR" <<'EOF'
+import json
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+out = Path(sys.argv[1]) / 'gsplat'
+doc = json.load(open(out / 'transforms.json'))
+scale = 0.5
+w, h = int(doc['w'] * scale), int(doc['h'] * scale)
+x0, y0, w2, h2 = 100, 80, 600, 440  # crop the lens vignette
+(out / 'images_crop').mkdir(exist_ok=True)
+for fr in doc['frames']:
+    name = Path(fr['file_path']).name
+    img = Image.open(out / fr['file_path']).resize((w, h), Image.LANCZOS)
+    img.crop((x0, y0, x0 + w2, y0 + h2)).save(out / 'images_crop' / name)
+    fr['file_path'] = f'images_crop/{name}'
+doc['w'], doc['h'] = w2, h2
+doc['fl_x'] *= scale
+doc['fl_y'] *= scale
+doc['cx'] = doc['cx'] * scale - x0
+doc['cy'] = doc['cy'] * scale - y0
+json.dump(doc, open(out / 'transforms_crop.json', 'w'))
+print(f'training set: {len(doc["frames"])} views @ {w2}x{h2}')
+EOF
+
+python3 tools/gaussian_splatting/train_gsplat.py \
+  --transforms "${OUT_DIR}/gsplat/transforms_crop.json" \
+  --out "${OUT_DIR}/gsplat/point_cloud.ply" \
+  --init-ply "${OUT_DIR}/gsplat/lidar_init.ply" \
+  --densify --sh-degree 1 --iters "${ITERS}"
+
+echo "== [4/4] sim2real detection gap (real detections surviving on the render) =="
+python3 tools/gaussian_splatting/sim2real_gap.py \
+  --ply "${OUT_DIR}/gsplat/point_cloud.ply" \
+  --transforms "${OUT_DIR}/gsplat/transforms_crop.json" \
+  --out "${OUT_DIR}/sim2real" \
+  --offsets=-0.5,-0.25,0.25,0.5 --scale 1.0 --views 30 \
+  --detector "${DETECTOR}" --det-conf 0.3
+
+echo "done: ${OUT_DIR}/sim2real/metrics.json (recon_det_agree = the detection gap)"


### PR DESCRIPTION
## What

Closes the perception thread on our **own LiDAR-primed scenes**. Phase 0 couldn't exercise the detector layer (`sim2real_gap --detector` / `recon_det_agree`) because the LiDAR-primed scenes on hand had no COCO objects. RTK-SLAM **stadtgarten_seq2** (outdoor city park, CC-BY 4.0) does — parked bicycles and pedestrians — so the existing tooling finally measures it. **No new tool code** (reuses the Phase 0 `sim2real_gap.py` detector layer): rosbag2 + RKO-LIO trajectory → posed images → LiDAR-primed gsplat → `sim2real_gap.py --detector`.

## Result (window 225–290 s, yolov8n, 30 views)
`recon 18.9 dB, det-agree 0.27` — which **separates cleanly by motion**:

| object | kind | real image | 3DGS render | agree |
|---|---|---|---|---|
| parked bicycle (views 18–80) | **static** | bicycle 0.72–0.77 | **bicycle 0.75–0.78** | **~1.0** |
| pedestrians (views 9/89/98/107) | **dynamic** | person 0.77 | **(none)** | **~0.0** |

- **Static COCO objects survive a LiDAR-primed 3DGS render at near-real confidence** (0.77→0.75) — sim2real detection gap ≈ 0 across the static-object views.
- **Dynamic objects ghost** in the static 3DGS and vanish from the render (agree ~0).
- Aggregate 0.27 just reflects the static/dynamic mix.

Answers Phase 0's data-blocked question, and is consistent with the Truck-scene (SfM) orbit/dolly results — detector behaviour is the same whether the init is LiDAR or SfM.

## Limits / next
- recon 18.9 dB is low (outdoor + frontend-raw drift + dynamic inconsistency); a dense backend-accurate trajectory would lift it (construction clean hit 28.9 dB).
- Dynamic-object detection gap needs a dynamic/4D-3DGS method; the actor-compositing path (#296–299) is the complementary route (insert dynamic actors into a static scene).

## Reproduce
```
BAG=datasets/rtk_slam/ros2/stadtgarten_seq2 \
TRAJ=output/rtkslam_stadtgarten_seq2_run/traj_raw.tum \
OUT_DIR=output/stadt_3dgs bash scripts/run_stadtgarten_detection_gap.sh
```
doc: `docs/research/3dgs-lidar-primed-detection-gap.md`