### PR TITLE
fix(bench): honor --skip-reference-gen and score corrected trajectory as sparse

### DIFF
--- a/scripts/run_rko_lio_graph_benchmark.sh
+++ b/scripts/run_rko_lio_graph_benchmark.sh
@@ -528,12 +528,15 @@ wrapped = {"/**": {"ros__parameters": data}}
 dst_path.write_text(yaml.safe_dump(wrapped, sort_keys=False))
 PY
 
-if [[ "$SKIP_REFERENCE_GEN" == "false" || ! -f "$REFERENCE_TUM" || ! -f "$REFERENCE_META" ]]; then
+if [[ "$SKIP_REFERENCE_GEN" == "false" ]]; then
   python3 "${SCRIPT_DIR}/generate_ntu_viral_tnp01_reference.py" \
     --source-bag "$REFERENCE_BAG" \
     --out "$REFERENCE_TUM" \
     --rko-param "$RKO_PARAM" \
     --write-meta "$REFERENCE_META"
+else
+  [[ -f "$REFERENCE_TUM" ]] || die "--skip-reference-gen set but reference TUM not found: $REFERENCE_TUM (pass --reference-tum)"
+  [[ -f "$REFERENCE_META" ]] || die "--skip-reference-gen set but reference meta not found: $REFERENCE_META (pass --reference-meta, e.g. an empty '{}' JSON if no prism-offset metadata applies)"
 fi
 
 echo "Running RKO-LIO benchmark"
@@ -679,6 +682,7 @@ python3 "${SCRIPT_DIR}/ape_from_tum.py" \
 python3 "${SCRIPT_DIR}/ape_from_tum.py" \
   --ref "$REFERENCE_TUM" \
   --est "$CORRECTED_TUM_PRISM" \
+  --sparse-match \
   --out "$CORRECTED_APE"
 
 BENCH_T1="$(python3 - <<'PY'


### PR DESCRIPTION
## Summary
Two harness bugs found and worked around during v0.8 Phase 0/1 HILTI benchmark runs (documented as known follow-ups in `docs/research/hilti-degeneracy-baseline.md`), now fixed properly:

- `--skip-reference-gen` was ignored whenever the default `REFERENCE_META` path didn't exist — which is always, for non-NTU substrates that only pass `--reference-tum`. Now the flag is honored, with a fail-fast check that both reference files were actually supplied when skipping.
- Corrected-trajectory APE scoring used the default 0.05s nearest-neighbour match, but `/modified_path` is submap-rate, not per-scan. On sparse reference checkpoints this rejects effectively all points, `ape_from_tum.py` exits 1, and `set -e` kills the script before `metrics.json` is written. Now passes `--sparse-match` (added in #322 for exactly this case).

## Test plan
- [x] `bash -n scripts/run_rko_lio_graph_benchmark.sh` — syntax OK
- [x] Synthetic reproduction of the corrected-APE bug via `ape_from_tum.py` directly: default nearest-neighbour mode exits 1 on near-total rejection (the `set -e` death), `--sparse-match` exits 0 with all points matched
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTNqieB785XZRXu5xPXZoL