### PR TITLE
feat(3dgs): closed-loop RL environment + PPO validation (Phase 4)

### DIFF
--- a/docs/research/3dgs-rl-drive-env-phase4.md
+++ b/docs/research/3dgs-rl-drive-env-phase4.md
@@ -1,0 +1,63 @@
+# 3DGS closed-loop RL — Phase 4 環境基盤 (2026-06-16)
+
+sim2real トラックの Phase 4（RL）の第一段 = **学習環境**。closed-loop の部品は
+既に揃っている（GPU レンダラ、sensor-sim node、depth-test actor 合成、検出
+スコアリング）ので、それらを標準の `gymnasium.Env` として包み、エージェントが
+学習できる基盤を作った。
+
+ツール: `tools/gaussian_splatting/drive_env.py`（pure 部 12 ケースを
+`graph_based_slam/test/test_gaussian_splatting_drive_env.py` で CPU テスト、
+gymnasium env_checker 通過、ament_flake8 clean）。
+学習: `tools/gaussian_splatting/train_drive_policy.py` / `scripts/run_drive_rl.sh`。
+
+## タスクと環境
+
+- **ego**: 平面 unicycle `(x, y, yaw)`。action = `[v, omega]`（正規化）。
+- **タスク**: goal pose に到達。ただし **valid viewpoint corridor**（Phase 0:
+  3DGS render が信頼できるのは記録軌跡から `max_dev` 以内）に留まる。
+- **報酬**: goal への前進 − step cost − corridor 逸脱ペナルティ（+ 到達ボーナス）。
+- **終了**: goal 到達 / 場外 / corridor を `hard_dev` 超で逸脱 / timeout。
+- **観測 2 モード**:
+  - `state` — 低次元ベクトル `[goal_dist, cos(bearing), sin(bearing), corridor_dev]`。
+    GPU 不要、CPU で数秒学習・単体テスト可能。
+  - `camera` — ego カメラの 3DGS render（注入する `render_fn` = `GaussianRenderer`
+    クロージャ）。これが **sim2real 観測**で、closed-loop sensor-sim が配信する像と一致。
+
+運動学・報酬・終了は pure numpy ヘルパー（単体テスト済み）で、`DriveEnv` は
+それらを Gymnasium API と任意のレンダラに配線するだけ。
+
+## 学習結果（state 観測、PPO、合成 arc コリドー）
+
+stable-baselines3 PPO / MlpPolicy / 60k step（CPU）:
+
+```
+random policy : mean return -26.07, success  0%
+PPO (60k step): mean return  23.78, success 100%
+```
+
+- **RL ループが収束**: ランダム方策は corridor を外れて 0% 成功なのに対し、PPO は
+  60k step で **goal 到達 100%**・return が大きく改善。環境が end-to-end で学習可能
+  であることを実証（= Phase 4 RL 着手）。
+- 報酬が「前進 − corridor 逸脱」なので、学習方策は **Phase 0 の有効視点範囲内に
+  留まりながら goal へ向かう**走り方を獲得する（sim2real の前提と一貫）。
+
+## sim2real ブリッジ（pixel 観測）と次
+
+- `obs_mode='camera'` + `render_fn`（`GaussianRenderer.render(pose→viewmat)`）で、
+  **エージェントが 3DGS render を直接観測**して学習できる。これは GPU rollout で
+  重いので本検証（state 観測）から分離した、明確な次ステップ。
+- corridor anchors は記録 SLAM 軌跡（TUM）をそのまま使える（`--traj`）。stadtgarten /
+  construction の実コリドーで「有効視点範囲内を走る」方策を学べる。
+- dynamic actor（`3dgs-actor-compositing-phase3.md` の box/sprite/ply）を毎 step
+  シーンに合成すれば、**動的交通下の知覚-行動方策**（回避・追従）に拡張できる。検出
+  スコアリング（`detect_in_scene` / `sim2real_gap`）はそのまま報酬項に使える。
+
+## ロードマップ上の位置づけ
+
+```
+Phase 0  外挿安定性 / 有効視点範囲                  ← 完了
+Phase 1  open-loop RGB-D データ生成                 ← 完了
+Phase 2  closed-loop sensor-sim ROS 2 node          ← 完了
+Phase 3  dynamic actors + 検出 gap (orbit/dolly/LiDAR-primed) ← 完了
+Phase 4  closed-loop RL                              ← 本ノート（env + PPO 収束。pixel/dynamic は次）
+```

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -498,6 +498,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_gaussian_splatting_drive_env
+    test/test_gaussian_splatting_drive_env.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_mid360_robot_preflight
     test/test_mid360_robot_preflight.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_gaussian_splatting_drive_env.py
+++ b/graph_based_slam/test/test_gaussian_splatting_drive_env.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the 3DGS driving RL env (pure helpers + state-mode rollout, CPU)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+
+
+def _load():
+    if str(TOOL_DIR) not in sys.path:
+        sys.path.insert(0, str(TOOL_DIR))
+    import drive_env
+
+    return drive_env
+
+
+de = _load()
+
+
+def test_wrap_angle_range():
+    # +-pi are the same heading; the wrap maps odd multiples of pi to |pi|
+    assert abs(de.wrap_angle(3.0 * np.pi)) == pytest.approx(np.pi)
+    assert abs(de.wrap_angle(-3.0 * np.pi)) == pytest.approx(np.pi)
+    assert de.wrap_angle(0.0) == 0.0
+    assert de.wrap_angle(np.pi / 2) == pytest.approx(np.pi / 2)
+
+
+def test_unicycle_step_drives_along_heading():
+    p = de.unicycle_step([0.0, 0.0, 0.0], 2.0, 0.0, 0.5)
+    assert np.allclose(p, [1.0, 0.0, 0.0])
+    p2 = de.unicycle_step([0.0, 0.0, np.pi / 2], 2.0, 0.0, 0.5)
+    assert np.allclose(p2[:2], [0.0, 1.0], atol=1e-9)
+
+
+def test_unicycle_step_turns_with_omega():
+    p = de.unicycle_step([0.0, 0.0, 0.0], 0.0, 1.0, 0.5)
+    assert p[2] == pytest.approx(0.5)
+    assert np.allclose(p[:2], [0.0, 0.0])
+
+
+def test_goal_range_bearing_ahead_and_left():
+    dist, bearing = de.goal_range_bearing([0.0, 0.0, 0.0], [3.0, 0.0])
+    assert dist == pytest.approx(3.0) and bearing == pytest.approx(0.0)
+    _, bl = de.goal_range_bearing([0.0, 0.0, 0.0], [0.0, 5.0])
+    assert bl == pytest.approx(np.pi / 2)  # goal to the left
+
+
+def test_corridor_deviation_nearest_anchor():
+    anchors = np.array([[0.0, 0.0], [10.0, 0.0], [20.0, 0.0]])
+    assert de.corridor_deviation([10.0, 3.0], anchors) == pytest.approx(3.0)
+    assert de.corridor_deviation([0.0, 0.0], anchors) == pytest.approx(0.0)
+
+
+def test_step_reward_rewards_progress_and_penalises_dev():
+    # closing 2 m, inside corridor: progress 2 - step_cost
+    r = de.step_reward(10.0, 8.0, 0.1, max_dev=0.25)
+    assert r == pytest.approx(2.0 - 0.02)
+    # straying beyond max_dev costs dev_weight * excess
+    r2 = de.step_reward(10.0, 10.0, 1.25, max_dev=0.25)
+    assert r2 == pytest.approx(-0.02 - 0.5 * 1.0)
+
+
+def test_step_reward_goal_bonus():
+    r = de.step_reward(2.0, 0.5, 0.0, max_dev=0.25, goal_tol=1.0)
+    assert r > 10.0  # progress + goal_bonus
+
+
+def test_episode_status_goal_and_bounds_and_corridor():
+    g = [5.0, 0.0]
+    term, trunc, reason = de.episode_status(
+        [5.0, 0.2, 0.0], g, dev=0.0, goal_tol=1.0, bounds=50.0,
+        hard_dev=1.0, step=1, max_steps=200)
+    assert term and reason == 'goal'
+    term, _, reason = de.episode_status(
+        [99.0, 0.0, 0.0], g, dev=0.0, goal_tol=1.0, bounds=50.0,
+        hard_dev=1.0, step=1, max_steps=200)
+    assert term and reason == 'out_of_bounds'
+    term, _, reason = de.episode_status(
+        [0.0, 0.0, 0.0], g, dev=2.0, goal_tol=1.0, bounds=50.0,
+        hard_dev=1.0, step=1, max_steps=200)
+    assert term and reason == 'left_corridor'
+    _, trunc, reason = de.episode_status(
+        [0.0, 0.0, 0.0], g, dev=0.0, goal_tol=1.0, bounds=50.0,
+        hard_dev=1.0, step=200, max_steps=200)
+    assert trunc and reason == 'timeout'
+
+
+def _anchors():
+    return np.stack([np.linspace(0, 10, 11), np.zeros(11)], axis=1)
+
+
+def test_env_reset_and_obs_shape():
+    pytest.importorskip('gymnasium')
+    env = de.make_drive_env(_anchors(), [10.0, 0.0], max_steps=50)
+    obs, info = env.reset(seed=0)
+    assert obs.shape == (4,) and obs.dtype == np.float32
+    assert env.observation_space.contains(obs)
+    assert 'pose' in info
+
+
+def test_env_driving_straight_reaches_goal():
+    pytest.importorskip('gymnasium')
+    env = de.make_drive_env(_anchors(), [10.0, 0.0], dt=0.5, v_max=2.0,
+                            max_steps=100, goal_tol=1.0)
+    env.reset(seed=0)
+    total, done = 0.0, False
+    for _ in range(100):
+        obs, r, term, trunc, info = env.step([1.0, 0.0])  # full speed ahead
+        total += r
+        if term or trunc:
+            done = True
+            break
+    assert done and info['reason'] == 'goal'
+    assert total > 0.0  # net positive: progressed and arrived
+
+
+def test_env_leaving_corridor_terminates_with_penalty():
+    pytest.importorskip('gymnasium')
+    env = de.make_drive_env(_anchors(), [10.0, 0.0], dt=0.5, v_max=2.0,
+                            omega_max=1.0, hard_dev=1.0, max_steps=100)
+    env.reset(seed=0)
+    # turn hard left and drive: leaves the y=0 corridor quickly
+    reason = ''
+    for _ in range(100):
+        _, _, term, trunc, info = env.step([1.0, 1.0])
+        reason = info['reason']
+        if term or trunc:
+            break
+    assert reason in ('left_corridor', 'out_of_bounds')
+
+
+def test_env_passes_gymnasium_checker():
+    pytest.importorskip('gymnasium')
+    from gymnasium.utils.env_checker import check_env
+
+    env = de.make_drive_env(_anchors(), [10.0, 0.0], max_steps=50)
+    check_env(env, skip_render_check=True)

--- a/scripts/run_drive_rl.sh
+++ b/scripts/run_drive_rl.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Train a PPO policy in the 3DGS DriveEnv (Phase 4 RL substrate). The closed-loop
+# 3DGS sim is wrapped as a Gymnasium env (tools/gaussian_splatting/drive_env.py);
+# this trains a stable-baselines3 agent on the low-dim `state` observation so the
+# RL loop validates in seconds on CPU. The ego (planar unicycle) must reach a
+# goal while staying inside the valid-viewpoint corridor (Phase 0).
+#
+# Corridor anchors come from a recorded SLAM trajectory (TRAJ, TUM, recentred)
+# or a synthetic arc when TRAJ is empty. The `camera` observation (the 3DGS
+# render, the real sim2real signal) plugs into the same env via a
+# GaussianRenderer render_fn -- pixel-space training is the GPU-heavy next step.
+#
+# Requires: gymnasium + stable-baselines3 + torch.
+#
+# Usage:
+#   bash scripts/run_drive_rl.sh                     # synthetic arc corridor
+#   TRAJ=output/rtkslam_stadtgarten_seq2_run/traj_raw.tum \
+#     STEPS=80000 bash scripts/run_drive_rl.sh       # real trajectory corridor
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}/tools/gaussian_splatting"
+
+TRAJ="${TRAJ:-}"
+STEPS="${STEPS:-60000}"
+EVAL_EPISODES="${EVAL_EPISODES:-30}"
+SAVE="${SAVE:-}"
+
+ARGS=(--steps "${STEPS}" --eval-episodes "${EVAL_EPISODES}")
+[[ -n "${TRAJ}" ]] && ARGS+=(--traj "${REPO_ROOT}/${TRAJ}")
+[[ -n "${SAVE}" ]] && ARGS+=(--save "${SAVE}")
+
+python3 train_drive_policy.py "${ARGS[@]}"

--- a/tools/gaussian_splatting/drive_env.py
+++ b/tools/gaussian_splatting/drive_env.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Gymnasium driving environment over a 3DGS scene (closed-loop sim2real RL).
+
+Phase 4 of the 3DGS-as-sim2real track: the RL substrate. The closed-loop pieces
+already exist -- a GPU renderer, a sensor-sim node, depth-tested actor
+compositing, detection scoring -- so this wraps them as a standard
+``gymnasium.Env`` an agent can learn in. The ego is a planar unicycle; the task
+is to reach a goal pose while staying inside the **valid viewpoint corridor**
+(Phase 0: the 3DGS render is only trustworthy within ``max_dev`` of the recorded
+trajectory), within bounds, before timeout.
+
+Two observation modes:
+
+* ``state`` -- a low-dim vector (goal range/bearing, corridor deviation). No GPU,
+  so a policy trains in seconds and the env is unit tested on CPU.
+* ``camera`` -- the 3DGS render from the ego camera via an injected ``render_fn``
+  (a ``GaussianRenderer``-backed closure). This is the sim2real observation; the
+  agent sees exactly what the closed-loop sensor-sim would publish.
+
+The dynamics, reward, and termination are pure numpy helpers (unit tested);
+``DriveEnv`` only wires them to the Gymnasium API and the optional renderer.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Sequence
+
+import numpy as np
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (no gym/torch/CUDA)
+# --------------------------------------------------------------------------- #
+def wrap_angle(a: float) -> float:
+    """Wrap an angle to (-pi, pi]."""
+    return float((a + np.pi) % (2.0 * np.pi) - np.pi)
+
+
+def unicycle_step(pose: Sequence[float], v: float, omega: float,
+                  dt: float) -> np.ndarray:
+    """Advance a planar unicycle ``(x, y, yaw)`` by speed ``v`` / yaw-rate ``omega``."""
+    x, y, yaw = (float(p) for p in pose)
+    x += v * np.cos(yaw) * dt
+    y += v * np.sin(yaw) * dt
+    yaw = wrap_angle(yaw + omega * dt)
+    return np.array([x, y, yaw], dtype=float)
+
+
+def goal_range_bearing(pose: Sequence[float],
+                       goal_xy: Sequence[float]) -> tuple[float, float]:
+    """Distance to the goal and its bearing in the ego frame (0 = straight ahead)."""
+    dx = float(goal_xy[0]) - float(pose[0])
+    dy = float(goal_xy[1]) - float(pose[1])
+    dist = float(np.hypot(dx, dy))
+    bearing = wrap_angle(np.arctan2(dy, dx) - float(pose[2]))
+    return dist, bearing
+
+
+def corridor_deviation(pose_xy: Sequence[float],
+                       anchors: np.ndarray) -> float:
+    """Distance from the ego to the nearest recorded-trajectory anchor point."""
+    pts = np.asarray(anchors, dtype=float)
+    d = pts - np.asarray(pose_xy, dtype=float)[None, :]
+    return float(np.sqrt((d * d).sum(axis=1)).min())
+
+
+def step_reward(prev_dist: float, dist: float, dev: float, *, max_dev: float,
+                step_cost: float = 0.02, dev_weight: float = 0.5,
+                goal_tol: float = 1.0, goal_bonus: float = 10.0) -> float:
+    """Progress toward the goal, penalising corridor exits and time.
+
+    Reward = (prev_dist - dist) progress - step_cost - dev_weight * max(0, dev -
+    max_dev), plus ``goal_bonus`` on arrival (``dist <= goal_tol``).
+    """
+    r = (prev_dist - dist) - step_cost
+    r -= dev_weight * max(0.0, dev - max_dev)
+    if dist <= goal_tol:
+        r += goal_bonus
+    return float(r)
+
+
+def episode_status(pose: Sequence[float], goal_xy: Sequence[float], *,
+                   dev: float, goal_tol: float, bounds: float,
+                   hard_dev: float, step: int, max_steps: int) -> tuple:
+    """Return ``(terminated, truncated, reason)`` for the current state.
+
+    Terminates on goal arrival, leaving the world ``bounds``, or straying past
+    ``hard_dev`` from the corridor (the render is meaningless there); truncates
+    at ``max_steps``.
+    """
+    dist, _ = goal_range_bearing(pose, goal_xy)
+    if dist <= goal_tol:
+        return True, False, 'goal'
+    if abs(pose[0]) > bounds or abs(pose[1]) > bounds:
+        return True, False, 'out_of_bounds'
+    if dev > hard_dev:
+        return True, False, 'left_corridor'
+    if step >= max_steps:
+        return False, True, 'timeout'
+    return False, False, ''
+
+
+# --------------------------------------------------------------------------- #
+# Gymnasium environment
+# --------------------------------------------------------------------------- #
+class DriveEnv:
+    """Planar driving over a 3DGS scene; ``gymnasium.Env`` subclass at runtime.
+
+    Constructed lazily as a ``gymnasium.Env`` so the pure helpers above stay
+    importable without gymnasium. Use :func:`make_drive_env` to instantiate.
+    """
+
+
+def make_drive_env(anchors: np.ndarray, goal_xy: Sequence[float], *,
+                   start_pose: Sequence[float] = (0.0, 0.0, 0.0),
+                   max_dev: float = 0.25, hard_dev: float = 1.0,
+                   bounds: float = 50.0, dt: float = 0.2, v_max: float = 2.0,
+                   omega_max: float = 1.0, max_steps: int = 200,
+                   goal_tol: float = 1.0, obs_mode: str = 'state',
+                   render_fn: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+                   render_size: Sequence[int] = (120, 160)):
+    """Build a Gymnasium ``DriveEnv`` instance (imports gymnasium lazily)."""
+    import gymnasium as gym
+    from gymnasium import spaces
+
+    anchors = np.asarray(anchors, dtype=float)
+    goal_xy = np.asarray(goal_xy, dtype=float)
+    start_pose = np.asarray(start_pose, dtype=float)
+
+    class _DriveEnv(gym.Env):
+        metadata = {'render_modes': []}
+
+        def __init__(self):
+            super().__init__()
+            self.action_space = spaces.Box(-1.0, 1.0, (2,), dtype=np.float32)
+            if obs_mode == 'camera':
+                if render_fn is None:
+                    raise ValueError('camera obs_mode needs a render_fn')
+                h, w = int(render_size[0]), int(render_size[1])
+                self.observation_space = spaces.Box(0, 255, (h, w, 3),
+                                                    dtype=np.uint8)
+            else:
+                # [goal_dist, cos(bearing), sin(bearing), corridor_dev]
+                span = 4.0 * float(bounds)
+                hi = np.array([span, 1.0, 1.0, span], dtype=np.float32)
+                lo = np.array([0.0, -1.0, -1.0, 0.0], dtype=np.float32)
+                self.observation_space = spaces.Box(lo, hi, dtype=np.float32)
+            self._pose = start_pose.copy()
+            self._step = 0
+            self._prev_dist = 0.0
+
+        def _obs(self):
+            if obs_mode == 'camera':
+                return np.asarray(render_fn(self._pose), dtype=np.uint8)
+            dist, bearing = goal_range_bearing(self._pose, goal_xy)
+            dev = corridor_deviation(self._pose[:2], anchors)
+            return np.array([dist, np.cos(bearing), np.sin(bearing), dev],
+                            dtype=np.float32)
+
+        def reset(self, *, seed=None, options=None):
+            super().reset(seed=seed)
+            self._pose = start_pose.copy()
+            self._step = 0
+            self._prev_dist, _ = goal_range_bearing(self._pose, goal_xy)
+            return self._obs(), {'pose': self._pose.copy()}
+
+        def step(self, action):
+            a = np.clip(np.asarray(action, dtype=float), -1.0, 1.0)
+            v, omega = float(a[0]) * v_max, float(a[1]) * omega_max
+            self._pose = unicycle_step(self._pose, v, omega, dt)
+            self._step += 1
+            dist, _ = goal_range_bearing(self._pose, goal_xy)
+            dev = corridor_deviation(self._pose[:2], anchors)
+            reward = step_reward(self._prev_dist, dist, dev, max_dev=max_dev,
+                                 goal_tol=goal_tol)
+            self._prev_dist = dist
+            terminated, truncated, reason = episode_status(
+                self._pose, goal_xy, dev=dev, goal_tol=goal_tol, bounds=bounds,
+                hard_dev=hard_dev, step=self._step, max_steps=max_steps)
+            if reason == 'out_of_bounds' or reason == 'left_corridor':
+                reward -= 5.0
+            info = {'pose': self._pose.copy(), 'dev': dev, 'dist': dist,
+                    'reason': reason}
+            return self._obs(), float(reward), terminated, truncated, info
+
+    return _DriveEnv()

--- a/tools/gaussian_splatting/train_drive_policy.py
+++ b/tools/gaussian_splatting/train_drive_policy.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Train a PPO policy in the 3DGS DriveEnv (state obs) to validate the RL loop.
+
+Phase 4 demonstration: the closed-loop 3DGS sim is wrapped as a Gymnasium env
+(``drive_env.py``); this trains a stable-baselines3 PPO agent on the low-dim
+``state`` observation so a policy converges in seconds on CPU, proving the env is
+learnable end to end. The agent must drive the unicycle ego to the goal while
+staying inside the valid-viewpoint corridor.
+
+The ``camera`` observation (the 3DGS render, the real sim2real signal) plugs into
+the same env via a ``GaussianRenderer`` ``render_fn``; training on pixels is the
+GPU-heavy next step and is intentionally out of this quick validation.
+
+Corridor anchors come from a recorded SLAM trajectory (``--traj`` TUM, recentred)
+or a synthetic arc; the goal is the far end of the corridor.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Optional, Sequence
+
+import numpy as np
+
+import drive_env
+
+
+def load_traj_xy(path: Path) -> np.ndarray:
+    """Read the x,y columns of a TUM trajectory (cols 2,3) as (N, 2)."""
+    rows = []
+    for line in Path(path).read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        parts = line.split()
+        rows.append([float(parts[1]), float(parts[2])])
+    return np.asarray(rows, dtype=float)
+
+
+def synthetic_arc(n: int = 40, radius: float = 12.0,
+                  sweep_deg: float = 80.0) -> np.ndarray:
+    """A gentle arc corridor centred on the origin start (deterministic)."""
+    ang = np.radians(np.linspace(0.0, sweep_deg, n))
+    xy = np.stack([radius * np.sin(ang), radius * (1.0 - np.cos(ang))], axis=1)
+    return xy
+
+
+def recenter_corridor(xy: np.ndarray) -> tuple:
+    """Translate so the path starts at the origin; heading toward the 2nd point."""
+    xy = np.asarray(xy, dtype=float)
+    xy = xy - xy[0]
+    heading = float(np.arctan2(xy[1, 1] - xy[0, 1], xy[1, 0] - xy[0, 0]))
+    return xy, heading
+
+
+def evaluate(env, policy, episodes: int) -> tuple:
+    """Mean return and goal-success rate over greedy episodes."""
+    returns, goals = [], 0
+    for _ in range(episodes):
+        obs, _ = env.reset()
+        done, total = False, 0.0
+        while not done:
+            action = (env.action_space.sample() if policy is None
+                      else policy.predict(obs, deterministic=True)[0])
+            obs, r, term, trunc, info = env.step(action)
+            total += r
+            done = term or trunc
+        returns.append(total)
+        goals += int(info.get('reason') == 'goal')
+    return float(np.mean(returns)), goals / episodes
+
+
+def build_env(args):
+    """Construct the DriveEnv from a trajectory or synthetic arc."""
+    if args.traj:
+        xy = load_traj_xy(Path(args.traj))
+        step = max(1, len(xy) // 40)
+        xy = xy[::step]
+    else:
+        xy = synthetic_arc()
+    anchors, heading = recenter_corridor(xy)
+    return drive_env.make_drive_env(
+        anchors, anchors[-1], start_pose=(0.0, 0.0, heading),
+        max_dev=args.max_dev, hard_dev=args.hard_dev, dt=0.2, v_max=2.0,
+        omega_max=1.0, max_steps=args.max_steps, goal_tol=1.0, obs_mode='state')
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """CLI entry point."""
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument('--traj', default='', help='TUM trajectory for corridor anchors')
+    p.add_argument('--steps', type=int, default=60000, help='PPO training steps')
+    p.add_argument('--eval-episodes', type=int, default=20)
+    p.add_argument('--max-dev', type=float, default=1.0)
+    p.add_argument('--hard-dev', type=float, default=3.0)
+    p.add_argument('--max-steps', type=int, default=200)
+    p.add_argument('--seed', type=int, default=0)
+    p.add_argument('--save', default='', help='optional path to save the policy')
+    args = p.parse_args(argv)
+
+    from stable_baselines3 import PPO
+
+    env = build_env(args)
+    base_ret, base_succ = evaluate(env, None, args.eval_episodes)
+    print(f'random policy: mean return {base_ret:.2f}, success {base_succ:.0%}')
+
+    model = PPO('MlpPolicy', env, seed=args.seed, verbose=0)
+    model.learn(total_timesteps=args.steps)
+    ret, succ = evaluate(env, model, args.eval_episodes)
+    print(f'PPO ({args.steps} steps): mean return {ret:.2f}, success {succ:.0%}')
+    if args.save:
+        model.save(args.save)
+        print(f'saved policy to {args.save}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Phase 4 of the sim2real track: the **RL substrate**. The closed-loop pieces already exist (GPU renderer, sensor-sim node, depth-tested actor compositing, detection scoring), so this wraps them as a standard `gymnasium.Env` an agent can learn in.

## Env (`drive_env.py`)
- Planar-unicycle ego; task = **reach a goal while staying inside the valid-viewpoint corridor** (Phase 0: the render is trustworthy within `max_dev` of the recorded trajectory).
- Reward = progress − corridor-exit penalty − step cost (+ goal bonus); terminates on goal / out-of-bounds / corridor exit / timeout.
- Two observation modes:
  - `state` — low-dim `[goal_dist, cos/sin(bearing), corridor_dev]`; no GPU, trains in seconds, unit tested.
  - `camera` — the **3DGS render** from the ego camera via an injected `GaussianRenderer` `render_fn` (the sim2real observation).
- Dynamics/reward/termination are pure numpy helpers.

## Tests
12 CPU tests (helpers + state-mode rollout + gymnasium `env_checker`); the gym-dependent ones `importorskip` so CI without gymnasium still runs the pure helpers. ament_flake8 clean.

## PPO validation (`train_drive_policy.py` / `run_drive_rl.sh`)
stable-baselines3 PPO on the `state` obs, synthetic arc corridor:
```
random policy : mean return -26.07, success   0%
PPO (60k step): mean return  23.78, success 100%
```
The RL loop **converges** — the learned policy reaches the goal 100% while staying inside the valid-viewpoint corridor.

## Next (documented)
Pixel-space (`camera` obs) and dynamic-actor traffic are GPU-rollout next steps; detection scoring (`detect_in_scene` / `sim2real_gap`) plugs straight into the reward. Real corridors load from a SLAM TUM via `--traj`.

## Reproduce
```
bash scripts/run_drive_rl.sh                 # synthetic arc
TRAJ=output/rtkslam_stadtgarten_seq2_run/traj_raw.tum bash scripts/run_drive_rl.sh
```
doc: `docs/research/3dgs-rl-drive-env-phase4.md`