### PR TITLE
[codex] polish autoware map diagnosis cli

### DIFF
--- a/graph_based_slam/test/test_autoware_map_run_diagnosis.py
+++ b/graph_based_slam/test/test_autoware_map_run_diagnosis.py
@@ -33,6 +33,8 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+import subprocess
+import sys
 
 import yaml
 
@@ -104,3 +106,113 @@ def test_summary_reports_tf_issue_hints(tmp_path: Path):
     assert 'The /map_save service call failed' in hints
     assert 'A ROS node died during the run' in hints
     assert any('tail -n 120' in step for step in summary['suggested_next_steps'])
+
+
+def test_cli_help_is_user_facing():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), '--help'],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert 'Autoware-compatible map workflow output directory' in result.stdout
+    assert 'not its pointcloud_map/ child' in result.stdout
+    assert 'Files this tool checks when present:' in result.stdout
+    assert 'diagnose_autoware_map_run.py output/my_map_run --write' in result.stdout
+
+
+def test_cli_rejects_missing_run_dir_without_traceback(tmp_path: Path):
+    missing_run_dir = tmp_path / 'missing_run'
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(missing_run_dir)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert 'error:' in result.stderr
+    assert 'run directory does not exist' in result.stderr
+    assert 'Traceback' not in result.stderr
+
+
+def test_cli_rejects_pointcloud_map_child_without_traceback(tmp_path: Path):
+    pointcloud_map_dir = tmp_path / 'run' / 'pointcloud_map'
+    pointcloud_map_dir.mkdir(parents=True)
+    (pointcloud_map_dir / 'pointcloud_map_metadata.yaml').write_text(
+        'tile_size: 20\n',
+        encoding='utf-8',
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(pointcloud_map_dir)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert 'error:' in result.stderr
+    assert 'nested pointcloud_map directory' in result.stderr
+    assert 'Traceback' not in result.stderr
+
+
+def test_cli_write_creates_diagnosis_files(tmp_path: Path):
+    run_dir = tmp_path / 'run'
+    run_dir.mkdir()
+    (run_dir / 'verify_autoware_map.log').write_text(
+        'PASS: 8  |  WARN: 0  |  FAIL: 0\nRESULT: PASS -- map is Autoware-compatible\n',
+        encoding='utf-8',
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(run_dir), '--write'],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert '# Autoware Map Run Diagnosis' in result.stdout
+    assert (run_dir / 'autoware_map_diagnosis.md').is_file()
+    assert (run_dir / 'autoware_map_diagnosis.json').is_file()
+
+
+def test_cli_rejects_missing_bag_context_without_traceback(tmp_path: Path):
+    run_dir = tmp_path / 'run'
+    run_dir.mkdir()
+    missing_bag = tmp_path / 'missing_bag'
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(run_dir), '--bag', str(missing_bag)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert 'error:' in result.stderr
+    assert 'rosbag2 directory does not exist' in result.stderr
+    assert 'Traceback' not in result.stderr
+
+
+def test_cli_rejects_db3_bag_context_without_traceback(tmp_path: Path):
+    run_dir = tmp_path / 'run'
+    run_dir.mkdir()
+    db3_path = tmp_path / 'demo_0.db3'
+    db3_path.write_text('', encoding='utf-8')
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(run_dir), '--bag', str(db3_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert 'error:' in result.stderr
+    assert 'not the .db3 file' in result.stderr
+    assert 'Traceback' not in result.stderr

--- a/scripts/diagnose_autoware_map_run.py
+++ b/scripts/diagnose_autoware_map_run.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -66,7 +67,12 @@ def _parse_projector_type(run_dir: Path) -> str | None:
     path = run_dir / 'map_projector_info.yaml'
     if not path.is_file():
         return None
-    data = yaml.safe_load(path.read_text(encoding='utf-8')) or {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding='utf-8')) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f'failed to parse {path}: {exc}') from exc
+    if not isinstance(data, dict):
+        raise ValueError(f'{path} must contain a YAML mapping.')
     return data.get('projector_type')
 
 
@@ -186,6 +192,8 @@ def summarize_run(run_dir: Path, bag_path: Path | None = None) -> dict[str, Any]
 
     if bag_path is not None:
         module = _load_preflight_module()
+        if hasattr(module, 'validate_bag_path'):
+            module.validate_bag_path(bag_path)
         summary['bag_preflight'] = module.build_preflight_payload(bag_path)
     summary['suggested_next_steps'] = _suggest_next_steps(summary)
     return summary
@@ -244,10 +252,72 @@ def render_markdown(summary: dict[str, Any]) -> str:
     return '\n'.join(lines)
 
 
+def validate_run_dir(run_dir: Path) -> None:
+    """Validate a CLI run directory input."""
+    if run_dir.is_file():
+        raise FileNotFoundError(
+            f'run directory path is a file, not a directory: {run_dir}. '
+            'Pass the output directory created by the map workflow.'
+        )
+    if not run_dir.exists():
+        raise FileNotFoundError(
+            f'run directory does not exist: {run_dir}. '
+            'Pass the output directory created by the map workflow.'
+        )
+    if not run_dir.is_dir():
+        raise FileNotFoundError(
+            f'run directory path is not a directory: {run_dir}. '
+            'Pass the output directory created by the map workflow.'
+        )
+    if run_dir.name == 'pointcloud_map' and (run_dir / 'pointcloud_map_metadata.yaml').is_file():
+        raise ValueError(
+            f'run_dir points to the nested pointcloud_map directory: {run_dir}. '
+            'Pass its parent output directory instead.'
+        )
+
+
+def _help_epilog() -> str:
+    return '\n'.join([
+        'The input must be the map workflow output directory.',
+        'Pass output/autoware_map_authoring_<bag>_<timestamp>, not its pointcloud_map/ child.',
+        '',
+        'Files this tool checks when present:',
+        '  lidarslam.launch.log or slam.launch.log',
+        '  map_save.log',
+        '  verify_autoware_map.log',
+        '  pointcloud_map/pointcloud_map_metadata.yaml',
+        '  map_projector_info.yaml',
+        '',
+        'Examples:',
+        '  python3 scripts/diagnose_autoware_map_run.py output/my_map_run',
+        '  python3 scripts/diagnose_autoware_map_run.py output/my_map_run --write',
+        (
+            '  python3 scripts/diagnose_autoware_map_run.py output/my_map_run '
+            '--bag /path/to/rosbag2'
+        ),
+        '  python3 scripts/diagnose_autoware_map_run.py output/my_map_run --json',
+    ])
+
+
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description='Diagnose a map-authoring output directory.')
-    parser.add_argument('run_dir', help='Output directory containing logs and pointcloud_map artifacts.')
-    parser.add_argument('--bag', help='Optional source rosbag2 directory to include preflight context.')
+    parser = argparse.ArgumentParser(
+        description=(
+            'Diagnose an Autoware-compatible map workflow output directory and '
+            'suggest the next command.'
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_help_epilog(),
+    )
+    parser.add_argument(
+        'run_dir',
+        metavar='output_dir',
+        help='Map workflow output directory containing logs and map artifacts.',
+    )
+    parser.add_argument(
+        '--bag',
+        metavar='<rosbag2_dir>',
+        help='Optional source rosbag2 directory to include preflight context.',
+    )
     parser.add_argument('--json', action='store_true', help='Print JSON instead of markdown.')
     parser.add_argument(
         '--write',
@@ -259,17 +329,30 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    run_dir = Path(args.run_dir)
+    run_dir = Path(args.run_dir).expanduser().resolve()
     bag_path = Path(args.bag).expanduser().resolve() if args.bag else None
-    summary = summarize_run(run_dir, bag_path)
+    try:
+        validate_run_dir(run_dir)
+        summary = summarize_run(run_dir, bag_path)
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f'error: {exc}', file=sys.stderr)
+        return 2
+
     markdown = render_markdown(summary)
 
     if args.write:
-        (run_dir / 'autoware_map_diagnosis.md').write_text(markdown, encoding='utf-8')
-        (run_dir / 'autoware_map_diagnosis.json').write_text(
-            json.dumps(summary, indent=2, sort_keys=True),
-            encoding='utf-8',
-        )
+        try:
+            (run_dir / 'autoware_map_diagnosis.md').write_text(markdown, encoding='utf-8')
+            (run_dir / 'autoware_map_diagnosis.json').write_text(
+                json.dumps(summary, indent=2, sort_keys=True),
+                encoding='utf-8',
+            )
+        except OSError as exc:
+            print(
+                f'error: failed to write diagnosis files under {run_dir}: {exc}',
+                file=sys.stderr,
+            )
+            return 2
 
     if args.json:
         print(json.dumps(summary, indent=2, sort_keys=True))


### PR DESCRIPTION
## Summary

- Improve `diagnose_autoware_map_run.py --help` with clearer output-directory guidance, checked files, and practical examples.
- Add CLI validation for missing run directories, file inputs, nested `pointcloud_map/` inputs, and invalid optional bag context.
- Convert write failures and malformed YAML into clean `error:` messages instead of Python tracebacks.
- Add CLI regression tests for help text, clean error paths, `--write`, and bag-context validation.

## Validation

- `python3 -m pytest -q graph_based_slam/test/test_autoware_map_run_diagnosis.py`
- `python3 -m pytest -q graph_based_slam/test/test_autoware_map_run_diagnosis.py graph_based_slam/test/test_docs_entrypoints.py lidarslam/test/test_autoware_map_runner_script.py graph_based_slam/test/test_autoware_map_preflight.py`
- `python3 -m compileall -q scripts/diagnose_autoware_map_run.py`
- `git diff --check`
