### PR TITLE
[codex] polish autoware quickstart cli

### DIFF
--- a/graph_based_slam/test/test_autoware_quickstart_script.py
+++ b/graph_based_slam/test/test_autoware_quickstart_script.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""CLI regression tests for the public Autoware quickstart wrapper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+QUICKSTART_SCRIPT = REPO_ROOT / 'scripts' / 'run_autoware_quickstart.sh'
+
+
+def _run_quickstart(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ['bash', str(QUICKSTART_SCRIPT), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_quickstart_help_exits_successfully():
+    result = _run_quickstart('--help')
+
+    assert result.returncode == 0
+    assert 'run_autoware_quickstart.sh' in result.stderr
+    assert 'dogfood' in result.stderr
+    assert 'existing <graph_slam_output_dir>' in result.stderr
+
+
+def test_quickstart_existing_requires_source_directory():
+    result = _run_quickstart('existing')
+
+    assert result.returncode == 2
+    assert 'error: existing requires <graph_slam_output_dir>.' in result.stderr
+
+
+def test_quickstart_existing_rejects_missing_source_directory(tmp_path: Path):
+    result = _run_quickstart('existing', str(tmp_path / 'missing_output'))
+
+    assert result.returncode == 2
+    assert 'error: graph_slam_output_dir does not exist' in result.stderr
+    assert 'run_rko_lio_graph_autoware_dogfood.sh' not in result.stderr
+
+
+def test_quickstart_missing_path_is_not_treated_as_dogfood_option(tmp_path: Path):
+    result = _run_quickstart(str(tmp_path / 'missing_output'), '--dry-run')
+
+    assert result.returncode == 2
+    assert 'error: graph_slam_output_dir does not exist' in result.stderr
+    assert 'Unknown option:' not in result.stderr

--- a/scripts/run_autoware_quickstart.sh
+++ b/scripts/run_autoware_quickstart.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 DEFAULT_AUTO_EXIT_SECS=20
 
 usage() {
+  local exit_code="${1:-1}"
   cat <<'EOF' >&2
 Usage:
   run_autoware_quickstart.sh
@@ -24,7 +25,15 @@ Examples:
   bash scripts/run_autoware_quickstart.sh dogfood --viewer-rebuild
   bash scripts/run_autoware_quickstart.sh output/bench_rko_lio_ntu_viral_loopgate_20260324
 EOF
-  exit 1
+  exit "$exit_code"
+}
+
+fail() {
+  echo "error: $1" >&2
+  if [[ $# -gt 1 ]]; then
+    echo "hint: $2" >&2
+  fi
+  exit 2
 }
 
 has_auto_exit_flag() {
@@ -52,6 +61,11 @@ run_existing() {
   local source_dir="$1"
   shift
 
+  if [[ ! -d "$source_dir" ]]; then
+    fail "graph_slam_output_dir does not exist or is not a directory: ${source_dir}" \
+      "pass an existing graph_based_slam output directory, or use 'dogfood'."
+  fi
+
   local cmd=(
     bash "${SCRIPT_DIR}/run_graph_slam_pointcloud_map_in_autoware.sh"
     "${source_dir}"
@@ -68,14 +82,17 @@ case "${1:-}" in
     run_dogfood
     ;;
   --help|-h)
-    usage
+    usage 0
     ;;
   dogfood)
     shift
     run_dogfood "$@"
     ;;
   existing)
-    [[ $# -ge 2 ]] || usage
+    if [[ $# -lt 2 || "$2" == --* ]]; then
+      fail "existing requires <graph_slam_output_dir>." \
+        "usage: bash scripts/run_autoware_quickstart.sh existing <graph_slam_output_dir>"
+    fi
     source_dir="$2"
     shift 2
     run_existing "${source_dir}" "$@"
@@ -85,8 +102,11 @@ case "${1:-}" in
       source_dir="$1"
       shift
       run_existing "${source_dir}" "$@"
-    else
+    elif [[ "$1" == --* ]]; then
       run_dogfood "$@"
+    else
+      fail "graph_slam_output_dir does not exist or is not a directory: $1" \
+        "use 'dogfood' for the bundled demo path, or pass an existing output directory."
     fi
     ;;
 esac


### PR DESCRIPTION
## Summary
- Make `run_autoware_quickstart.sh --help` exit successfully.
- Add explicit quickstart errors for `existing` without a source directory and missing graph_slam output paths.
- Keep direct dogfood option forwarding for leading `--...` arguments, while avoiding treating missing paths as dogfood options.
- Add quickstart CLI regression tests.

## Validation
- python3 -m pytest -q graph_based_slam/test/test_autoware_quickstart_script.py
- python3 -m pytest -q graph_based_slam/test/test_docs_entrypoints.py graph_based_slam/test/test_autoware_quickstart_script.py
- bash -n scripts/run_autoware_quickstart.sh
- git diff --check
