### PR TITLE
feat(3dgs): perception-driven RL — detector output as the RL reward (active perception)

### DIFF
--- a/docs/research/3dgs-rl-drive-env-phase4.md
+++ b/docs/research/3dgs-rl-drive-env-phase4.md
@@ -102,6 +102,38 @@ PPO (120k, omega_max=0.5): mean return  25.30, success 100%
 - 罠: pixel 観測は idle ローカル最適に落ちやすい（操舵自由度を task 難度に合わせる）。
   start heading は隣接アンカーの y ジッタで荒れるので **始点→終点の全体方向**から取る。
 
+## 追記: 知覚駆動 RL（能動知覚, 2026-06-16）
+
+pixel 観測の閉ループに、**報酬を検出器の出力に差し替え**た = 知覚駆動方策。エージェントは
+camera 観測（3DGS render）から学習し、**報酬 = その render 上で YOLO が対象を検出する
+confidence のみ**（`percept_only`、ナビ報酬なし）。Phase 3 で測った**検出レンジの sweet spot**
+（truck は 7–13m・正面で conf 0.83、遠近で低下）が報酬地形になるので、エージェントは
+「対象が最もよく見える視点に自分を立たせる」ことを学ぶ。
+
+- env: `drive_env` に `percept_reward_fn`(ego pose→scalar) / `percept_weight` / `percept_only`
+  フック追加（後方互換、pure テスト済み 4 ケース）。
+- カメラ: `scene_camera.make_target_orbit_render_fn` — ego が対象を周回し常に対象を注視
+  （`azimuth_basis`/`target_orbit_eye`、`detect_in_scene.dolly_viewmats` と同一幾何、pure 3 ケース）。
+- 報酬: 別レンダ（320px, fx 240）に `sim2real_gap.Detector`(yolov8n) をかけ、対象クラスの
+  最大 conf を返すクロージャ。観測は 84×84（fx 60）の同一視点 render。`CnnPolicy` PPO。
+
+Truck シーン（Tanks&Temples, 2.06M Gaussian）、対象=truck(COCO 7)、azimuth 125°、start_range 14m:
+
+```
+random policy : mean return  60.4, mean detect-conf 0.302
+PPO (40k step): mean return 136.5, mean detect-conf 0.683
+```
+
+- **検出 conf を 2 倍以上（0.302→0.683）に改善**。rollout では range 13.7m から **sweet spot
+  ~10–12m・正面（lateral→-0.27）に収束**して dwell、conf は終盤 0.91 まで上昇
+  （`output/stadt_3dgs/pixel_rl/detect_pov.gif`/`_strip.png` で truck がフレーム中央に寄る）。
+  **84×84 pixel だけを観測し、YOLO の出力だけを報酬に、対象が最もよく見える視点を獲得**した。
+- これで Phase 0–4 が完全な閉ループに: render → CNN 方策 → 行動 → render → **検出器 → 報酬**。
+  検出スコアリング（`detect_in_scene`/`sim2real_gap`）がそのまま RL 報酬として機能することを実証。
+- 罠: **obs と検出の render は別物**（obs=fx60 広角 / 検出=fx240 望遠 320px）。評価時に obs の fx を
+  学習時(=60)と変えると方策が別観測を受け取り性能が崩れる（fx240 で評価し 0.30 と誤認 → fx60 で 0.68 に訂正）。
+  検出 conf は同一 pose でもフレーム間で揺れる（recon フローター）ので報酬はノイジー、horizon を長めに。
+
 ## sim2real ブリッジ（pixel 観測）と次
 
 - `obs_mode='camera'` + `render_fn`（`GaussianRenderer.render(pose→viewmat)`）で、
@@ -120,5 +152,5 @@ Phase 0  外挿安定性 / 有効視点範囲                  ← 完了
 Phase 1  open-loop RGB-D データ生成                 ← 完了
 Phase 2  closed-loop sensor-sim ROS 2 node          ← 完了
 Phase 3  dynamic actors + 検出 gap (orbit/dolly/LiDAR-primed) ← 完了
-Phase 4  closed-loop RL                              ← 本ノート（env + state PPO + dynamic 回避 + pixel 観測 100% 走破）
+Phase 4  closed-loop RL                              ← 本ノート（env + state PPO + dynamic 回避 + pixel 観測 100% 走破 + 知覚駆動 detect-conf 0.30→0.68）
 ```

--- a/graph_based_slam/test/test_gaussian_splatting_drive_env.py
+++ b/graph_based_slam/test/test_gaussian_splatting_drive_env.py
@@ -210,3 +210,52 @@ def test_actor_env_collision_terminates():
         if term or trunc:
             break
     assert reason == 'collision'
+
+
+def test_percept_reward_adds_weighted_term():
+    pytest.importorskip('gymnasium')
+    # a percept_fn that returns ego x; weight 2 -> reward gains 2 * pose_x
+    percept = lambda pose: float(pose[0])  # noqa: E731
+    env = de.make_drive_env(_anchors(), [10.0, 0.0], dt=0.5, v_max=2.0,
+                            max_steps=50, percept_reward_fn=percept,
+                            percept_weight=2.0)
+    base = de.make_drive_env(_anchors(), [10.0, 0.0], dt=0.5, v_max=2.0,
+                             max_steps=50)
+    env.reset(seed=0)
+    base.reset(seed=0)
+    _, r, _, _, info = env.step([1.0, 0.0])
+    _, rb, _, _, _ = base.step([1.0, 0.0])
+    assert 'percept' in info
+    assert r == pytest.approx(rb + 2.0 * info['percept'])
+
+
+def test_percept_only_reward_is_just_perception():
+    pytest.importorskip('gymnasium')
+    # percept_only: navigation terms dropped; reward == weight * percept until
+    # bounds/timeout. Constant percept of 1.0, weight 0.5 -> reward 0.5/step.
+    percept = lambda pose: 1.0  # noqa: E731
+    env = de.make_drive_env(_anchors(), [1e3, 0.0], dt=0.5, v_max=2.0,
+                            bounds=50.0, max_steps=3, percept_reward_fn=percept,
+                            percept_weight=0.5, percept_only=True)
+    env.reset(seed=0)
+    _, r, term, trunc, info = env.step([1.0, 0.0])
+    assert r == pytest.approx(0.5) and not term and not trunc
+    env.step([1.0, 0.0])
+    _, _, _, trunc, info = env.step([1.0, 0.0])
+    assert trunc and info['reason'] == 'timeout'  # ends on horizon, not goal
+
+
+def test_percept_only_terminates_out_of_bounds():
+    pytest.importorskip('gymnasium')
+    percept = lambda pose: 0.0  # noqa: E731
+    env = de.make_drive_env(_anchors(), [1e3, 0.0], dt=0.5, v_max=2.0,
+                            bounds=1.5, max_steps=50, percept_reward_fn=percept,
+                            percept_weight=1.0, percept_only=True)
+    env.reset(seed=0)
+    reason = ''
+    for _ in range(50):
+        _, _, term, trunc, info = env.step([1.0, 0.0])  # drive past bounds
+        reason = info['reason']
+        if term or trunc:
+            break
+    assert reason == 'out_of_bounds'

--- a/graph_based_slam/test/test_gaussian_splatting_scene_camera.py
+++ b/graph_based_slam/test/test_gaussian_splatting_scene_camera.py
@@ -109,3 +109,31 @@ def test_look_at_viewmat_is_world_to_camera():
     # eye maps to the origin
     e = vm @ np.array([0.0, 0.0, 0.0, 1.0])
     assert np.allclose(e[:3], 0.0, atol=1e-9)
+
+
+def test_azimuth_basis_orthonormal_and_in_plane():
+    e_app, e_lat, up = sc.azimuth_basis(125.0, up_axis='y')
+    assert np.allclose(up, [0.0, 1.0, 0.0])
+    # e_app, e_lat lie in the ground plane (no up component)
+    assert e_app[1] == pytest.approx(0.0)
+    assert e_lat[1] == pytest.approx(0.0)
+    # right-handed orthonormal: up x e_app == e_lat
+    assert np.allclose(np.cross(up, e_app), e_lat, atol=1e-9)
+    assert np.linalg.norm(e_app) == pytest.approx(1.0)
+
+
+def test_azimuth_basis_matches_dolly_convention():
+    # azimuth 0 about y-up points along +x (dolly: eye[x] += d*cos(a))
+    e_app, _, _ = sc.azimuth_basis(0.0, up_axis='y')
+    assert np.allclose(e_app, [1.0, 0.0, 0.0], atol=1e-9)
+
+
+def test_target_orbit_eye_distance_and_elevation():
+    e_app, e_lat, up = sc.azimuth_basis(90.0, up_axis='y')  # +z
+    target = np.array([1.0, 0.0, -2.0])
+    eye = sc.target_orbit_eye(10.0, 0.0, target=target, e_app=e_app,
+                              e_lat=e_lat, up=up, elevation=-2.0)
+    ground = eye - np.array([0.0, eye[1], 0.0])  # drop up component
+    tground = target - np.array([0.0, target[1], 0.0])
+    assert np.linalg.norm(ground - tground) == pytest.approx(10.0)  # range
+    assert eye[1] == pytest.approx(target[1] - 2.0)  # elevation along up

--- a/scripts/run_drive_rl.sh
+++ b/scripts/run_drive_rl.sh
@@ -19,6 +19,8 @@
 #   CAMERA=1 PLY=output/stadt_3dgs/gsplat/point_cloud.ply \
 #     TRANSFORMS=output/stadt_3dgs/gsplat/transforms.json \
 #     STEPS=40000 bash scripts/run_drive_rl.sh       # pixel-observation (GPU)
+#   DETECT=1 PLY=output/assets/truck_scene.ply STEPS=40000 \
+#     bash scripts/run_drive_rl.sh                    # active perception (GPU+YOLO)
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -29,6 +31,7 @@ STEPS="${STEPS:-60000}"
 EVAL_EPISODES="${EVAL_EPISODES:-30}"
 SAVE="${SAVE:-}"
 CAMERA="${CAMERA:-}"
+DETECT="${DETECT:-}"
 PLY="${PLY:-}"
 TRANSFORMS="${TRANSFORMS:-}"
 RENDER_SIZE="${RENDER_SIZE:-84}"
@@ -36,7 +39,9 @@ RENDER_SIZE="${RENDER_SIZE:-84}"
 ARGS=(--steps "${STEPS}" --eval-episodes "${EVAL_EPISODES}")
 [[ -n "${TRAJ}" ]] && ARGS+=(--traj "${REPO_ROOT}/${TRAJ}")
 [[ -n "${SAVE}" ]] && ARGS+=(--save "${SAVE}")
-if [[ -n "${CAMERA}" ]]; then
+if [[ -n "${DETECT}" ]]; then
+  ARGS+=(--detect-target --ply "${REPO_ROOT}/${PLY}" --render-size "${RENDER_SIZE}")
+elif [[ -n "${CAMERA}" ]]; then
   ARGS+=(--camera --ply "${REPO_ROOT}/${PLY}" \
          --transforms "${REPO_ROOT}/${TRANSFORMS}" --render-size "${RENDER_SIZE}")
 fi

--- a/tools/gaussian_splatting/drive_env.py
+++ b/tools/gaussian_splatting/drive_env.py
@@ -142,13 +142,22 @@ def make_drive_env(anchors: np.ndarray, goal_xy: Sequence[float], *,
                    render_size: Sequence[int] = (120, 160),
                    actor_fn: Optional[Callable[[int], np.ndarray]] = None,
                    actor_radius: float = 1.0, yield_dist: float = 4.0,
-                   collision_penalty: float = 10.0):
+                   collision_penalty: float = 10.0,
+                   percept_reward_fn: Optional[Callable[[np.ndarray], float]] = None,
+                   percept_weight: float = 1.0, percept_only: bool = False):
     """Build a Gymnasium ``DriveEnv`` instance (imports gymnasium lazily).
 
     When ``actor_fn`` (step -> world xy) is given, a dynamic actor (e.g. a
     crossing pedestrian) is added: the state obs gains the actor's ego-frame
     range/bearing, a proximity cost applies within ``yield_dist`` ahead, and a
     collision (within ``actor_radius``) ends the episode with ``collision_penalty``.
+
+    When ``percept_reward_fn`` (ego pose -> scalar, e.g. a detector's confidence
+    on the ego render) is given, ``percept_weight * percept_reward_fn(pose)`` is
+    added to the step reward -- the perception-driven loop. With ``percept_only``
+    the navigation terms (progress / goal / corridor) are dropped so the detector
+    output is the sole reward: an active-perception task where the agent learns to
+    stand where the object is best detected, terminating only on bounds/timeout.
     """
     import gymnasium as gym
     from gymnasium import spaces
@@ -214,16 +223,33 @@ def make_drive_env(anchors: np.ndarray, goal_xy: Sequence[float], *,
             self._step += 1
             dist, _ = goal_range_bearing(self._pose, goal_xy)
             dev = corridor_deviation(self._pose[:2], anchors)
-            reward = step_reward(self._prev_dist, dist, dev, max_dev=max_dev,
-                                 goal_tol=goal_tol)
+            if percept_only:
+                # active perception: detector output is the only reward; only
+                # leaving the world bounds or running out of time ends it.
+                reward = 0.0
+                if abs(self._pose[0]) > bounds or abs(self._pose[1]) > bounds:
+                    terminated, truncated, reason = True, False, 'out_of_bounds'
+                    reward -= 5.0
+                elif self._step >= max_steps:
+                    terminated, truncated, reason = False, True, 'timeout'
+                else:
+                    terminated, truncated, reason = False, False, ''
+            else:
+                reward = step_reward(self._prev_dist, dist, dev, max_dev=max_dev,
+                                     goal_tol=goal_tol)
+                terminated, truncated, reason = episode_status(
+                    self._pose, goal_xy, dev=dev, goal_tol=goal_tol,
+                    bounds=bounds, hard_dev=hard_dev, step=self._step,
+                    max_steps=max_steps)
+                if reason == 'out_of_bounds' or reason == 'left_corridor':
+                    reward -= 5.0
             self._prev_dist = dist
-            terminated, truncated, reason = episode_status(
-                self._pose, goal_xy, dev=dev, goal_tol=goal_tol, bounds=bounds,
-                hard_dev=hard_dev, step=self._step, max_steps=max_steps)
-            if reason == 'out_of_bounds' or reason == 'left_corridor':
-                reward -= 5.0
             info = {'pose': self._pose.copy(), 'dev': dev, 'dist': dist,
                     'reason': reason}
+            if percept_reward_fn is not None:
+                pr = float(percept_reward_fn(self._pose))
+                reward += percept_weight * pr
+                info['percept'] = pr
             if has_actor:
                 actor_xy = self._actor_xy()
                 arange, abear = goal_range_bearing(self._pose, actor_xy)

--- a/tools/gaussian_splatting/scene_camera.py
+++ b/tools/gaussian_splatting/scene_camera.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Sequence
 
 import numpy as np
 
@@ -103,6 +103,66 @@ def look_at_viewmat(eye: np.ndarray, target: np.ndarray,
     c2w = np.eye(4)
     c2w[:3, 0], c2w[:3, 1], c2w[:3, 2], c2w[:3, 3] = right, down, fwd, eye
     return np.linalg.inv(c2w)
+
+
+_AXIS = {'x': 0, 'y': 1, 'z': 2}
+
+
+def azimuth_basis(azimuth_deg: float, up_axis: str = 'y') -> tuple:
+    """Ground-plane ``(e_app, e_lat, up)`` for a bearing about ``up_axis``.
+
+    ``e_app`` points outward from a target at ``azimuth_deg`` in the plane
+    perpendicular to ``up_axis`` (matching ``detect_in_scene.dolly_viewmats``);
+    ``e_lat = up x e_app`` is the in-plane lateral. An eye at distance ``d`` and
+    lateral ``l`` from a target ``T`` is ``T + d*e_app + l*e_lat + elev*up``.
+    """
+    if up_axis not in _AXIS:
+        raise ValueError(f'up_axis must be one of x/y/z, got {up_axis!r}')
+    ui = _AXIS[up_axis]
+    h0, h1 = (i for i in range(3) if i != ui)
+    up = np.zeros(3)
+    up[ui] = 1.0
+    a = np.radians(float(azimuth_deg))
+    e_app = np.zeros(3)
+    e_app[h0], e_app[h1] = np.cos(a), np.sin(a)
+    e_lat = np.cross(up, e_app)
+    return e_app, e_lat / np.linalg.norm(e_lat), up
+
+
+def target_orbit_eye(approach_range: float, lateral: float, *,
+                     target: np.ndarray, e_app: np.ndarray, e_lat: np.ndarray,
+                     up: np.ndarray, elevation: float) -> np.ndarray:
+    """Eye position at ``approach_range``/``lateral`` from ``target`` (look-at cam)."""
+    return (np.asarray(target, dtype=float) + float(approach_range) * e_app
+            + float(lateral) * e_lat + float(elevation) * up)
+
+
+def make_target_orbit_render_fn(renderer, *, target: Sequence[float],
+                                azimuth_deg: float, up_axis: str = 'y',
+                                elevation: float = -2.0, start_range: float = 14.0,
+                                fx: float = 240.0, width: int = 84,
+                                height: int = 84
+                                ) -> Callable[[np.ndarray], np.ndarray]:
+    """Build ``pose (ex, ey, _) -> uint8 image`` for an ego circling a target.
+
+    The ego advances ``+ex`` to approach (range ``= start_range - ex``) and
+    ``ey`` is the lateral offset; the camera always looks at ``target`` (yaw is
+    unused -- the view is governed by where the ego stands). This is the
+    active-perception substrate: a detector on this render rewards the agent for
+    standing where the object is best seen (Phase 3 detection-range sweet spot).
+    """
+    target = np.asarray(target, dtype=float)
+    e_app, e_lat, up = azimuth_basis(azimuth_deg, up_axis)
+    k = np.array([[fx, 0.0, width / 2.0], [0.0, fx, height / 2.0],
+                  [0.0, 0.0, 1.0]], dtype=float)
+
+    def render_fn(pose: np.ndarray) -> np.ndarray:
+        eye = target_orbit_eye(start_range - float(pose[0]), float(pose[1]),
+                               target=target, e_app=e_app, e_lat=e_lat, up=up,
+                               elevation=elevation)
+        return renderer.render(look_at_viewmat(eye, target, up), k, width, height)
+
+    return render_fn
 
 
 def make_scene_render_fn(renderer, frame: dict, *, fx: float = 60.0,

--- a/tools/gaussian_splatting/train_drive_policy.py
+++ b/tools/gaussian_splatting/train_drive_policy.py
@@ -60,21 +60,33 @@ def recenter_corridor(xy: np.ndarray) -> tuple:
 
 
 def evaluate(env, policy, episodes: int) -> tuple:
-    """Mean return, goal-success rate, and collision rate over greedy episodes."""
-    returns, goals, collisions = [], 0, 0
+    """Mean return, goal-success, collision rate, mean percept over greedy episodes.
+
+    ``mean_percept`` averages the per-step perception signal (e.g. detector
+    confidence) over all steps -- the active-perception headline; 0 when the env
+    has no ``percept_reward_fn``.
+    """
+    returns, goals, collisions, percepts = [], 0, 0, []
     for _ in range(episodes):
         obs, _ = env.reset()
         done, total = False, 0.0
+        ep_percept = []
         while not done:
             action = (env.action_space.sample() if policy is None
                       else policy.predict(obs, deterministic=True)[0])
             obs, r, term, trunc, info = env.step(action)
             total += r
+            if 'percept' in info:
+                ep_percept.append(info['percept'])
             done = term or trunc
         returns.append(total)
         goals += int(info.get('reason') == 'goal')
         collisions += int(info.get('reason') == 'collision')
-    return float(np.mean(returns)), goals / episodes, collisions / episodes
+        if ep_percept:
+            percepts.append(float(np.mean(ep_percept)))
+    mean_percept = float(np.mean(percepts)) if percepts else 0.0
+    return (float(np.mean(returns)), goals / episodes, collisions / episodes,
+            mean_percept)
 
 
 def build_camera_env(args):
@@ -109,6 +121,47 @@ def build_camera_env(args):
         obs_mode='camera', render_fn=render_fn, render_size=(h, w))
 
 
+def build_detect_env(args):
+    """Build an active-perception DriveEnv: reward = a detector on the ego render.
+
+    The ego circles a target object in a 3DGS scene (camera always looking at it);
+    a YOLO detector runs on the render and its target-class confidence *is* the
+    reward (``percept_only``). Detection peaks at a viewpoint sweet spot (Phase 3
+    detection range), so the agent -- observing only pixels -- must learn to stand
+    where the object is best seen. This closes the perception-driven loop:
+    render -> policy -> action -> render -> detector -> reward.
+    """
+    import scene_camera as sc
+    from gaussian_renderer import GaussianRenderer
+    from sim2real_gap import Detector
+
+    target = [float(v) for v in args.target.split(',')]
+    renderer = GaussianRenderer(args.ply)
+    h = w = int(args.render_size)
+    common = dict(target=target, azimuth_deg=args.azimuth, up_axis=args.up_axis,
+                  elevation=args.elevation, start_range=args.start_range)
+    obs_fn = sc.make_target_orbit_render_fn(renderer, fx=args.fx, width=w,
+                                            height=h, **common)
+    det_fn = sc.make_target_orbit_render_fn(renderer, fx=args.det_fx,
+                                            width=args.det_size,
+                                            height=args.det_size, **common)
+    detector = Detector(args.detector, conf=args.det_conf)
+    cls = args.class_id
+
+    def percept_reward_fn(pose):
+        dets = detector(det_fn(pose))
+        confs = [d['conf'] for d in dets if d['cls'] == cls]
+        return max(confs) if confs else 0.0
+
+    return drive_env.make_drive_env(
+        np.array([[0.0, 0.0]]), [1e3, 0.0], start_pose=(0.0, 0.0, 0.0),
+        max_dev=1e3, hard_dev=1e3, bounds=args.bounds, dt=0.2, v_max=1.5,
+        omega_max=1.0, max_steps=args.max_steps, obs_mode='camera',
+        render_fn=obs_fn, render_size=(h, w),
+        percept_reward_fn=percept_reward_fn, percept_weight=1.0,
+        percept_only=True)
+
+
 def build_env(args):
     """Construct the DriveEnv from a trajectory, a straight corridor, or an arc.
 
@@ -116,6 +169,8 @@ def build_env(args):
     crossing the centreline timed to a full-speed run -- so a naive fast policy
     collides and the agent must yield (slow, let it pass) to reach the goal.
     """
+    if args.detect_target:
+        return build_detect_env(args)
     if args.camera:
         return build_camera_env(args)
     v_max, dt = 2.0, 0.2
@@ -166,6 +221,26 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                    help='square render resolution for camera obs')
     p.add_argument('--fx', type=float, default=60.0,
                    help='focal length px for camera obs')
+    p.add_argument('--detect-target', action='store_true',
+                   help='active perception: reward = detector conf on the render')
+    p.add_argument('--target', default='0.75,0,-2.0',
+                   help='object centre x,y,z in the model frame (detect mode)')
+    p.add_argument('--azimuth', type=float, default=125.0,
+                   help='approach bearing deg about the up axis (detect mode)')
+    p.add_argument('--up-axis', default='y', help='scene up axis (detect mode)')
+    p.add_argument('--elevation', type=float, default=-2.0,
+                   help='ego eye offset along the up axis (detect mode)')
+    p.add_argument('--start-range', type=float, default=14.0,
+                   help='ego start distance from the target (detect mode)')
+    p.add_argument('--bounds', type=float, default=20.0)
+    p.add_argument('--detector', default='yolov8n.pt')
+    p.add_argument('--class-id', type=int, default=7,
+                   help='COCO class to detect (7 = truck)')
+    p.add_argument('--det-conf', type=float, default=0.25)
+    p.add_argument('--det-fx', type=float, default=240.0,
+                   help='focal length px for the detector render')
+    p.add_argument('--det-size', type=int, default=320,
+                   help='detector render resolution (needs to be detectable)')
     p.add_argument('--seed', type=int, default=0)
     p.add_argument('--save', default='', help='optional path to save the policy')
     args = p.parse_args(argv)
@@ -174,18 +249,25 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if args.camera and not (args.ply and args.transforms):
         p.error('--camera requires --ply and --transforms')
+    if args.detect_target and not args.ply:
+        p.error('--detect-target requires --ply')
+
+    pixel = args.camera or args.detect_target
+
+    def report(tag, ret, succ, col, perc):
+        if args.detect_target:
+            print(f'{tag}: mean return {ret:.2f}, mean detect-conf {perc:.3f}')
+        else:
+            print(f'{tag}: mean return {ret:.2f}, success {succ:.0%}, '
+                  f'collision {col:.0%}')
 
     env = build_env(args)
-    base_ret, base_succ, base_col = evaluate(env, None, args.eval_episodes)
-    print(f'random policy: mean return {base_ret:.2f}, success {base_succ:.0%}, '
-          f'collision {base_col:.0%}')
+    report('random policy', *evaluate(env, None, args.eval_episodes))
 
-    policy = 'CnnPolicy' if args.camera else 'MlpPolicy'
-    model = PPO(policy, env, seed=args.seed, verbose=0)
+    model = PPO('CnnPolicy' if pixel else 'MlpPolicy', env, seed=args.seed,
+                verbose=0)
     model.learn(total_timesteps=args.steps)
-    ret, succ, col = evaluate(env, model, args.eval_episodes)
-    print(f'PPO ({args.steps} steps): mean return {ret:.2f}, success {succ:.0%}, '
-          f'collision {col:.0%}')
+    report(f'PPO ({args.steps} steps)', *evaluate(env, model, args.eval_episodes))
     if args.save:
         model.save(args.save)
         print(f'saved policy to {args.save}')


### PR DESCRIPTION
## 概要

pixel 観測の閉ループ（#305）に対し、**報酬を検出器の出力に差し替えた** = 知覚駆動方策。エージェントは camera 観測（3DGS render）から学習し、**報酬 = その render 上で YOLO が対象を検出する confidence のみ**（`percept_only`）。Phase 3 で測った**検出レンジの sweet spot**（truck は 7–13m・正面で conf 0.83）が報酬地形になるので、エージェントは「対象が最もよく見える視点に自分を立たせる」能動知覚を学ぶ。

これで **Phase 0–4 が完全な閉ループ**に: render → CNN 方策 → 行動 → render → **検出器 → 報酬**。

## 変更

- **`drive_env.py`**: `percept_reward_fn`(ego pose→scalar) / `percept_weight` / `percept_only` フック。検出器 conf を step 報酬に加算、または唯一の報酬に。後方互換、pure テスト 4 ケース。
- **`scene_camera.py`**: `make_target_orbit_render_fn`（+ `azimuth_basis`/`target_orbit_eye`）— ego が対象を周回し常に注視。`detect_in_scene.dolly_viewmats` と同一幾何。pure 3 ケース。
- **`train_drive_policy.py`**: `--detect-target` モード（truck シーン、YOLO truck conf を `percept_only` 報酬、`CnnPolicy` PPO）。`evaluate()` が mean detect-conf を報告。
- **`run_drive_rl.sh`**: `DETECT=1` エントリ。テスト登録済み（scene_camera は #305 で登録済）。

## 結果（Tanks&Temples truck シーン, 対象=truck, azimuth 125°, start 14m）

| policy | mean return | mean detect-conf |
|---|---|---|
| random | 60.4 | 0.302 |
| **PPO 40k** | **136.5** | **0.683** |

- **検出 conf を 2 倍以上（0.302→0.683）に改善**。rollout では range 13.7m から **sweet spot ~10–12m・正面（lateral→−0.27）に収束**して dwell、conf は終盤 0.91。**84×84 pixel だけを観測し YOLO の出力だけを報酬に、対象が最もよく見える視点を獲得**。

## 再現

\`\`\`bash
DETECT=1 PLY=output/assets/truck_scene.ply STEPS=40000 bash scripts/run_drive_rl.sh
\`\`\`

## 注意

obs render（fx 60, 84px）と検出 render（fx 240, 320px）は別物。評価時に obs の fx を学習時(=60)と変えると方策が別観測を受け取り性能が崩れる。

## テスト

- \`colcon test --packages-select graph_based_slam\`（drive_env +4, scene_camera +3、ament_flake8 clean）