### PR TITLE
[codex] polish autoware dogfood cli

### DIFF
--- a/graph_based_slam/test/test_autoware_dogfood_script.py
+++ b/graph_based_slam/test/test_autoware_dogfood_script.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""CLI regression tests for the RKO-LIO Autoware dogfood wrapper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOGFOOD_SCRIPT = REPO_ROOT / 'scripts' / 'run_rko_lio_graph_autoware_dogfood.sh'
+
+
+def _run_dogfood(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ['bash', str(DOGFOOD_SCRIPT), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_minimal_bag(tmp_path: Path) -> Path:
+    bag_dir = tmp_path / 'demo_bag'
+    bag_dir.mkdir()
+    (bag_dir / 'metadata.yaml').write_text(
+        'rosbag2_bagfile_information: {}\n',
+        encoding='utf-8',
+    )
+    return bag_dir
+
+
+def test_dogfood_help_exits_successfully():
+    result = _run_dogfood('--help')
+
+    assert result.returncode == 0
+    assert 'run_rko_lio_graph_autoware_dogfood.sh' in result.stderr
+    assert '--skip-viewer' in result.stderr
+
+
+def test_dogfood_rejects_missing_option_value_before_realpath():
+    result = _run_dogfood('--bag', '--skip-viewer')
+
+    assert result.returncode == 2
+    assert 'error: option requires a value: --bag' in result.stderr
+    assert 'realpath' not in result.stderr
+
+
+def test_dogfood_rejects_invalid_bool_without_usage_dump():
+    result = _run_dogfood('--capture-corrected-path', 'maybe')
+
+    assert result.returncode == 2
+    assert 'error: --capture-corrected-path expects true or false.' in result.stderr
+    assert 'Usage:' not in result.stderr
+
+
+def test_dogfood_rejects_missing_bag_dir_without_realpath(tmp_path: Path):
+    result = _run_dogfood(
+        '--bag',
+        str(tmp_path / 'missing_bag'),
+        '--skip-viewer',
+    )
+
+    assert result.returncode == 2
+    assert 'error: rosbag2 directory not found:' in result.stderr
+    assert 'metadata.yaml' in result.stderr
+    assert 'realpath' not in result.stderr
+
+
+def test_dogfood_rejects_missing_metadata_without_ros_launch(tmp_path: Path):
+    bag_dir = tmp_path / 'bag_without_metadata'
+    bag_dir.mkdir()
+
+    result = _run_dogfood('--bag', str(bag_dir), '--skip-viewer')
+
+    assert result.returncode == 2
+    assert 'error: metadata.yaml not found under' in result.stderr
+    assert 'ros2 not found' not in result.stderr
+
+
+def test_dogfood_rejects_output_file_before_ros_launch(tmp_path: Path):
+    bag_dir = _write_minimal_bag(tmp_path)
+    output_file = tmp_path / 'map_output'
+    output_file.write_text('', encoding='utf-8')
+
+    result = _run_dogfood(
+        '--bag',
+        str(bag_dir),
+        '--output-dir',
+        str(output_file),
+        '--skip-viewer',
+    )
+
+    assert result.returncode == 2
+    assert 'error: output directory path is a file' in result.stderr
+    assert 'ros2 not found' not in result.stderr

--- a/scripts/run_rko_lio_graph_autoware_dogfood.sh
+++ b/scripts/run_rko_lio_graph_autoware_dogfood.sh
@@ -9,6 +9,7 @@ if [[ ! -f "${WS_ROOT}/install/setup.bash" && -f "${REPO_ROOT}/../install/setup.
 fi
 
 usage() {
+  local exit_code="${1:-1}"
   cat <<'EOF' >&2
 Usage:
   run_rko_lio_graph_autoware_dogfood.sh [options]
@@ -56,7 +57,35 @@ Defaults target the NTU VIRAL tnp_01 restamped VN100 rosbag2 currently stored in
 The script runs RKO-LIO + graph_based_slam, waits for offline odometry to finish, calls /map_save,
 then stages the resulting map for Autoware and opens it in the host's rviz2.
 EOF
-  exit 1
+  exit "$exit_code"
+}
+
+fail() {
+  echo "error: $1" >&2
+  if [[ $# -gt 1 ]]; then
+    echo "hint: $2" >&2
+  fi
+  exit 2
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    fail "option requires a value: ${option}" \
+      "run this script with --help for valid options."
+  fi
+}
+
+parse_bool() {
+  local option="$1"
+  local value="$2"
+  case "${value,,}" in
+    true|1|yes) echo true ;;
+    false|0|no) echo false ;;
+    *) fail "${option} expects true or false." \
+      "accepted values: true, false, 1, 0, yes, no." ;;
+  esac
 }
 
 DEFAULT_BAG="${REPO_ROOT}/demo_data/ntu_viral/tnp_01_points_restamped_vn100_rosbag2"
@@ -103,78 +132,78 @@ REFERENCE_TUM=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --bag)
-      [[ $# -ge 2 ]] || usage
-      BAG_PATH=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      BAG_PATH=$(realpath -m "$2")
       shift 2
       ;;
     --lidar-topic)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       LIDAR_TOPIC="$2"
       shift 2
       ;;
     --imu-topic)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       IMU_TOPIC="$2"
       shift 2
       ;;
     --base-frame)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       BASE_FRAME="$2"
       shift 2
       ;;
     --lidar-frame)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       LIDAR_FRAME="$2"
       shift 2
       ;;
     --imu-frame)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       IMU_FRAME="$2"
       shift 2
       ;;
     --lidarslam-param)
-      [[ $# -ge 2 ]] || usage
-      LIDARSLAM_PARAM=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      LIDARSLAM_PARAM=$(realpath -m "$2")
       shift 2
       ;;
     --rko-param)
-      [[ $# -ge 2 ]] || usage
-      RKO_PARAM=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      RKO_PARAM=$(realpath -m "$2")
       shift 2
       ;;
     --output-dir)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       OUTPUT_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --run-name)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       RUN_NAME="$2"
       shift 2
       ;;
     --save-timeout-secs)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       SAVE_TIMEOUT_SECS="$2"
       shift 2
       ;;
     --startup-timeout-secs)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       STARTUP_TIMEOUT_SECS="$2"
       shift 2
       ;;
     --offline-quiet-log-secs)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       OFFLINE_QUIET_LOG_SECS="$2"
       shift 2
       ;;
     --graph-drain-secs)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       GRAPH_DRAIN_SECS="$2"
       shift 2
       ;;
     --viewer-run-dir)
-      [[ $# -ge 2 ]] || usage
-      VIEWER_RUN_DIR=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      VIEWER_RUN_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --wait-for-offline-completion)
@@ -186,17 +215,17 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --auto-exit-secs)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       AUTO_EXIT_SECS="$2"
       shift 2
       ;;
     --autoware-core-dir)
-      [[ $# -ge 2 ]] || usage
-      AUTOWARE_CORE_DIR=$(realpath "$2")
+      require_value "$1" "${2:-}"
+      AUTOWARE_CORE_DIR=$(realpath -m "$2")
       shift 2
       ;;
     --work-dir)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       WORK_DIR=$(realpath -m "$2")
       shift 2
       ;;
@@ -209,54 +238,46 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --capture-corrected-path)
-      [[ $# -ge 2 ]] || usage
-      case "${2,,}" in
-        true|1|yes) CAPTURE_CORRECTED_PATH=true ;;
-        false|0|no) CAPTURE_CORRECTED_PATH=false ;;
-        *) echo "--capture-corrected-path expects true/false" >&2; usage ;;
-      esac
+      require_value "$1" "${2:-}"
+      CAPTURE_CORRECTED_PATH=$(parse_bool "$1" "$2")
       shift 2
       ;;
     --corrected-path-topic)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       CORRECTED_PATH_TOPIC="$2"
       shift 2
       ;;
     --generate-lanelet2)
-      [[ $# -ge 2 ]] || usage
-      case "${2,,}" in
-        true|1|yes) GENERATE_LANELET2=true ;;
-        false|0|no) GENERATE_LANELET2=false ;;
-        *) echo "--generate-lanelet2 expects true/false" >&2; usage ;;
-      esac
+      require_value "$1" "${2:-}"
+      GENERATE_LANELET2=$(parse_bool "$1" "$2")
       shift 2
       ;;
     --origin-lat)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       ORIGIN_LAT="$2"
       shift 2
       ;;
     --origin-lon)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       ORIGIN_LON="$2"
       shift 2
       ;;
     --lane-width)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       LANE_WIDTH="$2"
       shift 2
       ;;
     --reference-tum)
-      [[ $# -ge 2 ]] || usage
+      require_value "$1" "${2:-}"
       REFERENCE_TUM=$(realpath -m "$2")
       shift 2
       ;;
     --help|-h)
-      usage
+      usage 0
       ;;
     *)
-      echo "Unknown option: $1" >&2
-      usage
+      fail "unknown option: $1" \
+        "run this script with --help for valid options."
       ;;
   esac
 done
@@ -279,17 +300,33 @@ if [[ -z "$RUN_NAME" ]]; then
 fi
 
 if [[ ! -d "$BAG_PATH" ]]; then
-  echo "rosbag2 directory not found: $BAG_PATH" >&2
+  echo "error: rosbag2 directory not found: $BAG_PATH" >&2
   if [[ "$BAG_PATH" == "$DEFAULT_BAG" ]]; then
     default_bag_missing_hint
+  else
+    echo "hint: pass the rosbag2 directory that contains metadata.yaml." >&2
   fi
-  exit 1
+  exit 2
 fi
-[[ -f "$BAG_PATH/metadata.yaml" ]] || { echo "metadata.yaml not found under $BAG_PATH" >&2; exit 1; }
-[[ -f "$LIDARSLAM_PARAM" ]] || { echo "lidarslam param file not found: $LIDARSLAM_PARAM" >&2; exit 1; }
-[[ -f "$RKO_PARAM" ]] || { echo "RKO-LIO param file not found: $RKO_PARAM" >&2; exit 1; }
+[[ -f "$BAG_PATH/metadata.yaml" ]] ||
+  fail "metadata.yaml not found under $BAG_PATH" \
+    "pass the rosbag2 directory, not a .db3 file or parent folder."
+[[ -f "$LIDARSLAM_PARAM" ]] ||
+  fail "lidarslam param file not found: $LIDARSLAM_PARAM"
+[[ -f "$RKO_PARAM" ]] ||
+  fail "RKO-LIO param file not found: $RKO_PARAM"
+if [[ -e "$OUTPUT_DIR" && ! -d "$OUTPUT_DIR" ]]; then
+  fail "output directory path is a file, not a directory: $OUTPUT_DIR" \
+    "choose a directory path for generated map outputs and logs."
+fi
 if [[ "$SKIP_VIEWER" == "false" ]]; then
-  [[ -d "$AUTOWARE_CORE_DIR" ]] || { echo "autoware_core directory not found: $AUTOWARE_CORE_DIR" >&2; exit 1; }
+  [[ -d "$AUTOWARE_CORE_DIR" ]] ||
+    fail "autoware_core directory not found: $AUTOWARE_CORE_DIR" \
+      "pass --autoware-core-dir, or use --skip-viewer for map output only."
+  if [[ -n "$VIEWER_RUN_DIR" && ! -d "$VIEWER_RUN_DIR" ]]; then
+    fail "viewer run directory not found: $VIEWER_RUN_DIR" \
+      "omit --viewer-run-dir to let the viewer build or discover one."
+  fi
 fi
 
 set +u


### PR DESCRIPTION
## Summary
- Make `run_rko_lio_graph_autoware_dogfood.sh --help` exit successfully.
- Add shared `error:`/`hint:` handling for missing option values, unknown options, invalid boolean values, missing bag metadata, missing params, output-file paths, and viewer prerequisites.
- Avoid `realpath` leaking raw errors for user-supplied missing paths.
- Add dogfood CLI regression tests that stop before launching ROS.

## Validation
- python3 -m pytest -q graph_based_slam/test/test_autoware_dogfood_script.py
- python3 -m pytest -q graph_based_slam/test/test_docs_entrypoints.py graph_based_slam/test/test_autoware_dogfood_script.py
- python3 -m pytest -q graph_based_slam/test/test_autoware_quickstart_script.py graph_based_slam/test/test_autoware_dogfood_script.py lidarslam/test/test_autoware_map_runner_script.py
- bash -n scripts/run_rko_lio_graph_autoware_dogfood.sh
- git diff --check
