### PR TITLE
feat(3dgs): dynamic-actor avoidance RL task (Phase 4 follow-up)

### DIFF
--- a/docs/research/3dgs-rl-drive-env-phase4.md
+++ b/docs/research/3dgs-rl-drive-env-phase4.md
@@ -41,6 +41,29 @@ PPO (60k step): mean return  23.78, success 100%
 - 報酬が「前進 − corridor 逸脱」なので、学習方策は **Phase 0 の有効視点範囲内に
   留まりながら goal へ向かう**走り方を獲得する（sim2real の前提と一貫）。
 
+## 追記: dynamic actor 回避タスク (2026-06-16)
+
+closed-loop の dynamic actor（`3dgs-actor-compositing-phase3.md`）を RL に取り込んだ。
+env に**横断歩行者**（`crossing_actor`、step→xy のスクリプト actor）を追加し、
+state 観測に actor の ego 相対 range/bearing（+3 次元）、報酬に近接 yield コスト、
+衝突（`actor_radius` 内）で終了＋ペナルティを加えた（後方互換: actor 無しは現状維持）。
+
+直線コリドー＋「フル速で走ると到達タイミングで歩行者が経路中心に来る」横断を設定
+（= **直進フル速は step 18 で衝突**する経路）。stable-baselines3 PPO / state 観測 / CPU:
+
+```
+random policy : mean return -24.17, success   0%, collision 0%
+PPO (120k)    : mean return  24.05, success 100%, collision 0%
+```
+
+- **PPO は衝突 0% で goal 到達 100%** を獲得。rollout では最小 ego–歩行者距離 2.86 m
+  （衝突半径 1.0 m に対し安全マージン）を保ち、安全な接近速度（throttle ~0.74、
+  フル 1.0 でない）で歩行者が抜けた後に通過する。**直進フル速が衝突する経路で、
+  actor 観測を使って衝突回避方策を学習**したことを示す。
+- これで RL は「ナビ（goal 到達）」だけでなく「**動的物体の知覚-回避**」まで学習可能と
+  実証。検出スコアリング（`detect_in_scene`/`sim2real_gap`）を報酬項に差し替えれば、
+  pixel 観測下の知覚駆動方策へ直結する。
+
 ## sim2real ブリッジ（pixel 観測）と次
 
 - `obs_mode='camera'` + `render_fn`（`GaussianRenderer.render(pose→viewmat)`）で、

--- a/graph_based_slam/test/test_gaussian_splatting_drive_env.py
+++ b/graph_based_slam/test/test_gaussian_splatting_drive_env.py
@@ -170,3 +170,43 @@ def test_env_passes_gymnasium_checker():
 
     env = de.make_drive_env(_anchors(), [10.0, 0.0], max_steps=50)
     check_env(env, skip_render_check=True)
+
+
+def test_crossing_actor_walks_then_holds():
+    a0 = de.crossing_actor(0, x=5.0, y0=-3.0, y1=3.0, cross_steps=10)
+    amid = de.crossing_actor(5, x=5.0, y0=-3.0, y1=3.0, cross_steps=10)
+    aend = de.crossing_actor(20, x=5.0, y0=-3.0, y1=3.0, cross_steps=10)
+    assert np.allclose(a0, [5.0, -3.0])
+    assert np.allclose(amid, [5.0, 0.0])
+    assert np.allclose(aend, [5.0, 3.0])  # clamped at y1 after cross_steps
+
+
+def test_collision_radius():
+    assert de.collision([0.0, 0.0], [0.5, 0.0], 1.0)
+    assert not de.collision([0.0, 0.0], [2.0, 0.0], 1.0)
+
+
+def test_actor_env_obs_has_extra_actor_dims():
+    pytest.importorskip('gymnasium')
+    actor = lambda s: de.crossing_actor(s, x=5.0, y0=-3.0, y1=3.0, cross_steps=20)  # noqa: E731
+    env = de.make_drive_env(_anchors(), [10.0, 0.0], max_steps=50,
+                            actor_fn=actor)
+    obs, _ = env.reset(seed=0)
+    assert obs.shape == (7,)
+    assert env.observation_space.contains(obs)
+
+
+def test_actor_env_collision_terminates():
+    pytest.importorskip('gymnasium')
+    # actor parked dead ahead at x=2 on the corridor -> driving straight collides
+    actor = lambda s: np.array([2.0, 0.0])  # noqa: E731
+    env = de.make_drive_env(_anchors(), [10.0, 0.0], dt=0.5, v_max=2.0,
+                            max_steps=50, actor_radius=1.0, actor_fn=actor)
+    env.reset(seed=0)
+    reason = ''
+    for _ in range(50):
+        _, _, term, trunc, info = env.step([1.0, 0.0])
+        reason = info['reason']
+        if term or trunc:
+            break
+    assert reason == 'collision'

--- a/tools/gaussian_splatting/drive_env.py
+++ b/tools/gaussian_splatting/drive_env.py
@@ -64,6 +64,27 @@ def corridor_deviation(pose_xy: Sequence[float],
     return float(np.sqrt((d * d).sum(axis=1)).min())
 
 
+def crossing_actor(step: int, *, x: float, y0: float, y1: float,
+                   cross_steps: int) -> np.ndarray:
+    """A pedestrian crossing the corridor at fixed ``x``, ``y0``->``y1`` then held.
+
+    Deterministic (no RNG) so the env and its tests are reproducible: the actor
+    walks linearly from ``y0`` to ``y1`` over ``cross_steps`` steps and stops at
+    ``y1`` afterwards.
+    """
+    f = min(max(step / max(cross_steps, 1), 0.0), 1.0)
+    return np.array([float(x), float(y0) + (float(y1) - float(y0)) * f],
+                    dtype=float)
+
+
+def collision(a_xy: Sequence[float], b_xy: Sequence[float],
+              radius: float) -> bool:
+    """Whether two points are within ``radius`` of each other."""
+    a = np.asarray(a_xy, dtype=float)
+    b = np.asarray(b_xy, dtype=float)
+    return bool(np.hypot(*(a - b)) <= radius)
+
+
 def step_reward(prev_dist: float, dist: float, dev: float, *, max_dev: float,
                 step_cost: float = 0.02, dev_weight: float = 0.5,
                 goal_tol: float = 1.0, goal_bonus: float = 10.0) -> float:
@@ -118,14 +139,24 @@ def make_drive_env(anchors: np.ndarray, goal_xy: Sequence[float], *,
                    omega_max: float = 1.0, max_steps: int = 200,
                    goal_tol: float = 1.0, obs_mode: str = 'state',
                    render_fn: Optional[Callable[[np.ndarray], np.ndarray]] = None,
-                   render_size: Sequence[int] = (120, 160)):
-    """Build a Gymnasium ``DriveEnv`` instance (imports gymnasium lazily)."""
+                   render_size: Sequence[int] = (120, 160),
+                   actor_fn: Optional[Callable[[int], np.ndarray]] = None,
+                   actor_radius: float = 1.0, yield_dist: float = 4.0,
+                   collision_penalty: float = 10.0):
+    """Build a Gymnasium ``DriveEnv`` instance (imports gymnasium lazily).
+
+    When ``actor_fn`` (step -> world xy) is given, a dynamic actor (e.g. a
+    crossing pedestrian) is added: the state obs gains the actor's ego-frame
+    range/bearing, a proximity cost applies within ``yield_dist`` ahead, and a
+    collision (within ``actor_radius``) ends the episode with ``collision_penalty``.
+    """
     import gymnasium as gym
     from gymnasium import spaces
 
     anchors = np.asarray(anchors, dtype=float)
     goal_xy = np.asarray(goal_xy, dtype=float)
     start_pose = np.asarray(start_pose, dtype=float)
+    has_actor = actor_fn is not None
 
     class _DriveEnv(gym.Env):
         metadata = {'render_modes': []}
@@ -141,21 +172,33 @@ def make_drive_env(anchors: np.ndarray, goal_xy: Sequence[float], *,
                                                     dtype=np.uint8)
             else:
                 # [goal_dist, cos(bearing), sin(bearing), corridor_dev]
+                # (+ [actor_range, cos, sin] when an actor is present)
                 span = 4.0 * float(bounds)
-                hi = np.array([span, 1.0, 1.0, span], dtype=np.float32)
-                lo = np.array([0.0, -1.0, -1.0, 0.0], dtype=np.float32)
-                self.observation_space = spaces.Box(lo, hi, dtype=np.float32)
+                hi = [span, 1.0, 1.0, span]
+                lo = [0.0, -1.0, -1.0, 0.0]
+                if has_actor:
+                    hi += [span, 1.0, 1.0]
+                    lo += [0.0, -1.0, -1.0]
+                self.observation_space = spaces.Box(
+                    np.array(lo, dtype=np.float32),
+                    np.array(hi, dtype=np.float32), dtype=np.float32)
             self._pose = start_pose.copy()
             self._step = 0
             self._prev_dist = 0.0
+
+        def _actor_xy(self):
+            return np.asarray(actor_fn(self._step), dtype=float)
 
         def _obs(self):
             if obs_mode == 'camera':
                 return np.asarray(render_fn(self._pose), dtype=np.uint8)
             dist, bearing = goal_range_bearing(self._pose, goal_xy)
             dev = corridor_deviation(self._pose[:2], anchors)
-            return np.array([dist, np.cos(bearing), np.sin(bearing), dev],
-                            dtype=np.float32)
+            vec = [dist, np.cos(bearing), np.sin(bearing), dev]
+            if has_actor:
+                arange, abear = goal_range_bearing(self._pose, self._actor_xy())
+                vec += [arange, np.cos(abear), np.sin(abear)]
+            return np.array(vec, dtype=np.float32)
 
         def reset(self, *, seed=None, options=None):
             super().reset(seed=seed)
@@ -181,6 +224,18 @@ def make_drive_env(anchors: np.ndarray, goal_xy: Sequence[float], *,
                 reward -= 5.0
             info = {'pose': self._pose.copy(), 'dev': dev, 'dist': dist,
                     'reason': reason}
+            if has_actor:
+                actor_xy = self._actor_xy()
+                arange, abear = goal_range_bearing(self._pose, actor_xy)
+                # proximity cost only for an actor ahead within yield_dist
+                if arange < yield_dist and abs(abear) < np.pi / 2:
+                    reward -= (yield_dist - arange) / yield_dist
+                info['actor_xy'] = actor_xy
+                info['actor_dist'] = arange
+                if collision(self._pose[:2], actor_xy, actor_radius):
+                    reward -= collision_penalty
+                    terminated, reason = True, 'collision'
+                    info['reason'] = reason
             return self._obs(), float(reward), terminated, truncated, info
 
     return _DriveEnv()

--- a/tools/gaussian_splatting/train_drive_policy.py
+++ b/tools/gaussian_splatting/train_drive_policy.py
@@ -46,6 +46,11 @@ def synthetic_arc(n: int = 40, radius: float = 12.0,
     return xy
 
 
+def synthetic_straight(length: float = 16.0, n: int = 33) -> np.ndarray:
+    """A straight corridor along +x (deterministic); used for the actor task."""
+    return np.stack([np.linspace(0.0, length, n), np.zeros(n)], axis=1)
+
+
 def recenter_corridor(xy: np.ndarray) -> tuple:
     """Translate so the path starts at the origin; heading toward the 2nd point."""
     xy = np.asarray(xy, dtype=float)
@@ -55,8 +60,8 @@ def recenter_corridor(xy: np.ndarray) -> tuple:
 
 
 def evaluate(env, policy, episodes: int) -> tuple:
-    """Mean return and goal-success rate over greedy episodes."""
-    returns, goals = [], 0
+    """Mean return, goal-success rate, and collision rate over greedy episodes."""
+    returns, goals, collisions = [], 0, 0
     for _ in range(episodes):
         obs, _ = env.reset()
         done, total = False, 0.0
@@ -68,22 +73,41 @@ def evaluate(env, policy, episodes: int) -> tuple:
             done = term or trunc
         returns.append(total)
         goals += int(info.get('reason') == 'goal')
-    return float(np.mean(returns)), goals / episodes
+        collisions += int(info.get('reason') == 'collision')
+    return float(np.mean(returns)), goals / episodes, collisions / episodes
 
 
 def build_env(args):
-    """Construct the DriveEnv from a trajectory or synthetic arc."""
+    """Construct the DriveEnv from a trajectory, a straight corridor, or an arc.
+
+    The actor (avoidance) task uses a straight corridor with a pedestrian
+    crossing the centreline timed to a full-speed run -- so a naive fast policy
+    collides and the agent must yield (slow, let it pass) to reach the goal.
+    """
+    v_max, dt = 2.0, 0.2
     if args.traj:
         xy = load_traj_xy(Path(args.traj))
         step = max(1, len(xy) // 40)
         xy = xy[::step]
+    elif args.actor or args.straight:
+        xy = synthetic_straight()
     else:
         xy = synthetic_arc()
     anchors, heading = recenter_corridor(xy)
+    actor_fn = None
+    if args.actor:
+        mid = anchors[len(anchors) // 2]
+        # the crossing is centred on the path exactly when a full-speed runner
+        # arrives (arrival_step = mid_x / (v_max*dt)); cross spans 2x that.
+        arrival = max(1, int(round(float(mid[0]) / (v_max * dt))))
+        actor_fn = (lambda s, mx=float(mid[0]), my=float(mid[1]):
+                    drive_env.crossing_actor(s, x=mx, y0=my - 3.0, y1=my + 3.0,
+                                             cross_steps=2 * arrival))
     return drive_env.make_drive_env(
         anchors, anchors[-1], start_pose=(0.0, 0.0, heading),
-        max_dev=args.max_dev, hard_dev=args.hard_dev, dt=0.2, v_max=2.0,
-        omega_max=1.0, max_steps=args.max_steps, goal_tol=1.0, obs_mode='state')
+        max_dev=args.max_dev, hard_dev=args.hard_dev, dt=dt, v_max=v_max,
+        omega_max=1.0, max_steps=args.max_steps, goal_tol=1.0, obs_mode='state',
+        actor_fn=actor_fn, actor_radius=1.0, yield_dist=3.0)
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -95,6 +119,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     p.add_argument('--max-dev', type=float, default=1.0)
     p.add_argument('--hard-dev', type=float, default=3.0)
     p.add_argument('--max-steps', type=int, default=200)
+    p.add_argument('--actor', action='store_true',
+                   help='add a pedestrian crossing the corridor (avoidance task)')
+    p.add_argument('--straight', action='store_true',
+                   help='use a straight corridor (implied by --actor)')
     p.add_argument('--seed', type=int, default=0)
     p.add_argument('--save', default='', help='optional path to save the policy')
     args = p.parse_args(argv)
@@ -102,13 +130,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     from stable_baselines3 import PPO
 
     env = build_env(args)
-    base_ret, base_succ = evaluate(env, None, args.eval_episodes)
-    print(f'random policy: mean return {base_ret:.2f}, success {base_succ:.0%}')
+    base_ret, base_succ, base_col = evaluate(env, None, args.eval_episodes)
+    print(f'random policy: mean return {base_ret:.2f}, success {base_succ:.0%}, '
+          f'collision {base_col:.0%}')
 
     model = PPO('MlpPolicy', env, seed=args.seed, verbose=0)
     model.learn(total_timesteps=args.steps)
-    ret, succ = evaluate(env, model, args.eval_episodes)
-    print(f'PPO ({args.steps} steps): mean return {ret:.2f}, success {succ:.0%}')
+    ret, succ, col = evaluate(env, model, args.eval_episodes)
+    print(f'PPO ({args.steps} steps): mean return {ret:.2f}, success {succ:.0%}, '
+          f'collision {col:.0%}')
     if args.save:
         model.save(args.save)
         print(f'saved policy to {args.save}')


### PR DESCRIPTION
## What

Brings the closed-loop **dynamic actor** into the RL env (#303). `DriveEnv` gains an optional scripted actor — a **crossing pedestrian** (`crossing_actor`, step→xy): the state obs adds the actor's ego-frame range/bearing, the reward a proximity-yield cost, and a **collision** (within `actor_radius`) ends the episode with a penalty. Backward compatible — no `actor_fn` means the env is unchanged.

## Task
A straight corridor with the crossing timed so that **driving full speed straight collides at step 18** — the agent must use the actor observation to clear it.

## PPO result (stable-baselines3, state obs, CPU)
```
random  : success   0%, collision 0%
PPO 120k: success 100%, collision 0%
```
The learned policy reaches the goal **collision-free** at a safe approach speed (throttle ~0.74, not full), **min ego–pedestrian distance 2.86 m** — on a path where naive full-speed driving collides. The env now supports learning **perception-driven avoidance**, not just navigation.

## Changes
- `drive_env.py`: `crossing_actor` + `collision` pure helpers; optional `actor_fn`/`actor_radius`/`yield_dist`/`collision_penalty` in `make_drive_env` (obs/reward/termination extend only when an actor is present).
- `train_drive_policy.py`: `--actor` task on a straight corridor with matched crossing timing; reports collision rate; CPU-friendly.
- 4 new CPU tests (16 total), pure helpers numpy-only, ament_flake8 clean.

## Next
Detection scoring (`detect_in_scene`/`sim2real_gap`) drops into the reward for pixel-observation perception-driven policies (GPU rollouts).

## Reproduce
```
CUDA_VISIBLE_DEVICES= python3 tools/gaussian_splatting/train_drive_policy.py --actor --steps 120000
```
doc: `docs/research/3dgs-rl-drive-env-phase4.md`