### PR TITLE
[codex] polish autoware map staging cli

### DIFF
--- a/graph_based_slam/test/test_autoware_map_tools.py
+++ b/graph_based_slam/test/test_autoware_map_tools.py
@@ -307,6 +307,80 @@ def test_prepare_script_replaces_existing_pointcloud_map_contents(tmp_path):
     assert (target_root / 'pointcloud_map' / '0_0.pcd').is_file()
 
 
+def test_prepare_script_help_is_user_facing():
+    """The staging script help should be a successful command."""
+    result = subprocess.run(
+        ['bash', str(PREPARE_SCRIPT), '--help'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert 'prepare_autoware_map_from_graph_slam.sh' in result.stderr
+    assert 'graph_slam_output_dir' in result.stderr
+    assert '--smoke' in result.stderr
+
+
+def test_prepare_script_rejects_missing_output_dir_before_realpath(tmp_path):
+    """A missing output positional should produce a direct script error."""
+    source_root, _ = _create_map_bundle(tmp_path / 'graph_output')
+
+    result = subprocess.run(
+        ['bash', str(PREPARE_SCRIPT), str(source_root), '--smoke'],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert 'error: autoware_map_dir is required before options.' in result.stderr
+    assert 'realpath' not in result.stderr
+
+
+def test_prepare_script_rejects_missing_option_value_before_realpath(
+    tmp_path,
+):
+    """Missing option values should not fall through to realpath."""
+    source_root, _ = _create_map_bundle(tmp_path / 'graph_output')
+    target_root = tmp_path / 'staged_map'
+
+    result = subprocess.run(
+        [
+            'bash',
+            str(PREPARE_SCRIPT),
+            str(source_root),
+            str(target_root),
+            '--autoware-core-dir',
+            '--smoke',
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert 'error: option requires a value: --autoware-core-dir' in result.stderr
+    assert 'realpath' not in result.stderr
+
+
+def test_prepare_script_rejects_output_file_without_traceback(tmp_path):
+    """The staged-map output must be a directory path."""
+    source_root, _ = _create_map_bundle(tmp_path / 'graph_output')
+    output_file = tmp_path / 'staged_map'
+    output_file.write_text('', encoding='utf-8')
+
+    result = subprocess.run(
+        ['bash', str(PREPARE_SCRIPT), str(source_root), str(output_file)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert 'error: Autoware map output path is a file' in result.stderr
+
+
 def test_prepare_script_fails_without_projector_file(tmp_path):
     """The staging script should reject source dirs without projector info."""
     source_root = tmp_path / 'graph_output'

--- a/scripts/prepare_autoware_map_from_graph_slam.sh
+++ b/scripts/prepare_autoware_map_from_graph_slam.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 usage() {
+  local exit_code="${1:-1}"
   cat <<'EOF' >&2
 Usage:
   prepare_autoware_map_from_graph_slam.sh <graph_slam_output_dir> <autoware_map_dir> [options]
@@ -15,11 +16,53 @@ Options:
 This script copies a graph_based_slam output directory into an Autoware-style
 map bundle, verifies the result, and can optionally run the Docker smoke test.
 EOF
-  exit 1
+  exit "$exit_code"
 }
 
+fail() {
+  echo "error: $1" >&2
+  if [[ $# -gt 1 ]]; then
+    echo "hint: $2" >&2
+  fi
+  exit 2
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    fail "option requires a value: ${option}" \
+      "run this script with --help for valid options."
+  fi
+}
+
+if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+  usage 0
+fi
+
 if [[ $# -lt 2 ]]; then
-  usage
+  fail "graph_slam_output_dir and autoware_map_dir are required." \
+    "pass source and target directories before options; run --help for details."
+fi
+
+if [[ "$1" == --* ]]; then
+  fail "graph_slam_output_dir is required before options." \
+    "put <graph_slam_output_dir> before options; run --help for details."
+fi
+
+if [[ "$2" == --* ]]; then
+  fail "autoware_map_dir is required before options." \
+    "put <autoware_map_dir> before options; run --help for details."
+fi
+
+if [[ ! -d "$1" ]]; then
+  fail "graph_based_slam output directory not found: $1" \
+    "pass the output directory that contains pointcloud_map/."
+fi
+
+if [[ -e "$2" && ! -d "$2" ]]; then
+  fail "Autoware map output path is a file, not a directory: $2" \
+    "choose a directory path for the staged map bundle."
 fi
 
 SOURCE_DIR=$(realpath "$1")
@@ -37,40 +80,44 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --autoware-core-dir)
-      [[ $# -ge 2 ]] || usage
-      AUTOWARE_CORE_DIR=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      AUTOWARE_CORE_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --work-dir)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       WORK_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --help|-h)
-      usage
+      usage 0
       ;;
     *)
-      echo "Unknown option: $1" >&2
-      usage
+      fail "unknown option: $1" \
+        "run this script with --help for valid options."
       ;;
   esac
 done
 
 if [[ ! -d "$SOURCE_DIR/pointcloud_map" ]]; then
-  echo "pointcloud_map directory not found under $SOURCE_DIR" >&2
-  exit 1
+  fail "pointcloud_map directory not found under $SOURCE_DIR" \
+    "pass the graph_based_slam output directory, not the parent workspace."
 fi
 if [[ ! -f "$SOURCE_DIR/pointcloud_map/pointcloud_map_metadata.yaml" ]]; then
-  echo "pointcloud_map_metadata.yaml not found under $SOURCE_DIR/pointcloud_map" >&2
-  exit 1
+  fail "pointcloud_map_metadata.yaml not found under $SOURCE_DIR/pointcloud_map" \
+    "run the map workflow until /map_save writes pointcloud_map metadata."
 fi
 if [[ ! -f "$SOURCE_DIR/map_projector_info.yaml" ]]; then
-  echo "map_projector_info.yaml not found under $SOURCE_DIR" >&2
-  exit 1
+  fail "map_projector_info.yaml not found under $SOURCE_DIR" \
+    "stage an output directory produced by the Autoware-compatible map workflow."
 fi
 if [[ "$RUN_SMOKE" == "true" && -z "$AUTOWARE_CORE_DIR" ]]; then
-  echo "--smoke requires --autoware-core-dir" >&2
-  exit 1
+  fail "--smoke requires --autoware-core-dir <dir>" \
+    "pass an autoware_core checkout for the Docker smoke test."
+fi
+if [[ "$RUN_SMOKE" == "true" && ! -d "$AUTOWARE_CORE_DIR" ]]; then
+  fail "autoware_core directory not found: $AUTOWARE_CORE_DIR" \
+    "pass an existing autoware_core checkout to --autoware-core-dir."
 fi
 
 mkdir -p "$TARGET_DIR"


### PR DESCRIPTION
## Summary
- Make `prepare_autoware_map_from_graph_slam.sh --help` exit successfully.
- Add clear `error:`/`hint:` messages for missing positional args, missing option values, missing bundle files, output-file paths, and smoke-test prerequisites.
- Add regression coverage for the staging CLI error paths.

## Validation
- python3 -m pytest -q graph_based_slam/test/test_autoware_map_tools.py
- python3 -m pytest -q graph_based_slam/test/test_docs_entrypoints.py graph_based_slam/test/test_autoware_map_tools.py
- python3 -m pytest -q graph_based_slam/test/test_autoware_map_tools.py graph_based_slam/test/test_autoware_viewer_scripts.py
- bash -n scripts/prepare_autoware_map_from_graph_slam.sh
- git diff --check
