### PR TITLE
Refactor shared Python tooling

### DIFF
--- a/graph_based_slam/test/test_run_lidar_slam.py
+++ b/graph_based_slam/test/test_run_lidar_slam.py
@@ -1,3 +1,32 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 """Tests for the user-facing LiDAR SLAM launcher."""
 
 from __future__ import annotations

--- a/scripts/lidarslam_tools/__init__.py
+++ b/scripts/lidarslam_tools/__init__.py
@@ -1,0 +1,5 @@
+"""Shared, dependency-light building blocks for repository command-line tools."""
+
+from .serialization import payload_to_json
+
+__all__ = ['payload_to_json']

--- a/scripts/lidarslam_tools/mid360_models.py
+++ b/scripts/lidarslam_tools/mid360_models.py
@@ -1,0 +1,112 @@
+"""Data contracts shared by MID-360 planning and preflight tools."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RobotFrames:
+    base_frame: str = 'base_link'
+    lidar_frame: str = 'livox_frame'
+    imu_frame: str = 'livox_frame'
+
+
+@dataclass(frozen=True)
+class RobotProfile:
+    robot_name: str
+    frames: RobotFrames
+    expected_pointcloud_topic: str = ''
+    expected_imu_topic: str = ''
+    mount: dict[str, Any] | None = None
+    source_path: str = ''
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'robot_name': self.robot_name,
+            'frames': asdict(self.frames),
+            'expected_pointcloud_topic': self.expected_pointcloud_topic,
+            'expected_imu_topic': self.expected_imu_topic,
+            'mount': self.mount or {},
+            'source_path': self.source_path,
+        }
+
+
+@dataclass(frozen=True)
+class TopicSelection:
+    pointcloud: str | None
+    imu: str | None
+
+    @property
+    def ready(self) -> bool:
+        return bool(self.pointcloud and self.imu)
+
+
+@dataclass(frozen=True)
+class MessageSample:
+    topic: str
+    msg_type: str
+    timestamp_ns: int | None = None
+    header_stamp_ns: int | None = None
+    frame_id: str = ''
+    tf_pairs: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class PreflightCheck:
+    id: str
+    status: str
+    message: str
+
+
+@dataclass(frozen=True)
+class MapRunOptions:
+    output_dir: Path | None = None
+    run_name: str = ''
+    save_timeout_secs: str = ''
+    startup_timeout_secs: str = ''
+    viewer: str = 'none'
+    viewer_rebuild: bool = False
+    viewer_run_dir: str = ''
+    autoware_core_dir: str = ''
+    work_dir: str = ''
+    auto_exit_secs: str = ''
+    keep_launch: bool = False
+
+
+@dataclass(frozen=True)
+class MapRunPlan:
+    output_dir: Path
+    dogfood_command: list[str]
+    foxglove_command: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'output_dir': str(self.output_dir),
+            'dogfood_command': self.dogfood_command,
+            'dogfood_command_shell': shlex.join(self.dogfood_command),
+            'foxglove_command': self.foxglove_command,
+            'foxglove_command_shell': (
+                shlex.join(self.foxglove_command) if self.foxglove_command else ''
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class DiagnosisPlan:
+    command: list[str]
+    markdown_path: Path
+    json_path: Path
+    ran: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'command': self.command,
+            'command_shell': shlex.join(self.command),
+            'markdown_path': str(self.markdown_path),
+            'json_path': str(self.json_path),
+            'ran': self.ran,
+        }

--- a/scripts/lidarslam_tools/serialization.py
+++ b/scripts/lidarslam_tools/serialization.py
@@ -1,0 +1,11 @@
+"""Stable serialization helpers shared by command-line tools."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def payload_to_json(payload: dict[str, Any]) -> str:
+    """Serialize a CLI payload using the repository's canonical formatting."""
+    return json.dumps(payload, indent=2, sort_keys=True)

--- a/scripts/lidarslam_tools/slam_runtime.py
+++ b/scripts/lidarslam_tools/slam_runtime.py
@@ -1,0 +1,148 @@
+"""Storage discovery and process supervision for LiDAR SLAM commands."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from typing import Iterable
+
+import yaml
+
+
+DEFAULT_SCAN_ROOTS = (Path('/media'), Path('/mnt'))
+MAP_POINTS_RE = re.compile(r'number of points in the map\s*:\s*(\d+)')
+
+
+def read_bag_summary(bag: Path) -> dict:
+    """Read the small, stable subset of rosbag2 metadata used by the UI."""
+    try:
+        payload = yaml.safe_load((bag / 'metadata.yaml').read_text(encoding='utf-8')) or {}
+        info = payload.get('rosbag2_bagfile_information') or {}
+        duration = info.get('duration') or {}
+        topics = info.get('topics_with_message_count') or []
+        topic_names = {
+            str((row.get('topic_metadata') or {}).get('name') or '') for row in topics
+        }
+        return {
+            'duration_sec': float(duration.get('nanoseconds') or 0) / 1e9,
+            'message_count': int(info.get('message_count') or 0),
+            'topics': topic_names,
+            'supported': '/hesai/pandar' in topic_names,
+        }
+    except (OSError, TypeError, ValueError, yaml.YAMLError):
+        return {'duration_sec': 0.0, 'message_count': 0, 'topics': set(), 'supported': False}
+
+
+def discover_bags(roots: Iterable[Path]) -> list[tuple[Path, dict]]:
+    """Find rosbag2 directories under mounted storage, without following links."""
+    found: list[tuple[Path, dict]] = []
+    seen: set[Path] = set()
+    for root in roots:
+        root = root.expanduser()
+        if not root.is_dir():
+            continue
+        for metadata in root.glob('**/metadata.yaml'):
+            bag = metadata.parent.resolve()
+            if bag not in seen:
+                seen.add(bag)
+                found.append((bag, read_bag_summary(bag)))
+    return sorted(found, key=lambda item: str(item[0]))
+
+
+def resolve_bag(value: str, candidates: list[tuple[Path, dict]]) -> Path:
+    path = Path(value).expanduser()
+    if (path / 'metadata.yaml').is_file():
+        return path.resolve()
+    matches = [bag for bag, _ in candidates if bag.name in {value, f'{value}_ros2'}]
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise ValueError(f'「{value}」が複数あります。フルパスで指定してください。')
+    raise ValueError(f'ROS bag「{value}」が見つかりません。--list で候補を確認してください。')
+
+
+def default_output_dir(bag: Path) -> Path:
+    """Keep large generated maps on the same mounted drive when possible."""
+    parts = bag.parts
+    if len(parts) >= 4 and parts[1] in {'media', 'mnt'}:
+        mount_root = Path(*parts[:4]) if parts[1] == 'media' else Path(*parts[:3])
+        return mount_root / 'lidarslam_work' / 'output' / 'maps'
+    return Path.home() / 'lidarslam_work' / 'output' / 'maps'
+
+
+def free_gib(path: Path) -> float:
+    probe = path
+    while not probe.exists() and probe != probe.parent:
+        probe = probe.parent
+    return shutil.disk_usage(probe).free / 1024**3
+
+
+def latest_map_points(log_path: Path) -> int:
+    """Return the latest published map size from the tail of a SLAM log."""
+    try:
+        with log_path.open('rb') as stream:
+            stream.seek(0, os.SEEK_END)
+            stream.seek(max(0, stream.tell() - 64 * 1024))
+            text = stream.read().decode('utf-8', errors='replace')
+    except OSError:
+        return 0
+    matches = MAP_POINTS_RE.findall(text)
+    return int(matches[-1]) if matches else 0
+
+
+def clock(seconds: float) -> str:
+    seconds = max(0, round(seconds))
+    minutes, sec = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    return f'{hours:d}:{minutes:02d}:{sec:02d}' if hours else f'{minutes:02d}:{sec:02d}'
+
+
+def progress_line(elapsed: float, expected: float, points: int) -> str:
+    ratio = min(0.99, elapsed / expected) if expected > 0 else 0.0
+    width = 20
+    filled = min(width, int(ratio * width))
+    bar = '#' * filled + '-' * (width - filled)
+    point_text = f'{points:,}点' if points else '準備中'
+    return (f'[{bar}] {ratio * 100:5.1f}%  残り約{clock(max(0.0, expected - elapsed))}'
+            f'  地図 {point_text}')
+
+
+def run_with_progress(command: list[str], env: dict[str, str], expected_sec: float,
+                      slam_log: Path) -> tuple[int, bool]:
+    """Run the SLAM process group, displaying progress and stopping it safely."""
+    process = subprocess.Popen(command, env=env, start_new_session=True)
+    started = time.monotonic()
+    last_plain_update = -5
+    interrupted = False
+    try:
+        while process.poll() is None:
+            elapsed = time.monotonic() - started
+            line = progress_line(elapsed, expected_sec, latest_map_points(slam_log))
+            if sys.stdout.isatty():
+                print('\r' + line, end='', flush=True)
+            elif elapsed - last_plain_update >= 5:
+                print(line, flush=True)
+                last_plain_update = elapsed
+            time.sleep(1)
+    except KeyboardInterrupt:
+        interrupted = True
+        print('\n停止要求を受け取りました。途中地図を安全に保存しています…', flush=True)
+        os.killpg(process.pid, signal.SIGINT)
+        try:
+            process.wait(timeout=12)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait()
+    if sys.stdout.isatty():
+        print()
+    return process.returncode or 0, interrupted

--- a/scripts/mid360_robot_tools.py
+++ b/scripts/mid360_robot_tools.py
@@ -4,141 +4,32 @@
 from __future__ import annotations
 
 import importlib.util
-import json
 import shlex
 import textwrap
-from dataclasses import asdict, dataclass
+from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import yaml
 
+from lidarslam_tools.serialization import payload_to_json
+from lidarslam_tools.mid360_models import (
+    DiagnosisPlan,
+    MapRunOptions,
+    MapRunPlan,
+    MessageSample,
+    PreflightCheck,
+    RobotFrames,
+    RobotProfile,
+    TopicSelection,
+)
+
 
 MID360_PROFILE_ID = 'rko_lio_graph_mid360_preset'
 DEFAULT_SAMPLE_MESSAGES = 20
 POINTCLOUD_MIN_METADATA_HZ = 5.0
 IMU_MIN_METADATA_HZ = 50.0
-
-
-@dataclass(frozen=True)
-class RobotFrames:
-    """Frame names used by the robot mapping launch."""
-
-    base_frame: str = 'base_link'
-    lidar_frame: str = 'livox_frame'
-    imu_frame: str = 'livox_frame'
-
-
-@dataclass(frozen=True)
-class RobotProfile:
-    """Robot-specific MID-360 mapping defaults."""
-
-    robot_name: str
-    frames: RobotFrames
-    expected_pointcloud_topic: str = ''
-    expected_imu_topic: str = ''
-    mount: dict[str, Any] | None = None
-    source_path: str = ''
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            'robot_name': self.robot_name,
-            'frames': asdict(self.frames),
-            'expected_pointcloud_topic': self.expected_pointcloud_topic,
-            'expected_imu_topic': self.expected_imu_topic,
-            'mount': self.mount or {},
-            'source_path': self.source_path,
-        }
-
-
-@dataclass(frozen=True)
-class TopicSelection:
-    """Topic names selected from rosbag2 metadata."""
-
-    pointcloud: str | None
-    imu: str | None
-
-    @property
-    def ready(self) -> bool:
-        return bool(self.pointcloud and self.imu)
-
-
-@dataclass(frozen=True)
-class MessageSample:
-    """Small, standard-message sample extracted from a rosbag2 topic."""
-
-    topic: str
-    msg_type: str
-    timestamp_ns: int | None = None
-    header_stamp_ns: int | None = None
-    frame_id: str = ''
-    tf_pairs: tuple[tuple[str, str], ...] = ()
-
-
-@dataclass(frozen=True)
-class PreflightCheck:
-    """A single robot preflight check."""
-
-    id: str
-    status: str
-    message: str
-
-
-@dataclass(frozen=True)
-class MapRunOptions:
-    """Options that affect the MID-360 map runner command."""
-
-    output_dir: Path | None = None
-    run_name: str = ''
-    save_timeout_secs: str = ''
-    startup_timeout_secs: str = ''
-    viewer: str = 'none'
-    viewer_rebuild: bool = False
-    viewer_run_dir: str = ''
-    autoware_core_dir: str = ''
-    work_dir: str = ''
-    auto_exit_secs: str = ''
-    keep_launch: bool = False
-
-
-@dataclass(frozen=True)
-class MapRunPlan:
-    """Commands needed for one MID-360 map run."""
-
-    output_dir: Path
-    dogfood_command: list[str]
-    foxglove_command: list[str]
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            'output_dir': str(self.output_dir),
-            'dogfood_command': self.dogfood_command,
-            'dogfood_command_shell': shlex.join(self.dogfood_command),
-            'foxglove_command': self.foxglove_command,
-            'foxglove_command_shell': (
-                shlex.join(self.foxglove_command) if self.foxglove_command else ''
-            ),
-        }
-
-
-@dataclass(frozen=True)
-class DiagnosisPlan:
-    """Command and expected outputs for map-run diagnosis."""
-
-    command: list[str]
-    markdown_path: Path
-    json_path: Path
-    ran: bool = False
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            'command': self.command,
-            'command_shell': shlex.join(self.command),
-            'markdown_path': str(self.markdown_path),
-            'json_path': str(self.json_path),
-            'ran': self.ran,
-        }
 
 
 class Mid360RunDiagnosisPlanner:
@@ -1416,8 +1307,3 @@ class Mid360MapRunPlanner:
         if options.auto_exit_secs:
             command.extend(['--auto-exit-secs', options.auto_exit_secs])
         return command
-
-
-def payload_to_json(payload: dict[str, Any]) -> str:
-    """Serialize payloads consistently for CLIs."""
-    return json.dumps(payload, indent=2, sort_keys=True)

--- a/scripts/run_lidar_slam.py
+++ b/scripts/run_lidar_slam.py
@@ -6,154 +6,24 @@ from __future__ import annotations
 import argparse
 import os
 from pathlib import Path
-import re
-import shutil
-import signal
-import subprocess
 import sys
-import time
-from typing import Iterable
 
-import yaml
+from lidarslam_tools.slam_runtime import (
+    DEFAULT_SCAN_ROOTS,
+    clock as _clock,
+    default_output_dir,
+    discover_bags,
+    free_gib as _free_gib,
+    latest_map_points as _latest_map_points,
+    progress_line as _progress_line,
+    read_bag_summary,
+    resolve_bag,
+    run_with_progress as _run_with_progress,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 HILTI_RUNNER = REPO_ROOT / 'tools/gaussian_splatting/bim_reference_scripts/run_hilti_slam.sh'
-DEFAULT_SCAN_ROOTS = (Path('/media'), Path('/mnt'))
-MAP_POINTS_RE = re.compile(r'number of points in the map\s*:\s*(\d+)')
-
-
-def read_bag_summary(bag: Path) -> dict:
-    """Read the small, stable subset of rosbag2 metadata used by the UI."""
-    try:
-        payload = yaml.safe_load((bag / 'metadata.yaml').read_text(encoding='utf-8')) or {}
-        info = payload.get('rosbag2_bagfile_information') or {}
-        duration = info.get('duration') or {}
-        topics = info.get('topics_with_message_count') or []
-        topic_names = {
-            str((row.get('topic_metadata') or {}).get('name') or '') for row in topics
-        }
-        return {
-            'duration_sec': float(duration.get('nanoseconds') or 0) / 1e9,
-            'message_count': int(info.get('message_count') or 0),
-            'topics': topic_names,
-            'supported': '/hesai/pandar' in topic_names,
-        }
-    except (OSError, TypeError, ValueError, yaml.YAMLError):
-        return {'duration_sec': 0.0, 'message_count': 0, 'topics': set(), 'supported': False}
-
-
-def discover_bags(roots: Iterable[Path]) -> list[tuple[Path, dict]]:
-    """Find rosbag2 directories under mounted storage, without following links."""
-    found: list[tuple[Path, dict]] = []
-    seen: set[Path] = set()
-    for root in roots:
-        root = root.expanduser()
-        if not root.is_dir():
-            continue
-        for metadata in root.glob('**/metadata.yaml'):
-            bag = metadata.parent.resolve()
-            if bag in seen:
-                continue
-            seen.add(bag)
-            found.append((bag, read_bag_summary(bag)))
-    return sorted(found, key=lambda item: str(item[0]))
-
-
-def resolve_bag(value: str, candidates: list[tuple[Path, dict]]) -> Path:
-    path = Path(value).expanduser()
-    if (path / 'metadata.yaml').is_file():
-        return path.resolve()
-    matches = [bag for bag, _ in candidates if bag.name in {value, f'{value}_ros2'}]
-    if len(matches) == 1:
-        return matches[0]
-    if len(matches) > 1:
-        raise ValueError(f'「{value}」が複数あります。フルパスで指定してください。')
-    raise ValueError(f'ROS bag「{value}」が見つかりません。--list で候補を確認してください。')
-
-
-def default_output_dir(bag: Path) -> Path:
-    """Keep large generated maps on the same mounted drive when possible."""
-    parts = bag.parts
-    if len(parts) >= 4 and parts[1] in {'media', 'mnt'}:
-        mount_root = Path(*parts[:4]) if parts[1] == 'media' else Path(*parts[:3])
-        return mount_root / 'lidarslam_work' / 'output' / 'maps'
-    return Path.home() / 'lidarslam_work' / 'output' / 'maps'
-
-
-def _free_gib(path: Path) -> float:
-    probe = path
-    while not probe.exists() and probe != probe.parent:
-        probe = probe.parent
-    return shutil.disk_usage(probe).free / 1024**3
-
-
-def _latest_map_points(log_path: Path) -> int:
-    """Return the latest published map size from the tail of a SLAM log."""
-    try:
-        with log_path.open('rb') as stream:
-            stream.seek(0, os.SEEK_END)
-            stream.seek(max(0, stream.tell() - 64 * 1024))
-            text = stream.read().decode('utf-8', errors='replace')
-    except OSError:
-        return 0
-    matches = MAP_POINTS_RE.findall(text)
-    return int(matches[-1]) if matches else 0
-
-
-def _clock(seconds: float) -> str:
-    seconds = max(0, round(seconds))
-    minutes, sec = divmod(seconds, 60)
-    hours, minutes = divmod(minutes, 60)
-    return f'{hours:d}:{minutes:02d}:{sec:02d}' if hours else f'{minutes:02d}:{sec:02d}'
-
-
-def _progress_line(elapsed: float, expected: float, points: int) -> str:
-    ratio = min(0.99, elapsed / expected) if expected > 0 else 0.0
-    percent = ratio * 100
-    remaining = max(0.0, expected - elapsed)
-    width = 20
-    filled = min(width, int(ratio * width))
-    bar = '#' * filled + '-' * (width - filled)
-    point_text = f'{points:,}点' if points else '準備中'
-    return f'[{bar}] {percent:5.1f}%  残り約{_clock(remaining)}  地図 {point_text}'
-
-
-def _run_with_progress(command: list[str], env: dict[str, str], expected_sec: float,
-                       slam_log: Path) -> tuple[int, bool]:
-    """Run the SLAM process group, displaying progress and stopping it safely."""
-    process = subprocess.Popen(command, env=env, start_new_session=True)
-    started = time.monotonic()
-    last_plain_update = -5
-    interrupted = False
-    try:
-        while process.poll() is None:
-            elapsed = time.monotonic() - started
-            line = _progress_line(elapsed, expected_sec, _latest_map_points(slam_log))
-            if sys.stdout.isatty():
-                print('\r' + line, end='', flush=True)
-            elif elapsed - last_plain_update >= 5:
-                print(line, flush=True)
-                last_plain_update = elapsed
-            time.sleep(1)
-    except KeyboardInterrupt:
-        interrupted = True
-        print('\n停止要求を受け取りました。途中地図を安全に保存しています…', flush=True)
-        os.killpg(process.pid, signal.SIGINT)
-        try:
-            process.wait(timeout=12)
-        except subprocess.TimeoutExpired:
-            os.killpg(process.pid, signal.SIGTERM)
-            try:
-                process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                os.killpg(process.pid, signal.SIGKILL)
-                process.wait()
-    if sys.stdout.isatty():
-        print()
-    return process.returncode or 0, interrupted
-
-
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description='SSDのROS bagを見つけて、LiDAR SLAM地図を簡単に生成します。',


### PR DESCRIPTION
## What changed

- Added a dependency-light `lidarslam_tools` package for shared CLI infrastructure.
- Extracted LiDAR bag discovery and process supervision from the user-facing launcher.
- Extracted MID-360 data contracts from the 1,423-line compatibility module.
- Centralized canonical JSON payload serialization while preserving existing imports.

## Why

Repository command-line tools had storage, process, model, and presentation responsibilities concentrated in large flat modules. These boundaries make later refactors smaller and keep existing callers compatible.

## Impact

- `run_lidar_slam.py`: 268 to 138 lines.
- `mid360_robot_tools.py`: 1,423 to 1,309 lines.
- No CLI or import changes required for existing callers.

## Validation

- `python3 -m pytest graph_based_slam/test/test_mid360_robot*.py graph_based_slam/test/test_run_lidar_slam.py -q` (160 passed)
- `python3 -m compileall -q scripts`
- Real SSD HILTI bag discovery and exp04 dry-run
- `git diff --check`
