### PR TITLE
feat(3dgs): pixel-observation RL — drive a 3DGS scene from renders (Phase 4 closeout)

### DIFF
--- a/docs/research/3dgs-rl-drive-env-phase4.md
+++ b/docs/research/3dgs-rl-drive-env-phase4.md
@@ -64,6 +64,44 @@ PPO (120k)    : mean return  24.05, success 100%, collision 0%
   実証。検出スコアリング（`detect_in_scene`/`sim2real_gap`）を報酬項に差し替えれば、
   pixel 観測下の知覚駆動方策へ直結する。
 
+## 追記: pixel 観測 RL（閉ループ完成, 2026-06-16）
+
+`state` 観測（低次元ベクトル）で env の学習可能性を確かめたので、最終段の
+**pixel 観測**＝エージェントが **3DGS render を直接見て**学習する閉ループを実装した。
+
+- ツール: `tools/gaussian_splatting/scene_camera.py`（ego pose `(x,y,yaw)` →
+  3DGS viewmat の写像。pure 幾何 4 ケースを `test_gaussian_splatting_scene_camera.py`
+  で CPU テスト、ament_flake8 clean）。
+- コリドー/カメラは記録済み軌跡（`transforms.json`）から導出: カメラ姿勢の up 列を
+  平均して **world-up** を、位置を ground 平面に射影して PCA で **travel 軸 e1**
+  （`e2 = up×e1`）を復元。ego は `origin + x·e1 + y·e2 + height·up` に立ち、heading
+  方向を見る。これで env の 2D コリドー（Phase 0 有効視点範囲）と 3DGS render が同一
+  frame に揃う。
+- render は GPU 常駐 `GaussianRenderer`（84×84 で **509 FPS**）。`obs_mode='camera'`
+  で毎 step ego カメラから rasterise → `CnnPolicy` PPO。
+
+stadtgarten LiDAR-primed 3DGS（recon 18.9 dB）の実コリドー（直線 17 m）で学習:
+
+```
+random policy : mean return -19.44, success   0%
+PPO (40k,  omega_max=1.0): mean return  -3.54, success 0%   # idle ローカル最適
+PPO (120k, omega_max=0.5): mean return  25.30, success 100%
+```
+
+- 当初 40k では return が −35→−3.5 に改善しただけで **success 0%**。−3.5 ≈
+  `step_cost × ~175 step` で、「**コリドー逸脱の −5 を避けて idle する**」ローカル最適に
+  陥っていた（過操舵での逸脱リスクを学習）。直線コリドーなので **操舵自由度を絞り**
+  （`omega_max` 1.0→0.5）、学習量を 120k に増やすと **goal 到達 100%** に到達。
+- 学習方策の rollout（`output/stadt_3dgs/pixel_rl/rollout_pov.gif` / `_strip.png`）:
+  goal 到達・57 step・x −8.48→8.05 m（コリドー全長走破）・最大横ずれ 0.64 m・
+  throttle 0.99（フル前進）。**3DGS render だけを観測してコリドーを走破**する方策を獲得。
+- これで Phase 0–4 の全部品（render・actor・検出・RL）が **1 本の閉ループ**に繋がった:
+  記録軌跡 → 3DGS シーン → ego カメラ render → CNN 方策 → 行動 → 次 pose。検出
+  スコアリング（`detect_in_scene` / `sim2real_gap`）を報酬項に差し替えれば知覚駆動方策へ
+  そのまま拡張できる。
+- 罠: pixel 観測は idle ローカル最適に落ちやすい（操舵自由度を task 難度に合わせる）。
+  start heading は隣接アンカーの y ジッタで荒れるので **始点→終点の全体方向**から取る。
+
 ## sim2real ブリッジ（pixel 観測）と次
 
 - `obs_mode='camera'` + `render_fn`（`GaussianRenderer.render(pose→viewmat)`）で、
@@ -82,5 +120,5 @@ Phase 0  外挿安定性 / 有効視点範囲                  ← 完了
 Phase 1  open-loop RGB-D データ生成                 ← 完了
 Phase 2  closed-loop sensor-sim ROS 2 node          ← 完了
 Phase 3  dynamic actors + 検出 gap (orbit/dolly/LiDAR-primed) ← 完了
-Phase 4  closed-loop RL                              ← 本ノート（env + PPO 収束。pixel/dynamic は次）
+Phase 4  closed-loop RL                              ← 本ノート（env + state PPO + dynamic 回避 + pixel 観測 100% 走破）
 ```

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -503,6 +503,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_gaussian_splatting_scene_camera
+    test/test_gaussian_splatting_scene_camera.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_mid360_robot_preflight
     test/test_mid360_robot_preflight.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_gaussian_splatting_scene_camera.py
+++ b/graph_based_slam/test/test_gaussian_splatting_scene_camera.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the ego-pose -> 3DGS camera bridge (pure geometry, CPU)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+
+
+def _load():
+    if str(TOOL_DIR) not in sys.path:
+        sys.path.insert(0, str(TOOL_DIR))
+    import scene_camera
+
+    return scene_camera
+
+
+sc = _load()
+
+
+def _synthetic_c2w(n=20, length=10.0):
+    """Cameras marching along world +x at height 1.5 (world up = +z, OpenGL)."""
+    # OpenGL camera looking along -z would not march in x; build a c2w whose
+    # forward (-col2) is +x: right=+y? Use right=[0,-1,0], up=[0,0,1], fwd=[1,0,0].
+    right = np.array([0.0, -1.0, 0.0])
+    up = np.array([0.0, 0.0, 1.0])
+    fwd = np.array([1.0, 0.0, 0.0])
+    base = np.eye(4)
+    base[:3, 0] = right
+    base[:3, 1] = up
+    base[:3, 2] = -fwd  # OpenGL: camera looks down -z, so col2 = -forward
+    mats = []
+    for x in np.linspace(0.0, length, n):
+        m = base.copy()
+        m[:3, 3] = [x, 0.0, 1.5]
+        mats.append(m)
+    return np.array(mats)
+
+
+def test_derive_ground_frame_recovers_up_and_height():
+    frame = sc.derive_ground_frame(_synthetic_c2w())
+    assert np.allclose(np.abs(frame['up']), [0.0, 0.0, 1.0], atol=1e-6)
+    assert frame['height'] == pytest.approx(1.5)
+    # e1, e2, up orthonormal right-handed
+    assert np.allclose(np.cross(frame['e1'], frame['e2']), frame['up'], atol=1e-6)
+
+
+def test_corridor_xy_runs_along_plus_x():
+    c2w = _synthetic_c2w(length=10.0)
+    frame = sc.derive_ground_frame(c2w)
+    xy = sc.corridor_xy(c2w, frame)
+    assert xy.shape == (20, 2)
+    assert xy[-1, 0] > xy[0, 0]  # travel toward +x
+    assert np.abs(xy[:, 1]).max() < 1e-6  # straight: no lateral spread
+
+
+def test_eye_target_up_places_camera_at_height_and_heading():
+    c2w = _synthetic_c2w()
+    frame = sc.derive_ground_frame(c2w)
+    eye, target, up = sc.eye_target_up(2.0, 0.0, 0.0, frame)
+    assert eye[2] == pytest.approx(1.5)  # eye at recorded height
+    fwd = target - eye
+    fwd = fwd / np.linalg.norm(fwd)
+    assert np.dot(fwd, frame['e1']) == pytest.approx(1.0)  # yaw=0 -> along e1
+
+
+def test_look_at_viewmat_is_world_to_camera():
+    eye = np.array([0.0, 0.0, 0.0])
+    target = np.array([1.0, 0.0, 0.0])
+    up = np.array([0.0, 0.0, 1.0])
+    vm = sc.look_at_viewmat(eye, target, up)
+    # the target maps in front of the camera (+z in OpenCV optical frame)
+    p = vm @ np.array([1.0, 0.0, 0.0, 1.0])
+    assert p[2] > 0.0
+    # eye maps to the origin
+    e = vm @ np.array([0.0, 0.0, 0.0, 1.0])
+    assert np.allclose(e[:3], 0.0, atol=1e-9)

--- a/scripts/run_drive_rl.sh
+++ b/scripts/run_drive_rl.sh
@@ -16,6 +16,9 @@
 #   bash scripts/run_drive_rl.sh                     # synthetic arc corridor
 #   TRAJ=output/rtkslam_stadtgarten_seq2_run/traj_raw.tum \
 #     STEPS=80000 bash scripts/run_drive_rl.sh       # real trajectory corridor
+#   CAMERA=1 PLY=output/stadt_3dgs/gsplat/point_cloud.ply \
+#     TRANSFORMS=output/stadt_3dgs/gsplat/transforms.json \
+#     STEPS=40000 bash scripts/run_drive_rl.sh       # pixel-observation (GPU)
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -25,9 +28,17 @@ TRAJ="${TRAJ:-}"
 STEPS="${STEPS:-60000}"
 EVAL_EPISODES="${EVAL_EPISODES:-30}"
 SAVE="${SAVE:-}"
+CAMERA="${CAMERA:-}"
+PLY="${PLY:-}"
+TRANSFORMS="${TRANSFORMS:-}"
+RENDER_SIZE="${RENDER_SIZE:-84}"
 
 ARGS=(--steps "${STEPS}" --eval-episodes "${EVAL_EPISODES}")
 [[ -n "${TRAJ}" ]] && ARGS+=(--traj "${REPO_ROOT}/${TRAJ}")
 [[ -n "${SAVE}" ]] && ARGS+=(--save "${SAVE}")
+if [[ -n "${CAMERA}" ]]; then
+  ARGS+=(--camera --ply "${REPO_ROOT}/${PLY}" \
+         --transforms "${REPO_ROOT}/${TRANSFORMS}" --render-size "${RENDER_SIZE}")
+fi
 
-python3 train_drive_policy.py "${ARGS[@]}"
+python3 -u train_drive_policy.py "${ARGS[@]}"

--- a/tools/gaussian_splatting/scene_camera.py
+++ b/tools/gaussian_splatting/scene_camera.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Map a planar ego pose to a 3DGS camera view (pixel-observation RL bridge).
+
+Phase 4 (pixel observation) of the 3DGS-as-sim2real track. ``drive_env`` drives a
+planar unicycle ``(x, y, yaw)``; to let the agent *see* the scene we need to turn
+that pose into a ``GaussianRenderer`` view. The recorded camera trajectory
+(``transforms.json``) defines a **driving plane**: its cameras lie on a near-flat
+ground patch, so we recover a world-up axis and an in-plane 2D frame from them
+(PCA), express the corridor in that frame, and place the ego camera at the
+recorded eye height looking along its heading.
+
+This keeps the env's 2D corridor (Phase 0 valid-viewpoint range) and the 3DGS
+render in one consistent frame: ``(x, y)`` are metres in the ground plane,
+``yaw=0`` points along the travelled direction, and renders stay trustworthy
+while the ego is near the recorded path.
+
+The geometry (``load_cam_c2w``, ``derive_ground_frame``, ``corridor_xy``,
+``eye_target_up``, ``look_at_viewmat``) is pure numpy and unit tested on CPU. Only
+:func:`make_scene_render_fn` touches the GPU renderer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+
+
+def load_cam_c2w(transforms_path: str | Path) -> np.ndarray:
+    """Read camera-to-world matrices (OpenGL/nerfstudio) from a transforms.json.
+
+    Returns an ``(N, 4, 4)`` array of the frames' ``transform_matrix`` entries.
+    """
+    doc = json.loads(Path(transforms_path).read_text())
+    return np.array([np.asarray(f['transform_matrix'], dtype=float)
+                     for f in doc['frames']], dtype=float)
+
+
+def derive_ground_frame(c2w: np.ndarray) -> dict:
+    """Recover a driving frame from recorded OpenGL camera-to-world matrices.
+
+    The cameras' up columns average to the world-up axis; projecting their
+    positions off that axis gives a ground patch whose principal direction is the
+    travel axis ``e1`` (``e2 = up x e1`` completes a right-handed in-plane basis).
+    Returns ``{origin, e1, e2, up, height}``: ``origin`` is the ground centroid,
+    ``height`` the mean camera elevation above it, so an ego at plane ``(x, y)``
+    sits at ``origin + x*e1 + y*e2 + height*up``.
+    """
+    c2w = np.asarray(c2w, dtype=float)
+    pos = c2w[:, :3, 3]
+    up = c2w[:, :3, 1].mean(axis=0)
+    up = up / np.linalg.norm(up)
+    elev = pos @ up
+    ground = pos - np.outer(elev, up)
+    origin = ground.mean(axis=0)
+    centred = ground - origin
+    _, _, vt = np.linalg.svd(centred, full_matrices=False)
+    e1 = vt[0]
+    e1 = e1 / np.linalg.norm(e1)
+    if (pos[-1] - pos[0]) @ e1 < 0.0:  # orient e1 along the travel direction
+        e1 = -e1
+    e2 = np.cross(up, e1)
+    e2 = e2 / np.linalg.norm(e2)
+    return {'origin': origin, 'e1': e1, 'e2': e2, 'up': up,
+            'height': float(elev.mean())}
+
+
+def corridor_xy(c2w: np.ndarray, frame: dict) -> np.ndarray:
+    """Express recorded camera positions as ``(N, 2)`` plane coords in ``frame``.
+
+    The path runs in the ``+x`` (``e1``) direction (oriented in the frame); the
+    returned points are the env's corridor anchors.
+    """
+    pos = np.asarray(c2w, dtype=float)[:, :3, 3]
+    rel = pos - frame['origin']
+    return np.stack([rel @ frame['e1'], rel @ frame['e2']], axis=1)
+
+
+def eye_target_up(x: float, y: float, yaw: float,
+                  frame: dict) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """World-space ``(eye, target, up)`` for an ego at plane ``(x, y)`` heading ``yaw``.
+
+    ``yaw=0`` looks along ``+e1`` (the travel direction); the camera sits at the
+    recorded eye height above the ground plane.
+    """
+    e1, e2, up = frame['e1'], frame['e2'], frame['up']
+    eye = frame['origin'] + float(x) * e1 + float(y) * e2 + frame['height'] * up
+    direction = np.cos(float(yaw)) * e1 + np.sin(float(yaw)) * e2
+    return eye, eye + direction, up
+
+
+def look_at_viewmat(eye: np.ndarray, target: np.ndarray,
+                    up: np.ndarray) -> np.ndarray:
+    """World->camera (OpenCV optical) matrix for a camera looking at ``target``."""
+    eye = np.asarray(eye, dtype=float)
+    fwd = np.asarray(target, dtype=float) - eye
+    fwd = fwd / np.linalg.norm(fwd)
+    right = np.cross(np.asarray(up, dtype=float), fwd)
+    right = right / np.linalg.norm(right)
+    down = np.cross(fwd, right)
+    c2w = np.eye(4)
+    c2w[:3, 0], c2w[:3, 1], c2w[:3, 2], c2w[:3, 3] = right, down, fwd, eye
+    return np.linalg.inv(c2w)
+
+
+def make_scene_render_fn(renderer, frame: dict, *, fx: float = 60.0,
+                         width: int = 84, height: int = 84
+                         ) -> Callable[[np.ndarray], np.ndarray]:
+    """Build ``pose (x, y, yaw) -> uint8 (H, W, 3)`` over a resident renderer.
+
+    The returned closure is the env's ``render_fn`` for ``obs_mode='camera'``: it
+    converts the ego pose to a look-at viewmat in the model frame and rasterises.
+    """
+    k = np.array([[fx, 0.0, width / 2.0], [0.0, fx, height / 2.0],
+                  [0.0, 0.0, 1.0]], dtype=float)
+
+    def render_fn(pose: np.ndarray) -> np.ndarray:
+        eye, target, up = eye_target_up(pose[0], pose[1], pose[2], frame)
+        vm = look_at_viewmat(eye, target, up)
+        return renderer.render(vm, k, width, height)
+
+    return render_fn

--- a/tools/gaussian_splatting/train_drive_policy.py
+++ b/tools/gaussian_splatting/train_drive_policy.py
@@ -77,6 +77,38 @@ def evaluate(env, policy, episodes: int) -> tuple:
     return float(np.mean(returns)), goals / episodes, collisions / episodes
 
 
+def build_camera_env(args):
+    """Build a pixel-observation DriveEnv: the agent sees the 3DGS render itself.
+
+    Corridor and camera come from a recorded trajectory (``transforms.json``): the
+    ground plane / world-up / travel axis are recovered from the camera poses, the
+    ego drives in that plane, and each step rasterises the resident 3DGS model from
+    the ego camera. This closes the sim2real loop -- the policy learns from exactly
+    the image the closed-loop sensor-sim publishes.
+    """
+    import scene_camera as sc
+    from gaussian_renderer import GaussianRenderer
+
+    v_max, dt = 1.5, 0.2
+    c2w = sc.load_cam_c2w(args.transforms)
+    frame = sc.derive_ground_frame(c2w)
+    anchors = sc.corridor_xy(c2w, frame)
+    renderer = GaussianRenderer(args.ply)
+    h = w = int(args.render_size)
+    render_fn = sc.make_scene_render_fn(renderer, frame, fx=args.fx,
+                                        width=w, height=h)
+    start = anchors[0]
+    # heading from the overall travel direction (adjacent anchors jitter in y)
+    heading = float(np.arctan2(anchors[-1, 1] - anchors[0, 1],
+                               anchors[-1, 0] - anchors[0, 0]))
+    return drive_env.make_drive_env(
+        anchors, anchors[-1], start_pose=(float(start[0]), float(start[1]),
+                                          heading),
+        max_dev=args.max_dev, hard_dev=args.hard_dev, dt=dt, v_max=v_max,
+        omega_max=0.5, max_steps=args.max_steps, goal_tol=1.0,
+        obs_mode='camera', render_fn=render_fn, render_size=(h, w))
+
+
 def build_env(args):
     """Construct the DriveEnv from a trajectory, a straight corridor, or an arc.
 
@@ -84,6 +116,8 @@ def build_env(args):
     crossing the centreline timed to a full-speed run -- so a naive fast policy
     collides and the agent must yield (slow, let it pass) to reach the goal.
     """
+    if args.camera:
+        return build_camera_env(args)
     v_max, dt = 2.0, 0.2
     if args.traj:
         xy = load_traj_xy(Path(args.traj))
@@ -123,18 +157,31 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                    help='add a pedestrian crossing the corridor (avoidance task)')
     p.add_argument('--straight', action='store_true',
                    help='use a straight corridor (implied by --actor)')
+    p.add_argument('--camera', action='store_true',
+                   help='pixel observation: learn from the 3DGS render (GPU)')
+    p.add_argument('--ply', default='', help='3DGS model .ply (camera obs)')
+    p.add_argument('--transforms', default='',
+                   help='transforms.json for corridor/camera (camera obs)')
+    p.add_argument('--render-size', type=int, default=84,
+                   help='square render resolution for camera obs')
+    p.add_argument('--fx', type=float, default=60.0,
+                   help='focal length px for camera obs')
     p.add_argument('--seed', type=int, default=0)
     p.add_argument('--save', default='', help='optional path to save the policy')
     args = p.parse_args(argv)
 
     from stable_baselines3 import PPO
 
+    if args.camera and not (args.ply and args.transforms):
+        p.error('--camera requires --ply and --transforms')
+
     env = build_env(args)
     base_ret, base_succ, base_col = evaluate(env, None, args.eval_episodes)
     print(f'random policy: mean return {base_ret:.2f}, success {base_succ:.0%}, '
           f'collision {base_col:.0%}')
 
-    model = PPO('MlpPolicy', env, seed=args.seed, verbose=0)
+    policy = 'CnnPolicy' if args.camera else 'MlpPolicy'
+    model = PPO(policy, env, seed=args.seed, verbose=0)
     model.learn(total_timesteps=args.steps)
     ret, succ, col = evaluate(env, model, args.eval_episodes)
     print(f'PPO ({args.steps} steps): mean return {ret:.2f}, success {succ:.0%}, '


### PR DESCRIPTION
## 概要

sim2real トラック Phase 4 の最終段 = **pixel 観測 RL**。エージェントが **3DGS render を直接観測**して stadtgarten LiDAR-primed シーン（recon 18.9 dB）の実コリドーを運転する閉ループを実装。これで Phase 0–4 の全部品（render・actor・検出・RL）が **1 本の閉 pixel ループ**に繋がった。

## 変更

- **`tools/gaussian_splatting/scene_camera.py`** (新規): ego pose `(x,y,yaw)` → 3DGS viewmat の写像。記録カメラ姿勢（`transforms.json`）の up 列平均で world-up、位置を ground 平面へ射影して PCA で travel 軸 e1 を復元し、コリドーをその frame で表現。ego は記録カメラ高で heading 方向を見る。幾何は pure numpy で **CPU テスト 4 ケース**、`make_scene_render_fn` のみ GPU レンダラに触れる（84×84 で **509 FPS**）。
- **`train_drive_policy.py`**: `--camera`（+ `--ply`/`--transforms`/`--render-size`/`--fx`）で `obs_mode='camera'` の `CnnPolicy` PPO 学習。
- **`run_drive_rl.sh`**: `CAMERA=1` の pixel 観測エントリポイント。
- テスト登録（CMakeLists）、Phase 4 doc 追記。

## 結果（stadtgarten 直線 17 m コリドー）

| policy | mean return | success |
|---|---|---|
| random | -19.44 | 0% |
| PPO 40k (omega_max=1.0) | -3.54 | 0%（idle ローカル最適）|
| **PPO 120k (omega_max=0.5)** | **25.30** | **100%** |

- 40k では「コリドー逸脱 −5 を避けて idle する」ローカル最適に陥った（return ≈ step_cost×175）。直線コリドーゆえ操舵自由度を絞り（omega 1.0→0.5）学習量を増やすと **goal 到達 100%**。
- rollout: goal 到達・57 step・x −8.48→8.05 m（全長走破）・最大横ずれ 0.64 m・throttle 0.99。**3DGS render だけを観測してコリドーを走破**。

## 再現

\`\`\`bash
CAMERA=1 PLY=output/stadt_3dgs/gsplat/point_cloud.ply \
  TRANSFORMS=output/stadt_3dgs/gsplat/transforms.json \
  STEPS=120000 bash scripts/run_drive_rl.sh
\`\`\`

## テスト

- \`colcon test --packages-select graph_based_slam\`（新規 \`test_gaussian_splatting_scene_camera\` 4 ケース含む、ament_flake8 clean）