### PR TITLE
feat(v0.8): Phase 0 — freeze degeneracy metrics (HILTI baselines + synthetic oracle)

### DIFF
--- a/docs/research/hilti-degeneracy-baseline.md
+++ b/docs/research/hilti-degeneracy-baseline.md
@@ -1,0 +1,342 @@
+# HILTI degeneracy baseline (v0.8 Phase 0)
+
+Status: recorded 2026-07-05, before any degeneracy-aware detection or
+intervention code exists. This is the "the optimizer must not be allowed to
+move its own judge" freeze for `docs/roadmap/v0.8.md` — the same discipline
+`docs/research/map-quality-baseline.md` used for v0.7 Phase 1. Every later
+v0.8 phase gate (Phase 1 classification accuracy, Phase 2 recovery targets,
+Phase 3 default-on decision) is judged against the numbers in this document,
+not the other way around.
+
+Two independent things are frozen here:
+
+1. **Real-substrate raw-odometry baseline** — HILTI 2022 exp01/exp07 (already
+   measured, v0.7 Phase 4) plus exp04 (measured 2026-07-05 in this pass, §3).
+2. **Synthetic degenerate-scenario oracle** — three deterministic fixtures
+   (corridor / box / single-plane) with recorded point-to-plane Gauss-Newton
+   `H` eigenvalue signatures, the fixture data Phase 1's planned
+   `localizability_analysis.hpp` classifier will be unit-tested against.
+
+## 1. Real-substrate raw-odometry baseline (HILTI 2022)
+
+Source: exp01/exp07 from v0.7 Phase 4 (`plan.md` §2.4, PR #280/#282),
+reconfirmed here unchanged; exp04 measured 2026-07-05 in this pass (§3).
+Sensor: Hesai PandarXT-32 + Alphasense IMU (handheld Phasma
+platform). License: CC BY-NC-SA 3.0, evaluation-only, not redistributed.
+Config: `configs/hilti2022/rko_lio_hilti2022_pandar.yaml` (voxel 0.25,
+deskew on). Scoring: dense RKO-LIO raw odometry vs the sparse
+total-station control points, `ape_from_tum.py --interpolate` (the dense
+trajectory is scored, not the sparse submap/corrected trajectory — see
+"Methodology note" below).
+
+| sequence | environment | RKO-LIO raw RMSE (m) | median (m) | path | pairs | loops |
+|---|---|---:|---:|---|---:|---:|
+| exp01 | construction ground level (feature-rich) | **0.066** | 0.053 | 904 m one-shot sweep | 13 | 0 |
+| exp07 | long corridor (degenerate) | **0.318** | 0.329 | 124 m one-shot sweep | 6 | 0 |
+| exp04 | construction upper level (feature-rich) | **0.071** | 0.055 | 82 m one-shot sweep (125.8 s) | 7 | 0 |
+
+Per-axis residuals, exp07 (the frozen evidence motivating v0.8) vs exp04
+(measured 2026-07-05, same SE(3)-Umeyama-aligned interpolate scoring):
+
+| axis | exp07 residual (m) | exp04 residual (m) |
+|---|---:|---:|
+| x | 0.145 | 0.040 |
+| y | 0.235 | 0.039 |
+| z | 0.157 | 0.045 |
+
+On exp07, one axis (empirically the largest of the three, the long axis of
+the corridor) carries substantially more error than the other two — the
+signature of a *directionally* under-constrained registration problem, not
+a uniformly noisy one (`docs/roadmap/v0.8.md` §0). exp04's residuals are
+near-isotropic (0.039–0.045 m across all three axes) — the feature-rich
+control case showing what a well-constrained sweep looks like on the same
+sensor/config, mirroring exp01.
+
+All three sequences contribute **zero loop edges** from `graph_based_slam`,
+so this is confirmed a raw-odometry accuracy problem, not a
+backend/loop-closure problem (corrected == raw at every submap timestamp:
+0.000 m on exp01/exp07, v0.7 Phase 4 finding; re-verified 0.0000 m across
+all 42 submap poses on exp04). exp01/exp07 are non-revisiting single
+sweeps. exp04 *does* physically revisit its start (the first and last of
+its 7 control points are the same coordinates), but its 82 m path never
+clears the 100 m `distance_loop_closure` gate, so no loop candidate is
+ever eligible — the pose graph holds only the adjacent-window constraints
+(max edge `|i-j|` = 5), same passthrough behaviour as exp01.
+
+**Methodology note** (carried over from v0.7 Phase 4, `plan.md` §2.4): score
+the *dense* RKO-LIO odometry trajectory, not the sparse
+submap/pose-graph-corrected trajectory. HILTI's control points are captured
+while the platform is stationary; a sparse corrected/submap trajectory's
+linear interpolation across those stationary dwells introduces a scoring
+artifact (observed ~0.89 m on exp01's corrected trajectory, versus 0.066 m
+scored correctly on the dense trajectory) — this is an interpolation
+artifact of sparse-trajectory scoring, not real degradation. Use
+`ape_from_tum.py --interpolate` against the dense trajectory (as the
+commands below do), or `--sparse-match` if a sparse trajectory is ever the
+only one available.
+
+## 2. Release-gate wiring (`scripts/release_profiles.yaml`)
+
+Three new **report-only** rows, `report_only_until: v0.8`, added in this
+Phase 0 pass (no HILTI profile existed in `release_profiles.yaml` before
+this):
+
+| profile | match | metric | pass (frozen) |
+|---|---|---|---:|
+| `hilti2022_exp01` | `points_topic: /hesai/pandar`, `reference_kind: ground_truth`, `reference_source_contains: hilti2022_exp01_control_points_gt`, `min_ape_pairs: 10` | `ape_rmse_gt_m` | 0.066 |
+| `hilti2022_exp07` | `points_topic: /hesai/pandar`, `reference_kind: ground_truth`, `reference_source_contains: hilti2022_exp07_control_points_gt`, `min_ape_pairs: 4` | `ape_rmse_gt_m` | 0.318 |
+| `hilti2022_exp04` | `points_topic: /hesai/pandar`, `reference_kind: ground_truth`, `reference_source_contains: hilti2022_exp04_control_points_gt`, `min_ape_pairs: 5` | `ape_rmse_gt_m` | 0.072 |
+
+Unlike prior soak-then-graduate report-only rows (e.g.
+`mid360_gt_rtkslam_stadtgarten_*`), `pass` here is pinned to the *exact*
+frozen baseline rather than a looser graduation threshold — these rows
+exist as a regression canary against this document's numbers, not as a
+target to clear. (`hilti2022_exp04`'s 0.072 is the measured 0.0715 rounded
+*up* to 3 dp so the frozen run itself evaluates PASS; rounding down to
+0.071 would make the baseline run WARN against its own freeze. Verified
+PASS at 0.071 against the 2026-07-05 run via `benchmark_summary.py
+--release-profile`.) No `target` is set (no improvement number is chosen yet;
+`docs/roadmap/v0.8.md` §9 item 3 explicitly defers the Phase 3 improvement
+margin until Phase 2 data exists). Because these rows only evaluate when a
+matching local run under `--root` exists, and HILTI is CC BY-NC-SA /
+manually fetched (no guaranteed CI access), "blocking" for this substrate
+is a manual `RELEASING.md` pre-release checklist item, not a
+`report_only_until` flip (`docs/roadmap/v0.8.md` §6).
+
+`scripts/download_hilti2022.sh`'s suggested `--reference-source` label was
+corrected in this pass from `hilti2022_${SEQUENCE}_control_points` to
+`hilti2022_${SEQUENCE}_control_points_gt` — `benchmark_summary.py`'s
+`_infer_reference_kind` only classifies a reference as `ground_truth` when
+its source label contains `gt` or `ground_truth`; without the suffix the
+profiles above would never match a real run (`reference_kind:
+ground_truth` would never be satisfied).
+
+## 3. exp04 — measured 2026-07-05
+
+exp04 (`exp04_construction_upper_level`, "construction upper level"): bag
+downloaded and converted via `scripts/download_hilti2022.sh --sequence
+exp04` (13.5 GB rosbag2, 125.8 s, 1258 `/hesai/pandar` PointCloud2 + 50198
+`/alphasense/imu` msgs; kept off-repo under an external datasets
+directory), 7 total-station control points. Run 2026-07-05 on ROS 2 Jazzy
+(Ubuntu 24.04), workspace built with `colcon build --symlink-install
+--cmake-args -DCMAKE_BUILD_TYPE=Release` (note: the `rko_lio` Thirdparty
+submodule additionally needs `-DRKO_LIO_FETCH_CONTENT_DEPS=ON` on a
+machine without a system Sophus, per `Thirdparty/rko_lio/README.md`).
+
+**Frozen result** (dense raw odometry vs 7 control points,
+`ape_from_tum.py --interpolate --max-time-diff 3.0`, SE(3) Umeyama):
+
+- RMSE **0.0715 m**, median 0.0546 m, mean 0.0665 m, min/max
+  0.0355/0.1141 m, 7/7 paired (0 rejected, max interpolation bracket
+  0.100 s)
+- per-axis RMSE x 0.040 / y 0.039 / z 0.045 m — near-isotropic (§1)
+- path 82 m, 1258 raw poses @ ~10 Hz, wall 169 s (RTF 1.34 incl. 60 s
+  quiescence), zero loop edges (82 m < the 100 m `distance_loop_closure`
+  gate despite the start-revisit in the GT; §1), corrected == raw to
+  0.0000 m at all 42 submap poses, Autoware map verify 8/8 PASS
+
+Commands as actually run (bag + outputs on an external disk; repo root
+otherwise as in §5):
+
+```bash
+# 1. Download + convert (run once; ~13.5 GB rosbag2)
+bash scripts/download_hilti2022.sh --sequence exp04
+
+# 2. Raw-odometry benchmark run (same config family as exp01/exp07).
+#    --reference-meta points at a `{}` placeholder JSON: see the harness
+#    caveat below.
+bash scripts/run_rko_lio_graph_benchmark.sh \
+  --bag <datasets>/hilti2022/exp04_ros2 \
+  --lidar-topic /hesai/pandar --imu-topic /alphasense/imu \
+  --rko-param configs/hilti2022/rko_lio_hilti2022_pandar.yaml \
+  --reference-tum <datasets>/hilti2022/exp04_construction_upper_level_gt.txt \
+  --reference-meta <work>/hilti2022_exp04_reference_meta.json \
+  --skip-reference-gen --reference-source hilti2022_exp04_control_points_gt \
+  --quiescence-secs 60 --offline-timeout-secs 5400 \
+  --output-dir <work>/output/hilti2022_exp04_run
+
+# 3. Score dense raw odometry vs the sparse stationary control points
+python3 scripts/ape_from_tum.py --interpolate --max-time-diff 3.0 \
+  --ref <datasets>/hilti2022/exp04_construction_upper_level_gt.txt \
+  --est <work>/output/hilti2022_exp04_run/traj_raw.tum \
+  --out <work>/output/hilti2022_exp04_run/ape_raw_interpolate_vs_gt.txt
+
+# 4. Fold into the release-gate summary (hilti2022_exp04 row added in this
+#    pass; evaluated PASS at 0.071 <= 0.072 against this run)
+python3 scripts/benchmark_summary.py --root <work>/output \
+  --release-profile scripts/release_profiles.yaml --write-md summary.md
+```
+
+Harness caveats found while running this (pre-existing
+`run_rko_lio_graph_benchmark.sh` behaviour, worked around — not fixed in
+this pass; candidates for a separate PR):
+
+1. `--skip-reference-gen` does not fully skip reference generation: the
+   guard also regenerates whenever the reference TUM/meta files are
+   missing, and the default `--reference-meta` is the NTU-VIRAL-specific
+   `output/ntu_viral_tnp01_reference.json`. On a HILTI run without that
+   file present, the script calls the NTU-only
+   `generate_ntu_viral_tnp01_reference.py` and dies on a missing
+   `leica_prism.yaml`. Workaround: pass `--reference-meta` explicitly,
+   pointing at a `{}` placeholder JSON (safe — the metrics writer treats
+   every field as optional and the prism offset defaults to zero, which is
+   correct for HILTI's IMU-frame control points).
+2. The script's built-in corrected-trajectory APE uses default
+   nearest-neighbour association (0.05 s): on exp04 all 7 stationary
+   control points fall > 0.05 s from the sparse 42-pose submap trajectory,
+   `ape_from_tum.py` exits 1, and `set -e` aborts the script *before*
+   `metrics.json` is written (the raw APE and all trajectories/maps are
+   already on disk at that point). `metrics.json` was therefore written by
+   invoking `scripts/write_rko_lio_benchmark_metrics.py` directly with the
+   same arguments the script would have passed, feeding the §3-step-3
+   dense-trajectory interpolate APE report as the canonical APE — honest
+   here because corrected == raw to 0.0000 m (backend passthrough, §1) and
+   the methodology note (§1) mandates dense-trajectory scoring; a
+   sparse-match score of the 42-pose submap trajectory against stationary
+   control points reads 1.55 m purely from temporal staleness (up to
+   5.04 s), the same artifact class as exp01's ~0.89 m.
+
+exp04 is the designated second freeze substrate and Phase 3 holdout
+companion to exp01 (`docs/roadmap/v0.8.md` §5, §6) — it must **not** be
+touched again once Phase 2 threshold-tuning starts (holdout hygiene,
+`docs/roadmap/v0.8.md` §5 Phase 3).
+
+## 4. Synthetic degenerate-scenario oracle
+
+Deterministic fixture generator: `graph_based_slam/include/graph_based_slam/synthetic_degeneracy_fixtures.hpp`
+(clean-room; only the published point-to-plane ICP residual/Jacobian
+`r = n^T(Rp + t - q)`, `J = [n^T, (p x n)^T]` is used — no GPL reference
+implementation was read). Unit tests:
+`graph_based_slam/test/test_synthetic_degeneracy_fixtures.cpp` (6 cases, all
+passing as of this recording — see §5).
+
+Three scenarios (`docs/roadmap/v0.8.md` §4.3, §6), all built from a fixed
+point lattice (no randomness in point placement) with optional
+along-plane-normal thickness noise (fixed-seed `std::mt19937`, applied
+strictly along each correspondence's own normal — this perturbs the
+residual `b` but *never* the Jacobian's moment arm `p x n`, so it leaves
+every `H` eigenvalue bit-identical; verified by
+`AlongNormalNoiseChangesResidualNotHessian`):
+
+- **corridor**: parallel side walls (`y = ±1 m`, 2 m wide) + floor/ceiling
+  (`z ∈ {0, 2.5 m}`), extruded 20 m along `x` (0.5 m grid, 902
+  correspondences). No correspondence's plane normal has an `x` component
+  anywhere, so `H`'s along-corridor-translation (`tx`) row/column is
+  *exactly* zero by construction — an algebraic degeneracy, not merely a
+  small numeric one.
+- **box**: the corridor cross-section plus two end walls (`x ∈ {0, 20 m}`,
+  normal `±x`), i.e. a fully closed six-plane room (962 correspondences).
+- **single_plane**: a floor only, same footprint as the corridor's own
+  floor/ceiling extended to a 20 m × 2 m patch (205 correspondences); the
+  open-field degenerate case (`docs/roadmap/v0.8.md` §4.3's "single-plane /
+  open-field").
+
+### Eigenvalue signatures (ascending; `H` from the default fixture configs, identity pose)
+
+| scenario | λ0 | λ1 | λ2 | λ3 | λ4 | λ5 | classification |
+|---|---:|---:|---:|---:|---:|---:|---|
+| corridor | **0.000000000** | 89.563973183 | 105.715130718 | 791.640728099 | 55654.284869282 | 67363.295298718 | along-axis degenerate (λ0 exact zero, eigenvector = pure `tx`; λ1..λ5 well-conditioned) |
+| box | 59.250234388 | 89.641377404 | 107.115865582 | 791.987407460 | 55791.133900030 | 67392.871215136 | fully observable (all six eigenvalues bounded away from zero; min/max condition number 1137.4) |
+| single_plane | **0.000000000** | **0.000000000** | **0.000000000** | 52.857565359 | 102.500000000 | 27827.142434641 | non-observable in three directions (`tx`, `ty`, yaw/`rz` exactly zero; only `tz`, pitch/`rx`, roll/`ry` constrained) |
+
+`H` column norms (`[tx, ty, tz, rx, ry, rz]`), the exact-zero-column proof
+underlying the eigenvalue table:
+
+| scenario | tx | ty | tz | rx | ry | rz |
+|---|---:|---:|---:|---:|---:|---:|
+| corridor | **0** | 4982.638758730 | 4120.449004660 | 6322.679910449 | 55501.644119792 | 66885.314531667 |
+| box | 96.046863561 | 4982.638758730 | 4120.449004660 | 6322.679910449 | 55638.819912450 | 66915.105917872 |
+| single_plane | **0** | **0** | 2060.224502330 | 102.500000000 | 27750.822059896 | **0** |
+
+Reading: corridor's only zero column is `tx` (the along-corridor axis) —
+matching the exp07 evidence that one specific axis, not a rotation, carries
+the drift (`docs/roadmap/v0.8.md` §0). Adding the two end walls (box) makes
+every column nonzero and lifts the minimum eigenvalue from exact zero to
+59.25 — a clean before/after proof that closing the corridor's ends removes
+exactly the one missing constraint direction. single_plane's three zero
+columns (`tx`, `ty`, `rz`) are exactly the directions a single horizontal
+plane cannot constrain (in-plane translation and yaw about the normal);
+`rx`/`ry` (tilt) and `tz` (height) remain observable from the plane's own
+points — the fixture correctly lands on "non-observable in three
+directions", not a false "well-conditioned" reading, which is the specific
+failure mode Phase 1's detector gate (`docs/roadmap/v0.8.md` §5 Phase 1)
+must avoid.
+
+These are the frozen oracle values Phase 1's `localizability_analysis.hpp`
+classifier must reproduce (majority-of-frames along-axis-degenerate on
+corridor, all-well-conditioned on box, correct non-observable — not
+well-conditioned — on single_plane) before any real-substrate
+classification claim is made.
+
+## 5. Reproduction
+
+Real substrates (exp01/exp07 measured in v0.7 Phase 4; exp04 measured
+2026-07-05, exact commands and harness caveats in §3):
+
+```bash
+bash scripts/download_hilti2022.sh --sequence exp01   # or exp07
+bash scripts/run_rko_lio_graph_benchmark.sh \
+  --bag datasets/hilti2022/exp01_ros2 \
+  --lidar-topic /hesai/pandar --imu-topic /alphasense/imu \
+  --rko-param configs/hilti2022/rko_lio_hilti2022_pandar.yaml \
+  --reference-tum datasets/hilti2022/exp01_construction_ground_level_gt.txt \
+  --skip-reference-gen --reference-source hilti2022_exp01_control_points_gt \
+  --quiescence-secs 60 --output-dir output/hilti2022_exp01_run
+python3 scripts/ape_from_tum.py --interpolate --max-time-diff 3.0 \
+  --ref datasets/hilti2022/exp01_construction_ground_level_gt.txt \
+  --est output/hilti2022_exp01_run/traj_raw.tum --out ape.txt
+python3 scripts/benchmark_summary.py --root output \
+  --release-profile scripts/release_profiles.yaml --write-md summary.md
+```
+
+Synthetic fixtures + eigenvalue signatures (unit tests; no bag, no ROS
+runtime needed):
+
+```bash
+colcon build --packages-select graph_based_slam --cmake-args -DBUILD_TESTING=ON
+colcon test --packages-select graph_based_slam \
+  --ctest-args -R test_synthetic_degeneracy_fixtures
+colcon test-result --verbose
+```
+
+Release-profile YAML regression tests (must stay green; see §6 for the two
+pre-existing, unrelated failures already present before this Phase 0 pass):
+
+```bash
+python3 -m pytest -q lidarslam/test/test_benchmark_summary_profiles.py
+```
+
+## 6. Test status at recording time (2026-07-05)
+
+- `test_synthetic_degeneracy_fixtures` (new, 6 cases): **6/6 pass**
+  (`CorridorGenerationIsDeterministic`,
+  `CorridorHasExactAlongAxisDegeneracy`, `BoxIsFullyObservable`,
+  `SinglePlaneIsNonObservableInThreeDirections`,
+  `AlongNormalNoiseChangesResidualNotHessian`,
+  `EigenSignatureCanonicalizationIsDeterministic`).
+- Full `graph_based_slam` gtest + pytest suite (`colcon test-result
+  --verbose` after `colcon test --packages-select graph_based_slam`):
+  **1378 tests, 0 errors, 0 failures, 74 skipped** — no regression from the
+  new fixtures/tests or the CMakeLists wiring.
+- `lidarslam/test/test_benchmark_summary_profiles.py`: **12 passed, 2
+  failed**. The 2 failures
+  (`test_research_track_profiles_graduated_to_blocking`,
+  `test_graduated_profile_fails_gate_on_regression`) are **pre-existing**
+  and unrelated to this Phase 0 change — they assert `mid360_vs_glim` has
+  no `report_only_until`, which stopped being true when `mid360_vs_glim`
+  was demoted to report-only under decision D-GT-2 (v0.5); this predates
+  and is independent of the HILTI rows added here. Confirmed by
+  running the same test file against `scripts/release_profiles.yaml`
+  before this pass's edits: identical 12 passed / 2 failed split.
+  Re-run after adding the `hilti2022_exp04` row (§3): still exactly
+  **12 passed, 2 failed** — the exp04 row introduces no new failure.
+
+---
+
+(Related: `docs/roadmap/v0.8.md` — the phase-gate discipline this document
+freezes metrics for; `docs/research/map-quality-baseline.md` — the v0.7
+Phase 1 precedent this document's structure follows; `plan.md` §2.4 — the
+original HILTI exp01/exp07 measurement this document reconfirms and
+freezes; `docs/research/map-refinement-clean-room-design.md` — the
+synthetic-fixture and clean-room discipline reused for the corridor/box/
+single-plane generator.)

--- a/docs/roadmap/v0.8.md
+++ b/docs/roadmap/v0.8.md
@@ -481,6 +481,9 @@ separately, `docs/rosdistro-release.md`).
    the diagnostic-only Phase 1 patch as a smaller, separately-approvable
    first step). This needs explicit sign-off before Phase 2 starts; Phase 0
    and Phase 1 do not require it.
+   **→ 決定（2026-07-05, maintainer）: 承認。** Phase 2 Track A の guarded・
+   default-off・opt-in パッチに限り RKO-LIO 内部改変を許可する（default パスの
+   書き換えは引き続き不可）。
 2. **What "blocking" means for a non-redistributable, manually-fetched
    dataset.** HILTI's CC BY-NC-SA / on-demand-download status doesn't fit the
    `report_only_until` flip mechanism cleanly (§6). Deciding whether

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -279,6 +279,15 @@ if(BUILD_TESTING)
     target_include_directories(test_plane_ba PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_synthetic_degeneracy_fixtures
+    test/test_synthetic_degeneracy_fixtures.cpp
+  )
+  if(TARGET test_synthetic_degeneracy_fixtures)
+    target_include_directories(
+      test_synthetic_degeneracy_fixtures PRIVATE include ${EIGEN3_INCLUDE_DIR}
+    )
+  endif()
+  ament_add_gtest(
     test_map_refiner
     test/test_map_refiner.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/synthetic_degeneracy_fixtures.hpp
+++ b/graph_based_slam/include/graph_based_slam/synthetic_degeneracy_fixtures.hpp
@@ -1,0 +1,364 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__SYNTHETIC_DEGENERACY_FIXTURES_HPP_
+#define GRAPH_BASED_SLAM__SYNTHETIC_DEGENERACY_FIXTURES_HPP_
+
+// Deterministic synthetic degenerate-scenario fixtures + point-to-plane
+// Gauss-Newton (H, b) assembly, built for docs/roadmap/v0.8.md Phase 0
+// ("freeze metrics"). These are the oracle fixtures Phase 1's planned
+// `localizability_analysis.hpp` (eigenvalue/condition-number classification
+// per Zhang, Kaess, Singh, "On Degeneracy of Optimization-based State
+// Estimation Problems", ICRA 2016; direction categories per Tuna et al.,
+// "X-ICP", arXiv:2306.08258 / IEEE T-RO 2024) will be unit-tested against.
+//
+// Clean-room: only the published point-to-plane ICP residual/Jacobian
+//   r_i = n_i^T (R p_i + t - q_i),   J_i = [ n_i^T , (R p_i x n_i)^T ]
+// (the standard SE(3) point-to-plane linearization about a perturbation
+// R ~= I + skew(theta), twist order [translation, rotation], exactly as
+// used by graph_based_slam/plane_ba.hpp's se3_lie.hpp convention) is used
+// here; no GPL reference implementation was read for this file, and no
+// upstream RKO-LIO source was consulted.
+//
+// Three scenarios (docs/roadmap/v0.8.md Phase 0 / §4.3 / §6):
+//
+//   - corridor: parallel side walls (+/- y normal) + floor/ceiling
+//     (+/- z normal), extruded along x with no x-normal texture anywhere.
+//     No correspondence's plane normal has an x component, and the moment
+//     arm (p x n) never produces an x-translation Jacobian entry either
+//     (see the derivation below) -- so H's row/column for pure
+//     x-translation (the along-corridor axis) is *exactly* zero, an exact
+//     algebraic degeneracy proof, not merely "small". This matches the v0.8
+//     motivating evidence (docs/roadmap/v0.8.md §0): exp07's corridor drift
+//     is along the corridor's long axis specifically, not a rotational
+//     (yaw) degeneracy.
+//   - box: the corridor cross-section plus two end walls (+/- x normal),
+//     i.e. a fully closed six-plane room. Every one of the six directions
+//     now has a directly- or moment-arm-constrained Jacobian column ->
+//     well-conditioned in all six directions.
+//   - single_plane: a floor only. Only tz, rx, ry receive any constraint;
+//     tx, ty, and rz (yaw about the plane normal) are exactly zero columns
+//     -> three simultaneously non-observable directions, the
+//     "do-not-move" multi-directional degenerate case (the same shape of
+//     hazard the v0.7 Phase 2 plane-BA gauge fixing was built to respect).
+//
+// Jacobian derivation used above (identity pose, R=I): for a wall/plane
+// with fixed unit normal n and surface point p = (px, py, pz),
+//   J_t     = n                      (translation block, always n itself)
+//   J_theta = p x n                  (rotation block, the moment arm)
+// A corridor wall at y=+w/2 with inward normal n=(0,-1,0) gives
+// J = [0,-1,0, pz,0,-px] (no px-independent trace of tx anywhere); the
+// floor/ceiling normals (0,0,+-1) give J = [0,0,+-1, +-py,-+px,0] -- neither
+// family ever has a nonzero *tx* entry, so summing J J^T over any number of
+// such correspondences leaves the tx row/column exactly zero. Adding end
+// walls with normal (+-1,0,0) contributes J = [+-1,0,0, 0,+-pz,-+py], which
+// is what promotes the corridor to the fully-observable box.
+//
+// Determinism: every fixture point lattice is a fixed nested loop (no
+// randomness in point placement, no floating-point-order-dependent
+// reductions); the optional along-normal "wall thickness" noise uses a
+// std::mt19937 seeded with a fixed, fixture-local constant, drawn in a
+// fixed per-sample order. Noise is applied strictly along each
+// correspondence's own plane normal, so it perturbs the ideal-vs-noisy
+// point offset (and therefore `b`) but leaves the moment arm p x n --
+// and therefore every eigenvalue of H -- unaffected. Eigen decompositions
+// (`computeEigenSignature`) sort eigenvalues ascending and canonicalize
+// each eigenvector's sign by its largest-magnitude component, the same
+// discipline as `scatter_eigen_cost.hpp`'s `canonicalNormal`, so repeated
+// runs are bitwise identical.
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Eigenvalues>  // NOLINT(build/include_order)
+
+namespace graphslam
+{
+namespace degeneracy
+{
+
+using Vector6d = Eigen::Matrix<double, 6, 1>;
+using Matrix6d = Eigen::Matrix<double, 6, 6>;
+
+/// One point-to-plane correspondence in the local (sensor) frame: a surface
+/// point `point` and its unit plane normal `normal`. `planar_offset` is the
+/// signed along-normal noise already baked into `point` (so the noise-free
+/// ideal surface point is `point - planar_offset * normal`); it only feeds
+/// the residual `b`, never the Jacobian.
+struct PlaneCorrespondence
+{
+  Eigen::Vector3d point {Eigen::Vector3d::Zero()};
+  Eigen::Vector3d normal {Eigen::Vector3d::Zero()};
+  double planar_offset {0.0};
+};
+
+struct DegeneracyFixture
+{
+  std::string name;
+  std::vector<PlaneCorrespondence> correspondences;
+};
+
+struct CorridorFixtureConfig
+{
+  double length {20.0};            // along x, sampled over [0, length]
+  double width {2.0};               // side walls at y = +/- width/2
+  double height {2.5};              // floor z=0, ceiling z=height
+  double grid_step {0.5};           // sample spacing along every axis
+  double wall_noise_sigma {0.0};    // along-normal thickness noise; 0 = exact
+  std::uint32_t seed {20260705u};
+};
+
+struct BoxFixtureConfig
+{
+  double length {20.0};
+  double width {2.0};
+  double height {2.5};
+  double grid_step {0.5};
+  double wall_noise_sigma {0.0};
+  std::uint32_t seed {20260705u};
+};
+
+struct SinglePlaneFixtureConfig
+{
+  double extent_x {20.0};           // floor spans x in [0, extent_x]
+  double extent_y {2.0};            // floor spans y in [-extent_y/2, extent_y/2]
+  double grid_step {0.5};
+  double wall_noise_sigma {0.0};
+  std::uint32_t seed {20260705u};
+};
+
+namespace detail
+{
+
+// Deterministic per-sample noise: a fixed-seed engine drawn strictly in
+// ascending sample-index order, so regenerating a fixture always reproduces
+// the identical noise sequence bitwise.
+inline std::vector<double> deterministicNoise(
+  std::size_t count, double sigma, std::uint32_t seed)
+{
+  std::vector<double> noise(count, 0.0);
+  if (sigma <= 0.0) {
+    return noise;
+  }
+  std::mt19937 rng(seed);
+  std::normal_distribution<double> dist(0.0, sigma);
+  for (std::size_t i = 0; i < count; ++i) {
+    noise[i] = dist(rng);
+  }
+  return noise;
+}
+
+inline void appendCorrespondences(
+  std::vector<PlaneCorrespondence> * out,
+  const std::vector<Eigen::Vector3d> & points,
+  const std::vector<Eigen::Vector3d> & normals,
+  double noise_sigma,
+  std::uint32_t seed)
+{
+  const std::vector<double> noise = deterministicNoise(points.size(), noise_sigma, seed);
+  out->reserve(out->size() + points.size());
+  for (std::size_t i = 0; i < points.size(); ++i) {
+    PlaneCorrespondence correspondence;
+    correspondence.point = points[i] + noise[i] * normals[i];
+    correspondence.normal = normals[i];
+    correspondence.planar_offset = noise[i];
+    out->push_back(correspondence);
+  }
+}
+
+}  // namespace detail
+
+/// Long straight corridor: parallel side walls + floor/ceiling, no texture
+/// along the corridor axis. Exact along-corridor (x) translation
+/// degeneracy (see file header derivation).
+inline DegeneracyFixture makeCorridorFixture(const CorridorFixtureConfig & config)
+{
+  DegeneracyFixture fixture;
+  fixture.name = "corridor";
+
+  std::vector<Eigen::Vector3d> points;
+  std::vector<Eigen::Vector3d> normals;
+
+  const double half_width = 0.5 * config.width;
+  for (double x = 0.0; x <= config.length + 1e-9; x += config.grid_step) {
+    // Side walls, normals pointing into the corridor interior.
+    for (double z = 0.0; z <= config.height + 1e-9; z += config.grid_step) {
+      points.emplace_back(x, half_width, z);
+      normals.emplace_back(0.0, -1.0, 0.0);
+      points.emplace_back(x, -half_width, z);
+      normals.emplace_back(0.0, 1.0, 0.0);
+    }
+    // Floor (z=0) / ceiling (z=height).
+    for (double y = -half_width; y <= half_width + 1e-9; y += config.grid_step) {
+      points.emplace_back(x, y, 0.0);
+      normals.emplace_back(0.0, 0.0, 1.0);
+      points.emplace_back(x, y, config.height);
+      normals.emplace_back(0.0, 0.0, -1.0);
+    }
+  }
+
+  detail::appendCorrespondences(
+    &fixture.correspondences, points, normals, config.wall_noise_sigma, config.seed);
+  return fixture;
+}
+
+/// Closed six-plane room: the corridor cross-section plus two end walls
+/// (x=0, x=length). Fully observable in all six directions.
+inline DegeneracyFixture makeBoxFixture(const BoxFixtureConfig & config)
+{
+  CorridorFixtureConfig corridor_config;
+  corridor_config.length = config.length;
+  corridor_config.width = config.width;
+  corridor_config.height = config.height;
+  corridor_config.grid_step = config.grid_step;
+  corridor_config.wall_noise_sigma = config.wall_noise_sigma;
+  corridor_config.seed = config.seed;
+  DegeneracyFixture fixture = makeCorridorFixture(corridor_config);
+  fixture.name = "box";
+
+  std::vector<Eigen::Vector3d> points;
+  std::vector<Eigen::Vector3d> normals;
+  const double half_width = 0.5 * config.width;
+  for (double y = -half_width; y <= half_width + 1e-9; y += config.grid_step) {
+    for (double z = 0.0; z <= config.height + 1e-9; z += config.grid_step) {
+      points.emplace_back(0.0, y, z);
+      normals.emplace_back(1.0, 0.0, 0.0);
+      points.emplace_back(config.length, y, z);
+      normals.emplace_back(-1.0, 0.0, 0.0);
+    }
+  }
+  // Distinct seed offset from the corridor draw so the end-wall noise
+  // sequence is independent of (but still fully determined by) the
+  // corridor's own noise sequence.
+  detail::appendCorrespondences(
+    &fixture.correspondences, points, normals, config.wall_noise_sigma, config.seed + 1u);
+  return fixture;
+}
+
+/// Single ground plane / open field: non-observable in translation-x,
+/// translation-y, and yaw (rotation about the plane normal) simultaneously.
+inline DegeneracyFixture makeSinglePlaneFixture(const SinglePlaneFixtureConfig & config)
+{
+  DegeneracyFixture fixture;
+  fixture.name = "single_plane";
+
+  std::vector<Eigen::Vector3d> points;
+  std::vector<Eigen::Vector3d> normals;
+  const double half_y = 0.5 * config.extent_y;
+  for (double x = 0.0; x <= config.extent_x + 1e-9; x += config.grid_step) {
+    for (double y = -half_y; y <= half_y + 1e-9; y += config.grid_step) {
+      points.emplace_back(x, y, 0.0);
+      normals.emplace_back(0.0, 0.0, 1.0);
+    }
+  }
+
+  detail::appendCorrespondences(
+    &fixture.correspondences, points, normals, config.wall_noise_sigma, config.seed);
+  return fixture;
+}
+
+/// Point-to-plane Gauss-Newton (H, b) accumulated over a fixture's
+/// correspondences, linearized at the given pose (identity by default).
+struct GaussNewtonSystem
+{
+  Matrix6d h {Matrix6d::Zero()};
+  Vector6d b {Vector6d::Zero()};
+  int residual_count {0};
+};
+
+inline GaussNewtonSystem buildGaussNewtonSystem(
+  const std::vector<PlaneCorrespondence> & correspondences,
+  const Eigen::Matrix3d & rotation = Eigen::Matrix3d::Identity(),
+  const Eigen::Vector3d & translation = Eigen::Vector3d::Zero())
+{
+  GaussNewtonSystem system;
+  for (const PlaneCorrespondence & correspondence : correspondences) {
+    const Eigen::Vector3d rotated_point = rotation * correspondence.point;
+    const Eigen::Vector3d ideal_point =
+      correspondence.point - correspondence.planar_offset * correspondence.normal;
+
+    Vector6d jacobian;
+    jacobian.head<3>() = correspondence.normal;
+    jacobian.tail<3>() = rotated_point.cross(correspondence.normal);
+
+    const double residual =
+      correspondence.normal.dot(rotated_point + translation - ideal_point);
+
+    system.h.noalias() += jacobian * jacobian.transpose();
+    system.b.noalias() += jacobian * residual;
+    ++system.residual_count;
+  }
+  return system;
+}
+
+/// Ascending eigenvalues + sign-canonicalized eigenvectors of a symmetric
+/// 6x6 Gauss-Newton Hessian: the Phase 1 detector oracle representation.
+struct EigenSignature
+{
+  Vector6d values {Vector6d::Zero()};
+  Matrix6d vectors {Matrix6d::Zero()};
+};
+
+inline EigenSignature computeEigenSignature(const Matrix6d & h)
+{
+  // Symmetrize defensively: callers accumulate H as sum(J J^T), which is
+  // exactly symmetric up to floating-point summation order, but
+  // SelfAdjointEigenSolver only reads the lower triangle by default -- make
+  // that explicit rather than relying on the caller's construction.
+  const Matrix6d symmetric = 0.5 * (h + h.transpose());
+  Eigen::SelfAdjointEigenSolver<Matrix6d> solver(symmetric);
+  EigenSignature signature;
+  signature.values = solver.eigenvalues();
+  signature.vectors = solver.eigenvectors();
+  for (int col = 0; col < 6; ++col) {
+    int largest_index = 0;
+    double largest_abs = std::abs(signature.vectors(0, col));
+    for (int row = 1; row < 6; ++row) {
+      const double component_abs = std::abs(signature.vectors(row, col));
+      if (component_abs > largest_abs) {
+        largest_abs = component_abs;
+        largest_index = row;
+      }
+    }
+    if (signature.vectors(largest_index, col) < 0.0) {
+      signature.vectors.col(col) = -signature.vectors.col(col);
+    }
+  }
+  return signature;
+}
+
+}  // namespace degeneracy
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__SYNTHETIC_DEGENERACY_FIXTURES_HPP_

--- a/graph_based_slam/test/test_synthetic_degeneracy_fixtures.cpp
+++ b/graph_based_slam/test/test_synthetic_degeneracy_fixtures.cpp
@@ -1,0 +1,215 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+#include "graph_based_slam/synthetic_degeneracy_fixtures.hpp"
+
+namespace
+{
+
+using graphslam::degeneracy::BoxFixtureConfig;
+using graphslam::degeneracy::buildGaussNewtonSystem;
+using graphslam::degeneracy::computeEigenSignature;
+using graphslam::degeneracy::CorridorFixtureConfig;
+using graphslam::degeneracy::DegeneracyFixture;
+using graphslam::degeneracy::EigenSignature;
+using graphslam::degeneracy::GaussNewtonSystem;
+using graphslam::degeneracy::makeBoxFixture;
+using graphslam::degeneracy::makeCorridorFixture;
+using graphslam::degeneracy::makeSinglePlaneFixture;
+using graphslam::degeneracy::SinglePlaneFixtureConfig;
+
+constexpr double kZeroTol = 1e-6;
+constexpr double kWellConditionedMargin = 1.0;
+
+TEST(SyntheticDegeneracyFixtures, CorridorGenerationIsDeterministic)
+{
+  const CorridorFixtureConfig config;
+  const DegeneracyFixture a = makeCorridorFixture(config);
+  const DegeneracyFixture b = makeCorridorFixture(config);
+
+  ASSERT_EQ(a.correspondences.size(), b.correspondences.size());
+  for (size_t i = 0; i < a.correspondences.size(); ++i) {
+    EXPECT_EQ(a.correspondences[i].point, b.correspondences[i].point) << i;
+    EXPECT_EQ(a.correspondences[i].normal, b.correspondences[i].normal) << i;
+    EXPECT_EQ(a.correspondences[i].planar_offset, b.correspondences[i].planar_offset) << i;
+  }
+
+  const GaussNewtonSystem system_a = buildGaussNewtonSystem(a.correspondences);
+  const GaussNewtonSystem system_b = buildGaussNewtonSystem(b.correspondences);
+  EXPECT_TRUE(system_a.h.isApprox(system_b.h, 0.0));
+  EXPECT_TRUE(system_a.b.isApprox(system_b.b, 0.0));
+}
+
+TEST(SyntheticDegeneracyFixtures, CorridorHasExactAlongAxisDegeneracy)
+{
+  const CorridorFixtureConfig config;
+  const DegeneracyFixture fixture = makeCorridorFixture(config);
+  ASSERT_EQ(fixture.correspondences.size(), 902u);
+
+  const GaussNewtonSystem system = buildGaussNewtonSystem(fixture.correspondences);
+
+  // No correspondence's Jacobian has a tx (along-corridor translation)
+  // entry, so H's tx column/row is exactly zero -- an algebraic, not
+  // merely numeric, degeneracy.
+  EXPECT_DOUBLE_EQ(system.h.col(0).norm(), 0.0);
+  for (int c = 1; c < 6; ++c) {
+    EXPECT_GT(system.h.col(c).norm(), 0.0) << "column " << c;
+  }
+
+  const EigenSignature signature = computeEigenSignature(system.h);
+  ASSERT_TRUE(std::is_sorted(signature.values.data(), signature.values.data() + 6));
+
+  // Exactly one near-zero eigenvalue (the along-corridor direction); the
+  // remaining five are well separated from zero.
+  EXPECT_NEAR(signature.values(0), 0.0, kZeroTol);
+  for (int i = 1; i < 6; ++i) {
+    EXPECT_GT(signature.values(i), kWellConditionedMargin) << "eigenvalue " << i;
+  }
+
+  // The degenerate eigenvalue is a simple root (not repeated) whose
+  // eigenvector is exactly the along-corridor translation axis, matching
+  // the roadmap's "one axis carries substantially more error" evidence
+  // (docs/roadmap/v0.8.md §0) -- not a rotational (yaw) degeneracy.
+  Eigen::Matrix<double, 6, 1> expected_axis = Eigen::Matrix<double, 6, 1>::Zero();
+  expected_axis(0) = 1.0;
+  EXPECT_NEAR(std::abs(signature.vectors.col(0).dot(expected_axis)), 1.0, 1e-9);
+}
+
+TEST(SyntheticDegeneracyFixtures, BoxIsFullyObservable)
+{
+  const BoxFixtureConfig config;
+  const DegeneracyFixture fixture = makeBoxFixture(config);
+  ASSERT_EQ(fixture.correspondences.size(), 962u);
+
+  const GaussNewtonSystem system = buildGaussNewtonSystem(fixture.correspondences);
+  for (int c = 0; c < 6; ++c) {
+    EXPECT_GT(system.h.col(c).norm(), 0.0) << "column " << c;
+  }
+
+  const EigenSignature signature = computeEigenSignature(system.h);
+  ASSERT_TRUE(std::is_sorted(signature.values.data(), signature.values.data() + 6));
+
+  // All six directions well-conditioned: even the smallest eigenvalue sits
+  // well above the corridor's near-zero floor.
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_GT(signature.values(i), kWellConditionedMargin) << "eigenvalue " << i;
+  }
+}
+
+TEST(SyntheticDegeneracyFixtures, SinglePlaneIsNonObservableInThreeDirections)
+{
+  const SinglePlaneFixtureConfig config;
+  const DegeneracyFixture fixture = makeSinglePlaneFixture(config);
+  ASSERT_EQ(fixture.correspondences.size(), 205u);
+
+  const GaussNewtonSystem system = buildGaussNewtonSystem(fixture.correspondences);
+
+  // tx, ty, and rz (yaw about the plane normal) never appear in any
+  // correspondence's Jacobian for a single horizontal plane.
+  EXPECT_DOUBLE_EQ(system.h.col(0).norm(), 0.0);  // tx
+  EXPECT_DOUBLE_EQ(system.h.col(1).norm(), 0.0);  // ty
+  EXPECT_DOUBLE_EQ(system.h.col(5).norm(), 0.0);  // rz (yaw)
+  EXPECT_GT(system.h.col(2).norm(), 0.0);         // tz
+  EXPECT_GT(system.h.col(3).norm(), 0.0);         // rx
+  EXPECT_GT(system.h.col(4).norm(), 0.0);         // ry
+
+  const EigenSignature signature = computeEigenSignature(system.h);
+  ASSERT_TRUE(std::is_sorted(signature.values.data(), signature.values.data() + 6));
+
+  // Three simultaneously non-observable directions, not a single one --
+  // this must not collapse to a "well-conditioned" false reading (the
+  // exact failure mode the Phase 1 detector must avoid, per
+  // docs/roadmap/v0.8.md §4.3).
+  EXPECT_NEAR(signature.values(0), 0.0, kZeroTol);
+  EXPECT_NEAR(signature.values(1), 0.0, kZeroTol);
+  EXPECT_NEAR(signature.values(2), 0.0, kZeroTol);
+  for (int i = 3; i < 6; ++i) {
+    EXPECT_GT(signature.values(i), kWellConditionedMargin) << "eigenvalue " << i;
+  }
+}
+
+TEST(SyntheticDegeneracyFixtures, AlongNormalNoiseChangesResidualNotHessian)
+{
+  CorridorFixtureConfig noiseless_config;
+  CorridorFixtureConfig noisy_config;
+  noisy_config.wall_noise_sigma = 0.01;
+
+  const DegeneracyFixture noiseless = makeCorridorFixture(noiseless_config);
+  const DegeneracyFixture noisy = makeCorridorFixture(noisy_config);
+
+  const GaussNewtonSystem noiseless_system = buildGaussNewtonSystem(noiseless.correspondences);
+  const GaussNewtonSystem noisy_system = buildGaussNewtonSystem(noisy.correspondences);
+
+  // Along-normal noise only ever adds a multiple of `normal` to `point`;
+  // p x n is unaffected because n x n = 0, so H (and its eigenvalue
+  // signature) must be bitwise unaffected while b picks up the residual.
+  EXPECT_TRUE(noiseless_system.h.isApprox(noisy_system.h, 0.0));
+  EXPECT_DOUBLE_EQ(noiseless_system.b.norm(), 0.0);
+  EXPECT_GT(noisy_system.b.norm(), 0.0);
+
+  const EigenSignature noiseless_signature = computeEigenSignature(noiseless_system.h);
+  const EigenSignature noisy_signature = computeEigenSignature(noisy_system.h);
+  EXPECT_TRUE(noiseless_signature.values.isApprox(noisy_signature.values, 0.0));
+}
+
+TEST(SyntheticDegeneracyFixtures, EigenSignatureCanonicalizationIsDeterministic)
+{
+  const CorridorFixtureConfig config;
+  const DegeneracyFixture fixture = makeCorridorFixture(config);
+  const GaussNewtonSystem system = buildGaussNewtonSystem(fixture.correspondences);
+
+  const EigenSignature first = computeEigenSignature(system.h);
+  const EigenSignature second = computeEigenSignature(system.h);
+
+  EXPECT_TRUE(first.values.isApprox(second.values, 0.0));
+  EXPECT_TRUE(first.vectors.isApprox(second.vectors, 0.0));
+
+  // Canonicalization convention: each eigenvector's largest-magnitude
+  // component is non-negative.
+  for (int col = 0; col < 6; ++col) {
+    int largest_index = 0;
+    double largest_abs = std::abs(first.vectors(0, col));
+    for (int row = 1; row < 6; ++row) {
+      const double component_abs = std::abs(first.vectors(row, col));
+      if (component_abs > largest_abs) {
+        largest_abs = component_abs;
+        largest_index = row;
+      }
+    }
+    EXPECT_GE(first.vectors(largest_index, col), 0.0) << "column " << col;
+  }
+}
+
+}  // namespace

--- a/scripts/download_hilti2022.sh
+++ b/scripts/download_hilti2022.sh
@@ -93,7 +93,7 @@ echo "    --bag ${ROS2_DIR} \\"
 echo "    --lidar-topic /hesai/pandar --imu-topic /alphasense/imu \\"
 echo "    --rko-param configs/hilti2022/rko_lio_hilti2022_pandar.yaml \\"
 echo "    --reference-tum ${GT_FILE} \\"
-echo "    --skip-reference-gen --reference-source hilti2022_${SEQUENCE}_control_points \\"
+echo "    --skip-reference-gen --reference-source hilti2022_${SEQUENCE}_control_points_gt \\"
 echo "    --quiescence-secs 60 --output-dir output/hilti2022_${SEQUENCE}_run"
 echo
 echo "Scoring (dense raw odometry vs sparse stationary control points):"

--- a/scripts/release_profiles.yaml
+++ b/scripts/release_profiles.yaml
@@ -21,6 +21,18 @@
 #     cross-val caveat (separate track).
 #   - ``report_only_until`` is the demotion/soak mechanism (FAIL -> WARN while
 #     set); new profiles introduced mid-cycle soak as report-only first.
+#   - As of v0.8 Phase 0 (docs/roadmap/v0.8.md §5), two HILTI 2022 rows
+#     (``hilti2022_exp01``, ``hilti2022_exp07``) are added as
+#     ``report_only_until: v0.8``. Unlike prior soak-then-graduate rows,
+#     these two are *frozen baselines*: ``pass`` is pinned to the exact
+#     measured raw-odometry RMSE (v0.7 Phase 4 evidence, reconfirmed in
+#     ``docs/research/hilti-degeneracy-baseline.md``), not a looser
+#     graduation target, so any drift shows as WARN without blocking. HILTI
+#     is CC BY-NC-SA / evaluation-only and fetched on demand
+#     (``scripts/download_hilti2022.sh``), so these rows only evaluate when
+#     a matching local run exists; "blocking" for this substrate is a
+#     manual pre-release checklist item, not a ``report_only_until`` flip
+#     (§6 of the roadmap).
 #
 # Fields:
 #   name: short identifier (snake_case)
@@ -142,6 +154,62 @@ release_profiles:
     pass: 2.20
     target: 1.70
     report_only_until: v0.6
+
+  # v0.8 Phase 0 (docs/roadmap/v0.8.md §5): HILTI 2022 raw-odometry baseline
+  # freeze, new wiring (no HILTI profile existed before this). exp01 is the
+  # feature-rich companion substrate (construction ground level, one-shot
+  # 904 m sweep, 13 control-point pairs, zero loop closures -- backend
+  # passthrough). pass is pinned to the exact frozen RMSE so this is a
+  # regression canary against the v0.8 baseline, not a graduation target;
+  # report_only_until: v0.8 keeps it WARN-only through the whole roadmap.
+  # Reproduce: docs/research/hilti-degeneracy-baseline.md.
+  - name: hilti2022_exp01
+    description: HILTI 2022 Hesai PandarXT-32 exp01 construction ground level vs mm total-station control points (feature-rich, dense raw odometry)
+    match:
+      points_topic: /hesai/pandar
+      reference_kind: ground_truth
+      reference_source_contains: hilti2022_exp01_control_points_gt
+      min_ape_pairs: 10
+    metric: ape_rmse_gt_m
+    pass: 0.066
+    report_only_until: v0.8
+
+  # Companion degenerate substrate: 124 m long-corridor one-shot sweep, only
+  # 6 control-point pairs, zero loop closures. RMSE ~5x exp01 on the same
+  # sensor/pipeline -- the exact evidence v0.8 degeneracy-aware registration
+  # exists to address (docs/roadmap/v0.8.md §0). Frozen, not a threshold to
+  # tune against; do not lower `pass` on this row to celebrate a detector
+  # change before Phase 3 holdout validation says so.
+  - name: hilti2022_exp07
+    description: HILTI 2022 Hesai PandarXT-32 exp07 long corridor vs mm total-station control points (degenerate, dense raw odometry)
+    match:
+      points_topic: /hesai/pandar
+      reference_kind: ground_truth
+      reference_source_contains: hilti2022_exp07_control_points_gt
+      min_ape_pairs: 4
+    metric: ape_rmse_gt_m
+    pass: 0.318
+    report_only_until: v0.8
+
+  # Third freeze substrate and designated Phase 3 holdout companion to exp01
+  # (docs/roadmap/v0.8.md §5, §6): 82 m construction-upper-level one-shot
+  # sweep, 7 control-point pairs, zero loop edges (the 82 m path never
+  # clears the 100 m distance_loop_closure gate, so the physical revisit in
+  # the GT is never eligible -- backend passthrough, corrected == raw to
+  # 0.0000 m). Frozen at the dense raw-odometry RMSE measured 2026-07-05
+  # (0.0715, rounded up to 3 dp so the frozen run itself evaluates PASS);
+  # docs/research/hilti-degeneracy-baseline.md §3. Holdout hygiene: do not
+  # tune against this row once Phase 2 threshold-tuning starts.
+  - name: hilti2022_exp04
+    description: HILTI 2022 Hesai PandarXT-32 exp04 construction upper level vs mm total-station control points (feature-rich, dense raw odometry)
+    match:
+      points_topic: /hesai/pandar
+      reference_kind: ground_truth
+      reference_source_contains: hilti2022_exp04_control_points_gt
+      min_ape_pairs: 5
+    metric: ape_rmse_gt_m
+    pass: 0.072
+    report_only_until: v0.8
 
   - name: leo_drive_applanix_velodyne_cross
     description: Leo Drive applanix/velodyne open data vs Applanix GSOF49 cross-validation


### PR DESCRIPTION
## Summary
Phase 0 of [docs/roadmap/v0.8.md](../blob/develop/docs/roadmap/v0.8.md) (degeneracy-aware registration): freeze every number this roadmap will be judged against, before any detector or intervention code exists. Same "the optimizer must not move its own judge" discipline as v0.7 Phase 1.

## Frozen baselines (raw odometry, SE(3)-aligned checkpoint RMSE vs mm control points)

| sequence | env | RMSE (m) | per-axis (x/y/z) | pass (report-only until v0.8) |
|---|---|---|---|---|
| exp01 | construction ground | 0.066 | — | 0.066 |
| **exp04** (new, measured 2026-07-05) | construction upper | **0.0715** | 0.040 / 0.039 / 0.045 (isotropic) | 0.072 |
| exp07 | long corridor (degenerate) | 0.318 | 0.145 / 0.235 / 0.157 (y-heavy) | 0.318 |

exp04 is the second non-corridor control case: feature-rich → ~7 cm and isotropic, vs exp07's 5× anisotropic corridor drift — exactly the contrast the v0.8 detector must reproduce. exp04 run details: 82 m sweep / 125.8 s bag / zero loops (82 m is under the 100 m `distance_loop_closure` gate) / corrected == raw at all 42 submap poses / Autoware map verify 8/8 PASS. Gate row verified PASS against the real run via `benchmark_summary.py --release-profile`.

## Synthetic detector oracle
`synthetic_degeneracy_fixtures.hpp` (+ 6 gtests): deterministic corridor / box / single-plane generators with point-to-plane Gauss-Newton `(H, b)` assembly and sign-canonicalized eigen signatures. Corridor's along-axis eigenvalue and single-plane's tx/ty/yaw are **algebraically exact zeros** (bit-exact zero H columns), box is well-conditioned in all six directions, and along-normal noise leaves `H` bitwise unchanged. Clean-room: published point-to-plane linearization only.

## Also in this PR
- `download_hilti2022.sh`: fix the suggested `--reference-source` label to end in `_gt` — without it `_infer_reference_kind` never classifies HILTI runs as ground_truth and the new profile rows could never match.
- `docs/roadmap/v0.8.md` §9-1: record maintainer approval (2026-07-05) for the guarded, default-off Phase 2 Track A RKO-LIO patch.
- `docs/research/hilti-degeneracy-baseline.md`: frozen tables + full repro commands (build flags incl. `-DRKO_LIO_FETCH_CONTENT_DEPS=ON`, dataset location, scoring invocations).

## Tests
- `colcon test --packages-select graph_based_slam`: **1378 tests, 0 errors, 0 failures** (includes the 6 new fixture tests)
- `test_benchmark_summary_profiles.py`: 12 passed, 2 failed — both failures pre-existing on develop (stale expectations from the v0.5 `mid360_vs_glim` demotion), unchanged by this PR.

## Harness bugs found while running exp04 (deliberately NOT fixed here; follow-up PR)
1. `run_rko_lio_graph_benchmark.sh:531` — `--skip-reference-gen` is defeated by a tri-OR: a merely-absent default `REFERENCE_META` regenerates the NTU-only reference and dies on non-NTU datasets.
2. `run_rko_lio_graph_benchmark.sh:679` — corrected-trajectory APE uses the tight 0.05 s NN default; on sparse submap trajectories every GT point is rejected and `set -e` kills the script before metrics.json. This is the `--sparse-match` wiring gap flagged in #322.

Phase 0 gate: **met** (3/3 real substrates frozen, synthetic oracle frozen, 3 report-only gate rows wired and verified, baseline doc written). exp04 is untouchable as a Phase 3 holdout from here on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTNqieB785XZRXu5xPXZoL