### PR TITLE
[codex] polish autoware map verify cli

### DIFF
--- a/graph_based_slam/test/test_autoware_map_tools.py
+++ b/graph_based_slam/test/test_autoware_map_tools.py
@@ -177,6 +177,41 @@ def test_map_verifier_rejects_float_tile_coordinates(tmp_path):
     assert _has_text(verifier.failures, 'YAML coordinates are floats')
 
 
+def test_map_verifier_rejects_string_tile_coordinates_without_throwing(tmp_path):
+    """String YAML coordinates should fail cleanly, not raise ValueError."""
+    _, pointcloud_dir = _create_map_bundle(tmp_path)
+    metadata_path = pointcloud_dir / 'pointcloud_map_metadata.yaml'
+    metadata = {
+        'x_resolution': 20,
+        'y_resolution': 20,
+        '0_0.pcd': ['0', '0'],
+    }
+    metadata_path.write_text(
+        yaml.safe_dump(metadata, sort_keys=False),
+        encoding='utf-8',
+    )
+
+    verifier = MapVerifier(str(pointcloud_dir))
+
+    assert verifier.run() is False
+    assert _has_text(verifier.failures, 'Coordinates must be YAML integers')
+
+
+def test_map_verifier_rejects_non_mapping_metadata_without_throwing(tmp_path):
+    """Metadata must be a mapping."""
+    pointcloud_dir = tmp_path / 'pointcloud_map'
+    pointcloud_dir.mkdir()
+    (pointcloud_dir / 'pointcloud_map_metadata.yaml').write_text(
+        '- not\n- metadata\n',
+        encoding='utf-8',
+    )
+
+    verifier = MapVerifier(str(pointcloud_dir))
+
+    assert verifier.run() is False
+    assert _has_text(verifier.failures, 'must contain a YAML mapping')
+
+
 def test_map_verifier_requires_origin_for_local_cartesian(tmp_path):
     """Require map_origin for LocalCartesian maps."""
     _, pointcloud_dir = _create_map_bundle(
@@ -299,3 +334,75 @@ def test_prepare_script_fails_without_projector_file(tmp_path):
 
     assert result.returncode != 0
     assert 'map_projector_info.yaml not found' in result.stderr
+
+
+def test_verify_cli_help_is_user_facing():
+    """The CLI help should show expected inputs and examples."""
+    result = subprocess.run(
+        ['python3', str(VERIFY_SCRIPT), '--help'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert 'pointcloud_map directory or parent output directory' in result.stdout
+    assert 'Expected map files:' in result.stdout
+    assert 'Exit codes:' in result.stdout
+    assert '--check-bounds' in result.stdout
+
+
+def test_verify_cli_rejects_missing_map_dir_without_traceback(tmp_path):
+    """Missing CLI input should be an argument error."""
+    missing_dir = tmp_path / 'missing_map'
+
+    result = subprocess.run(
+        ['python3', str(VERIFY_SCRIPT), str(missing_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert 'error:' in result.stderr
+    assert 'map directory does not exist' in result.stderr
+    assert 'Traceback' not in result.stderr
+
+
+def test_verify_cli_rejects_pcd_file_without_traceback(tmp_path):
+    """A PCD file is not a valid map_dir argument."""
+    pcd_file = tmp_path / '0_0.pcd'
+    _write_binary_xyz_pcd(pcd_file, [(0.0, 0.0, 0.0)])
+
+    result = subprocess.run(
+        ['python3', str(VERIFY_SCRIPT), str(pcd_file)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert 'error:' in result.stderr
+    assert 'PCD tile file' in result.stderr
+    assert 'Traceback' not in result.stderr
+
+
+def test_verify_cli_reports_bad_metadata_without_traceback(tmp_path):
+    """Malformed metadata content should return a compatibility failure."""
+    pointcloud_dir = tmp_path / 'pointcloud_map'
+    pointcloud_dir.mkdir()
+    (pointcloud_dir / 'pointcloud_map_metadata.yaml').write_text(
+        '- not\n- metadata\n',
+        encoding='utf-8',
+    )
+
+    result = subprocess.run(
+        ['python3', str(VERIFY_SCRIPT), str(pointcloud_dir)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert 'must contain a YAML mapping' in result.stdout
+    assert 'Traceback' not in result.stderr

--- a/scripts/verify_autoware_map.py
+++ b/scripts/verify_autoware_map.py
@@ -130,7 +130,7 @@ def read_xyz_from_pcd(filepath: str, header: dict) -> list[tuple[float, float, f
 # Main verification
 # ---------------------------------------------------------------------------
 class MapVerifier:
-    def __init__(self, map_dir: str, check_bounds: bool = False, verbose: bool = False):
+    def __init__(self, map_dir: str | Path, check_bounds: bool = False, verbose: bool = False):
         self.map_dir = Path(map_dir)
         self.check_bounds = check_bounds
         self.verbose = verbose
@@ -177,6 +177,10 @@ class MapVerifier:
             self.fail(f"Failed to parse YAML: {e}")
             self._print_summary()
             return False
+        if not isinstance(config, dict):
+            self.fail(f"{meta_path.name} must contain a YAML mapping")
+            self._print_summary()
+            return False
         self.ok(f"metadata YAML parsed: {meta_path.name}")
 
         # --- 3. Resolution ---
@@ -184,6 +188,18 @@ class MapVerifier:
         y_res = config.get("y_resolution")
         if x_res is None or y_res is None:
             self.fail("x_resolution or y_resolution missing from metadata")
+            self._print_summary()
+            return False
+        if (
+            not isinstance(x_res, (int, float))
+            or not isinstance(y_res, (int, float))
+            or isinstance(x_res, bool)
+            or isinstance(y_res, bool)
+        ):
+            self.fail(
+                "x_resolution and y_resolution must be numeric values: "
+                f"x_resolution={x_res}, y_resolution={y_res}"
+            )
             self._print_summary()
             return False
         if x_res <= 0 or y_res <= 0:
@@ -216,6 +232,17 @@ class MapVerifier:
                         f"Autoware parses as std::vector<int>."
                     )
                     continue
+            elif (
+                not isinstance(cx, int)
+                or not isinstance(cy, int)
+                or isinstance(cx, bool)
+                or isinstance(cy, bool)
+            ):
+                self.fail(
+                    f"entry '{key}' has non-integer coordinates: [{cx}, {cy}]. "
+                    "Coordinates must be YAML integers."
+                )
+                continue
 
             ix, iy = int(cx), int(cy)
             tiles[key] = (ix, iy)
@@ -373,20 +400,88 @@ class MapVerifier:
             print("RESULT: FAIL -- map has compatibility issues")
 
 
-def main():
+def validate_map_path(map_dir: Path) -> None:
+    """Validate CLI input without treating map content failures as argument errors."""
+    if map_dir.is_file():
+        if map_dir.suffix == ".pcd":
+            raise FileNotFoundError(
+                f"map path points to a PCD tile file: {map_dir}. "
+                "Pass the pointcloud_map directory or its parent output directory."
+            )
+        raise FileNotFoundError(
+            f"map path is a file, not a directory: {map_dir}. "
+            "Pass the pointcloud_map directory or its parent output directory."
+        )
+    if not map_dir.exists():
+        raise FileNotFoundError(
+            f"map directory does not exist: {map_dir}. "
+            "Pass the pointcloud_map directory or its parent output directory."
+        )
+    if not map_dir.is_dir():
+        raise FileNotFoundError(
+            f"map path is not a directory: {map_dir}. "
+            "Pass the pointcloud_map directory or its parent output directory."
+        )
+
+
+def _help_epilog() -> str:
+    return "\n".join([
+        "The input may be either:",
+        "  output/<run_dir>/pointcloud_map",
+        "  output/<run_dir> containing pointcloud_map/",
+        "",
+        "Expected map files:",
+        "  pointcloud_map_metadata.yaml",
+        "  one or more referenced .pcd tile files",
+        "  map_projector_info.yaml in the map directory or its parent",
+        "",
+        "Examples:",
+        "  python3 scripts/verify_autoware_map.py output/my_map/pointcloud_map",
+        "  python3 scripts/verify_autoware_map.py output/my_map",
+        (
+            "  python3 scripts/verify_autoware_map.py output/my_map/pointcloud_map "
+            "--check-bounds"
+        ),
+        "  python3 scripts/verify_autoware_map.py output/my_map/pointcloud_map --verbose",
+        "",
+        "Exit codes:",
+        "  0: compatible map",
+        "  1: map compatibility issue",
+        "  2: invalid CLI input",
+    ])
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Verify a pointcloud map directory for Autoware compatibility")
-    parser.add_argument("map_dir", help="Path to map directory (contains pointcloud_map_metadata.yaml or pointcloud_map/ subdir)")
+        description="Verify a pointcloud map directory for Autoware compatibility.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_help_epilog(),
+    )
+    parser.add_argument(
+        "map_dir",
+        metavar="map_dir",
+        help="pointcloud_map directory or parent output directory.",
+    )
     parser.add_argument("--check-bounds", action="store_true",
                         help="Check that all points fall within their tile bounds (slow)")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Show per-file details")
-    args = parser.parse_args()
+    return parser.parse_args(argv)
 
-    verifier = MapVerifier(args.map_dir, check_bounds=args.check_bounds, verbose=args.verbose)
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    map_dir = Path(args.map_dir).expanduser().resolve()
+    try:
+        validate_map_path(map_dir)
+    except OSError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    verifier = MapVerifier(map_dir, check_bounds=args.check_bounds, verbose=args.verbose)
     success = verifier.run()
-    sys.exit(0 if success else 1)
+    return 0 if success else 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Improve `verify_autoware_map.py --help` with accepted input forms, expected files, examples, and exit codes.
- Add CLI validation for missing map paths and accidental PCD-file inputs, returning clean `error:` messages.
- Harden metadata parsing so non-mapping YAML, non-numeric resolutions, and string/boolean tile coordinates fail as compatibility issues instead of throwing Python exceptions.
- Add regression tests for the new CLI help/error behavior and metadata validation paths.

## Validation

- `python3 -m pytest -q graph_based_slam/test/test_autoware_map_tools.py`
- `python3 -m pytest -q graph_based_slam/test/test_docs_entrypoints.py lidarslam/test/test_autoware_map_runner_script.py graph_based_slam/test/test_autoware_map_run_diagnosis.py graph_based_slam/test/test_autoware_map_preflight.py graph_based_slam/test/test_autoware_map_tools.py`
- `python3 -m compileall -q scripts/verify_autoware_map.py`
- `git diff --check`
