### PR TITLE
[codex] polish beginner map wrapper cli

### DIFF
--- a/lidarslam/test/test_autoware_map_runner_script.py
+++ b/lidarslam/test/test_autoware_map_runner_script.py
@@ -226,6 +226,47 @@ def test_beginner_wrapper_help_is_user_facing():
     assert 'The input must be the rosbag2 directory' in result.stderr
     assert 'Expected successful outputs:' in result.stderr
     assert '--output-dir <dir>' in result.stderr
+    assert '--viewer-rebuild' in result.stderr
+
+
+def test_beginner_wrapper_rejects_missing_option_value_before_bag_validation(
+    tmp_path: Path,
+):
+    result = subprocess.run(
+        [
+            'bash',
+            str(BEGINNER_SCRIPT_PATH),
+            str(tmp_path / 'missing_bag'),
+            '--output-dir',
+            '--dry-run',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert 'error: option requires a value: --output-dir' in result.stderr
+    assert 'metadata.yaml not found' not in result.stderr
+
+
+def test_beginner_wrapper_rejects_conflicting_viewer_flags(tmp_path: Path):
+    result = subprocess.run(
+        [
+            'bash',
+            str(BEGINNER_SCRIPT_PATH),
+            str(tmp_path / 'missing_bag'),
+            '--foxglove',
+            '--autoware',
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert 'error: viewer already set to foxglove; cannot also use --autoware' in result.stderr
+    assert 'metadata.yaml not found' not in result.stderr
 
 
 def test_runner_prefers_mid360_preset_for_livox_bag(tmp_path: Path):

--- a/scripts/run_autoware_map_beginner.sh
+++ b/scripts/run_autoware_map_beginner.sh
@@ -24,6 +24,10 @@ Common forwarded options:
   --output-dir <dir>            Write outputs to a specific directory
   --profile <id>                Force a compatible workflow profile
   --no-verify-map               Skip pointcloud_map verification
+  --viewer-rebuild              Rebuild viewer runtime before opening
+  --autoware-core-dir <dir>     autoware_core checkout for the Dockerized viewer
+  --work-dir <dir>              Runtime workspace for Autoware/Foxglove viewers
+  --viewer-run-dir <dir>        Existing built viewer runtime to reuse
   --auto-exit-secs <seconds>    Close the viewer after a timeout
 
 Expected successful outputs:
@@ -41,12 +45,40 @@ EOF
   exit "$exit_code"
 }
 
+fail() {
+  echo "error: $1" >&2
+  if [[ $# -gt 1 ]]; then
+    echo "hint: $2" >&2
+  fi
+  exit 2
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    fail "option requires a value: ${option}" \
+      "run 'bash scripts/run_autoware_map_beginner.sh --help' for valid options."
+  fi
+}
+
+set_viewer() {
+  local selected="$1"
+  local option="$2"
+  if [[ "$VIEWER" != "none" && "$selected" != "none" && "$VIEWER" != "$selected" ]]; then
+    fail "viewer already set to ${VIEWER}; cannot also use ${option}" \
+      "choose one of --foxglove, --autoware, or --no-viewer."
+  fi
+  VIEWER="$selected"
+}
+
 if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
   usage 0
 fi
 
 if [[ $# -lt 1 ]]; then
-  usage 1
+  fail "rosbag2_dir is required." \
+    "pass the rosbag2 directory that contains metadata.yaml."
 fi
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -60,15 +92,15 @@ FORWARDED_ARGS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --foxglove)
-      VIEWER=foxglove
+      set_viewer foxglove "$1"
       shift
       ;;
     --autoware)
-      VIEWER=autoware
+      set_viewer autoware "$1"
       shift
       ;;
     --no-viewer)
-      VIEWER=none
+      set_viewer none "$1"
       shift
       ;;
     --preflight-only)
@@ -83,28 +115,29 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --profile|--output-dir|--autoware-core-dir|--work-dir|--viewer-run-dir|--auto-exit-secs)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       FORWARDED_ARGS+=("$1" "$2")
       shift 2
       ;;
     -*)
-      echo "Unknown option: $1" >&2
-      usage 1
+      fail "unknown option: $1" \
+        "run 'bash scripts/run_autoware_map_beginner.sh --help' for valid options."
       ;;
     *)
       if [[ -z "$BAG_PATH" ]]; then
         BAG_PATH="$1"
         shift
       else
-        echo "Unexpected positional argument: $1" >&2
-        usage 1
+        fail "unexpected positional argument: $1" \
+          "pass exactly one rosbag2 directory."
       fi
       ;;
   esac
 done
 
 if [[ -z "$BAG_PATH" ]]; then
-  usage 1
+  fail "rosbag2_dir is required." \
+    "pass the rosbag2 directory that contains metadata.yaml."
 fi
 
 if [[ ! -d "$BAG_PATH" ]]; then


### PR DESCRIPTION
## Summary
- Add explicit beginner-wrapper errors for missing option values, unknown options, missing bag path, and conflicting viewer flags.
- Document forwarded viewer options in the wrapper help.
- Cover the new CLI behavior with regression tests.

## Validation
- python3 -m pytest -q lidarslam/test/test_autoware_map_runner_script.py
- python3 -m pytest -q graph_based_slam/test/test_docs_entrypoints.py lidarslam/test/test_autoware_map_runner_script.py
- bash -n scripts/run_autoware_map_beginner.sh
- git diff --check
