### PR TITLE
feat(eval): score sparse submap trajectories at submap times (--sparse-match)

### DIFF
--- a/lidarslam/CMakeLists.txt
+++ b/lidarslam/CMakeLists.txt
@@ -153,6 +153,11 @@ if(BUILD_TESTING)
     test/test_rko_lio_mid360_crossval_benchmark_script.py
     TIMEOUT 120
   )
+  ament_add_pytest_test(
+    test_sparse_trajectory_scoring
+    test/test_sparse_trajectory_scoring.py
+    TIMEOUT 120
+  )
 endif()
 
 add_executable(lidarslam

--- a/lidarslam/test/test_sparse_trajectory_scoring.py
+++ b/lidarslam/test/test_sparse_trajectory_scoring.py
@@ -1,0 +1,287 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Regression tests for the sparse (submap-rate) trajectory scoring mode.
+
+Background (plan.md Sec. 2.4, HILTI 2022 exp01): pose graph optimization was
+a verified no-op (corrected == raw odometry, 0.000 m diff) yet the sparse
+"corrected" submap trajectory (median 1.2 s / max 19.9 s pose spacing) scored
+an APE of 0.891 m against mm-level total-station control points, versus
+0.066 m for the dense raw trajectory. The cause was a scoring artifact, not
+a SLAM regression: `ape_from_tum.py --interpolate` linearly blends the two
+estimated poses bracketing each (sparse, static-dwell) reference timestamp;
+when those two poses are many seconds apart the straight-line assumption
+between them does not hold and the interpolated position can be many metres
+off. The fix is `--sparse-match`: pair each reference sample with its
+temporally nearest estimate sample (never fabricate a blended position),
+report it (and any rejected reference points) via diagnostics instead of
+silently dropping them.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / 'scripts' / 'ape_from_tum.py'
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location('ape_from_tum', SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+APE = _load_module()
+
+
+def _write_tum(path: Path, rows: list[tuple[float, float, float, float]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for t, x, y, z in rows:
+        lines.append(f'{t:.4f} {x:.6f} {y:.6f} {z:.6f} 0 0 0 1')
+    path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
+
+
+def _run_ape(ref_tum: Path, est_tum: Path, out: Path, *extra_args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            '--ref', str(ref_tum),
+            '--est', str(est_tum),
+            '--out', str(out),
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+
+
+def _parse_report(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding='utf-8').splitlines():
+        if ':' not in line:
+            continue
+        key, value = line.split(':', 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+# ---------------------------------------------------------------------------
+# Synthetic sparse-submap scenario shared by the CLI-level tests.
+#
+# A submap-rate estimated trajectory travels along a straight line at 3 m/s
+# from t=0 to t=12, then -- exactly like a HILTI control-point dwell where no
+# submap is created while the platform is stationary -- there is no submap
+# between t=12 and t=32. The platform actually paused right where the t=12
+# submap was taken (the true, GT-surveyed position at t=13 is only 0.05 m /
+# 0.02 m off the t=12 pose), then resumed and made a long, differently
+# directed traverse before the next submap at t=32. From t=32 onward it again
+# moves in a straight line, matched 1:1 by both trajectories.
+# ---------------------------------------------------------------------------
+
+_EST_ROWS = [
+    (0.0, 0.0, 0.0, 0.0),
+    (4.0, 12.0, 0.0, 0.0),
+    (8.0, 24.0, 0.0, 0.0),
+    (12.0, 36.0, 0.0, 0.0),
+    (32.0, 136.0, 40.0, 0.0),
+    (36.0, 148.0, 40.0, 0.0),
+    (40.0, 160.0, 40.0, 0.0),
+    (44.0, 172.0, 40.0, 0.0),
+    (48.0, 184.0, 40.0, 0.0),
+]
+
+_REF_ROWS = [
+    (0.0, 0.0, 0.0, 0.0),
+    (4.0, 12.0, 0.0, 0.0),
+    (8.0, 24.0, 0.0, 0.0),
+    (12.0, 36.0, 0.0, 0.0),
+    (13.0, 36.05, 0.02, 0.0),  # the sparse "control point" that falls in the gap
+    (36.0, 148.0, 40.0, 0.0),
+    (40.0, 160.0, 40.0, 0.0),
+    (44.0, 172.0, 40.0, 0.0),
+    (48.0, 184.0, 40.0, 0.0),
+]
+
+
+def test_interpolate_produces_artifact_error_and_sparse_match_scores_correctly(tmp_path):
+    """--interpolate fabricates a several-metre error for the sparse
+    trajectory's gap; --sparse-match, anchored on the real nearby submap
+    pose, scores it correctly (sub-metre).
+    """
+    ref_tum = tmp_path / 'ref.tum'
+    est_tum = tmp_path / 'est.tum'
+    _write_tum(ref_tum, _REF_ROWS)
+    _write_tum(est_tum, _EST_ROWS)
+
+    interp_out = tmp_path / 'ape_interpolate.txt'
+    result_interp = _run_ape(
+        ref_tum, est_tum, interp_out,
+        '--interpolate', '--max-time-diff', '3.0',
+    )
+    assert result_interp.returncode == 0, result_interp.stderr
+    interp_report = _parse_report(interp_out)
+    assert interp_report['mode'] == 'interpolate'
+    assert interp_report['pairs'] == str(len(_REF_ROWS))
+    assert interp_report['rejected_ref_points'] == '0'
+    # The bracket spanning the gap (t=12 -> t=32) is 20 s wide.
+    assert float(interp_report['max_time_gap']) == pytest.approx(20.0)
+    interp_max_error = float(interp_report['max'])
+
+    sparse_out = tmp_path / 'ape_sparse_match.txt'
+    result_sparse = _run_ape(ref_tum, est_tum, sparse_out, '--sparse-match')
+    assert result_sparse.returncode == 0, result_sparse.stderr
+    sparse_report = _parse_report(sparse_out)
+    assert sparse_report['mode'] == 'sparse_match'
+    assert sparse_report['pairs'] == str(len(_REF_ROWS))
+    assert sparse_report['rejected_ref_points'] == '0'
+    # The nearest submap to the t=13 control point is t=12, 1 s away.
+    assert float(sparse_report['max_time_gap']) == pytest.approx(1.0)
+    sparse_max_error = float(sparse_report['max'])
+
+    # The artifact: naive interpolation across the 20 s gap is off by
+    # several metres, while nearest-neighbour matching against the real,
+    # temporally-close submap pose is off by a few centimetres.
+    assert interp_max_error > 3.0
+    assert sparse_max_error < 0.5
+    assert sparse_max_error < interp_max_error
+
+
+def test_sparse_match_association_matches_nearest_pose_not_interpolated(tmp_path):
+    """Unit-level check directly on `associate`/`interpolate_association`:
+    the sparse-match association returns the estimate's own raw position
+    (not a fabricated blend) for the reference point that falls in the gap.
+    """
+    ref_xyz, est_xyz, diagnostics = APE.associate(_REF_ROWS_AS_TUPLES(), _EST_ROWS_AS_TUPLES(), 10.0)
+    # ref index 4 is the t=13 control point (see _REF_ROWS).
+    assert est_xyz[4] == (36.0, 0.0, 0.0)
+    assert diagnostics['pairs'] == len(_REF_ROWS)
+    assert diagnostics['rejected_ref_points'] == 0
+    assert diagnostics['max_time_gap'] == pytest.approx(1.0)
+
+    ref_xyz_i, est_xyz_i, diagnostics_i = APE.interpolate_association(
+        _REF_ROWS_AS_TUPLES(), _EST_ROWS_AS_TUPLES(), 3.0,
+    )
+    ex, ey, ez = est_xyz_i[4]
+    assert ex == pytest.approx(41.0)
+    assert ey == pytest.approx(2.0)
+    assert diagnostics_i['max_time_gap'] == pytest.approx(20.0)
+
+
+def _REF_ROWS_AS_TUPLES():
+    return [(t, (x, y, z)) for t, x, y, z in _REF_ROWS]
+
+
+def _EST_ROWS_AS_TUPLES():
+    return [(t, (x, y, z)) for t, x, y, z in _EST_ROWS]
+
+
+def test_sparse_match_rejects_out_of_tolerance_reference_points_with_diagnostics(tmp_path):
+    """A reference (GT) point with no estimate pose within tolerance must be
+    rejected -- and that rejection must be visible in the diagnostics and a
+    stderr warning, not silently dropped (plan.md Sec. 2.4 / 11.3: silent
+    drops of sparse reference points have historically produced biased
+    scores).
+    """
+    ref_rows = [
+        (0.0, 0.0, 0.0, 0.0),
+        (1.0, 1.0, 0.0, 0.0),
+        (2.0, 2.0, 0.0, 0.0),
+        (3.0, 3.0, 0.0, 0.0),
+        (100.0, 999.0, 999.0, 999.0),  # far outside the estimate's time range
+    ]
+    est_rows = [
+        (0.0, 0.0, 0.0, 0.0),
+        (1.0, 1.0, 0.0, 0.0),
+        (2.0, 2.0, 0.0, 0.0),
+        (3.0, 3.0, 0.0, 0.0),
+    ]
+    ref_tum = tmp_path / 'ref.tum'
+    est_tum = tmp_path / 'est.tum'
+    _write_tum(ref_tum, ref_rows)
+    _write_tum(est_tum, est_rows)
+
+    out = tmp_path / 'ape_sparse_match.txt'
+    result = _run_ape(ref_tum, est_tum, out, '--sparse-match', '--max-time-diff', '5.0')
+    assert result.returncode == 0, result.stderr
+
+    report = _parse_report(out)
+    assert report['mode'] == 'sparse_match'
+    assert report['pairs'] == '4'
+    assert report['total_ref_points'] == '5'
+    assert report['rejected_ref_points'] == '1'
+    # The rejection must not be silent: a diagnostic warning goes to stderr.
+    assert 'rejected 1/5 reference point' in result.stderr
+    assert 'sparse_match' in result.stderr
+
+
+def test_interpolate_and_sparse_match_are_mutually_exclusive(tmp_path):
+    ref_tum = tmp_path / 'ref.tum'
+    est_tum = tmp_path / 'est.tum'
+    rows = [(float(i), float(i), 0.0, 0.0) for i in range(4)]
+    _write_tum(ref_tum, rows)
+    _write_tum(est_tum, rows)
+
+    out = tmp_path / 'ape.txt'
+    result = _run_ape(ref_tum, est_tum, out, '--interpolate', '--sparse-match')
+    assert result.returncode != 0
+    assert 'mutually exclusive' in result.stderr
+
+
+def test_default_mode_is_unchanged(tmp_path):
+    """No new flags: default nearest-neighbour behaviour and output format
+    (existing keys) must be preserved; only new, additive diagnostic lines
+    are appended to the report.
+    """
+    rows = [(float(i), float(i) * 2.0, 0.0, 0.0) for i in range(6)]
+    ref_tum = tmp_path / 'ref.tum'
+    est_tum = tmp_path / 'est.tum'
+    _write_tum(ref_tum, rows)
+    _write_tum(est_tum, rows)
+
+    out = tmp_path / 'ape.txt'
+    result = _run_ape(ref_tum, est_tum, out)
+    assert result.returncode == 0, result.stderr
+    report = _parse_report(out)
+    assert report['mode'] == 'nearest_neighbor'
+    assert float(report['rmse']) == pytest.approx(0.0, abs=1e-9)
+    assert report['pairs'] == str(len(rows))
+    assert report['rejected_ref_points'] == '0'

--- a/scripts/ape_from_tum.py
+++ b/scripts/ape_from_tum.py
@@ -4,7 +4,9 @@ import argparse
 import bisect
 import math
 import statistics
+import sys
 from pathlib import Path
+from typing import Any
 
 
 def read_tum(path: Path) -> list[tuple[float, tuple[float, float, float]]]:
@@ -31,11 +33,25 @@ def associate(
     ref: list[tuple[float, tuple[float, float, float]]],
     est: list[tuple[float, tuple[float, float, float]]],
     max_diff: float,
-) -> tuple[list[tuple[float, float, float]], list[tuple[float, float, float]]]:
+) -> tuple[list[tuple[float, float, float]], list[tuple[float, float, float]], dict[str, Any]]:
+    """Nearest-neighbour association: pair each reference sample with the
+    temporally closest estimate sample, provided it is within max_diff.
+
+    No interpolation is performed -- the position used for a matched
+    reference sample is the estimate's own recorded (raw or corrected)
+    position at its own timestamp. This is the right approach for sparse
+    estimated trajectories (e.g. submap-rate corrected poses): it never
+    fabricates a position by blending two estimate samples that may
+    bracket a large time gap, it simply reports (and, via the returned
+    diagnostics, exposes) how temporally stale the nearest available
+    estimate sample is for each reference point.
+    """
     est_times = [ts for ts, _ in est]
     est_xyz = [xyz for _, xyz in est]
     ref_xyz_matched: list[tuple[float, float, float]] = []
     est_xyz_matched: list[tuple[float, float, float]] = []
+    matched_gaps: list[float] = []
+    rejected = 0
 
     for ref_ts, ref_xyz in ref:
         idx = bisect.bisect_left(est_times, ref_ts)
@@ -52,18 +68,26 @@ def associate(
                 best_idx = cand
                 best_dt = dt
         if best_idx is None:
+            rejected += 1
             continue
         ref_xyz_matched.append(ref_xyz)
         est_xyz_matched.append(est_xyz[best_idx])
+        matched_gaps.append(best_dt if best_dt is not None else 0.0)
 
-    return ref_xyz_matched, est_xyz_matched
+    diagnostics = {
+        "total_ref_points": len(ref),
+        "pairs": len(ref_xyz_matched),
+        "rejected_ref_points": rejected,
+        "max_time_gap": max(matched_gaps) if matched_gaps else None,
+    }
+    return ref_xyz_matched, est_xyz_matched, diagnostics
 
 
 def interpolate_association(
     ref: list[tuple[float, tuple[float, float, float]]],
     est: list[tuple[float, tuple[float, float, float]]],
     max_edge_diff: float,
-) -> tuple[list[tuple[float, float, float]], list[tuple[float, float, float]]]:
+) -> tuple[list[tuple[float, float, float]], list[tuple[float, float, float]], dict[str, Any]]:
     """Sample the estimated trajectory at the reference timestamps.
 
     Linear position interpolation between the two estimated poses that
@@ -72,22 +96,43 @@ def interpolate_association(
     which fall into the time gaps of a submap-rate trajectory). Outside the
     estimated time range the nearest endpoint is used only when it is
     within max_edge_diff.
+
+    Caveat (see scripts/write_aligned_trajectory_metrics.py and plan.md
+    Sec. 2.4): this mode is appropriate when `est` is dense (e.g. raw
+    per-scan odometry), so the bracketing samples are always close in time
+    to the reference. If `est` itself is sparse (e.g. a submap-rate
+    corrected trajectory), the two bracketing samples can be many seconds
+    apart and the straight-line assumption between them does not hold,
+    fabricating a position that can be several metres off the true one.
+    For sparse estimated trajectories, use --sparse-match instead (see
+    `associate`). The returned diagnostics' max_time_gap is the widest
+    interpolation bracket span (or edge clamp distance) used for any
+    matched reference point, so this risk is visible even when
+    --interpolate is (mis)used on a sparse trajectory.
     """
     est_times = [ts for ts, _ in est]
     est_xyz = [xyz for _, xyz in est]
     ref_xyz_matched: list[tuple[float, float, float]] = []
     est_xyz_matched: list[tuple[float, float, float]] = []
+    matched_spans: list[float] = []
+    rejected = 0
 
     for ref_ts, ref_xyz in ref:
         idx = bisect.bisect_left(est_times, ref_ts)
         if idx == 0:
-            if est_times[0] - ref_ts > max_edge_diff:
+            gap = est_times[0] - ref_ts
+            if gap > max_edge_diff:
+                rejected += 1
                 continue
             sampled = est_xyz[0]
+            span = gap
         elif idx == len(est_times):
-            if ref_ts - est_times[-1] > max_edge_diff:
+            gap = ref_ts - est_times[-1]
+            if gap > max_edge_diff:
+                rejected += 1
                 continue
             sampled = est_xyz[-1]
+            span = gap
         else:
             t0, t1 = est_times[idx - 1], est_times[idx]
             p0, p1 = est_xyz[idx - 1], est_xyz[idx]
@@ -97,10 +142,18 @@ def interpolate_association(
                 p0[1] + w * (p1[1] - p0[1]),
                 p0[2] + w * (p1[2] - p0[2]),
             )
+            span = t1 - t0
         ref_xyz_matched.append(ref_xyz)
         est_xyz_matched.append(sampled)
+        matched_spans.append(span)
 
-    return ref_xyz_matched, est_xyz_matched
+    diagnostics = {
+        "total_ref_points": len(ref),
+        "pairs": len(ref_xyz_matched),
+        "rejected_ref_points": rejected,
+        "max_time_gap": max(matched_spans) if matched_spans else None,
+    }
+    return ref_xyz_matched, est_xyz_matched, diagnostics
 
 
 def align_first_pose(
@@ -157,7 +210,14 @@ def calc_errors(
     return out
 
 
-def write_report(path: Path, errors: list[float], pairs: int, alignment: str) -> None:
+def write_report(
+    path: Path,
+    errors: list[float],
+    pairs: int,
+    alignment: str,
+    mode: str,
+    diagnostics: dict[str, Any],
+) -> None:
     rmse = math.sqrt(sum(e * e for e in errors) / len(errors))
     mean = statistics.fmean(errors)
     median = statistics.median(errors)
@@ -165,6 +225,7 @@ def write_report(path: Path, errors: list[float], pairs: int, alignment: str) ->
     min_v = min(errors)
     max_v = max(errors)
 
+    max_time_gap = diagnostics.get("max_time_gap")
     lines = [
         "APE translation (m)",
         f"pairs: {pairs}",
@@ -175,6 +236,10 @@ def write_report(path: Path, errors: list[float], pairs: int, alignment: str) ->
         f"std: {std}",
         f"min: {min_v}",
         f"max: {max_v}",
+        f"mode: {mode}",
+        f"total_ref_points: {diagnostics.get('total_ref_points', pairs)}",
+        f"rejected_ref_points: {diagnostics.get('rejected_ref_points', 0)}",
+        f"max_time_gap: {max_time_gap if max_time_gap is not None else 'nan'}",
     ]
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -185,16 +250,55 @@ def main() -> int:
     ap.add_argument("--ref", required=True, help="Reference TUM trajectory")
     ap.add_argument("--est", required=True, help="Estimated TUM trajectory")
     ap.add_argument("--out", required=True, help="Output report path")
-    ap.add_argument("--max-time-diff", type=float, default=0.05, help="Max timestamp association gap in seconds")
+    ap.add_argument(
+        "--max-time-diff",
+        type=float,
+        default=None,
+        help="Max timestamp association gap in seconds. Default 0.05s for "
+        "nearest-neighbour matching, 0.05s edge-extrapolation bound for "
+        "--interpolate, or 10.0s when --sparse-match is set (all "
+        "overridable).",
+    )
     ap.add_argument(
         "--interpolate",
         action="store_true",
         help="Linearly interpolate the estimated trajectory at the reference "
-        "timestamps instead of nearest-neighbour matching. For sparse "
-        "checkpoint references that fall between submap-rate poses; "
-        "--max-time-diff then only bounds extrapolation at the ends.",
+        "timestamps instead of nearest-neighbour matching. For a DENSE "
+        "estimated trajectory (e.g. raw per-scan odometry) whose samples "
+        "are always close in time to the sparse reference; --max-time-diff "
+        "then only bounds extrapolation at the ends. Do not use this for a "
+        "sparse estimated trajectory (e.g. a submap-rate corrected "
+        "trajectory) -- the interpolation brackets can span many seconds "
+        "and fabricate a position that is off by several metres if the "
+        "true path is not a straight line between them (see plan.md Sec. "
+        "2.4). Use --sparse-match instead. Mutually exclusive with "
+        "--sparse-match.",
+    )
+    ap.add_argument(
+        "--sparse-match",
+        action="store_true",
+        help="Score a sparse estimated trajectory (e.g. submap-rate "
+        "corrected poses) by nearest-neighbour matching instead of "
+        "interpolation: each reference sample is paired with the "
+        "temporally closest estimate sample, using the estimate's own "
+        "recorded position (never fabricated by blending). Reference "
+        "samples with no estimate pose within --max-time-diff (default "
+        "10.0s in this mode) are rejected, not silently dropped -- see "
+        "the 'rejected_ref_points' / 'max_time_gap' diagnostics in the "
+        "output report. Opt-in; default behaviour (no flags) is "
+        "unchanged. Mutually exclusive with --interpolate.",
     )
     args = ap.parse_args()
+
+    if args.interpolate and args.sparse_match:
+        ap.error("--interpolate and --sparse-match are mutually exclusive")
+
+    if args.max_time_diff is not None:
+        effective_max_diff = args.max_time_diff
+    elif args.sparse_match:
+        effective_max_diff = 10.0
+    else:
+        effective_max_diff = 0.05
 
     ref = read_tum(Path(args.ref).expanduser().resolve())
     est = read_tum(Path(args.est).expanduser().resolve())
@@ -202,15 +306,27 @@ def main() -> int:
         return 1
 
     if args.interpolate:
-        ref_xyz, est_xyz = interpolate_association(ref, est, args.max_time_diff)
+        mode = "interpolate"
+        ref_xyz, est_xyz, diagnostics = interpolate_association(ref, est, effective_max_diff)
     else:
-        ref_xyz, est_xyz = associate(ref, est, args.max_time_diff)
+        mode = "sparse_match" if args.sparse_match else "nearest_neighbor"
+        ref_xyz, est_xyz, diagnostics = associate(ref, est, effective_max_diff)
+
+    if diagnostics.get("rejected_ref_points", 0) > 0:
+        print(
+            "warning: ape_from_tum rejected "
+            f"{diagnostics['rejected_ref_points']}/{diagnostics['total_ref_points']} "
+            f"reference point(s) with no estimate pose within {effective_max_diff}s "
+            f"(mode={mode}); see 'rejected_ref_points' / 'max_time_gap' in {args.out}",
+            file=sys.stderr,
+        )
+
     if len(ref_xyz) < 2:
         return 1
 
     alignment, aligned_est = try_align_umeyama(ref_xyz, est_xyz)
     errors = calc_errors(ref_xyz, aligned_est)
-    write_report(Path(args.out).expanduser().resolve(), errors, len(errors), alignment)
+    write_report(Path(args.out).expanduser().resolve(), errors, len(errors), alignment, mode, diagnostics)
     return 0
 
 

--- a/scripts/write_aligned_trajectory_metrics.py
+++ b/scripts/write_aligned_trajectory_metrics.py
@@ -9,6 +9,7 @@ import json
 import math
 from pathlib import Path
 import re
+import sys
 from typing import Any
 
 import numpy as np
@@ -122,15 +123,35 @@ def _match_with_tolerance(
     # Default (match_tolerance is None): the historical 0.05 -> 0.15 s cascade,
     # right for a dense estimate sampled near the reference. A single explicit
     # tolerance is for sparse references (e.g. RTK-SLAM total-station
-    # checkpoints) scored against a downsampled trajectory, and to reproduce the
-    # dataset's own max_dt; it suppresses the silent dropping of checkpoints
-    # that have no estimate pose within 0.15 s.
+    # checkpoints, or HILTI-style submap-rate corrected trajectories) scored
+    # against a downsampled trajectory, and to reproduce the dataset's own
+    # max_dt; it suppresses the silent dropping of checkpoints that have no
+    # estimate pose within 0.15 s (see plan.md Sec. 2.4 / 11.3: an
+    # under-tolerant match silently drops sparse reference points and biases
+    # the reported error).
     if match_tolerance is not None:
         return _match_rows(ref_rows, est_rows, tolerance=match_tolerance)
     pairs = _match_rows(ref_rows, est_rows, tolerance=0.05)
     if len(pairs) < 10:
         pairs = _match_rows(ref_rows, est_rows, tolerance=0.15)
     return pairs
+
+
+def _match_diagnostics(
+    ref_rows: list[dict[str, float]],
+    pairs: list[tuple[dict[str, float], dict[str, float]]],
+) -> dict[str, Any]:
+    """Diagnostics that make silent-drop bias visible (plan.md Sec. 2.4 /
+    11.3): how many reference points were actually paired, how many were
+    rejected (no estimate pose within tolerance), and how stale the worst
+    matched pair is in time.
+    """
+    matched_gaps = [abs(ref['t'] - est['t']) for ref, est in pairs]
+    return {
+        'total_ref_points': len(ref_rows),
+        'rejected_ref_points': len(ref_rows) - len(pairs),
+        'max_time_gap_s': max(matched_gaps) if matched_gaps else None,
+    }
 
 
 def _ape_metrics(
@@ -162,6 +183,7 @@ def _ape_metrics(
             + sorted_errors[len(sorted_errors) // 2]
         )
 
+    diagnostics = _match_diagnostics(ref_rows, aligned_pairs)
     return {
         'alignment': 'se3_umeyama',
         'pairs': len(aligned_pairs),
@@ -174,6 +196,7 @@ def _ape_metrics(
         'path_length_est_m': _path_length(est_rows),
         'path_length_est_aligned_m': _path_length(est_aligned),
         'path_length_ref_m': _path_length(ref_rows),
+        **diagnostics,
     }
 
 
@@ -385,11 +408,29 @@ def main() -> int:
 
     match_tolerance = args.match_tolerance if args.match_tolerance > 0 else None
     corrected_ape = _ape_metrics(ref_rows, corrected_rows, match_tolerance)
+    if corrected_ape.get('rejected_ref_points', 0) > 0:
+        print(
+            "warning: corrected trajectory match rejected "
+            f"{corrected_ape['rejected_ref_points']}/{corrected_ape['total_ref_points']} "
+            "reference point(s) with no estimate pose within tolerance "
+            f"(max_time_gap_s={corrected_ape.get('max_time_gap_s')}); "
+            "see 'rejected_ref_points' / 'max_time_gap_s' in metrics.json",
+            file=sys.stderr,
+        )
     raw_ape = None
     if raw_tum and raw_tum.is_file():
         raw_rows = _load_tum(raw_tum)
         if raw_rows:
             raw_ape = _ape_metrics(ref_rows, raw_rows, match_tolerance)
+            if raw_ape.get('rejected_ref_points', 0) > 0:
+                print(
+                    "warning: raw trajectory match rejected "
+                    f"{raw_ape['rejected_ref_points']}/{raw_ape['total_ref_points']} "
+                    "reference point(s) with no estimate pose within tolerance "
+                    f"(max_time_gap_s={raw_ape.get('max_time_gap_s')}); "
+                    "see 'rejected_ref_points' / 'max_time_gap_s' in metrics.json",
+                    file=sys.stderr,
+                )
 
     bag_duration_sec = _bag_duration_seconds(bag_path / 'metadata.yaml')
     wall_sec = args.wall_sec
@@ -447,13 +488,19 @@ def main() -> int:
             'ape_log_path': '',
             'ape': {
                 key: corrected_ape[key]
-                for key in ('alignment', 'pairs', 'rmse', 'mean', 'median', 'max', 'min', 'std')
+                for key in (
+                    'alignment', 'pairs', 'rmse', 'mean', 'median', 'max', 'min', 'std',
+                    'rejected_ref_points', 'total_ref_points', 'max_time_gap_s',
+                )
             },
             'raw_ape_log_path': '',
             'raw_ape': (
                 {
                     key: raw_ape[key]
-                    for key in ('alignment', 'pairs', 'rmse', 'mean', 'median', 'max', 'min', 'std')
+                    for key in (
+                        'alignment', 'pairs', 'rmse', 'mean', 'median', 'max', 'min', 'std',
+                        'rejected_ref_points', 'total_ref_points', 'max_time_gap_s',
+                    )
                 }
                 if raw_ape is not None else None
             ),
@@ -465,6 +512,9 @@ def main() -> int:
             'estimated_path_length_m': corrected_ape['path_length_est_m'],
             'estimated_aligned_path_length_m': corrected_ape['path_length_est_aligned_m'],
             'reference_label': args.reference_label,
+            'rejected_ref_points': corrected_ape['rejected_ref_points'],
+            'total_ref_points': corrected_ape['total_ref_points'],
+            'max_time_gap_s': corrected_ape['max_time_gap_s'],
         },
     }
     if raw_tum and raw_tum.is_file():


### PR DESCRIPTION
## Summary
Implements the HILTI exp01 methodology note (plan.md §2.4): sparse corrected/submap trajectories must be scored at submap timestamps, not by linear interpolation. Interpolating across submap gaps fabricated a 0.891m APE on exp01 where the pose graph was a verified no-op (corrected == raw; dense raw = 0.066m).

## Changes
- **`scripts/ape_from_tum.py`**: new opt-in `--sparse-match` flag (mutually exclusive with `--interpolate`). Nearest-neighbour pairing at trajectory timestamps, 10.0s default tolerance when `--max-time-diff` is not given. Default (no-flag) numeric behaviour is unchanged.
- **Silent-drop diagnostics**: total/paired/rejected reference points and max time gap are reported in the text report and `metrics.json` (`evo.ape`, `evo.raw_ape`, `cross_validation`), with a stderr warning on any rejection.
- **`scripts/write_aligned_trajectory_metrics.py`**: additive-only — same diagnostics surfaced; the existing `--match-tolerance` cascade is untouched.
- **New tests** `lidarslam/test/test_sparse_trajectory_scoring.py` (registered for colcon test): synthetic 20s-gap submap scenario where `--interpolate` fabricates ~5m error while `--sparse-match` scores ~0.05m (reproduces the exp01 0.891m-vs-0.066m mechanism), tolerance rejection with visible diagnostics, flag mutual exclusivity, default-mode output unchanged.

## Test plan
- `python3 -m pytest -q lidarslam/test/test_sparse_trajectory_scoring.py` → 5 passed
- Full sweep over tests touching the edited scripts → 27 passed, 0 failed (5 new + 22 pre-existing, no regression)

## Follow-ups (not in this PR)
- Wire `--sparse-match` into the corrected-trajectory invocation of `scripts/run_rko_lio_graph_benchmark.sh` (and the small_gicp / lo_graph variants), which currently score corrected trajectories with the tight 0.05s default.
- Add a corrected-trajectory scoring example to `scripts/download_hilti2022.sh`'s printed usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTNqieB785XZRXu5xPXZoL