### PR TITLE
feat(v0.8): Phase 1 detector — localizability analysis + rko_lio diagnostic H/b exposure

### DIFF
--- a/docs/research/rko-lio-diagnostic-patch-characterization.md
+++ b/docs/research/rko-lio-diagnostic-patch-characterization.md
@@ -1,0 +1,77 @@
+# RKO-LIO diagnostic patch — characterization record (v0.8 Phase 1)
+
+Status: **frozen record, 2026-07-06.** Companion to
+[`docs/roadmap/v0.8.md`](../roadmap/v0.8.md) §5 Phase 1 and
+[`hilti-degeneracy-baseline.md`](hilti-degeneracy-baseline.md).
+
+## What the patch is
+
+`Thirdparty/rko_lio` fork commit `d6c767d`
+(rsasaki0109/rko_lio PR #1, `feat/diagnostic-icp-hessian-exposure`,
++207/−9 across 3 files):
+
+- `core/lio.cpp` — `icp()` returns `IcpResult{pose, H, b}`: the final
+  iteration's 6×6 Gauss-Newton normal-equations matrix and residual
+  vector, previously discarded. The solve path is untouched.
+- `core/util.hpp` — `LocalizabilitySummary` (ascending eigenvalues +
+  sign-canonicalized eigenvectors) and `IcpDiagnostics`;
+  `State::icp_diagnostics` is `std::optional`, cleared on every
+  no-solve path (first frame, dropped scan, kidnap recovery, local
+  reset).
+- `ros/node.cpp` — `publish_odometry()` fills `pose.covariance`
+  anisotropically from `Cov = V·diag(1/λ)·Vᵀ` (H is the
+  correspondence-averaged Gauss-Newton information matrix at the
+  optimum, per Zhang & Singh ICRA 2016). Eigenvalues are floored at
+  `max(1e-9, 1e-6·λ_max)` so exactly-degenerate directions publish
+  large-but-finite uncertainty; scans without diagnostics fall back to
+  a 1e6 diagonal. `pose.pose` / `twist.twist` assignments unchanged.
+
+## Byte-identity gate result: green
+
+| substrate | comparison | result |
+|---|---|---|
+| HILTI exp04 | full registered pose TUM (`dump_results`), 1258 poses | `cmp` exit 0 — byte-identical before/after patch |
+| HILTI exp07 | full registered pose TUM, 1322 poses | `cmp` exit 0 — byte-identical before/after patch |
+
+Covariance verified anisotropic on the wire (`/rko_lio/odometry` echo
+during exp04 replay: e.g. tz variance 1.885 vs tx 1.103, rotation
+block ~1e-3 rad², symmetric with off-diagonal terms).
+
+Config: `configs/hilti2022/rko_lio_hilti2022_pandar.yaml`, bags under
+`/media/sasaki/aiueo/datasets/hilti2022/`, artifacts under
+`/media/sasaki/aiueo/lidarslam_work/output/v0.8_phase1_characterization/`.
+
+## Methodology note: byte-identity must be judged single-core
+
+Under the default TBB threading, **two runs of the same binary** differ
+in `traj_raw.tum` from the first scans (last-digit float differences,
+~1e-19 order): `build_icp_linear_system`'s `tbb::parallel_reduce`
+reduction order is nondeterministic. This is the known upstream
+property that made v0.6 scope RKO-LIO raw odometry **out** of the
+byte-identical-map release gate (the gate holds for the backend and
+scanmatcher offline runners, which are deterministic).
+
+Therefore the before/after characterization is judged with
+`taskset -c 0` (single-core), which makes the reduction order — and
+the full pose stream — exactly reproducible. This adds **no new
+determinism obligation**: the v0.6 gate scope is unchanged; single-core
+execution is a measurement instrument for patch-neutrality, not a
+supported production mode.
+
+Secondary observation: live-subscriber TUM logs (`odom_to_tum.py`,
+queue 10) can drop messages under load, so line counts differ run to
+run even when the underlying pose stream is identical. Byte comparison
+must therefore use the LIO's own `dump_results` TUM (complete pose
+list), not the subscriber capture.
+
+## Known limitations
+
+- The fork's unit-test surface is Python/pybind only;
+  `State::icp_diagnostics` is deliberately not exposed to pybind (would
+  grow the upstream diff for no Phase 1 benefit). Eigen-analysis
+  correctness is unit-tested in the main repo against the Phase 0
+  synthetic fixtures (`localizability_analysis.hpp`, which consumes the
+  same H).
+- Characterization covers exp04/exp07 (the two locally-available HILTI
+  substrates). Extension to NTU / Newer College / MID-360 substrates
+  rides along with the Phase 1 release-readiness wiring.

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -288,6 +288,15 @@ if(BUILD_TESTING)
     )
   endif()
   ament_add_gtest(
+    test_localizability_analysis
+    test/test_localizability_analysis.cpp
+  )
+  if(TARGET test_localizability_analysis)
+    target_include_directories(
+      test_localizability_analysis PRIVATE include ${EIGEN3_INCLUDE_DIR}
+    )
+  endif()
+  ament_add_gtest(
     test_map_refiner
     test/test_map_refiner.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/localizability_analysis.hpp
+++ b/graph_based_slam/include/graph_based_slam/localizability_analysis.hpp
@@ -1,0 +1,354 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__LOCALIZABILITY_ANALYSIS_HPP_
+#define GRAPH_BASED_SLAM__LOCALIZABILITY_ANALYSIS_HPP_
+
+// Pure, ROS-free localizability/degeneracy detector for v0.8 Phase 1
+// (docs/roadmap/v0.8.md §3 "Target architecture", §5 "Phase 1 -- detection,
+// report-only"). Consumes any 6x6 Gauss-Newton normal-equations pair
+// `(H[, b])` -- from RKO-LIO's `build_icp_linear_system()`, scanmatcher's
+// NDT/GICP, or the Phase 0 synthetic fixtures
+// (`synthetic_degeneracy_fixtures.hpp`) -- and classifies each of the six
+// SE(3) pose-update directions (twist order `[translation, rotation]`, same
+// convention as `se3_lie.hpp` / `plane_ba.hpp` / the synthetic fixtures).
+// Report-only: this header never mutates `H`/`b` and never changes a pose;
+// Phase 2 (solution remapping / direction-wise blending) is a separate,
+// opt-in, default-off change layered on top of this detector's output.
+//
+// Clean-room: derived only from the published mathematics of
+//   - Zhang, Kaess, Singh, "On Degeneracy of Optimization-based State
+//     Estimation Problems", ICRA 2016: eigen-decompose the symmetric
+//     Gauss-Newton Hessian `H`; small eigenvalues along an eigenvector
+//     indicate the optimization is under-constrained along that direction
+//     of the pose update.
+//   - Tuna, Nubert, Pfreundschuh, Cadena, Khattak, Hutter, "X-ICP:
+//     Localizability-Aware LiDAR Registration for Robust Localization in
+//     Extreme Environments", arXiv:2306.08258 / IEEE T-RO 2024: classify
+//     each direction into well-conditioned / degenerate / non-observable
+//     from a *normalized* per-direction contribution test, rather than a
+//     single scale-dependent eigenvalue threshold (X-ICP's own test is
+//     computed per point correspondence; see the adaptation note below for
+//     why this file computes an aggregate analogue instead).
+// No GPL reference implementation of either paper was read for this file;
+// no upstream RKO-LIO source was consulted.
+//
+// -- Adaptation note: an aggregate, H-only normalized contribution test --
+// X-ICP's normalized test operates per point correspondence: each
+// correspondence's Jacobian row is projected onto an eigenvector and
+// normalized by that correspondence's own Jacobian norm, which cancels the
+// unit mismatch between the translation block (unit surface normals, O(1))
+// and the rotation block (moment arms `p x n`, scaling with the sensor's
+// distance to the surface -- tens of meters in a long corridor) *before*
+// the correspondences are summed into `H`. This file's API is intentionally
+// `(H, b)`-only (docs/roadmap/v0.8.md §3: "consumes any (H, b) Gauss-Newton
+// pair"), so it cannot see individual correspondences and instead computes
+// the aggregate analogue: `contribution_i = lambda_i / trace(H)`, the
+// fraction of the Hessian's total trace ("information") carried by
+// eigenvector `i`. This is exactly X-ICP's normalization goal (a
+// scale-portable ratio rather than a raw eigenvalue in `H`'s native units)
+// applied at the whole-Hessian level instead of the per-point level, at the
+// cost of not fully separating out the translation/rotation unit mismatch
+// the way the per-point version does -- e.g. a corridor's rotation-block
+// eigenvalues are inflated by the corridor length itself (see
+// `synthetic_degeneracy_fixtures.hpp`'s derivation), so `contribution_i` for
+// a perfectly well-observed translational direction can still be a small
+// *fraction* of the trace when a much longer lever arm dominates elsewhere
+// in the spectrum. Empirically (this file's own test fixtures) the
+// well-observed/unobserved gap remains many orders of magnitude regardless
+// of this effect, but the exact threshold is data-dependent by
+// construction, hence not fixed to a paper value below (see
+// `LocalizabilityThresholds`).
+//
+// -- Degenerate vs. non-observable: why they are not just two threshold
+//    tiers of the same test --
+// Both categories can present as an eigenvalue at (or numerically
+// indistinguishable from) exact zero -- a single ill-constrained direction
+// and a multi-dimensional unobservable subspace both zero out the relevant
+// eigenvalue(s). What differs is *multiplicity*: for a symmetric matrix,
+// eigenvectors belonging to a repeated (or near-repeated) eigenvalue are
+// only defined up to an arbitrary orthonormal rotation within that
+// eigenspace -- a basic linear-algebra fact, not a modeling choice. A
+// simple (non-repeated) near-zero eigenvalue names one specific, physically
+// meaningful ill-constrained direction (Zhang & Singh's "degenerate"); a
+// cluster of two or more mutually near-equal weak eigenvalues names a
+// *subspace* in which no individual reported eigenvector is uniquely
+// meaningful -- the stronger "non-observable" category. This file clusters
+// adjacent (post-sort) weak directions whose normalized contributions are
+// within `multiplicity_relative_gap` of each other and escalates any
+// cluster of size >= 2 from degenerate to non-observable. This is the
+// mechanism that gives the single-plane fixture's tx/ty/yaw trio
+// "non-observable" (a genuine rank-3 null space) while the corridor
+// fixture's lone along-axis direction stays "degenerate" (an isolated
+// simple root), matching docs/roadmap/v0.8.md §4.3's expected fixture
+// outcomes.
+//
+// Determinism: eigenvalues are returned ascending, eigenvectors sign-
+// canonicalized by largest-magnitude component (identical convention to
+// `synthetic_degeneracy_fixtures.hpp::computeEigenSignature` and
+// `scatter_eigen_cost.hpp::canonicalNormal`), and every reduction below is a
+// fixed-order loop over exactly six directions -- same input `H`/`b` always
+// produces a bitwise-identical `LocalizabilityReport`.
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Eigenvalues>  // NOLINT(build/include_order)
+
+namespace graphslam
+{
+namespace degeneracy
+{
+
+using Vector6d = Eigen::Matrix<double, 6, 1>;
+using Matrix6d = Eigen::Matrix<double, 6, 6>;
+
+/// Per-direction localizability category (X-ICP, arXiv:2306.08258).
+enum class LocalizabilityCategory
+{
+  WELL_CONDITIONED,
+  DEGENERATE,
+  NON_OBSERVABLE,
+};
+
+/// Classification thresholds. Every value here is a dimensionless ratio
+/// (invariant to `H -> c*H` for any `c > 0`, the "H scale invariance"
+/// property this file's tests check), so none of them are raw eigenvalue
+/// floors in `H`'s native physical units.
+///
+/// PROVISIONAL PHASE 1 DEFAULTS. Per docs/roadmap/v0.8.md §5 Phase 1 /
+/// §9 item 3, these are *not* borrowed from Zhang & Singh or X-ICP (their
+/// published values were tuned to their own sensors/feature scales and do
+/// not port directly) and are *not* the final answer -- they are only
+/// calibrated well enough to pass on the Phase 0 synthetic fixtures
+/// (corridor / box / single-plane). The Phase 1 gate requires recalibrating
+/// both ratios from real Phase 0 HILTI exp01/exp04/exp07 `(H, b)`
+/// telemetry before they are used to judge real substrates.
+struct LocalizabilityThresholds
+{
+  /// A direction is WELL_CONDITIONED when its normalized contribution
+  /// (`lambda_i / trace(H)`) is at least this fraction of the Hessian's
+  /// total information. Directions below this are "weak" candidates for
+  /// DEGENERATE or NON_OBSERVABLE (see the multiplicity rule above).
+  double well_conditioned_ratio {1.0e-4};
+
+  /// Two adjacent (post-sort) weak directions are considered part of the
+  /// same near-repeated eigenspace -- and therefore escalated together to
+  /// NON_OBSERVABLE -- when their normalized contributions differ by no
+  /// more than this amount. Deliberately far smaller than
+  /// `well_conditioned_ratio`: this only merges directions that are
+  /// mutually indistinguishable from each other (e.g. simultaneously
+  /// algebraically zero), not merely "both weak".
+  double multiplicity_relative_gap {1.0e-6};
+};
+
+/// Result for a single one of the six SE(3) update directions, in ascending
+/// eigenvalue order (index 0 = smallest / most ill-constrained).
+struct DirectionResult
+{
+  /// Raw eigenvalue of (the symmetrized) `H`, in `H`'s native units.
+  double eigenvalue {0.0};
+
+  /// Sign-canonicalized eigenvector (largest-magnitude component >= 0).
+  /// Twist order `[translation, rotation]`.
+  Vector6d eigenvector {Vector6d::Zero()};
+
+  /// `eigenvalue / trace(H)`; 0 when `trace(H) <= 0`. The aggregate,
+  /// H-only analogue of X-ICP's per-point normalized contribution (see
+  /// file header).
+  double normalized_contribution {0.0};
+
+  LocalizabilityCategory category {LocalizabilityCategory::WELL_CONDITIONED};
+};
+
+/// Full localizability report for a 6x6 Gauss-Newton system: per-direction
+/// categories plus the scalar summary fields the map-bundle degeneracy
+/// report / offline diagnostics CSV consume (docs/roadmap/v0.8.md §5
+/// Phase 1).
+struct LocalizabilityReport
+{
+  /// Ascending eigenvalue order (index 0 = smallest).
+  std::array<DirectionResult, 6> directions {};
+
+  double min_eigenvalue {0.0};
+  double max_eigenvalue {0.0};
+
+  /// `max_eigenvalue / min_eigenvalue`; `+inf` when `min_eigenvalue` is at
+  /// (or numerically indistinguishable from) zero, i.e. `H` is singular.
+  double condition_number {0.0};
+
+  int well_conditioned_count {0};
+  int degenerate_count {0};
+  int non_observable_count {0};
+
+  /// Diagnostic-only naive Gauss-Newton update `H.ldlt().solve(-b)`.
+  /// Deliberately *not* used by classification above, and only populated
+  /// (raw_update_valid = true) when every direction is WELL_CONDITIONED --
+  /// with any degenerate/non-observable direction present, `H` is singular
+  /// or near-singular along that direction and the naive solve is not
+  /// trustworthy without Phase 2's solution remapping / direction-wise
+  /// blending (docs/roadmap/v0.8.md §2 item 3, §5 Phase 2), which this
+  /// report-only Phase 1 detector does not perform.
+  Vector6d raw_update {Vector6d::Zero()};
+  bool raw_update_valid {false};
+};
+
+namespace detail
+{
+
+// Sign-canonicalize each eigenvector so its largest-magnitude component is
+// non-negative -- identical convention to
+// synthetic_degeneracy_fixtures.hpp::computeEigenSignature and
+// scatter_eigen_cost.hpp::canonicalNormal, required for the "same H twice ->
+// bitwise identical report" determinism contract (SelfAdjointEigenSolver
+// does not itself guarantee a canonical sign for a given eigenvalue).
+inline void canonicalizeEigenvectorSigns(Matrix6d * vectors)
+{
+  for (int col = 0; col < 6; ++col) {
+    int largest_index = 0;
+    double largest_abs = std::abs((*vectors)(0, col));
+    for (int row = 1; row < 6; ++row) {
+      const double component_abs = std::abs((*vectors)(row, col));
+      if (component_abs > largest_abs) {
+        largest_abs = component_abs;
+        largest_index = row;
+      }
+    }
+    if ((*vectors)(largest_index, col) < 0.0) {
+      vectors->col(col) = -vectors->col(col);
+    }
+  }
+}
+
+}  // namespace detail
+
+/// Classify a 6x6 Gauss-Newton system's six SE(3) update directions.
+///
+/// `h` need not be pre-symmetrized (it is symmetrized defensively, matching
+/// `synthetic_degeneracy_fixtures.hpp::computeEigenSignature`); `b` is
+/// optional and only feeds the diagnostic `raw_update` field, never the
+/// classification itself (Zhang & Singh's detector, and X-ICP's category
+/// test, are both purely a function of `H`'s eigenstructure).
+inline LocalizabilityReport analyzeLocalizability(
+  const Matrix6d & h,
+  const Vector6d & b = Vector6d::Zero(),
+  const LocalizabilityThresholds & thresholds = LocalizabilityThresholds())
+{
+  LocalizabilityReport report;
+
+  const Matrix6d symmetric = 0.5 * (h + h.transpose());
+  Eigen::SelfAdjointEigenSolver<Matrix6d> solver(symmetric);
+  Vector6d eigenvalues = solver.eigenvalues();
+  Matrix6d eigenvectors = solver.eigenvectors();
+  detail::canonicalizeEigenvectorSigns(&eigenvectors);
+
+  report.min_eigenvalue = eigenvalues(0);
+  report.max_eigenvalue = eigenvalues(5);
+
+  // Condition number: +inf when H is singular (or effectively so) rather
+  // than a raw division producing NaN/-inf from floating-point noise around
+  // zero.
+  constexpr double kSingularFloor = 1.0e-12;
+  if (report.min_eigenvalue <= kSingularFloor || report.max_eigenvalue <= 0.0) {
+    report.condition_number = std::numeric_limits<double>::infinity();
+  } else {
+    report.condition_number = report.max_eigenvalue / report.min_eigenvalue;
+  }
+
+  const double trace = eigenvalues.sum();
+  const bool have_information = trace > kSingularFloor && report.max_eigenvalue > kSingularFloor;
+
+  std::array<double, 6> contribution {};
+  std::array<bool, 6> is_weak {};
+  for (int i = 0; i < 6; ++i) {
+    contribution[i] = have_information ? (eigenvalues(i) / trace) : 0.0;
+    is_weak[i] = !have_information || (contribution[i] < thresholds.well_conditioned_ratio);
+  }
+
+  // Cluster adjacent (ascending-sorted) weak directions whose normalized
+  // contributions are mutually indistinguishable -- see the file header's
+  // "degenerate vs. non-observable" note. A well-conditioned direction
+  // never merges into a weak cluster (the merge test below requires both
+  // sides weak), so cluster membership among weak indices is exactly the
+  // repeated/near-repeated eigenspace the merge rule targets.
+  std::array<int, 6> cluster_id {};
+  cluster_id[0] = 0;
+  for (int i = 1; i < 6; ++i) {
+    const bool merge = is_weak[i] && is_weak[i - 1] &&
+      (contribution[i] - contribution[i - 1]) <= thresholds.multiplicity_relative_gap;
+    cluster_id[i] = merge ? cluster_id[i - 1] : cluster_id[i - 1] + 1;
+  }
+  std::array<int, 6> cluster_size {};
+  for (int i = 0; i < 6; ++i) {
+    ++cluster_size[cluster_id[i]];
+  }
+
+  for (int i = 0; i < 6; ++i) {
+    DirectionResult & direction = report.directions[i];
+    direction.eigenvalue = eigenvalues(i);
+    direction.eigenvector = eigenvectors.col(i);
+    direction.normalized_contribution = contribution[i];
+
+    if (!is_weak[i]) {
+      direction.category = LocalizabilityCategory::WELL_CONDITIONED;
+      ++report.well_conditioned_count;
+    } else if (cluster_size[cluster_id[i]] >= 2) {
+      direction.category = LocalizabilityCategory::NON_OBSERVABLE;
+      ++report.non_observable_count;
+    } else {
+      direction.category = LocalizabilityCategory::DEGENERATE;
+      ++report.degenerate_count;
+    }
+  }
+
+  // Diagnostic-only naive solve; only trusted when nothing is degenerate.
+  report.raw_update_valid = (report.degenerate_count == 0 && report.non_observable_count == 0);
+  if (report.raw_update_valid) {
+    Eigen::LDLT<Matrix6d> ldlt(symmetric);
+    if (ldlt.info() == Eigen::Success) {
+      report.raw_update = ldlt.solve(-b);
+      if (!report.raw_update.allFinite()) {
+        report.raw_update_valid = false;
+        report.raw_update.setZero();
+      }
+    } else {
+      report.raw_update_valid = false;
+    }
+  }
+
+  return report;
+}
+
+}  // namespace degeneracy
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__LOCALIZABILITY_ANALYSIS_HPP_

--- a/graph_based_slam/test/test_localizability_analysis.cpp
+++ b/graph_based_slam/test/test_localizability_analysis.cpp
@@ -1,0 +1,349 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+#include "graph_based_slam/localizability_analysis.hpp"
+#include "graph_based_slam/synthetic_degeneracy_fixtures.hpp"
+
+namespace
+{
+
+using graphslam::degeneracy::analyzeLocalizability;
+using graphslam::degeneracy::BoxFixtureConfig;
+using graphslam::degeneracy::buildGaussNewtonSystem;
+using graphslam::degeneracy::CorridorFixtureConfig;
+using graphslam::degeneracy::DegeneracyFixture;
+using graphslam::degeneracy::GaussNewtonSystem;
+using graphslam::degeneracy::LocalizabilityCategory;
+using graphslam::degeneracy::LocalizabilityReport;
+using graphslam::degeneracy::LocalizabilityThresholds;
+using graphslam::degeneracy::makeBoxFixture;
+using graphslam::degeneracy::makeCorridorFixture;
+using graphslam::degeneracy::makeSinglePlaneFixture;
+using graphslam::degeneracy::Matrix6d;
+using graphslam::degeneracy::SinglePlaneFixtureConfig;
+using graphslam::degeneracy::Vector6d;
+
+// -----------------------------------------------------------------------
+// Phase 0 synthetic fixtures as the Phase 1 detector oracle
+// (docs/roadmap/v0.8.md §4.3, §5 Phase 1 gate).
+// -----------------------------------------------------------------------
+
+TEST(LocalizabilityAnalysis, CorridorHasExactlyOneDegenerateAlongAxisDirection)
+{
+  const DegeneracyFixture fixture = makeCorridorFixture(CorridorFixtureConfig());
+  const GaussNewtonSystem system = buildGaussNewtonSystem(fixture.correspondences);
+  const LocalizabilityReport report = analyzeLocalizability(system.h, system.b);
+
+  EXPECT_EQ(report.degenerate_count, 1);
+  EXPECT_EQ(report.non_observable_count, 0);
+  EXPECT_EQ(report.well_conditioned_count, 5);
+
+  // Direction 0 (smallest eigenvalue, ascending order) is the along-corridor
+  // (tx) direction and must be DEGENERATE, not NON_OBSERVABLE: it is an
+  // isolated simple root (see file header), and must not be mistaken for a
+  // multi-directional unobservable subspace.
+  EXPECT_EQ(report.directions[0].category, LocalizabilityCategory::DEGENERATE);
+  EXPECT_NEAR(report.directions[0].eigenvalue, 0.0, 1e-6);
+
+  Vector6d expected_axis = Vector6d::Zero();
+  expected_axis(0) = 1.0;
+  EXPECT_NEAR(std::abs(report.directions[0].eigenvector.dot(expected_axis)), 1.0, 1e-9);
+
+  for (int i = 1; i < 6; ++i) {
+    EXPECT_EQ(report.directions[i].category, LocalizabilityCategory::WELL_CONDITIONED) << i;
+  }
+
+  EXPECT_TRUE(std::isinf(report.condition_number));
+  EXPECT_FALSE(report.raw_update_valid);
+  EXPECT_TRUE(report.raw_update.isZero());
+}
+
+TEST(LocalizabilityAnalysis, BoxIsWellConditionedInAllSixDirections)
+{
+  const DegeneracyFixture fixture = makeBoxFixture(BoxFixtureConfig());
+  const GaussNewtonSystem system = buildGaussNewtonSystem(fixture.correspondences);
+  const LocalizabilityReport report = analyzeLocalizability(system.h, system.b);
+
+  EXPECT_EQ(report.well_conditioned_count, 6);
+  EXPECT_EQ(report.degenerate_count, 0);
+  EXPECT_EQ(report.non_observable_count, 0);
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_EQ(report.directions[i].category, LocalizabilityCategory::WELL_CONDITIONED) << i;
+  }
+
+  EXPECT_FALSE(std::isinf(report.condition_number));
+  EXPECT_GT(report.condition_number, 1.0);
+
+  // All six directions well-conditioned -> the naive Gauss-Newton solve is
+  // trusted (diagnostic-only; not used by classification itself).
+  EXPECT_TRUE(report.raw_update_valid);
+}
+
+TEST(LocalizabilityAnalysis, SinglePlaneIsNonObservableInThreeDirectionsNotFalselyWellConditioned)
+{
+  const DegeneracyFixture fixture = makeSinglePlaneFixture(SinglePlaneFixtureConfig());
+  const GaussNewtonSystem system = buildGaussNewtonSystem(fixture.correspondences);
+  const LocalizabilityReport report = analyzeLocalizability(system.h, system.b);
+
+  // The hazard this fixture exists to catch (docs/roadmap/v0.8.md §4.3):
+  // three simultaneously unobservable directions must not collapse into a
+  // false WELL_CONDITIONED reading, and must be reported as NON_OBSERVABLE
+  // (a genuine rank-3 null space), not merely DEGENERATE.
+  EXPECT_EQ(report.non_observable_count, 3);
+  EXPECT_EQ(report.degenerate_count, 0);
+  EXPECT_EQ(report.well_conditioned_count, 3);
+
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(report.directions[i].category, LocalizabilityCategory::NON_OBSERVABLE) << i;
+    EXPECT_NEAR(report.directions[i].eigenvalue, 0.0, 1e-6);
+  }
+  for (int i = 3; i < 6; ++i) {
+    EXPECT_EQ(report.directions[i].category, LocalizabilityCategory::WELL_CONDITIONED) << i;
+  }
+
+  EXPECT_TRUE(std::isinf(report.condition_number));
+  EXPECT_FALSE(report.raw_update_valid);
+}
+
+// -----------------------------------------------------------------------
+// Determinism: same (H, b) twice -> bitwise identical report.
+// -----------------------------------------------------------------------
+
+TEST(LocalizabilityAnalysis, SameInputTwiceProducesBitwiseIdenticalReport)
+{
+  const DegeneracyFixture fixture = makeCorridorFixture(CorridorFixtureConfig());
+  const GaussNewtonSystem system = buildGaussNewtonSystem(fixture.correspondences);
+
+  const LocalizabilityReport first = analyzeLocalizability(system.h, system.b);
+  const LocalizabilityReport second = analyzeLocalizability(system.h, system.b);
+
+  EXPECT_DOUBLE_EQ(first.min_eigenvalue, second.min_eigenvalue);
+  EXPECT_DOUBLE_EQ(first.max_eigenvalue, second.max_eigenvalue);
+  EXPECT_DOUBLE_EQ(first.condition_number, second.condition_number);
+  EXPECT_EQ(first.well_conditioned_count, second.well_conditioned_count);
+  EXPECT_EQ(first.degenerate_count, second.degenerate_count);
+  EXPECT_EQ(first.non_observable_count, second.non_observable_count);
+  EXPECT_EQ(first.raw_update_valid, second.raw_update_valid);
+  EXPECT_TRUE(first.raw_update.isApprox(second.raw_update, 0.0));
+
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_DOUBLE_EQ(first.directions[i].eigenvalue, second.directions[i].eigenvalue) << i;
+    EXPECT_DOUBLE_EQ(
+      first.directions[i].normalized_contribution,
+      second.directions[i].normalized_contribution) << i;
+    EXPECT_EQ(first.directions[i].category, second.directions[i].category) << i;
+    EXPECT_TRUE(
+      first.directions[i].eigenvector.isApprox(second.directions[i].eigenvector, 0.0)) << i;
+  }
+}
+
+TEST(LocalizabilityAnalysis, EigenvectorSignsAreCanonicalized)
+{
+  const DegeneracyFixture fixture = makeSinglePlaneFixture(SinglePlaneFixtureConfig());
+  const GaussNewtonSystem system = buildGaussNewtonSystem(fixture.correspondences);
+  const LocalizabilityReport report = analyzeLocalizability(system.h, system.b);
+
+  for (int col = 0; col < 6; ++col) {
+    const Vector6d & v = report.directions[col].eigenvector;
+    int largest_index = 0;
+    double largest_abs = std::abs(v(0));
+    for (int row = 1; row < 6; ++row) {
+      const double component_abs = std::abs(v(row));
+      if (component_abs > largest_abs) {
+        largest_abs = component_abs;
+        largest_index = row;
+      }
+    }
+    EXPECT_GE(v(largest_index), 0.0) << col;
+  }
+}
+
+// -----------------------------------------------------------------------
+// H scale invariance: multiplying (H, b) by a positive constant must not
+// change any category or normalized_contribution (X-ICP's normalization
+// design goal), only the raw eigenvalue magnitudes and raw_update.
+// -----------------------------------------------------------------------
+
+TEST(LocalizabilityAnalysis, ScalingHPreservesCategoriesAndNormalizedContributions)
+{
+  const DegeneracyFixture fixture = makeCorridorFixture(CorridorFixtureConfig());
+  const GaussNewtonSystem system = buildGaussNewtonSystem(fixture.correspondences);
+
+  constexpr double kScale = 1000.0;
+  const Matrix6d scaled_h = kScale * system.h;
+  const Vector6d scaled_b = kScale * system.b;
+
+  const LocalizabilityReport base = analyzeLocalizability(system.h, system.b);
+  const LocalizabilityReport scaled = analyzeLocalizability(scaled_h, scaled_b);
+
+  EXPECT_NEAR(scaled.min_eigenvalue, kScale * base.min_eigenvalue, 1e-6);
+  EXPECT_NEAR(scaled.max_eigenvalue, kScale * base.max_eigenvalue, 1e-3);
+  EXPECT_DOUBLE_EQ(scaled.condition_number, base.condition_number);
+
+  EXPECT_EQ(scaled.well_conditioned_count, base.well_conditioned_count);
+  EXPECT_EQ(scaled.degenerate_count, base.degenerate_count);
+  EXPECT_EQ(scaled.non_observable_count, base.non_observable_count);
+
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_EQ(scaled.directions[i].category, base.directions[i].category) << i;
+    EXPECT_NEAR(
+      scaled.directions[i].normalized_contribution,
+      base.directions[i].normalized_contribution,
+      1e-9) << i;
+  }
+
+  // b scales, H scales -> the diagnostic dx = H^-1(-b) solve is itself
+  // scale-invariant (both numerator and denominator scale by kScale), even
+  // though this direction set is not all-well-conditioned so raw_update is
+  // marked invalid either way.
+  EXPECT_EQ(scaled.raw_update_valid, base.raw_update_valid);
+}
+
+TEST(LocalizabilityAnalysis, ScalingWellConditionedSystemPreservesRawUpdate)
+{
+  const DegeneracyFixture fixture = makeBoxFixture(BoxFixtureConfig());
+  const GaussNewtonSystem system = buildGaussNewtonSystem(fixture.correspondences);
+
+  constexpr double kScale = 250.0;
+  const Matrix6d scaled_h = kScale * system.h;
+  const Vector6d scaled_b = kScale * system.b;
+
+  const LocalizabilityReport base = analyzeLocalizability(system.h, system.b);
+  const LocalizabilityReport scaled = analyzeLocalizability(scaled_h, scaled_b);
+
+  ASSERT_TRUE(base.raw_update_valid);
+  ASSERT_TRUE(scaled.raw_update_valid);
+  EXPECT_TRUE(scaled.raw_update.isApprox(base.raw_update, 1e-6));
+}
+
+// -----------------------------------------------------------------------
+// Category-boundary threshold sensitivity: a synthetic, hand-built H whose
+// smallest eigenvalue sits close to well_conditioned_ratio flips category
+// as the threshold crosses it.
+// -----------------------------------------------------------------------
+
+TEST(LocalizabilityAnalysis, WellConditionedRatioThresholdControlsBoundaryDirection)
+{
+  // Diagonal H (eigenvectors are the coordinate axes, eigenvalues the
+  // diagonal entries themselves): five directions carry 0.199 of the total
+  // trace each (0.995 total) and one carries 0.005 -- a boundary direction
+  // whose normalized contribution (0.005) sits between two candidate
+  // well_conditioned_ratio thresholds (0.01 and 0.001).
+  Matrix6d h = Matrix6d::Zero();
+  h(0, 0) = 0.5;      // 0.005 of the trace (100.5 total)
+  for (int i = 1; i < 6; ++i) {
+    h(i, i) = 20.0;   // 0.199 of the trace each
+  }
+
+  LocalizabilityThresholds strict;
+  strict.well_conditioned_ratio = 0.01;   // 0.005 < 0.01 -> weak
+  const LocalizabilityReport strict_report = analyzeLocalizability(h, Vector6d::Zero(), strict);
+  EXPECT_EQ(strict_report.directions[0].category, LocalizabilityCategory::DEGENERATE);
+  EXPECT_EQ(strict_report.degenerate_count, 1);
+  EXPECT_EQ(strict_report.well_conditioned_count, 5);
+
+  LocalizabilityThresholds lenient;
+  lenient.well_conditioned_ratio = 0.001;  // 0.005 >= 0.001 -> well-conditioned
+  const LocalizabilityReport lenient_report = analyzeLocalizability(h, Vector6d::Zero(), lenient);
+  EXPECT_EQ(lenient_report.directions[0].category, LocalizabilityCategory::WELL_CONDITIONED);
+  EXPECT_EQ(lenient_report.degenerate_count, 0);
+  EXPECT_EQ(lenient_report.well_conditioned_count, 6);
+}
+
+// -----------------------------------------------------------------------
+// Multiplicity rule: isolated weak directions stay DEGENERATE individually;
+// only a mutually near-equal cluster of weak directions escalates to
+// NON_OBSERVABLE. This is the mechanism, exercised directly, that lets the
+// corridor and single-plane fixtures reach different categories despite
+// both having (numerically) zero eigenvalues.
+// -----------------------------------------------------------------------
+
+TEST(LocalizabilityAnalysis, TwoDistinctWeakEigenvaluesStayIndividuallyDegenerate)
+{
+  // Two weak-but-mutually-distinguishable eigenvalues (ratio gap far larger
+  // than multiplicity_relative_gap) must not be lumped into one
+  // NON_OBSERVABLE cluster -- each is its own isolated degenerate direction.
+  Matrix6d h = Matrix6d::Zero();
+  h(0, 0) = 0.0;      // exactly zero
+  h(1, 1) = 0.05;     // weak (contribution ~1.25e-5, below the 1e-4 default
+                      // well_conditioned_ratio) but far outside
+                      // multiplicity_relative_gap (1e-6) from direction 0's
+                      // contribution of exactly 0 -- a distinct, isolated
+                      // weak direction, not part of direction 0's cluster.
+  for (int i = 2; i < 6; ++i) {
+    h(i, i) = 1000.0;
+  }
+
+  const LocalizabilityReport report = analyzeLocalizability(h);
+  EXPECT_EQ(report.directions[0].category, LocalizabilityCategory::DEGENERATE);
+  EXPECT_EQ(report.directions[1].category, LocalizabilityCategory::DEGENERATE);
+  EXPECT_EQ(report.degenerate_count, 2);
+  EXPECT_EQ(report.non_observable_count, 0);
+}
+
+TEST(LocalizabilityAnalysis, ClusterOfMutuallyEqualWeakEigenvaluesIsNonObservable)
+{
+  // Three simultaneously (and mutually equal) near-zero eigenvalues form a
+  // genuine repeated eigenspace -> escalated together to NON_OBSERVABLE.
+  Matrix6d h = Matrix6d::Zero();
+  h(0, 0) = 0.0;
+  h(1, 1) = 0.0;
+  h(2, 2) = 0.0;
+  for (int i = 3; i < 6; ++i) {
+    h(i, i) = 1000.0;
+  }
+
+  const LocalizabilityReport report = analyzeLocalizability(h);
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(report.directions[i].category, LocalizabilityCategory::NON_OBSERVABLE) << i;
+  }
+  EXPECT_EQ(report.non_observable_count, 3);
+  EXPECT_EQ(report.degenerate_count, 0);
+}
+
+// -----------------------------------------------------------------------
+// Degenerate edge case: H == 0 (no information at all in any direction).
+// -----------------------------------------------------------------------
+
+TEST(LocalizabilityAnalysis, ZeroHessianIsNonObservableInAllSixDirections)
+{
+  const LocalizabilityReport report = analyzeLocalizability(Matrix6d::Zero());
+  EXPECT_EQ(report.non_observable_count, 6);
+  EXPECT_EQ(report.well_conditioned_count, 0);
+  EXPECT_EQ(report.degenerate_count, 0);
+  EXPECT_TRUE(std::isinf(report.condition_number));
+  EXPECT_FALSE(report.raw_update_valid);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary
The two foundational, report-only components of v0.8 Phase 1 (docs/roadmap/v0.8.md §5). No behaviour of any existing pipeline changes; poses are proven byte-identical.

### 1. `localizability_analysis.hpp` (pure header, ROS-free, clean-room)
- Eigen-decomposition of the 6×6 Gauss-Newton `H` (Zhang & Singh ICRA 2016) with **trace-normalized, scale-invariant** per-direction contributions (X-ICP-inspired; the roadmap's `(H,b)`-only API can't recover per-point contributions, documented as a deliberate adaptation).
- Weak directions are clustered by near-equal contribution: an **isolated** weak direction → `DEGENERATE`; a **near-repeated cluster** → `NON_OBSERVABLE` (eigenvectors of a repeated eigenvalue are only defined up to rotation within the eigenspace). This is what separates corridor's lone zero from single-plane's triple zero.
- Provisional thresholds (`well_conditioned_ratio 1e-4`, `multiplicity_relative_gap 1e-6`) are dimensionless and explicitly marked for Phase 1 calibration from real-substrate data — not paper-borrowed.
- **11 new gtests against the Phase 0 synthetic oracle**: corridor → along-axis DEGENERATE only; box → all six WELL_CONDITIONED; single-plane → tx/ty/yaw NON_OBSERVABLE (no false well-conditioned); determinism, H-scale invariance, threshold-boundary, multiplicity isolated-vs-clustered, zero-Hessian edge case.
- Package: **1414 tests, 0 failures**; cpplint/uncrustify/lint_cmake/xmllint green.

### 2. `Thirdparty/rko_lio` bump → `d6c767d` (rsasaki0109/rko_lio#1, diagnostic-only)
`icp()` returns the final iteration's `H`/`b` (previously discarded — solve untouched), `State` carries an optional per-scan localizability summary, and `Odometry.pose.covariance` is filled anisotropically (`Cov = V·diag(1/λ)·Vᵀ`, eigenvalues floored at `max(1e-9, 1e-6·λ_max)`).

**Characterization gate: green.** Full registered pose TUM byte-identical before/after the patch on HILTI exp04 (1258 poses) and exp07 (1322 poses), `cmp` exit 0. Judged **single-core** (`taskset -c 0`) because TBB `parallel_reduce` makes even same-binary multi-threaded runs differ in the last float digit — the known v0.6 nondeterminism; the v0.6 byte-identical-map gate scope is unchanged. Full record + methodology note: `docs/research/rko-lio-diagnostic-patch-characterization.md`.

## Remaining Phase 1 work (next PRs)
Per-scan diagnostics CSV in the offline runners, map-bundle degeneracy report, report-only `--degeneracy-report` release-readiness stage, exp07-vs-exp01 classification-asymmetry check, and threshold calibration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTNqieB785XZRXu5xPXZoL