### PR TITLE
[codex] Improve onboarding docs and beginner runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # lidarslam_ros2
 
-[![CI](https://github.com/rsasaki0109/lidarslam_ros2/actions/workflows/main.yml/badge.svg?branch=develop)](https://github.com/rsasaki0109/lidarslam_ros2/actions/workflows/main.yml)
+[![CI](https://github.com/rsasaki0109/lidar_slam_ros2/actions/workflows/main.yml/badge.svg?branch=develop)](https://github.com/rsasaki0109/lidar_slam_ros2/actions/workflows/main.yml)
 [![License: BSD-2-Clause](https://img.shields.io/badge/License-BSD--2--Clause-blue.svg)](https://opensource.org/licenses/BSD-2-Clause)
 [![ROS 2: Humble | Jazzy](https://img.shields.io/badge/ROS%202-Humble%20%7C%20Jazzy-22314E?logo=ros&logoColor=white)](#support-and-license)
-[![GitHub stars](https://img.shields.io/github/stars/rsasaki0109/lidarslam_ros2?style=flat&logo=github)](https://github.com/rsasaki0109/lidarslam_ros2/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/rsasaki0109/lidar_slam_ros2?style=flat&logo=github)](https://github.com/rsasaki0109/lidar_slam_ros2/stargazers)
 
 **Turn a rosbag into a map you can actually drive on.**
 
@@ -55,6 +55,9 @@ flowchart LR
 
 ## Quickstart
 
+Not sure which path fits your setup? Start with the
+[Getting Started guide](docs/getting-started.md).
+
 ### Try it with Docker (one command, no build)
 
 ```bash
@@ -74,20 +77,20 @@ appending `bash` instead drops you into an interactive shell.
 
 ```bash
 cd ~/ros2_ws/src
-git clone --recursive https://github.com/rsasaki0109/lidarslam_ros2.git
+git clone --recursive https://github.com/rsasaki0109/lidar_slam_ros2.git
 cd ..
 rosdep install --from-paths src --ignore-src -r -y
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 source install/setup.bash
 ```
 
-If you cloned without `--recursive`: `git -C src/lidarslam_ros2 submodule update --init --recursive`.
+If you cloned without `--recursive`: `git -C src/lidar_slam_ros2 submodule update --init --recursive`.
 
 Then run one public dataset end to end — NTU VIRAL `tnp_01` (~580 s outdoor bag)
 through RKO-LIO + graph_based_slam into an Autoware-loadable map:
 
 ```bash
-cd src/lidarslam_ros2
+cd src/lidar_slam_ros2
 bash scripts/download_ntu_viral_tnp01.sh
 bash scripts/run_autoware_quickstart.sh
 python3 scripts/verify_autoware_map.py output/.../pointcloud_map
@@ -169,7 +172,7 @@ Pipeline, quality levers, the [interactive viewer](docs/3dgs-viewer.md), and dat
 
 ## Docs
 
-- **Getting started**: [Autoware quickstart](docs/autoware-quickstart.md) · [Operator workflows](docs/workflows.md) · [Autoware Foxglove](docs/autoware-foxglove.md)
+- **Getting started**: [Getting Started](docs/getting-started.md) · [Autoware quickstart](docs/autoware-quickstart.md) · [Operator workflows](docs/workflows.md) · [Autoware Foxglove](docs/autoware-foxglove.md)
 - **Pipelines**: [Autoware-compatible map authoring](docs/autoware-map-authoring.md) · [3DGS map tutorial](docs/3dgs-map-tutorial.md)
 - **Benchmarking**: [Benchmarking and release gate](docs/benchmarking.md) · [Comparison](docs/comparison.md)
 - **Project**: [v0.2.2 release notes](docs/releases/v0.2.2.md) · [Contributing](CONTRIBUTING.md) · [Changelog](CHANGELOG.md) · [Releasing](RELEASING.md)

--- a/docs/assets/3dgs-viewer/index.html
+++ b/docs/assets/3dgs-viewer/index.html
@@ -196,7 +196,7 @@
 			<p>
 			<small class="nohf">
 				LiDAR-primed 3D Gaussian Splatting map from
-				<a href="https://github.com/rsasaki0109/lidarslam_ros2">lidarslam_ros2</a>.
+				<a href="https://github.com/rsasaki0109/lidar_slam_ros2">lidarslam_ros2</a>.
 				Renderer by
 				<a href="https://github.com/antimatter15/splat">antimatter15/splat</a>
 				(MIT).

--- a/docs/autoware-map-authoring.md
+++ b/docs/autoware-map-authoring.md
@@ -126,6 +126,7 @@ The current public position of this repository is:
 
 ## Related Docs
 
+- [Getting Started](getting-started.md)
 - [Autoware Quickstart](autoware-quickstart.md)
 - [Operator Workflows](workflows.md)
 - [Benchmarking And Release Gate](benchmarking.md)

--- a/docs/autoware-quickstart.md
+++ b/docs/autoware-quickstart.md
@@ -5,6 +5,8 @@ pointcloud map shown in `rviz2`.
 
 If you want the product-level overview first, see
 [Autoware-Compatible Map Authoring](autoware-map-authoring.md).
+If you are choosing between Docker, source build, or your own bag, start with
+[Getting Started](getting-started.md).
 For the optional browser-based viewer path, see
 [Autoware Foxglove](autoware-foxglove.md).
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -86,7 +86,9 @@ pure odometry novelty.
 
 ## Local Benchmark Snapshot
 
-These numbers come from local artifacts currently checked under `output/`.
+These numbers come from generated benchmark artifacts under local `output/`
+directories. `output/` is ignored by git; use the commands in
+[Benchmarking And Release Gate](benchmarking.md) to regenerate the reports.
 
 ### Release-track datasets
 
@@ -125,11 +127,11 @@ definition and attribution:
 
 Source artifacts:
 
-- `output/benchmark_summary.md`
-- `output/latest_report.html`
-- `output/stress_validation_report_20260325.md`
+- `output/benchmark_summary.md` (generated locally)
+- `output/latest_report.html` (generated locally)
+- `output/stress_validation_report_<YYYYMMDD>.md` (generated locally)
 - `scripts/release_profiles.yaml` (profile definitions)
-- `output/kitti_dev_<timestamp>/kitti_dev_report.md` (KITTI LO baseline)
+- `output/kitti_dev_<timestamp>/kitti_dev_report.md` (generated locally, KITTI LO baseline)
 
 ## Current Default Position
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,77 @@
+# Getting Started
+
+Use this page when you are new to `lidarslam_ros2` and want the shortest path
+to a working map.
+
+## Choose A Path
+
+| You have | Run |
+| --- | --- |
+| Docker only, no ROS 2 workspace | `docker run --rm -v "$PWD/lidarslam_output:/lidarslam_ws/output" ghcr.io/rsasaki0109/lidar_slam_ros2:humble` |
+| A rosbag2 directory and a built workspace | `bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2` |
+| A bag, but you are not sure which topics it has | `python3 scripts/preflight_autoware_map_bag.py /path/to/rosbag2` |
+| You want the fixed public demo dataset | `bash scripts/download_ntu_viral_tnp01.sh && bash scripts/run_autoware_quickstart.sh` |
+
+## 1. Build The Workspace
+
+```bash
+cd ~/ros2_ws/src
+git clone --recursive https://github.com/rsasaki0109/lidar_slam_ros2.git
+cd ..
+rosdep install --from-paths src --ignore-src -r -y
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+source install/setup.bash
+```
+
+If the repository was cloned without submodules:
+
+```bash
+git -C src/lidar_slam_ros2 submodule update --init --recursive
+```
+
+## 2. Run Your First Bag
+
+```bash
+cd ~/ros2_ws/src/lidar_slam_ros2
+bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2 --dry-run
+bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2
+```
+
+The dry run prints the selected public workflow before anything starts. The real
+run writes the map under `output/` by default.
+
+## 3. Check The Result
+
+Successful runs should leave these files:
+
+- `pointcloud_map/`
+- `pointcloud_map/pointcloud_map_metadata.yaml`
+- `map_projector_info.yaml`
+- `verify_autoware_map.log`
+- `autoware_map_diagnosis.md`
+
+Open the saved map in a browser viewer:
+
+```bash
+bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2 --foxglove
+```
+
+Or inspect an existing output directory:
+
+```bash
+python3 scripts/diagnose_autoware_map_run.py output/<run_dir> --write
+python3 scripts/verify_autoware_map.py output/<run_dir>/pointcloud_map
+```
+
+## Common First-Run Problems
+
+| Symptom | Next check |
+| --- | --- |
+| `metadata.yaml not found` | Pass the rosbag2 directory, not a `.db3` file. |
+| No compatible path is recommended | Run `python3 scripts/preflight_autoware_map_bag.py /path/to/rosbag2` and check for `PointCloud2` plus `Imu`, or `VelodyneScan` plus Applanix topics. |
+| Map verification fails | Open `verify_autoware_map.log` and `autoware_map_diagnosis.md` in the output directory. |
+| Viewer starts but no map appears | Confirm the run produced `pointcloud_map/` and try the Foxglove path before the full Autoware viewer. |
+
+For the full operator reference, continue with
+[Autoware Quickstart](autoware-quickstart.md) and
+[Operator Workflows](workflows.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@
       <span>Foxglove proof path</span>
     </div>
     <div class="hero__actions">
-      <a class="md-button md-button--primary" href="autoware-map-authoring.html">Start With Map Authoring</a>
+      <a class="md-button md-button--primary" href="getting-started.html">Start Here</a>
       <a class="md-button" href="autoware-quickstart.html">Run The Quickstart</a>
     </div>
   </div>
@@ -48,6 +48,10 @@
 ## Start Here
 
 <div class="card-grid">
+  <a class="link-card" href="getting-started.html">
+    <h3>Getting Started</h3>
+    <p>Choose Docker, a local build, or your own bag without reading every workflow first.</p>
+  </a>
   <a class="link-card" href="autoware-map-authoring.html">
     <h3>Autoware-Compatible Map Authoring</h3>
     <p>The shortest product-level summary of the supported public path.</p>

--- a/docs/social/autoware_map_authoring_post_v0.2.2.md
+++ b/docs/social/autoware_map_authoring_post_v0.2.2.md
@@ -26,7 +26,7 @@ bash scripts/run_autoware_quickstart.sh
 
 Release:
 
-- <https://github.com/rsasaki0109/lidarslam_ros2/releases/tag/v0.2.2>
+- <https://github.com/rsasaki0109/lidar_slam_ros2/releases/tag/v0.2.2>
 
 ### Medium
 
@@ -49,7 +49,7 @@ bash scripts/run_autoware_quickstart.sh
 
 Docs:
 
-- <https://github.com/rsasaki0109/lidarslam_ros2/blob/develop/docs/autoware-map-authoring.md>
+- <https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/docs/autoware-map-authoring.md>
 
 ## English
 
@@ -72,7 +72,7 @@ bash scripts/run_autoware_quickstart.sh
 
 Release:
 
-- <https://github.com/rsasaki0109/lidarslam_ros2/releases/tag/v0.2.2>
+- <https://github.com/rsasaki0109/lidar_slam_ros2/releases/tag/v0.2.2>
 
 ## Alt Text
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -11,7 +11,7 @@ README.
 
 ```bash
 cd ~/ros2_ws/src
-git clone --recursive https://github.com/rsasaki0109/lidarslam_ros2
+git clone --recursive https://github.com/rsasaki0109/lidar_slam_ros2
 cd ..
 rosdep install --from-paths src --ignore-src -r -y
 ```

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -41,7 +41,9 @@ VERSION_PATH = REPO_ROOT / 'VERSION'
 CHANGELOG_PATH = REPO_ROOT / 'CHANGELOG.md'
 RELEASING_PATH = REPO_ROOT / 'RELEASING.md'
 MKDOCS_CONFIG_PATH = REPO_ROOT / 'mkdocs.yml'
+GITIGNORE_PATH = REPO_ROOT / '.gitignore'
 DOCS_INDEX_PATH = REPO_ROOT / 'docs' / 'index.md'
+GETTING_STARTED = REPO_ROOT / 'docs' / 'getting-started.md'
 DOCS_ASSETS_DIR = REPO_ROOT / 'docs' / 'assets'
 DOCS_EXTRA_CSS_PATH = DOCS_ASSETS_DIR / 'stylesheets' / 'extra.css'
 DOCS_AUTOWARE_PROOF_SITE_IMAGE_PATH = DOCS_ASSETS_DIR / 'images' / 'autoware_map_loader_proof.png'
@@ -72,10 +74,6 @@ SOCIAL_CARD_PATH = (
 SOCIAL_DEMO_VIDEO_PATH = (
     REPO_ROOT / 'lidarslam' / 'images' / 'social_autoware_map_authoring_demo.mp4'
 )
-BENCHMARK_SUMMARY_PATH = REPO_ROOT / 'output' / 'benchmark_summary.md'
-BENCHMARK_REPORT_PATH = REPO_ROOT / 'output' / 'latest_report.html'
-STRESS_REPORT_PATH = REPO_ROOT / 'output' / 'stress_validation_report_20260325.md'
-V2_READINESS_PATH = REPO_ROOT / 'output' / 'v2_beta_readiness_20260324.md'
 
 
 def test_docs_exist_and_are_linked_from_readme():
@@ -90,6 +88,7 @@ def test_docs_exist_and_are_linked_from_readme():
     assert RELEASING_PATH.is_file()
     assert MKDOCS_CONFIG_PATH.is_file()
     assert DOCS_INDEX_PATH.is_file()
+    assert GETTING_STARTED.is_file()
     assert DOCS_ASSETS_DIR.is_dir()
     assert DOCS_EXTRA_CSS_PATH.is_file()
     assert DOCS_AUTOWARE_PROOF_SITE_IMAGE_PATH.is_file()
@@ -111,6 +110,7 @@ def test_docs_exist_and_are_linked_from_readme():
     assert '(CONTRIBUTING.md)' in readme
     assert '(CHANGELOG.md)' in readme
     assert '(RELEASING.md)' in readme
+    assert '(docs/getting-started.md)' in readme
     assert '(docs/autoware-map-authoring.md)' in readme
     assert '(docs/autoware-quickstart.md)' in readme
     assert '(docs/autoware-foxglove.md)' in readme
@@ -120,7 +120,7 @@ def test_docs_exist_and_are_linked_from_readme():
     assert 'python3 -m mkdocs serve' in readme
     assert 'run_autoware_map_beginner.sh' in readme
     assert '(lidarslam/images/autoware_map_loader_proof.png)' in readme
-    assert 'git clone --recursive https://github.com/rsasaki0109/lidarslam_ros2.git' in readme
+    assert 'git clone --recursive https://github.com/rsasaki0109/lidar_slam_ros2.git' in readme
     assert 'rosdep install --from-paths src --ignore-src -r -y' in readme
     # The required-topics table and the dynamic-object-filter figure moved to
     # docs/workflows.md so the README stays narrow; keep the assets on disk
@@ -214,12 +214,14 @@ def test_contributing_and_issue_templates_exist():
     assert 'run_autoware_quickstart.sh' in contributing
 
 
-def test_public_report_snapshots_exist():
-    """Public release docs should have tracked benchmark/report snapshots."""
-    assert BENCHMARK_SUMMARY_PATH.is_file()
-    assert BENCHMARK_REPORT_PATH.is_file()
-    assert STRESS_REPORT_PATH.is_file()
-    assert V2_READINESS_PATH.is_file()
+def test_generated_output_artifacts_are_local_only():
+    """Generated benchmark/report artifacts should stay out of git."""
+    gitignore = GITIGNORE_PATH.read_text(encoding='utf-8')
+    benchmarking_doc = BENCHMARKING_DOC.read_text(encoding='utf-8')
+
+    assert 'output/' in gitignore
+    assert 'benchmark_summary.md' in benchmarking_doc
+    assert 'latest_report.html' in benchmarking_doc
 
 
 def test_release_metadata_and_core_package_versions_match():
@@ -272,8 +274,10 @@ def test_release_metadata_and_core_package_versions_match():
 
     assert 'site_name: lidarslam_ros2 Docs' in mkdocs_config
     assert 'site_url: https://rsasaki0109.github.io/lidar_slam_ros2/' in mkdocs_config
+    assert 'repo_url: https://github.com/rsasaki0109/lidar_slam_ros2' in mkdocs_config
     assert 'name: material' in mkdocs_config
     assert 'assets/stylesheets/extra.css' in mkdocs_config
+    assert 'Getting Started: getting-started.md' in mkdocs_config
     assert 'Autoware-Compatible Map Authoring: autoware-map-authoring.md' in mkdocs_config
     assert 'Autoware Foxglove: autoware-foxglove.md' in mkdocs_config
     assert 'Benchmarking And Release Gate: benchmarking.md' in mkdocs_config
@@ -286,12 +290,21 @@ def test_release_metadata_and_core_package_versions_match():
 def test_docs_cover_autoware_and_release_gate_keywords():
     """The adoption docs should mention the supported operator workflows."""
     autoware_doc = AUTOWARE_QUICKSTART.read_text(encoding='utf-8')
+    getting_started_doc = GETTING_STARTED.read_text(encoding='utf-8')
     autoware_map_doc = AUTOWARE_MAP_AUTHORING.read_text(encoding='utf-8')
     autoware_foxglove_doc = AUTOWARE_FOXGLOVE.read_text(encoding='utf-8')
     benchmarking_doc = BENCHMARKING_DOC.read_text(encoding='utf-8')
     comparison_doc = COMPARISON_DOC.read_text(encoding='utf-8')
 
+    assert 'run_autoware_map_beginner.sh' in getting_started_doc
+    assert 'preflight_autoware_map_bag.py' in getting_started_doc
+    assert 'verify_autoware_map.py' in getting_started_doc
+    assert (
+        'git clone --recursive https://github.com/rsasaki0109/lidar_slam_ros2.git'
+        in getting_started_doc
+    )
     assert 'run_autoware_quickstart.sh' in autoware_doc
+    assert 'Getting Started' in autoware_doc
     assert 'preflight_autoware_map_bag.py' in autoware_doc
     assert 'run_autoware_map_beginner.sh' in autoware_doc
     assert 'run_autoware_map_from_bag.py' in autoware_doc

--- a/lidarslam/test/test_autoware_map_runner_script.py
+++ b/lidarslam/test/test_autoware_map_runner_script.py
@@ -110,6 +110,9 @@ def test_beginner_wrapper_exposes_simple_viewer_flags():
     assert '--autoware' in script
     assert '--no-viewer' in script
     assert '--dry-run' in script
+    assert '--preflight-only' in script
+    assert 'metadata.yaml not found' in script
+    assert 'not a .db3 file' in script
 
 
 def test_runner_prefers_mid360_preset_for_livox_bag(tmp_path: Path):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: lidarslam_ros2 Docs
 site_description: ROS 2 LiDAR SLAM docs for pointcloud-map authoring, benchmarking, and Autoware-compatible workflows.
 site_url: https://rsasaki0109.github.io/lidar_slam_ros2/
-repo_url: https://github.com/rsasaki0109/lidarslam_ros2
-repo_name: rsasaki0109/lidarslam_ros2
+repo_url: https://github.com/rsasaki0109/lidar_slam_ros2
+repo_name: rsasaki0109/lidar_slam_ros2
 docs_dir: docs
 use_directory_urls: false
 extra_css:
@@ -33,6 +33,7 @@ theme:
 
 nav:
   - Home: index.md
+  - Getting Started: getting-started.md
   - Autoware-Compatible Map Authoring: autoware-map-authoring.md
   - Autoware Quickstart: autoware-quickstart.md
   - Autoware Foxglove: autoware-foxglove.md

--- a/scripts/generate_social_autoware_demo_video.py
+++ b/scripts/generate_social_autoware_demo_video.py
@@ -167,7 +167,7 @@ def _make_slide_cta() -> Image.Image:
         [
             'bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2',
             'Docs: rsasaki0109.github.io/lidar_slam_ros2/',
-            'Release: github.com/rsasaki0109/lidarslam_ros2/releases/tag/v0.2.2',
+            'Release: github.com/rsasaki0109/lidar_slam_ros2/releases/tag/v0.2.2',
         ],
         eyebrow='quickstart',
     )

--- a/scripts/run_autoware_map_beginner.sh
+++ b/scripts/run_autoware_map_beginner.sh
@@ -9,6 +9,7 @@ Usage:
 Beginner-friendly wrapper around run_autoware_map_from_bag.py.
 
 Options:
+  --preflight-only             Print the bag preflight report and exit
   --foxglove                    Open the saved map in the Foxglove path after the run
   --autoware                    Open the saved map in the Dockerized Autoware viewer after the run
   --no-viewer                   Do not open a viewer after the run (default)
@@ -19,6 +20,7 @@ Any remaining options are forwarded to run_autoware_map_from_bag.py.
 
 Examples:
   bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2
+  bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2 --preflight-only
   bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2 --foxglove
   bash scripts/run_autoware_map_beginner.sh /path/to/rosbag2 --output-dir output/my_map
 EOF
@@ -31,8 +33,10 @@ fi
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 RUNNER="${SCRIPT_DIR}/run_autoware_map_from_bag.py"
+PREFLIGHT="${SCRIPT_DIR}/preflight_autoware_map_bag.py"
 BAG_PATH=""
 VIEWER=none
+PREFLIGHT_ONLY=false
 FORWARDED_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -47,6 +51,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-viewer)
       VIEWER=none
+      shift
+      ;;
+    --preflight-only)
+      PREFLIGHT_ONLY=true
       shift
       ;;
     --help|-h)
@@ -79,6 +87,23 @@ done
 
 if [[ -z "$BAG_PATH" ]]; then
   usage
+fi
+
+if [[ ! -d "$BAG_PATH" ]]; then
+  echo "error: rosbag2_dir does not exist or is not a directory: $BAG_PATH" >&2
+  echo "hint: pass the rosbag2 directory, not a .db3 file." >&2
+  exit 2
+fi
+
+if [[ ! -f "$BAG_PATH/metadata.yaml" ]]; then
+  echo "error: metadata.yaml not found under: $BAG_PATH" >&2
+  echo "hint: pass the rosbag2 directory that contains metadata.yaml." >&2
+  exit 2
+fi
+
+if [[ "$PREFLIGHT_ONLY" == "true" ]]; then
+  python3 "$PREFLIGHT" "$BAG_PATH"
+  exit 0
 fi
 
 python3 "$RUNNER" "$BAG_PATH" --viewer "$VIEWER" "${FORWARDED_ARGS[@]}"

--- a/scripts/run_autoware_map_from_bag.py
+++ b/scripts/run_autoware_map_from_bag.py
@@ -7,6 +7,7 @@ import argparse
 import importlib.util
 import shlex
 import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -132,6 +133,19 @@ def build_execution_plan(
         'command': command,
         'output_dir': output_dir,
     }
+
+
+def validate_bag_path(bag_path: Path) -> None:
+    if not bag_path.is_dir():
+        raise FileNotFoundError(
+            f'rosbag2 directory does not exist: {bag_path}. '
+            'Pass the directory that contains metadata.yaml, not a .db3 file.'
+        )
+    if not (bag_path / 'metadata.yaml').is_file():
+        raise FileNotFoundError(
+            f'metadata.yaml not found under {bag_path}. '
+            'Pass the rosbag2 directory that contains metadata.yaml.'
+        )
 
 
 def maybe_open_viewer(args: argparse.Namespace, output_dir: Path) -> None:
@@ -271,12 +285,17 @@ def main() -> int:
     output_dir = Path(args.output_dir).expanduser().resolve() if args.output_dir else (
         REPO_ROOT / 'output' / f'autoware_map_authoring_{bag_path.stem}_{timestamp}'
     )
-    plan = build_execution_plan(
-        bag_path=bag_path,
-        profile_id=args.profile,
-        output_dir=output_dir,
-        verify_map=not args.no_verify_map,
-    )
+    try:
+        validate_bag_path(bag_path)
+        plan = build_execution_plan(
+            bag_path=bag_path,
+            profile_id=args.profile,
+            output_dir=output_dir,
+            verify_map=not args.no_verify_map,
+        )
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        print(f'error: {exc}', file=sys.stderr)
+        return 2
 
     print(f"Selected profile: {plan['label']}")
     print(f"Output directory: {plan['output_dir']}")


### PR DESCRIPTION
## Summary
- Add a Getting Started guide that helps new users choose Docker, source build, preflight, or the fixed public demo path.
- Wire the new guide into README and MkDocs navigation, and correct user-facing repository URLs to `rsasaki0109/lidar_slam_ros2`.
- Make the beginner map runner friendlier with `--preflight-only` and clear errors for invalid rosbag paths.
- Update docs/tests for the current ignored `output/` artifact policy.

## Validation
- `python3 -m py_compile scripts/run_autoware_map_from_bag.py scripts/preflight_autoware_map_bag.py`
- `python3 -m pytest -q graph_based_slam/test/test_docs_entrypoints.py graph_based_slam/test/test_autoware_map_preflight.py lidarslam/test/test_autoware_map_runner_script.py`
- `python3 -m mkdocs build --strict`
- `git diff --check`