### PR TITLE
[codex] polish NTU VIRAL download cli

### DIFF
--- a/graph_based_slam/test/test_ntu_viral_download_script.py
+++ b/graph_based_slam/test/test_ntu_viral_download_script.py
@@ -1,0 +1,106 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""CLI regression tests for the NTU VIRAL demo dataset downloader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOWNLOAD_SCRIPT = REPO_ROOT / 'scripts' / 'download_ntu_viral_tnp01.sh'
+
+
+def _run_download(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ['bash', str(DOWNLOAD_SCRIPT), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
+    return result.stdout + result.stderr
+
+
+def test_download_help_exits_successfully():
+    result = _run_download('--help')
+    output = _combined_output(result)
+
+    assert result.returncode == 0
+    assert 'download_ntu_viral_tnp01.sh' in output
+    assert '--no-restamp' in output
+
+
+def test_download_rejects_missing_dest_value_before_dependency_checks():
+    result = _run_download('--dest', '--keep-zip')
+
+    assert result.returncode == 2
+    assert 'error: option requires a value: --dest' in result.stderr
+    assert 'shift' not in result.stderr
+    assert 'required command not found' not in result.stderr
+
+
+def test_download_rejects_unknown_option_with_help_hint():
+    result = _run_download('--bogus')
+
+    assert result.returncode == 2
+    assert 'error: unknown option: --bogus' in result.stderr
+    assert 'download_ntu_viral_tnp01.sh --help' in result.stderr
+    assert 'downloading zip' not in _combined_output(result)
+
+
+def test_download_rejects_destination_file_before_download(tmp_path: Path):
+    dest_file = tmp_path / 'not_a_directory'
+    dest_file.write_text('', encoding='utf-8')
+
+    result = _run_download(
+        '--dest',
+        str(dest_file),
+        '--no-convert',
+        '--no-restamp',
+    )
+
+    assert result.returncode == 2
+    assert 'error: destination path is not a directory:' in result.stderr
+    assert 'downloading zip' not in _combined_output(result)
+
+
+def test_download_rejects_no_convert_restamp_without_existing_rosbag2(
+    tmp_path: Path,
+):
+    result = _run_download('--dest', str(tmp_path / 'dataset'), '--no-convert')
+
+    assert result.returncode == 2
+    assert '--no-convert requires existing rosbag2 metadata' in result.stderr
+    assert 'rosbags-convert' not in result.stderr
+    assert 'downloading zip' not in _combined_output(result)

--- a/scripts/download_ntu_viral_tnp01.sh
+++ b/scripts/download_ntu_viral_tnp01.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 usage() {
-  cat <<'EOF'
+  cat >&2 <<'EOF'
 Usage:
   bash scripts/download_ntu_viral_tnp01.sh [options]
 
@@ -18,10 +18,16 @@ Options:
 
 This script downloads the official NTU VIRAL tnp_01 sequence referenced from
 the GLIM supplementary pages, extracts it, and optionally converts the ROS1 bag
- to rosbag2 format using rosbags-convert. By default it also writes the
- pointcloud+IMU rosbag2 expected by `run_autoware_quickstart.sh` and
- `run_rko_lio_graph_benchmark.sh`.
+to rosbag2 format using rosbags-convert. By default it also writes the
+pointcloud+IMU rosbag2 expected by `run_autoware_quickstart.sh` and
+`run_rko_lio_graph_benchmark.sh`.
 EOF
+}
+
+fail() {
+  echo "error: $*" >&2
+  echo "hint: run 'bash scripts/download_ntu_viral_tnp01.sh --help' for valid options." >&2
+  exit 2
 }
 
 die() {
@@ -29,15 +35,38 @@ die() {
   exit 1
 }
 
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "${value}" || "${value}" == -* ]]; then
+    fail "option requires a value: ${option}"
+  fi
+  OPTION_VALUE="${value}"
+}
+
+require_command() {
+  local command_name="$1"
+  local install_hint="$2"
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "error: required command not found: ${command_name}" >&2
+    echo "hint: ${install_hint}" >&2
+    exit 2
+  fi
+}
+
 DEST_DIR="${REPO_ROOT}/demo_data/ntu_viral"
 KEEP_ZIP="false"
 DO_CONVERT="true"
 DO_RESTAMP="true"
+OPTION_VALUE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dest)
-      DEST_DIR="${2:-}"; shift 2 ;;
+      require_value "$1" "${2:-}"
+      DEST_DIR="${OPTION_VALUE}"
+      shift 2
+      ;;
     --keep-zip)
       KEEP_ZIP="true"; shift ;;
     --no-convert)
@@ -47,20 +76,11 @@ while [[ $# -gt 0 ]]; do
     -h|--help)
       usage; exit 0 ;;
     *)
-      die "unknown arg: $1" ;;
+      fail "unknown option: $1" ;;
   esac
 done
 
-command -v wget >/dev/null 2>&1 || die "wget not found"
-command -v unzip >/dev/null 2>&1 || die "unzip not found"
-if [[ "${DO_CONVERT}" == "true" ]]; then
-  command -v rosbags-convert >/dev/null 2>&1 || die "rosbags-convert not found"
-fi
-if [[ "${DO_RESTAMP}" == "true" ]]; then
-  command -v python3 >/dev/null 2>&1 || die "python3 not found"
-fi
-
-mkdir -p "${DEST_DIR}"
+DEST_DIR="$(realpath -m "${DEST_DIR}")"
 
 SEQ_NAME="tnp_01"
 ZIP_PATH="${DEST_DIR}/${SEQ_NAME}.zip"
@@ -68,6 +88,25 @@ EXTRACT_DIR="${DEST_DIR}/${SEQ_NAME}"
 ROS2_DIR="${DEST_DIR}/${SEQ_NAME}_rosbag2"
 RESTAMPED_DIR="${DEST_DIR}/${SEQ_NAME}_points_restamped_vn100_rosbag2"
 URL="https://researchdata.ntu.edu.sg/api/access/datafile/98195"
+
+if [[ -e "${DEST_DIR}" && ! -d "${DEST_DIR}" ]]; then
+  fail "destination path is not a directory: ${DEST_DIR}"
+fi
+
+if [[ "${DO_CONVERT}" != "true" && "${DO_RESTAMP}" == "true" && ! -f "${ROS2_DIR}/metadata.yaml" ]]; then
+  fail "--no-convert requires existing rosbag2 metadata when restamp is enabled: ${ROS2_DIR}/metadata.yaml"
+fi
+
+require_command wget "install wget, for example: sudo apt install wget"
+require_command unzip "install unzip, for example: sudo apt install unzip"
+if [[ "${DO_CONVERT}" == "true" ]]; then
+  require_command rosbags-convert "install rosbags, for example: python3 -m pip install rosbags"
+fi
+if [[ "${DO_RESTAMP}" == "true" ]]; then
+  require_command python3 "install python3, for example: sudo apt install python3"
+fi
+
+mkdir -p "${DEST_DIR}" || die "failed to create destination directory: ${DEST_DIR}"
 
 echo "sequence:   ${SEQ_NAME}"
 echo "source:     ${URL}"
@@ -78,7 +117,9 @@ echo "restamped:  ${RESTAMPED_DIR}"
 
 if [[ ! -f "${ZIP_PATH}" ]]; then
   echo "downloading zip..."
-  wget -c -O "${ZIP_PATH}" "${URL}"
+  if ! wget -c -O "${ZIP_PATH}" "${URL}"; then
+    die "download failed from ${URL}"
+  fi
 else
   echo "zip already exists: ${ZIP_PATH}"
 fi
@@ -86,7 +127,9 @@ fi
 mkdir -p "${EXTRACT_DIR}"
 if ! find "${EXTRACT_DIR}" -maxdepth 2 -name '*.bag' | grep -q .; then
   echo "extracting zip..."
-  unzip -q -o "${ZIP_PATH}" -d "${EXTRACT_DIR}"
+  if ! unzip -q -o "${ZIP_PATH}" -d "${EXTRACT_DIR}"; then
+    die "failed to extract zip: ${ZIP_PATH}"
+  fi
 else
   echo "bag already extracted under: ${EXTRACT_DIR}"
 fi
@@ -103,7 +146,9 @@ if [[ "${DO_CONVERT}" == "true" ]]; then
   if [[ ! -e "${ROS2_DIR}/metadata.yaml" ]]; then
     echo "converting rosbag1 -> rosbag2..."
     rm -rf "${ROS2_DIR}"
-    rosbags-convert --src "${BAG_PATH}" --dst "${ROS2_DIR}"
+    if ! rosbags-convert --src "${BAG_PATH}" --dst "${ROS2_DIR}"; then
+      die "rosbag1 to rosbag2 conversion failed"
+    fi
   else
     echo "rosbag2 already exists: ${ROS2_DIR}"
   fi
@@ -114,12 +159,14 @@ if [[ "${DO_RESTAMP}" == "true" ]]; then
   [[ -f "${ROS2_DIR}/metadata.yaml" ]] || die "restamp requires rosbag2 at ${ROS2_DIR}"
   if [[ ! -e "${RESTAMPED_DIR}/metadata.yaml" ]]; then
     echo "creating restamped rosbag2 for RKO-LIO..."
-    python3 "${SCRIPT_DIR}/restamp_rosbag2_topics.py" \
+    if ! python3 "${SCRIPT_DIR}/restamp_rosbag2_topics.py" \
       --input "${ROS2_DIR}" \
       --output "${RESTAMPED_DIR}" \
       --topic /os1_cloud_node1/points \
       --copy-topic /imu/imu \
-      --force
+      --force; then
+      die "failed to create restamped rosbag2: ${RESTAMPED_DIR}"
+    fi
   else
     echo "restamped rosbag2 already exists: ${RESTAMPED_DIR}"
   fi


### PR DESCRIPTION
## Summary
- make download_ntu_viral_tnp01.sh reject missing option values and unknown options with explicit help hints
- validate destination and incompatible --no-convert/--no-restamp combinations before downloading
- add install hints for required commands and clearer failure wrapping around download/extract/convert/restamp steps
- add network-free CLI regression tests for the downloader

## Validation
- python3 -m pytest -q graph_based_slam/test/test_ntu_viral_download_script.py
- python3 -m pytest -q graph_based_slam/test/test_docs_entrypoints.py graph_based_slam/test/test_autoware_quickstart_script.py graph_based_slam/test/test_ntu_viral_download_script.py
- bash -n scripts/download_ntu_viral_tnp01.sh
- git diff --check