### PR TITLE
docs: v0.8 degeneracy-aware registration roadmap + plan.md status refresh

### DIFF
--- a/docs/roadmap/v0.8.md
+++ b/docs/roadmap/v0.8.md
@@ -1,0 +1,511 @@
+# lidarslam-ros2 v0.8 roadmap — degeneracy-aware registration
+
+> Status: **draft 2026-07-05**, not yet direction-approved. Successor to v0.7
+> (offline map refinement + map-quality gates, completed 2026-06-13,
+> `docs/roadmap/v0.7.md`). This is the first of the four v0.8 candidates
+> listed in v0.7 §6 (degeneracy-aware registration, multi-session mapping,
+> per-scan dynamic removal, intensity utilization) to get a design pass; the
+> other three are explicitly deferred (§8).
+
+## 0. Why this exists (the evidence)
+
+v0.7 Phase 4 put HILTI 2022 (Hesai PandarXT-32 + Alphasense IMU, millimeter
+total-station control points, CC BY-NC-SA, evaluation-only) on the bench as an
+external mm-GT substrate (`plan.md` §2.4). Two sequences, same sensor, same
+pipeline, same RKO-LIO raw-odometry config family:
+
+| sequence | environment | RKO-LIO raw RMSE (m) | median (m) | path | pairs | loops |
+|---|---|---:|---:|---|---:|---:|
+| exp01 | construction ground level (feature-rich) | **0.066** | 0.053 | 904 m one-shot sweep | 13 | 0 |
+| exp07 | long corridor (degenerate) | **0.318** | 0.329 | 124 m one-shot sweep | 6 | 0 |
+
+exp07 drifts **~5x** worse than exp01 on the same odometry stack. Per-axis
+residuals on exp07: `x=0.145 m`, `y=0.235 m`, `z=0.157 m` — one axis (the
+long axis of the corridor, empirically the largest of the three) carries
+substantially more error than the other two, which is the classic signature
+of a *directionally* under-constrained registration problem, not a uniformly
+noisy one. Both sequences are non-revisiting single sweeps, so
+`graph_based_slam` contributes zero loop edges on either — this is a
+**raw-odometry** accuracy problem, confirmed passthrough on the backend side
+(the v0.7 Phase 4 methodology note: corrected == raw to 0.000 m on these
+substrates).
+
+This is exactly the failure mode the SLAM literature calls **degeneracy**:
+in a long straight corridor, LiDAR point-to-point/point-to-plane registration
+sees strong constraints in the two cross-sectional directions (walls, floor,
+ceiling) and almost none along the corridor axis (uniform, self-similar wall
+texture), so the Gauss-Newton normal equations are close to singular in that
+one direction and the solution walks with the noise. It is not a
+mapping-quality problem (v0.7's domain) and not a place-recognition problem
+(no loop exists to close) — it is a registration-time problem, and it is the
+one gap in this repository's frontend that has never had a dedicated design
+pass. v0.8 closes it, or explicitly declines to based on evidence, following
+the same measurement-first discipline that shipped v0.6 and v0.7.
+
+**Non-goal at this point:** proving degeneracy handling fixes exp07 to
+exp01-like numbers. Corridors are a genuinely harder geometry class; the goal
+is a measured, bounded improvement with equally measured no-regression
+everywhere else, the same honesty standard v0.7 held itself to
+(`docs/research/byte-reproducible-map-authoring.md`, "What This Is Not").
+
+## 1. Technical approach survey (clean-room, papers only)
+
+Same clean-room discipline as v0.7: implementations are derived from
+published papers only, GPL reference code is not read, and every PR states
+so. The papers below are read for their **published mathematics**; none of
+their reference implementations are GPL-clean-room-blocked in this repo (LOAM
+and KISS-ICP-family degeneracy papers are typically MIT/BSD or paper-only to
+begin with, but the rule is applied uniformly regardless of the reference
+implementation's own license, exactly as v0.7 did for BALM2/HBA).
+
+| approach | source | mechanism | what it buys |
+|---|---|---|---|
+| Eigenvalue / condition-number degeneracy detection | Zhang, Kaess, Singh, *"On Degeneracy of Optimization-based State Estimation Problems"*, ICRA 2016 | Eigen-decompose the Gauss-Newton normal-equations matrix `H` (6x6 for SE(3) point-to-point/point-to-plane ICP); small eigenvalues along an eigenvector indicate the optimization is under-constrained along that direction of the pose update | A **detector**: per-scan, per-direction degeneracy classification. Does not by itself change the estimate. |
+| Solution remapping | same paper | Project the raw update `dx = H^-1(-b)` onto the well-conditioned eigenvector subspace; leave degenerate directions unmoved (or filled from a fallback estimate) rather than letting the optimizer walk them on noise | An **intervention** applied at the linear-solve step, directly inside the registration iteration. |
+| Direction-wise localizability categories + soft blending | Tuna, Nubert, Pfreundschuh, Cadena, Khattak, Hutter, *"X-ICP: Localizability-Aware LiDAR Registration for Robust Localization in Extreme Environments"*, arXiv:2306.08258 / IEEE T-RO 2024 | Classifies each of the 6 directions into well-conditioned / degenerate / non-observable using a normalized per-direction contribution test (rather than a single scale-dependent eigenvalue threshold), then blends the optimization update with a fallback prior (e.g. constant-velocity / IMU-predicted motion) per direction instead of hard-zeroing it | A more **graceful intervention**: avoids the hard cutoff sensitivity of a single eigenvalue threshold, and gives the degenerate direction *something* better than "frozen at zero" — the IMU/motion-model prior RKO-LIO already computes for its initial guess. |
+| Backend information-matrix propagation | general pose-graph practice, no single canonical paper; the closest structural precedent in this repo is the existing GNSS covariance-weighting path (`graph_based_slam_component.cpp`, `gnss_use_covariance_weighting`) and the NIS-driven `adjacent_edge_auto_scale.hpp` (Level 1) | Instead of changing the registration solve, expose the per-scan per-direction degeneracy signal as (anisotropic) odometry covariance and let the backend down-weight the degenerate direction on the adjacent edge — a **loosely-coupled, backend-side** compensation | Cheap, low-risk, reuses an existing repo pattern. Only helps when there is a *competing* constraint to blend against (a loop edge, GNSS, IMU-derived absolute orientation). See §2 for why this is not sufficient alone on the exp07 evidence. |
+
+None of these compete with each other; Zhang & Singh gives the detector and
+the simplest intervention, X-ICP gives a better-conditioned version of the
+same intervention, and backend information propagation is a genuinely
+different *layer* (§2) rather than an alternative algorithm. The recommended
+design (§2, §5) uses the detector from Zhang & Singh/X-ICP as a single shared
+component, and applies the intervention at two layers for two different
+reasons.
+
+## 2. Intervention layer decision
+
+This is the central architectural question of v0.8: where does a
+degeneracy-aware fix actually live? Three candidate layers exist in this
+codebase.
+
+### Candidates
+
+**A. Fork `Thirdparty/rko_lio` and intervene inside `icp()`.** RKO-LIO's
+`icp()` (`Thirdparty/rko_lio/rko_lio/core/lio.cpp`) already builds exactly the
+quantity needed: `build_icp_linear_system()` accumulates a 6x6
+Gauss-Newton `H` and 6x1 `b` per iteration (point-to-point residuals against
+the sparse voxel map, plus an optional IMU/gravity orientation-regularization
+term), then solves `dx = H.ldlt().solve(-b)` and applies
+`current_pose = Sophus::SE3d::exp(dx) * current_pose`. `H` and `dx` are
+discarded after each iteration; nothing about the conditioning of the solve
+is inspected or exposed today. This repo does not merely depend on upstream
+RKO-LIO — `Thirdparty/rko_lio` already points at our own fork
+(`github.com/rsasaki0109/rko_lio`, see `.gitmodules`), which already carries
+at least one nontrivial behavioral addition on top of upstream (`Add
+continuous kidnap relocalization recovery`, the current tip commit, plus the
+`enable_kidnap_relocalization` / `reset_on_registration_failure` config
+surface already in `LIO::Config`). Precedent for landing new opt-in,
+default-off behavior directly in the fork already exists in this exact file.
+
+**B. `graph_based_slam` (backend), consuming a degeneracy signal from the
+frontend.** The backend already has a working pattern for exactly this shape
+of problem: `gnss_use_covariance_weighting` turns NavSatFix covariance into
+per-edge information weighting, and `adjacent_edge_auto_scale.hpp` (Level 1)
+adapts the scalar `adjacent_edge_info_weight` from a NIS-median feedback loop.
+A `nav_msgs/Odometry.pose.covariance` field is already present on the wire
+between RKO-LIO and `graph_based_slam` and is currently unpopulated/unused.
+Filling it (anisotropically, per-axis, from a per-scan degeneracy signal) and
+extending the adjacent-edge weighting to a per-axis "Level 2" is a small,
+backend-only, fully in-repo BSD-2 change.
+
+**C. `scanmatcher` (our own NDT/FastGICP/SmallGICP frontend).** Fully in-repo,
+BSD-2, already core/shell split (v0.6 Phase 4), easiest to gate with the
+established pure-header/characterization/determinism-contract discipline —
+this is the same shape of engineering v0.7 already executed for BALM2/HBA.
+
+### Comparison
+
+| | invasiveness | maintenance cost | can it move the exp07 raw-RMSE number? | determinism impact |
+|---|---|---|---|---|
+| A: rko_lio fork, solve-step intervention | High — touches the default registration algorithm in a Thirdparty submodule | Ongoing: must be re-applied/rebased against a fast-moving upstream (dependabot-cadence commits visible in the fork's own log); v0.6 §5 named "RKO-LIO internals" out of scope as a locked convention, so this narrows that convention for the first time | **Yes — this is the only layer that touches the update before it is baked into the pose and the map.** | RKO-LIO odometry was already declared non-byte-deterministic and out of scope for the byte-identical claim (v0.6 §Risks); this does not add a *new* determinism obligation, but the new solve path must not introduce fresh nondeterminism beyond what already exists (thread-reduction order in `build_icp_linear_system`) |
+| B: backend edge reweighting | Low — additive config + a new pure header, same shape as existing Level 1 auto-scale | Low — fully owned code, same test discipline as everything else in `graph_based_slam` | **No, not on exp07 specifically.** exp07 is a non-revisiting sweep with **zero loop edges** (v0.7 Phase 4 finding, reconfirmed here) — there is no competing constraint for the backend to blend the degenerate direction against. Down-weighting an odometry edge that has no rival edge changes the reported uncertainty, not the trajectory. It *does* help on substrates that have loop closures, GNSS, or multi-session anchors. | None — pure backend-side, same recorded-input-stream determinism contract as today |
+| C: scanmatcher frontend | Low — fully in-repo, BSD-2, no submodule risk | Low | **No.** HILTI has never been run through `scanmatcher`; the motivating evidence (exp07 0.318 m) is RKO-LIO-only (`configs/hilti2022/rko_lio_hilti2022_pandar.yaml`). A scanmatcher-only fix demonstrates the concept on NTU/MID-360/Newer College but leaves the evidence that motivated v0.8 untouched. | scanmatcher already has its own offline-runner determinism gate (v0.6 Phase 4); a clean-room addition there follows that gate directly |
+
+### Recommendation: a phased, layered hybrid — not a single-layer choice
+
+1. **Detection is layer-agnostic and built once.** The eigenvalue/condition-
+   number classifier (Zhang & Singh + X-ICP direction categories) is a pure,
+   ROS-free, ideally shared header that consumes any `(H, b)` Gauss-Newton
+   pair, ascending eigenvalues, and eigenvectors. It does not care whether
+   `H` came from RKO-LIO, scanmatcher's NDT, or a synthetic fixture.
+2. **Getting `(H, b)` out of RKO-LIO is the smallest defensible fork patch**,
+   and it is diagnostic-only: change `icp()`'s return to also carry the
+   final iteration's `H_icp`/`b_icp` (or a pre-reduced per-axis eigen
+   summary) alongside the pose, and thread it out through `register_scan()`
+   into the existing (currently-unpopulated) `nav_msgs/Odometry.pose.covariance`
+   field. **The estimated pose itself does not change** — this is exposing an
+   already-computed-and-discarded value, not changing the algorithm. The
+   characterization test is a one-line assertion: input bag before/after the
+   patch produces byte-identical `poses_with_timestamps`. This is a much
+   smaller and more defensible intervention than option A's full solve-step
+   change, and it is what unlocks both B (backend reweighting) and further
+   work in A/C without committing to A up front.
+3. **The intervention that can actually move exp07's raw-RMSE number lives
+   in the fork (option A), scoped as tightly as possible**: an opt-in
+   `degeneracy_aware_solve` flag on `LIO::Config` (default `false`,
+   preserving every existing behavior and test byte-for-byte when unset) that
+   replaces the raw `H.ldlt().solve(-b)` step with solution remapping /
+   direction-wise blending against the same constant-velocity + IMU prior
+   RKO-LIO already computes for its initial guess. This mirrors the existing
+   `enable_kidnap_relocalization` precedent exactly: a guarded, default-off,
+   config-gated addition to the fork, not a rewrite of the default path.
+4. **Backend Level-2 anisotropic edge weighting (option B) is pursued in
+   parallel, not instead of (3)**, because it is nearly free once (2) exists,
+   and because it is real value on datasets this repo already cares about
+   (RTK-SLAM, NTU, Newer College, MID-360 — all of which do have loop
+   closures, GNSS, or repeat visits somewhere in the fleet) even though it is
+   provably a no-op on the specific zero-loop exp07 substrate. This must be
+   stated explicitly wherever results are reported, so nobody reads a
+   backend-only PR and expects the exp07 headline number to move.
+5. **scanmatcher reuse (option C) is opportunistic**, sharing the same
+   detector header, but is not gated by v0.8 and does not block any phase
+   below — it is only in scope if it falls out cheaply.
+
+**This recommendation narrows the v0.6 §5 "RKO-LIO internals: out of scope"
+convention for the first time in this project's history.** That is flagged
+explicitly as a decision requiring maintainer sign-off before Phase 2 starts
+(§9); Phase 0 and Phase 1 do not require it (Phase 1's fork patch is
+diagnostic-only and additive).
+
+## 3. Target architecture
+
+```
+Thirdparty/rko_lio (our fork)
+   build_icp_linear_system()  ->  H, b  (already computed, currently discarded)
+   icp()                      ->  [NEW] also returns final H, b (diagnostic-only, Phase 1)
+                               ->  [NEW, opt-in, default off] degeneracy_aware_solve (Phase 2)
+   register_scan()            ->  [NEW] per-axis eigen summary attached to State
+   rko_lio/ros/node.cpp       ->  [NEW] fills nav_msgs/Odometry.pose.covariance
+                                   (anisotropic, from the eigen summary)
+                                   │
+                                   ▼
+[NEW, shared, ROS-free] localizability_analysis.hpp
+   eigenvalue / condition-number classification (Zhang & Singh)
+   direction categories: well-conditioned | degenerate | non-observable (X-ICP)
+                                   │
+                     ┌─────────────┴─────────────┐
+                     ▼                           ▼
+graph_based_slam (backend)              map bundle / diagnostics
+   [NEW] Level-2 anisotropic              [NEW] degeneracy report
+   adjacent-edge info weighting            (report-only, v0.7 §6 backlog item)
+   (extends adjacent_edge_auto_scale.hpp)
+```
+
+- Detection is additive and report-only through Phase 1; nothing changes
+  numerically anywhere until Phase 2, and Phase 2's interventions are
+  themselves default-off until Phase 3 evidence, exactly mirroring v0.7's
+  Phase 1 (measure) -> Phase 2 (build, default off) -> Phase 3 (gate + flip)
+  shape.
+- The v0.6/v0.7 determinism contract is unaffected in its current scope:
+  RKO-LIO raw odometry was already excluded from the byte-identical claim
+  (v0.6 §Risks). The *backend*'s byte-identical claim is defined against a
+  **recorded** odometry-and-cloud input bag, not a live re-run of RKO-LIO —
+  so once a covariance-bearing bag is recorded, replaying it N times through
+  the backend is unaffected by whatever run-to-run jitter exists in how that
+  covariance was originally computed. This compatibility argument is made
+  explicit because it is not obvious on first read of the v0.6/v0.7 gates.
+
+## 4. Testing strategy
+
+Same four-layer discipline as v0.6/v0.7, with one addition specific to
+degeneracy work: a **synthetic degenerate-scenario oracle**, because unlike
+map refinement (which had real total-station GT on every substrate),
+degeneracy ground truth needs deliberately constructed scenes to test the
+failure mode in isolation.
+
+1. **Characterization tests before extraction/patching** — for the fork
+   patch in particular: same input bag, same config, `degeneracy_aware_solve`
+   unset -> byte-identical poses before and after every PR that touches
+   `Thirdparty/rko_lio`.
+2. **Unit tests per pure header** — `localizability_analysis.hpp` (eigenvalue
+   classification, direction categories), the Level-2 backend weighting
+   header, each independently testable on synthetic `(H, b)` fixtures without
+   any point cloud at all.
+3. **Synthetic degenerate-scenario fixtures** (new — this is this roadmap's
+   equivalent of v0.7's synthetic plane-world fixtures):
+   - **corridor**: parallel-wall point cloud, no cross-corridor texture,
+     known injected SE(3) trajectory and ground truth. Expected classifier
+     output: along-corridor direction flagged degenerate on the majority of
+     frames.
+   - **box/room**: four walls + floor + ceiling, fully observable. Expected:
+     all six directions well-conditioned.
+   - **single-plane** / **open-field**: degenerate in more than one
+     direction (the "do not move" case already proven useful in v0.7 Phase 2
+     for plane BA gauge fixing). Expected: correct non-observable
+     classification, not a false well-conditioned reading.
+   - Each fixture gets a gradient/finite-difference check on the eigenvalue
+     derivative used by any solution-remapping math, the same rigor v0.7
+     applied to the BALM2 eigenvalue cost.
+4. **Determinism contract tests** — the classifier and Level-2 backend
+   weighting must satisfy "same input twice -> bitwise identical", same as
+   every other pure header in this repo. The fork's `degeneracy_aware_solve`
+   path must not introduce *new* nondeterminism beyond what already exists in
+   `build_icp_linear_system`'s `tbb::parallel_reduce`; canonicalized
+   eigenvector signs and sorted-ascending eigenvalues are required (same
+   rule already codified for the v0.7 refinement core).
+5. **Replay/regression harness** — exp07/exp01 (and exp04, see §6) join the
+   substrate list already replayed through `run_release_readiness_checks.sh`,
+   report-only until Phase 3.
+
+## 5. Phases and gates
+
+### Phase 0 — freeze metrics (measure before touching)
+
+- Freeze the current exp07/exp01 raw-odometry numbers as the baseline this
+  entire roadmap is judged against: RMSE 0.318 m / 0.066 m, median 0.329 m /
+  0.053 m, per-axis `x=0.145, y=0.235, z=0.157` on exp07. This is the same
+  "the optimizer must not be allowed to move its own judge" discipline as
+  v0.7 Phase 1 (map-quality metrics frozen before the refinement optimizer
+  was built).
+- Add `hilti2022_exp01` and `hilti2022_exp07` to `scripts/release_profiles.yaml`
+  as new **report-only** rows (`report_only_until: v0.8`), using the same
+  shape as the existing `mid360_gt_rtkslam_*` entries. No HILTI profile
+  exists in `release_profiles.yaml` today — this is new wiring, not a
+  threshold change.
+- Additionally record a raw-odometry baseline for **exp04** ("construction
+  upper level" — already mapped in `scripts/download_hilti2022.sh` but never
+  run), as a second, non-corridor freeze substrate and a candidate Phase 3
+  holdout companion to exp01.
+- Build the synthetic degenerate-scenario generator (§4.3: corridor, box,
+  single-plane/open-field) as a committed, deterministic fixture generator,
+  and record each scenario's `(H, b)` eigenvalue signature as the Phase 1
+  detector oracle.
+- **Gate**: written baseline table (a new
+  `docs/research/hilti-degeneracy-baseline.md`, following the
+  `docs/research/map-quality-baseline.md` precedent) covering exp01/exp04/exp07
+  raw odometry + the three synthetic fixtures' eigenvalue signatures;
+  `release_profiles.yaml` carries the two new report-only HILTI rows.
+
+### Phase 1 — detection, report-only
+
+- `localizability_analysis.hpp` (pure header, ROS-free): eigenvalue /
+  condition-number classification per Zhang & Singh, direction categories
+  (well-conditioned / degenerate / non-observable) per X-ICP's normalized
+  test. Unit-tested against the Phase 0 synthetic fixtures.
+- Minimal `Thirdparty/rko_lio` fork patch (diagnostic-only, §2 item 2):
+  `icp()` also returns the final `H`/`b`; `register_scan()` threads a
+  per-axis eigen summary into `State`; `rko_lio/ros/node.cpp` fills
+  `nav_msgs/Odometry.pose.covariance` anisotropically. Characterization test:
+  poses byte-identical before/after the patch on every existing substrate.
+- Wire the score into: a per-scan diagnostics CSV in the offline runners, a
+  **degeneracy report** in the map bundle (the stretch item already named in
+  v0.7 §6), and a new report-only `--degeneracy-report` stage in
+  `run_release_readiness_checks.sh` (same rollout shape as v0.7's
+  `--offline-determinism-map-quality-profile`).
+- **Gate**:
+  - synthetic fixtures classify correctly (corridor -> along-axis degenerate
+    on the majority of frames; box -> all directions well-conditioned;
+    single-plane/open-field -> correct non-observable flag, not a false
+    well-conditioned reading);
+  - exp07 vs exp01 classification matches the documented drift asymmetry
+    (exp07's along-corridor direction flagged degenerate on a
+    majority of mid-corridor frames; exp01 flagged well-conditioned on
+    the large majority of frames) — exact numeric thresholds set from the
+    Phase 0 data, not borrowed from the papers (Zhang & Singh's own
+    threshold was tuned to their LOAM feature scale and does not port
+    directly; X-ICP's normalized test is the reason a scale-portable
+    threshold is feasible at all, but it still needs local calibration);
+  - fork patch characterization test green (byte-identical poses,
+    every existing substrate, every existing profile);
+  - zero change to any existing blocking APE/map-quality profile (report-only
+    means report-only, everywhere).
+
+### Phase 2 — intervention, clean-room, default off
+
+- **Track A (fork, the one that can move exp07's number)**: opt-in
+  `degeneracy_aware_solve` on `LIO::Config` (default `false`). Implements
+  solution remapping (Zhang & Singh) with X-ICP-style direction blending
+  against the existing constant-velocity + IMU prior in degenerate
+  directions, inside `icp()`'s solve step.
+- **Track B (backend, complementary, does not move exp07)**: Level-2
+  anisotropic `adjacent_edge_info_weight`, extending
+  `adjacent_edge_auto_scale.hpp`'s NIS-median pattern to consume the Phase 1
+  per-axis signal instead of a single scalar. Default off.
+- Both tracks get a synthetic-GT recovery oracle on the Phase 0 corridor
+  fixture (injected drift, known correction target), same discipline as
+  v0.7 Phase 2's BALM2 recovery fixtures, plus the "do not move" unobservable
+  fixture from v0.7 Phase 2 (single-plane/open-field must not be perturbed
+  by either track).
+- Real-substrate validation is opt-in only in this phase, not gating:
+  re-run exp07/exp01/exp04 with Track A enabled and record the delta; also
+  re-run every existing blocking release profile (NTU, Newer College,
+  MID-360 x4, RTK-SLAM x4) to catch the v0.7-style cautionary failure mode
+  ("polishing the wrong map" — here, "remapping the wrong direction" on a
+  repeated-geometry corridor with periodic doorframes is the direct analogue
+  of the doorframe false-minimum the v0.7 write-up documented for plane BA;
+  the same prior-blending discipline is the mitigation, not a coincidence).
+- **Gate**:
+  - synthetic corridor recovery >= a numeric target set from Phase 0/1 data
+    (e.g. a stated fraction of injected along-corridor error recovered),
+    documented before Phase 3, not tuned after seeing exp07;
+  - unobservable-direction fixture untouched (do-not-move policy holds);
+  - both tracks default off: **zero diff** on every existing blocking profile
+    when the flags are unset;
+  - with Track A enabled: no regression beyond a stated epsilon on any
+    non-corridor substrate (exp01, exp04, NTU, Newer College, MID-360 x4,
+    RTK-SLAM x4);
+  - fork determinism: no new nondeterminism source introduced by the solve
+    change (canonicalized eigen signs, sorted eigenvalues, no unordered
+    containers in the new path).
+
+### Phase 3 — holdout validation + default decision
+
+- **Holdout hygiene** (same rule as v0.7 Phase 3): any threshold/gain tuning
+  uses exp07 + the synthetic fixtures only. exp01 and exp04 are held out
+  untouched and evaluated once thresholds are frozen — the same
+  tuning-substrate/holdout-substrate split v0.7 used for
+  `construction_seq1` (tuning) / `construction_seq2` (holdout).
+- **Default-on decision criteria** (all required, on Track A specifically —
+  Track B's default decision is judged independently since it targets a
+  different substrate class):
+  - exp07 raw RMSE improves by a pre-registered margin from the 0.318 m
+    baseline (magnitude to be fixed at the end of Phase 2 from the recovery
+    data, not chosen after the fact);
+  - exp01, exp04, and every existing blocking release profile (NTU, Newer
+    College, MID-360 x4, RTK-SLAM x4) stay within the Phase 2 epsilon,
+    holdout-validated;
+  - the v0.7 map-quality gate also passes (or does not regress) on the
+    corridor substrate — a solution-remap that quietly parallel-shifts the
+    corridor without visibly breaking wall/floor plane thickness is exactly
+    the kind of silent failure the v0.7 metrics were built to catch, and
+    running that gate here is a cheap independent cross-check, not new work;
+  - 3-run determinism preserved wherever previously claimed (backend,
+    scanmatcher frontend); no new byte-identity claim is made for RKO-LIO
+    raw odometry itself (that scope boundary is unchanged from v0.6).
+- **Gate**: full release gate green (both determinism stages, map-quality
+  thresholds, the new HILTI profile rows now evaluated against real
+  thresholds rather than report-only-forever), holdout (exp01/exp04)
+  untouched during tuning, explicit default-on **or** honest default-off
+  documented decision (the triangle-descriptor-stack precedent,
+  `docs/research/triangle-stack-2026-05-summary.md`, is the template for an
+  honest "default off, evidence-bounded" outcome if Phase 2/3 data does not
+  support flipping the default).
+
+## 6. Validation infrastructure
+
+- **Can exp07 be a blocking gate?** Not in the same automated sense as
+  RTK-SLAM/NTU/Newer College. HILTI 2022 is CC BY-NC-SA, evaluation-only, not
+  redistributed, and downloaded on demand via `scripts/download_hilti2022.sh`
+  from the challenge host — there is no guarantee of unattended CI fetch
+  access the way the fully public CC-BY RTK-SLAM dataset has. The
+  recommended shape is: `release_profiles.yaml` rows exist and are evaluated
+  whenever a matching local run is present (report-only through Phase 2,
+  real thresholds from Phase 3), but promotion to "blocking" means a
+  **manual pre-release checklist item** (in `RELEASING.md`, alongside the
+  existing manual bloom/rosdistro maintainer steps in `docs/rosdistro-release.md`)
+  rather than a `report_only_until` flip that assumes CI-fetchable data. This
+  is flagged as a process-design decision, not a purely technical one (§9).
+- **Additional sequences**: exp04 ("construction upper level") is already
+  mapped in `download_hilti2022.sh` but has never been run — add it in
+  Phase 0 as a second freeze substrate and Phase 3 holdout companion to
+  exp01. Whether a second corridor-like HILTI sequence exists beyond exp07
+  is not established by anything read for this design (the download script
+  only wires exp01/exp04/exp07 today) and should not be assumed; if one
+  exists, it strengthens the holdout design considerably and is worth a
+  quick scouting pass before Phase 3 threshold-freezing.
+- **Synthetic corridor scenario design** (§4.3, §5 Phase 0): parametrized
+  straight-corridor point cloud (length, width, wall-texture density),
+  optional side-branch/doorway insert to test recovering local
+  non-degeneracy, known injected SE(3) trajectory and ground truth, injected
+  sensor noise. Reuses the same "deterministic synthetic-GT fixture"
+  pattern the v0.7 BALM2 tests already established
+  (`docs/research/map-refinement-clean-room-design.md` Test Plan) rather
+  than inventing a new fixture philosophy.
+- **Release-gate wiring**: `--degeneracy-report <profile>` on
+  `run_release_readiness_checks.sh`, report-only in Phase 1, following the
+  `--offline-determinism-map-quality-profile` precedent exactly (forward the
+  flag through the offline runner(s), check output against a profile,
+  blocking only once thresholds exist).
+
+## 7. Risks
+
+- **Fork drift / maintenance burden.** The `degeneracy_aware_solve` patch
+  (Phase 2 Track A) must stay small and isolated (ideally a single
+  self-contained diff hunk around the linear-solve step) so it survives
+  rebase against upstream `rko_lio`'s active dependabot/PR cadence. Mitigate
+  by keeping the patch behind a config flag that defaults off and documenting
+  the rebase procedure alongside the existing kidnap-relocalization fork
+  patch.
+- **False-positive degeneracy flags** on vegetation-heavy or otherwise messy
+  outdoor scenes could trigger spurious remapping and hurt otherwise-healthy
+  trajectories. Mitigate with the same "no-worse acceptance" / reject-with-
+  report discipline v0.7's refinement stage used, and require the Phase 2
+  gate to check every existing substrate, not just corridors.
+- **Repeated-geometry false minima.** A corridor with periodic doorframes is
+  the direct structural analogue of the doorframe false-minimum the v0.7
+  write-up documented for plane BA (a 1.2 m wrong-alignment jump when priors
+  were disabled). The mitigation is the same: keep the degenerate-direction
+  fallback blended toward the IMU/constant-velocity prior, never toward an
+  unconstrained local minimum, and never disable that blending for
+  real-data runs.
+- **Backend Track B produces a false sense of progress.** Because it is
+  provably a no-op on the zero-loop exp07 substrate, any report or PR
+  description must say so explicitly — it is real, general-purpose value on
+  loop-closing/GNSS/multi-session substrates, not a fix for the headline
+  evidence number.
+- **HILTI license/redistribution constraints limit automation** (§6) — this
+  changes what "blocking" can mean for this substrate and needs a
+  documented, deliberate process decision rather than an assumed CI flip.
+- **Determinism scope creep.** No new byte-identity claim is made for RKO-LIO
+  raw odometry; the existing v0.6 scope boundary (RKO-LIO odometry excluded
+  from the byte-identical claim) is preserved, not expanded, by this
+  roadmap.
+
+## 8. Out of scope
+
+The other three v0.7 §6 candidates are explicitly **not** part of v0.8 and
+remain an unscheduled backlog for v0.9+:
+
+- **Multi-session mapping** (relocalize into an existing map, anchor a new
+  session's graph, deterministic merge) — a different problem class
+  (cross-session data association and graph anchoring), not degeneracy.
+- **Per-scan dynamic object removal** — a different problem class (moving
+  object filtering), with its own license-check requirement before any
+  reference is consulted.
+- **Intensity utilization** — a different signal channel (intensity-
+  augmented registration/loop verification), orthogonal to geometric
+  degeneracy.
+
+Also out of scope for v0.8 specifically: `scanmatcher` frontend degeneracy
+handling beyond opportunistic detector reuse (§2 option C); any new
+cross-machine determinism claim; rosdistro/bloom release work (tracked
+separately, `docs/rosdistro-release.md`).
+
+## 9. Open questions requiring maintainer decision
+
+1. **Narrowing the "RKO-LIO internals out of scope" convention.** v0.6 §5
+   locked RKO-LIO internals as out of scope for this project. This roadmap's
+   Phase 2 Track A is the first proposal to cross that line (a guarded,
+   default-off, opt-in patch — not a rewrite of the default path, and with
+   the diagnostic-only Phase 1 patch as a smaller, separately-approvable
+   first step). This needs explicit sign-off before Phase 2 starts; Phase 0
+   and Phase 1 do not require it.
+2. **What "blocking" means for a non-redistributable, manually-fetched
+   dataset.** HILTI's CC BY-NC-SA / on-demand-download status doesn't fit the
+   `report_only_until` flip mechanism cleanly (§6). Deciding whether
+   "blocking" means a manual `RELEASING.md` checklist item versus something
+   else is a process decision, not just a technical one.
+3. **Numeric targets left intentionally unset in this draft**: the exact
+   eigenvalue/condition-number classification threshold (Phase 1), the
+   synthetic-corridor recovery-fraction target (Phase 2), and the exp07
+   default-on improvement margin (Phase 3) are deliberately left as "set
+   from Phase 0/1/2 data" rather than pre-committed numbers, following this
+   repo's stated discipline of not tuning acceptance criteria on the
+   substrate being fixed. A reviewer should confirm this is the right amount
+   of number-deferral for a roadmap document versus pinning at least
+   provisional numbers now.
+4. **Scope of the exp04 side-quest.** This roadmap folds "run exp04 raw
+   odometry for the first time" into Phase 0 as a freeze substrate. If that
+   is considered enough new work to deserve its own tracking (like v0.7
+   Phase 4 got its own phase for the initial HILTI substrate work), it may
+   be worth splitting out rather than folding into Phase 0 here.
+
+---
+
+(Related: `docs/roadmap/v0.7.md` — the measurement-first phase-gate
+discipline this roadmap follows; `plan.md` §2.4 — the HILTI evidence this
+roadmap is built on; `docs/research/map-refinement-clean-room-design.md` —
+the clean-room design-note format and synthetic-fixture discipline reused
+here; `docs/research/byte-reproducible-map-authoring.md` — the determinism
+scope statements this roadmap extends without expanding.)

--- a/plan.md
+++ b/plan.md
@@ -215,7 +215,9 @@ distance-threshold で submap が作られない時間帯に落ち、最寄り s
 （中央 1.2s, 最大 19.9s 間隔）の線形補間が誤差を生む。**結論: 短く非再訪な
 シーケンスでは backend は忠実なパススルー、deliverable は dense odometry
 （6.6cm）。疎な corrected/submap 軌跡は補間でなく submap 時刻で採点すべき**
-（評価ハーネスの methodology note）。extrinsic は calibration の quaternion を
+（評価ハーネスの methodology note → 2026-07-05 実装済み: `ape_from_tum.py
+--sparse-match`、棄却診断付き。`test_sparse_trajectory_scoring.py` で
+補間アーティファクト ~5m vs 正採点 ~0.05m を合成実証）。extrinsic は calibration の quaternion を
 `[x,y,z,w]` として読むのが正（`[w,x,y,z]` 解釈は z が −229m に発散、経験確定）。
 
 > 注（2026-06-13 訂正）: 当初「デフォルトループの過剰発火で corrected 悪化」と
@@ -334,7 +336,7 @@ distance-threshold で submap が作られない時間帯に落ち、最寄り s
 
 | 項目 | 状態 | 理由 |
 |------|------|------|
-| GNSS ポーズグラフ制約 | 🟡 部分実証 | 2026-06-12 RTK-SLAM stadtgarten_seq2 で初検証: #242 修正後にエッジ 163 本形成・RTK 判定・ENU 変換まで動作 ✅。ただし **odom→ENU の初期 yaw 整合が未実装**でアンカーがマップを剪断（pose0 で 0m → 遠方 337m の回転不整合パターン）→ 精度用途はまだ不可。詳細: `docs/research/gnss-constraint-first-validation.md` |
+| GNSS ポーズグラフ制約 | 🟡 部分実証 | 2026-06-12 RTK-SLAM stadtgarten_seq2 で初検証: #242 修正後にエッジ 163 本形成・RTK 判定・ENU 変換まで動作 ✅。odom→ENU 初期 yaw 整合も PR #244 で実装済み（2D Kabsch + vertex-0 gauge 解放、stadtgarten_seq2 で実証）。詳細: `docs/research/gnss-constraint-first-validation.md` |
 | ~~`map_projector_info.yaml`（LocalCartesian）~~ | ✅ | 同検証で初実証: LocalCartesian + WGS84 + 実origin（Stadtgarten 48.78199/9.17295）が出力された |
 | ~~Autoware 実環境読み込み~~ | ✅ | map loaders 読込 dogfood 済み |
 
@@ -396,7 +398,7 @@ distance-threshold で submap が作られない時間帯に落ち、最寄り s
 | 0h | **v0.7 Phase 4: HILTI 2022 外部 mm-GT 基盤（進行中）** | exp01 6.6cm / exp07 long corridor 0.32m（退化、§2.4、task #18、PR #280/#282）。両者ループゼロで backend パススルー（正常）。残り = 他 construction 系列 / sparse corrected 軌跡の採点改善 / **exp07 退化を v0.8 degeneracy registration の検証基盤に** |
 | 0d | ~~D1 8-vs-16 再現性ベンチ~~ | ✅ 2026-06-11 実施（GLIM MID-360 bag、3 run × {off/16, on/16, on/8}）。on/16 は APE 実質無回帰（差 0.06m ≪ noise 0.40m）だが分散縮小なし（σ 0.066→0.259）、on/8 arm の 2 実行で loop 試行ゼロ。mp8 の系統的 regression 署名は消滅し乱高下に置換（スケジューリング主要因子と整合、根本原因の証明ではない）。**default off 維持で D1 完全クローズ**（§1.2、research summary） |
 | 0e | **発信（P2-8）** | ghcr ワンコマンド + lanelet2 完全バンドル + 実 GT 数値が揃い、発信material は完成状態。ROS Discourse / Reddit / X はユーザー本人が実施。事前に B2 social preview 設定（Web UI 1 分） |
-| 1 | **GNSS odom→ENU yaw 整合の実装** | 初検証（2026-06-12）で制約形成 ✅・LocalCartesian projector ✅ まで実証済み。残るは yaw 整合（ENU トラックとの 2D 最小二乗 → アンカー回転 or vertex-0 gauge 解放）。これが入ると GNSS georeferencing が実用になる。`docs/research/gnss-constraint-first-validation.md` |
+| 1 | ~~GNSS odom→ENU yaw 整合の実装~~ | ✅ 実装済み（PR #244 `18fdbc1`、2026-06-12）。閉形式 2D Kabsch（`gnss_alignment.hpp`）+ vertex-0 gauge 解放方式。最小観測性ガード（`gnss_yaw_alignment_min_anchors`=10 / `gnss_yaw_alignment_min_baseline_m`=5.0）付き。stadtgarten_seq2 実データで yaw −111.83° / baseline 201.9m / rms 1.90m を確認済み。2026-07-05 再検証: build + 1379 tests 0 fail。`docs/research/gnss-constraint-first-validation.md` |
 | 2 | ~~Autoware 実環境での読み込みテスト~~ | ✅ map loaders 読込は検証済み（README の loader proof、§6） |
 | 3a | ~~MID-360 robot toolkit chain (操作員 pipeline)~~ | ✅ PR #168-#177 で 10 PR inside-out で landing 完了 (§10) |
 | 3b | **実機 Jetson + MID-360 robot での dogfood 実走** | chain (§10) を組んだものの実機 bag での E2E 検証はまだ。dogfood-vs-bench の cloud distribution 不一致も併せて調査 |


### PR DESCRIPTION
## Summary
Two documentation deliverables from today's planning session.

### 1. `docs/roadmap/v0.8.md` (new) — degeneracy-aware registration design
Motivated by HILTI exp07 (long corridor, mm control points): raw RMSE 0.318m ≈ 5× exp01's 0.066m, per-axis residuals x=0.145 / y=0.235 / z=0.157.

- **Key code finding**: RKO-LIO's `icp()` (`Thirdparty/rko_lio/rko_lio/core/lio.cpp`) already builds the exact 6×6 Gauss-Newton `H`/`b` needed for Zhang & Singh-style degeneracy detection each iteration, then discards it — detection is nearly free. `Thirdparty/rko_lio` is already our own fork with precedent for guarded default-off features.
- **Intervention layers (phased hybrid)**: layer-agnostic detection header → diagnostic-only fork patch (expose via `Odometry.pose.covariance`, pose output unchanged) → opt-in `degeneracy_aware_solve` in the solve step (the only layer that can move exp07's number; narrows the "RKO-LIO internals out of scope" convention, flagged for sign-off) → backend anisotropic edge reweighting in parallel (provably a no-op on exp07 — zero loop edges — general hygiene only).
- **Phases (v0.7 style)**: Phase 0 metric freeze (exp07/exp01 + new exp04 substrate + synthetic corridor fixtures) → Phase 1 report-only detection → Phase 2 clean-room intervention, two tracks, default-off → Phase 3 holdout validation + evidence-based default decision (honest "default off" outcome allowed, triangle-stack precedent).
- **§9 lists the open decisions** that need maintainer judgment (fork-internals sign-off, HILTI CC BY-NC-SA blocking semantics, threshold pinning, exp04 tracking).

### 2. `plan.md` status refresh
- High-priority task #1 (GNSS odom→ENU yaw alignment) was **already implemented** in PR #244 (closed-form 2D Kabsch + vertex-0 gauge release, observability guards, validated on stadtgarten_seq2: yaw −111.83°, rms 1.90m) but still listed as open. Marked done; §6 GNSS row updated. Re-verified today: build + `colcon test` → 1379 tests, 0 errors, 0 failures.
- §2.4 methodology note now points at the implemented fix (`ape_from_tum.py --sparse-match`, PR #322).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTNqieB785XZRXu5xPXZoL