### PR TITLE
[codex] polish autoware map viewer cli

### DIFF
--- a/graph_based_slam/test/test_autoware_viewer_scripts.py
+++ b/graph_based_slam/test/test_autoware_viewer_scripts.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""CLI regression tests for Autoware map viewer shell entrypoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = REPO_ROOT / 'scripts'
+
+GRAPH_VIEWER_WRAPPERS = (
+    'run_graph_slam_pointcloud_map_in_autoware.sh',
+    'run_graph_slam_pointcloud_map_in_autoware_foxglove.sh',
+)
+MAP_VIEWER_SCRIPTS = (
+    'run_autoware_pointcloud_map_viewer_docker.sh',
+    'run_autoware_pointcloud_map_foxglove.sh',
+)
+ALL_VIEWER_SCRIPTS = GRAPH_VIEWER_WRAPPERS + MAP_VIEWER_SCRIPTS
+
+
+def _run_script(script_name: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ['bash', str(SCRIPT_DIR / script_name), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize('script_name', ALL_VIEWER_SCRIPTS)
+def test_viewer_script_help_exits_successfully(script_name: str):
+    result = _run_script(script_name, '--help')
+
+    assert result.returncode == 0
+    assert 'Usage:' in result.stderr
+    assert script_name in result.stderr
+    assert 'GNU coreutils' not in result.stderr
+
+
+@pytest.mark.parametrize('script_name', GRAPH_VIEWER_WRAPPERS)
+def test_graph_viewer_wrapper_requires_source_before_options(script_name: str):
+    result = _run_script(script_name, '--stage-dir', '/tmp/stage')
+
+    assert result.returncode == 2
+    assert 'error: graph_slam_output_dir is required before options.' in result.stderr
+    assert 'realpath' not in result.stderr
+
+
+@pytest.mark.parametrize('script_name', MAP_VIEWER_SCRIPTS)
+def test_map_viewer_script_requires_map_dir_before_options(script_name: str):
+    result = _run_script(script_name, '--run-dir', '/tmp/runtime')
+
+    assert result.returncode == 2
+    assert 'error: autoware_map_dir is required before options.' in result.stderr
+    assert 'realpath' not in result.stderr
+
+
+@pytest.mark.parametrize('script_name', GRAPH_VIEWER_WRAPPERS)
+def test_graph_viewer_wrapper_rejects_missing_option_value(
+    tmp_path: Path,
+    script_name: str,
+):
+    source_dir = tmp_path / 'graph_output'
+    source_dir.mkdir()
+
+    result = _run_script(script_name, str(source_dir), '--stage-dir', '--rebuild')
+
+    assert result.returncode == 2
+    assert 'error: option requires a value: --stage-dir' in result.stderr
+    assert 'realpath' not in result.stderr
+
+
+@pytest.mark.parametrize('script_name', MAP_VIEWER_SCRIPTS)
+def test_map_viewer_script_rejects_missing_option_value(
+    tmp_path: Path,
+    script_name: str,
+):
+    map_dir = tmp_path / 'map_bundle'
+    map_dir.mkdir()
+
+    result = _run_script(script_name, str(map_dir), '--run-dir', '--rebuild')
+
+    assert result.returncode == 2
+    assert 'error: option requires a value: --run-dir' in result.stderr
+    assert 'realpath' not in result.stderr
+
+
+@pytest.mark.parametrize('script_name', GRAPH_VIEWER_WRAPPERS)
+def test_graph_viewer_wrapper_reports_missing_source_directory(
+    tmp_path: Path,
+    script_name: str,
+):
+    result = _run_script(script_name, str(tmp_path / 'missing_output'))
+
+    assert result.returncode == 2
+    assert 'error: graph_based_slam output directory not found:' in result.stderr
+    assert 'realpath' not in result.stderr
+
+
+@pytest.mark.parametrize('script_name', MAP_VIEWER_SCRIPTS)
+def test_map_viewer_script_reports_missing_map_directory(
+    tmp_path: Path,
+    script_name: str,
+):
+    result = _run_script(script_name, str(tmp_path / 'missing_map'))
+
+    assert result.returncode == 2
+    assert 'error: Autoware map directory not found:' in result.stderr
+    assert 'realpath' not in result.stderr

--- a/scripts/run_autoware_pointcloud_map_foxglove.sh
+++ b/scripts/run_autoware_pointcloud_map_foxglove.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 usage() {
+  local exit_code="${1:-1}"
   cat <<'EOF' >&2
 Usage:
   run_autoware_pointcloud_map_foxglove.sh <autoware_map_dir> [autoware_core_dir] [work_dir] [options]
@@ -20,11 +21,43 @@ This launches Autoware's map loaders in Docker, waits for `/map/pointcloud_map`,
 and then starts `foxglove_bridge` on the host so the map can be viewed from a
 browser or Foxglove Desktop.
 EOF
-  exit 1
+  exit "$exit_code"
 }
 
+fail() {
+  echo "error: $1" >&2
+  if [[ $# -gt 1 ]]; then
+    echo "hint: $2" >&2
+  fi
+  exit 2
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    fail "option requires a value: ${option}" \
+      "run this script with --help for valid options."
+  fi
+}
+
+if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+  usage 0
+fi
+
 if [[ $# -lt 1 ]]; then
-  usage
+  fail "autoware_map_dir is required." \
+    "pass the directory that contains pointcloud_map/ and map_projector_info.yaml."
+fi
+
+if [[ "$1" == --* ]]; then
+  fail "autoware_map_dir is required before options." \
+    "put <autoware_map_dir> before options; run --help for details."
+fi
+
+if [[ ! -d "$1" ]]; then
+  fail "Autoware map directory not found: $1" \
+    "pass the bundle directory, not pointcloud_map/ or a PCD tile."
 fi
 
 MAP_DIR=$(realpath "$1")
@@ -33,7 +66,7 @@ shift
 AUTOWARE_CORE_DIR=/tmp/autoware_core
 WORK_DIR=/tmp/autoware_map_runtime_ws
 if [[ $# -gt 0 && "$1" != --* ]]; then
-  AUTOWARE_CORE_DIR=$(realpath "$1")
+  AUTOWARE_CORE_DIR=$(realpath -m "$1")
   shift
 fi
 if [[ $# -gt 0 && "$1" != --* ]]; then
@@ -52,8 +85,8 @@ AUTO_EXIT_SECS=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --run-dir)
-      [[ $# -ge 2 ]] || usage
-      RUN_DIR=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      RUN_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --rebuild)
@@ -61,47 +94,51 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --foxglove-prefix)
-      [[ $# -ge 2 ]] || usage
-      FOXGLOVE_PREFIX=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      FOXGLOVE_PREFIX=$(realpath -m "$2")
       shift 2
       ;;
     --port)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       PORT="$2"
       shift 2
       ;;
     --address)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       ADDRESS="$2"
       shift 2
       ;;
     --topic-whitelist)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       TOPIC_WHITELIST="$2"
       shift 2
       ;;
     --auto-exit-secs)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       AUTO_EXIT_SECS="$2"
       shift 2
       ;;
     --help|-h)
-      usage
+      usage 0
       ;;
     *)
-      echo "Unknown option: $1" >&2
-      usage
+      fail "unknown option: $1" \
+        "run this script with --help for valid options."
       ;;
   esac
 done
 
 if [[ ! -d "$MAP_DIR/pointcloud_map" || ! -f "$MAP_DIR/map_projector_info.yaml" ]]; then
-  echo "Autoware map bundle is incomplete under $MAP_DIR" >&2
-  exit 1
+  fail "Autoware map bundle is incomplete under $MAP_DIR" \
+    "expected pointcloud_map/ and map_projector_info.yaml."
 fi
 if [[ ! -d "$AUTOWARE_CORE_DIR" ]]; then
-  echo "autoware_core directory not found: $AUTOWARE_CORE_DIR" >&2
-  exit 1
+  fail "autoware_core directory not found: $AUTOWARE_CORE_DIR" \
+    "pass the autoware_core checkout as the second positional argument."
+fi
+if [[ -n "$RUN_DIR" && ! -d "$RUN_DIR" ]]; then
+  fail "Autoware runtime run directory not found: $RUN_DIR" \
+    "omit --run-dir to let the script build or discover one under the work directory."
 fi
 
 command -v docker >/dev/null 2>&1 || { echo "docker not found" >&2; exit 1; }

--- a/scripts/run_autoware_pointcloud_map_viewer_docker.sh
+++ b/scripts/run_autoware_pointcloud_map_viewer_docker.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 usage() {
+  local exit_code="${1:-1}"
   cat <<'EOF' >&2
 Usage:
   run_autoware_pointcloud_map_viewer_docker.sh <autoware_map_dir> [autoware_core_dir] [work_dir] [options]
@@ -17,11 +18,43 @@ Docker, then opens the pointcloud map in the host's rviz2. The map directory mus
   pointcloud_map/
   map_projector_info.yaml
 EOF
-  exit 1
+  exit "$exit_code"
 }
 
+fail() {
+  echo "error: $1" >&2
+  if [[ $# -gt 1 ]]; then
+    echo "hint: $2" >&2
+  fi
+  exit 2
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    fail "option requires a value: ${option}" \
+      "run this script with --help for valid options."
+  fi
+}
+
+if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+  usage 0
+fi
+
 if [[ $# -lt 1 ]]; then
-  usage
+  fail "autoware_map_dir is required." \
+    "pass the directory that contains pointcloud_map/ and map_projector_info.yaml."
+fi
+
+if [[ "$1" == --* ]]; then
+  fail "autoware_map_dir is required before options." \
+    "put <autoware_map_dir> before options; run --help for details."
+fi
+
+if [[ ! -d "$1" ]]; then
+  fail "Autoware map directory not found: $1" \
+    "pass the bundle directory, not pointcloud_map/ or a PCD tile."
 fi
 
 MAP_DIR=$(realpath "$1")
@@ -30,7 +63,7 @@ shift
 AUTOWARE_CORE_DIR=/tmp/autoware_core
 WORK_DIR=/tmp/autoware_map_runtime_ws
 if [[ $# -gt 0 && "$1" != --* ]]; then
-  AUTOWARE_CORE_DIR=$(realpath "$1")
+  AUTOWARE_CORE_DIR=$(realpath -m "$1")
   shift
 fi
 if [[ $# -gt 0 && "$1" != --* ]]; then
@@ -45,8 +78,8 @@ AUTO_EXIT_SECS=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --run-dir)
-      [[ $# -ge 2 ]] || usage
-      RUN_DIR=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      RUN_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --rebuild)
@@ -54,27 +87,31 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --auto-exit-secs)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       AUTO_EXIT_SECS="$2"
       shift 2
       ;;
     --help|-h)
-      usage
+      usage 0
       ;;
     *)
-      echo "Unknown option: $1" >&2
-      usage
+      fail "unknown option: $1" \
+        "run this script with --help for valid options."
       ;;
   esac
 done
 
 if [[ ! -d "$MAP_DIR/pointcloud_map" || ! -f "$MAP_DIR/map_projector_info.yaml" ]]; then
-  echo "Autoware map bundle is incomplete under $MAP_DIR" >&2
-  exit 1
+  fail "Autoware map bundle is incomplete under $MAP_DIR" \
+    "expected pointcloud_map/ and map_projector_info.yaml."
 fi
 if [[ ! -d "$AUTOWARE_CORE_DIR" ]]; then
-  echo "autoware_core directory not found: $AUTOWARE_CORE_DIR" >&2
-  exit 1
+  fail "autoware_core directory not found: $AUTOWARE_CORE_DIR" \
+    "pass the autoware_core checkout as the second positional argument."
+fi
+if [[ -n "$RUN_DIR" && ! -d "$RUN_DIR" ]]; then
+  fail "Autoware runtime run directory not found: $RUN_DIR" \
+    "omit --run-dir to let the script build or discover one under the work directory."
 fi
 if [[ -z "${DISPLAY:-}" ]]; then
   echo "DISPLAY is not set; cannot launch RViz." >&2

--- a/scripts/run_graph_slam_pointcloud_map_in_autoware.sh
+++ b/scripts/run_graph_slam_pointcloud_map_in_autoware.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 usage() {
+  local exit_code="${1:-1}"
   cat <<'EOF' >&2
 Usage:
   run_graph_slam_pointcloud_map_in_autoware.sh <graph_slam_output_dir> [options]
@@ -19,11 +20,43 @@ This stages a graph_based_slam output directory into an Autoware-compatible
 pointcloud map bundle, verifies it, and opens the map in the host's rviz2
 through Autoware's Dockerized map loaders.
 EOF
-  exit 1
+  exit "$exit_code"
 }
 
+fail() {
+  echo "error: $1" >&2
+  if [[ $# -gt 1 ]]; then
+    echo "hint: $2" >&2
+  fi
+  exit 2
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    fail "option requires a value: ${option}" \
+      "run this script with --help for valid options."
+  fi
+}
+
+if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+  usage 0
+fi
+
 if [[ $# -lt 1 ]]; then
-  usage
+  fail "graph_slam_output_dir is required." \
+    "pass the output directory that contains pointcloud_map/ or graph SLAM map artifacts."
+fi
+
+if [[ "$1" == --* ]]; then
+  fail "graph_slam_output_dir is required before options." \
+    "put <graph_slam_output_dir> before options; run --help for details."
+fi
+
+if [[ ! -d "$1" ]]; then
+  fail "graph_based_slam output directory not found: $1" \
+    "pass the saved graph_based_slam output directory, not a pointcloud_map tile or option."
 fi
 
 SOURCE_DIR=$(realpath "$1")
@@ -39,23 +72,23 @@ AUTO_EXIT_SECS=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --stage-dir)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       STAGE_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --autoware-core-dir)
-      [[ $# -ge 2 ]] || usage
-      AUTOWARE_CORE_DIR=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      AUTOWARE_CORE_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --work-dir)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       WORK_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --run-dir)
-      [[ $# -ge 2 ]] || usage
-      RUN_DIR=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      RUN_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --rebuild)
@@ -63,16 +96,16 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --auto-exit-secs)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       AUTO_EXIT_SECS="$2"
       shift 2
       ;;
     --help|-h)
-      usage
+      usage 0
       ;;
     *)
-      echo "Unknown option: $1" >&2
-      usage
+      fail "unknown option: $1" \
+        "run this script with --help for valid options."
       ;;
   esac
 done

--- a/scripts/run_graph_slam_pointcloud_map_in_autoware_foxglove.sh
+++ b/scripts/run_graph_slam_pointcloud_map_in_autoware_foxglove.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 usage() {
+  local exit_code="${1:-1}"
   cat <<'EOF' >&2
 Usage:
   run_graph_slam_pointcloud_map_in_autoware_foxglove.sh <graph_slam_output_dir> [options]
@@ -19,11 +20,43 @@ Options:
   --auto-exit-secs <sec>         Auto-stop the bridge after N seconds
   --help                         Show this help
 EOF
-  exit 1
+  exit "$exit_code"
 }
 
+fail() {
+  echo "error: $1" >&2
+  if [[ $# -gt 1 ]]; then
+    echo "hint: $2" >&2
+  fi
+  exit 2
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    fail "option requires a value: ${option}" \
+      "run this script with --help for valid options."
+  fi
+}
+
+if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+  usage 0
+fi
+
 if [[ $# -lt 1 ]]; then
-  usage
+  fail "graph_slam_output_dir is required." \
+    "pass the output directory that contains pointcloud_map/ or graph SLAM map artifacts."
+fi
+
+if [[ "$1" == --* ]]; then
+  fail "graph_slam_output_dir is required before options." \
+    "put <graph_slam_output_dir> before options; run --help for details."
+fi
+
+if [[ ! -d "$1" ]]; then
+  fail "graph_based_slam output directory not found: $1" \
+    "pass the saved graph_based_slam output directory, not a pointcloud_map tile or option."
 fi
 
 SOURCE_DIR=$(realpath "$1")
@@ -43,23 +76,23 @@ AUTO_EXIT_SECS=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --stage-dir)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       STAGE_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --autoware-core-dir)
-      [[ $# -ge 2 ]] || usage
-      AUTOWARE_CORE_DIR=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      AUTOWARE_CORE_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --work-dir)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       WORK_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --run-dir)
-      [[ $# -ge 2 ]] || usage
-      RUN_DIR=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      RUN_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --rebuild)
@@ -67,36 +100,36 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --foxglove-prefix)
-      [[ $# -ge 2 ]] || usage
-      FOXGLOVE_PREFIX=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      FOXGLOVE_PREFIX=$(realpath -m "$2")
       shift 2
       ;;
     --port)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       PORT="$2"
       shift 2
       ;;
     --address)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       ADDRESS="$2"
       shift 2
       ;;
     --topic-whitelist)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       TOPIC_WHITELIST="$2"
       shift 2
       ;;
     --auto-exit-secs)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       AUTO_EXIT_SECS="$2"
       shift 2
       ;;
     --help|-h)
-      usage
+      usage 0
       ;;
     *)
-      echo "Unknown option: $1" >&2
-      usage
+      fail "unknown option: $1" \
+        "run this script with --help for valid options."
       ;;
   esac
 done


### PR DESCRIPTION
## Summary
- Make Autoware map viewer entrypoint `--help` return success instead of falling through to `realpath`.
- Add clear `error:`/`hint:` messages for missing source/map directories, option-before-positional usage, unknown options, and missing option values.
- Add shell CLI regression tests for the graph_slam viewer wrappers and low-level Autoware viewer scripts.

## Validation
- python3 -m pytest -q graph_based_slam/test/test_autoware_viewer_scripts.py
- python3 -m pytest -q graph_based_slam/test/test_docs_entrypoints.py graph_based_slam/test/test_autoware_viewer_scripts.py
- bash -n scripts/run_graph_slam_pointcloud_map_in_autoware.sh scripts/run_graph_slam_pointcloud_map_in_autoware_foxglove.sh scripts/run_autoware_pointcloud_map_viewer_docker.sh scripts/run_autoware_pointcloud_map_foxglove.sh
- git diff --check
