### PR TITLE
[codex] polish default ci checks cli

### DIFF
--- a/graph_based_slam/test/test_default_ci_checks_script.py
+++ b/graph_based_slam/test/test_default_ci_checks_script.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""CLI regression tests for the local default CI wrapper."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_SCRIPT = REPO_ROOT / 'scripts' / 'run_default_ci_checks.sh'
+BASH = Path(shutil.which('bash') or '/usr/bin/bash')
+
+
+def _run_ci(
+    *args: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(BASH), str(CI_SCRIPT), *args],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
+    return result.stdout + result.stderr
+
+
+def _write_executable(path: Path, text: str) -> None:
+    path.write_text(text, encoding='utf-8')
+    path.chmod(0o755)
+
+
+def _minimal_path(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    dirname = shutil.which('dirname')
+    assert dirname is not None
+    os.symlink(dirname, bin_dir / 'dirname')
+    return bin_dir
+
+
+def test_default_ci_help_exits_successfully():
+    result = _run_ci('--help')
+
+    assert result.returncode == 0
+    assert 'run_default_ci_checks.sh' in result.stderr
+    assert '--build-only' in result.stderr
+
+
+def test_default_ci_rejects_missing_cmake_build_type_value():
+    result = _run_ci('--cmake-build-type', '--build-only')
+
+    assert result.returncode == 2
+    assert 'error: option requires a value: --cmake-build-type' in result.stderr
+    assert 'required command not found' not in result.stderr
+
+
+def test_default_ci_rejects_unknown_option_with_help_hint():
+    result = _run_ci('--bogus')
+
+    assert result.returncode == 2
+    assert 'error: unknown option: --bogus' in result.stderr
+    assert 'run_default_ci_checks.sh --help' in result.stderr
+    assert 'Building default workflow packages' not in _combined_output(result)
+
+
+def test_default_ci_reports_missing_colcon_with_install_hint(tmp_path: Path):
+    bin_dir = _minimal_path(tmp_path)
+    env = {**os.environ, 'PATH': str(bin_dir)}
+
+    result = _run_ci('--build-only', env=env)
+
+    assert result.returncode == 2
+    assert 'error: required command not found: colcon' in result.stderr
+    assert 'python3-colcon-common-extensions' in result.stderr
+
+
+def test_default_ci_wraps_colcon_build_failure(tmp_path: Path):
+    bin_dir = _minimal_path(tmp_path)
+    _write_executable(
+        bin_dir / 'colcon',
+        f'#!{BASH}\n'
+        'echo "fake colcon build failure" >&2\n'
+        'exit 7\n',
+    )
+    _write_executable(
+        bin_dir / 'ros2',
+        f'#!{BASH}\n'
+        'exit 0\n',
+    )
+    env = {**os.environ, 'PATH': str(bin_dir)}
+
+    result = _run_ci('--build-only', env=env)
+
+    assert result.returncode == 1
+    assert 'fake colcon build failure' in result.stderr
+    assert 'error: colcon build failed for default workflow packages' in result.stderr

--- a/scripts/run_default_ci_checks.sh
+++ b/scripts/run_default_ci_checks.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 usage() {
   cat <<'EOF' >&2
 Usage:
-  run_default_ci_checks.sh [options]
+  bash scripts/run_default_ci_checks.sh [options]
 
 Options:
   --build-only                 Build the default workflow packages without running tests
@@ -15,11 +15,36 @@ This script verifies the default permissive-license workflow for this repository
   - build: ndt_omp_ros2, lidarslam_msgs, scanmatcher, graph_based_slam, lidarslam, rko_lio
   - test:  lidarslam_msgs, scanmatcher, graph_based_slam, lidarslam
 EOF
-  exit 1
+}
+
+fail() {
+  echo "error: $*" >&2
+  echo "hint: run 'bash scripts/run_default_ci_checks.sh --help' for valid options." >&2
+  exit 2
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "${value}" || "${value}" == -* ]]; then
+    fail "option requires a value: ${option}"
+  fi
+  OPTION_VALUE="${value}"
+}
+
+require_command() {
+  local command_name="$1"
+  local install_hint="$2"
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    echo "error: required command not found: ${command_name}" >&2
+    echo "hint: ${install_hint}" >&2
+    exit 2
+  fi
 }
 
 BUILD_ONLY=false
 CMAKE_BUILD_TYPE="Release"
+OPTION_VALUE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -28,16 +53,16 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --cmake-build-type)
-      [[ $# -ge 2 ]] || usage
-      CMAKE_BUILD_TYPE="$2"
+      require_value "$1" "${2:-}"
+      CMAKE_BUILD_TYPE="${OPTION_VALUE}"
       shift 2
       ;;
     --help|-h)
       usage
+      exit 0
       ;;
     *)
-      echo "Unknown option: $1" >&2
-      usage
+      fail "unknown option: $1"
       ;;
   esac
 done
@@ -46,10 +71,7 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
 cd "${REPO_ROOT}"
 
-if ! command -v colcon >/dev/null 2>&1; then
-  echo "colcon not found in PATH" >&2
-  exit 1
-fi
+require_command colcon "install colcon, for example: sudo apt install python3-colcon-common-extensions"
 
 if ! command -v ros2 >/dev/null 2>&1; then
   for candidate in jazzy humble rolling iron; do
@@ -64,8 +86,9 @@ if ! command -v ros2 >/dev/null 2>&1; then
 fi
 
 if ! command -v ros2 >/dev/null 2>&1; then
-  echo "ros2 not found in PATH and no /opt/ros/<distro>/setup.bash was detected" >&2
-  exit 1
+  echo "error: required command not found: ros2" >&2
+  echo "hint: source a ROS 2 setup file, for example: source /opt/ros/humble/setup.bash" >&2
+  exit 2
 fi
 
 BUILD_TARGETS=(
@@ -81,10 +104,14 @@ TEST_TARGETS=(
 )
 
 echo "==> Building default workflow packages"
-colcon build \
+echo "==> Build targets: ${BUILD_TARGETS[*]}"
+if ! colcon build \
   --event-handlers console_direct+ \
   --packages-up-to "${BUILD_TARGETS[@]}" \
-  --cmake-args -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
+  --cmake-args -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"; then
+  echo "error: colcon build failed for default workflow packages" >&2
+  exit 1
+fi
 
 if [[ -f "${REPO_ROOT}/install/setup.bash" ]]; then
   set +u
@@ -99,10 +126,17 @@ if [[ "${BUILD_ONLY}" == "true" ]]; then
 fi
 
 echo "==> Running default workflow tests"
-colcon test \
+echo "==> Test targets: ${TEST_TARGETS[*]}"
+if ! colcon test \
   --event-handlers console_direct+ \
   --return-code-on-test-failure \
-  --packages-select "${TEST_TARGETS[@]}"
+  --packages-select "${TEST_TARGETS[@]}"; then
+  echo "error: colcon test failed for default workflow packages" >&2
+  exit 1
+fi
 
 echo "==> Test results"
-colcon test-result --verbose
+if ! colcon test-result --verbose; then
+  echo "error: colcon test-result reported failures" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- make run_default_ci_checks.sh --help exit successfully and reject bad arguments with explicit errors
- add install/source hints for missing colcon or ROS 2 setup
- wrap colcon build/test/test-result failures with clearer terminal errors
- add lightweight CLI regression tests with fake colcon/ros2 commands

## Validation
- python3 -m pytest -q graph_based_slam/test/test_default_ci_checks_script.py
- python3 -m pytest -q graph_based_slam/test/test_docs_entrypoints.py graph_based_slam/test/test_default_ci_checks_script.py graph_based_slam/test/test_ntu_viral_download_script.py
- python3 -m pytest -q graph_based_slam/test/test_default_ci_checks_script.py graph_based_slam/test/test_docs_entrypoints.py
- bash -n scripts/run_default_ci_checks.sh
- git diff --check