### PR TITLE
Extract GNSS geometry from graph SLAM component

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -126,6 +126,13 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_gnss_weighting sensor_msgs)
   endif()
   ament_add_gtest(
+    test_gnss_geometry
+    test/test_gnss_geometry.cpp
+  )
+  if(TARGET test_gnss_geometry)
+    target_include_directories(test_gnss_geometry PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  endif()
+  ament_add_gtest(
     test_adjacent_edge_auto_scale
     test/test_adjacent_edge_auto_scale.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/gnss_geometry.hpp
+++ b/graph_based_slam/include/graph_based_slam/gnss_geometry.hpp
@@ -1,0 +1,112 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__GNSS_GEOMETRY_HPP_
+#define GRAPH_BASED_SLAM__GNSS_GEOMETRY_HPP_
+
+#include <cmath>
+
+#include <Eigen/Core>
+
+namespace graphslam
+{
+namespace detail
+{
+
+struct GeodeticOrigin
+{
+  double latitude_deg {0.0};
+  double longitude_deg {0.0};
+  double altitude_m {0.0};
+};
+
+inline bool isUsableGeodeticFix(double latitude_deg, double longitude_deg, double altitude_m)
+{
+  if (!std::isfinite(latitude_deg) || !std::isfinite(longitude_deg) ||
+    !std::isfinite(altitude_m))
+  {
+    return false;
+  }
+  if (latitude_deg < -90.0 || latitude_deg > 90.0) {
+    return false;
+  }
+  if (longitude_deg < -180.0 || longitude_deg > 180.0) {
+    return false;
+  }
+  return std::abs(latitude_deg) >= 1e-6 || std::abs(longitude_deg) >= 1e-6;
+}
+
+inline double approximateGeodeticDistanceMeters(
+  double latitude_0_deg, double longitude_0_deg,
+  double latitude_1_deg, double longitude_1_deg)
+{
+  constexpr double kEarthRadiusM = 6378137.0;
+  constexpr double kDegreesToRadians = 3.14159265358979323846 / 180.0;
+  const double latitude_0_rad = latitude_0_deg * kDegreesToRadians;
+  const double latitude_1_rad = latitude_1_deg * kDegreesToRadians;
+  const double delta_latitude = latitude_1_rad - latitude_0_rad;
+  const double delta_longitude =
+    (longitude_1_deg - longitude_0_deg) * kDegreesToRadians;
+  const double x =
+    delta_longitude * std::cos((latitude_0_rad + latitude_1_rad) * 0.5);
+  return std::hypot(x, delta_latitude) * kEarthRadiusM;
+}
+
+inline Eigen::Vector3d geodeticToEnu(
+  double latitude_deg, double longitude_deg, double altitude_m,
+  const GeodeticOrigin & origin)
+{
+  constexpr double kSemiMajorAxisM = 6378137.0;
+  constexpr double kFlattening = 1.0 / 298.257223563;
+  constexpr double kEccentricitySquared =
+    2.0 * kFlattening - kFlattening * kFlattening;
+  constexpr double kDegreesToRadians = 3.14159265358979323846 / 180.0;
+
+  const double origin_latitude_rad = origin.latitude_deg * kDegreesToRadians;
+  const double delta_latitude =
+    (latitude_deg - origin.latitude_deg) * kDegreesToRadians;
+  const double delta_longitude =
+    (longitude_deg - origin.longitude_deg) * kDegreesToRadians;
+  const double sin_origin_latitude = std::sin(origin_latitude_rad);
+  const double curvature = 1.0 -
+    kEccentricitySquared * sin_origin_latitude * sin_origin_latitude;
+  const double prime_vertical_radius = kSemiMajorAxisM / std::sqrt(curvature);
+  const double meridian_radius =
+    kSemiMajorAxisM * (1.0 - kEccentricitySquared) / std::pow(curvature, 1.5);
+
+  return Eigen::Vector3d(
+    delta_longitude * prime_vertical_radius * std::cos(origin_latitude_rad),
+    delta_latitude * meridian_radius,
+    altitude_m - origin.altitude_m);
+}
+
+}  // namespace detail
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__GNSS_GEOMETRY_HPP_

--- a/graph_based_slam/include/graph_based_slam/gnss_geometry.hpp
+++ b/graph_based_slam/include/graph_based_slam/gnss_geometry.hpp
@@ -32,7 +32,7 @@
 
 #include <cmath>
 
-#include <Eigen/Core>
+#include <Eigen/Core>  // NOLINT(build/include_order)
 
 namespace graphslam
 {

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -42,6 +42,7 @@
 #include "graph_based_slam/degeneracy_diagnostics_csv.hpp"
 #include "graph_based_slam/dynamic_object_filter.hpp"
 #include "graph_based_slam/gnss_alignment.hpp"
+#include "graph_based_slam/gnss_geometry.hpp"
 #include "graph_based_slam/loop_verifier.hpp"
 #include "graph_based_slam/map_saver.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
@@ -1862,21 +1863,7 @@ void GraphBasedSlamComponent::receiveNavSatFix(const sensor_msgs::msg::NavSatFix
 
 bool GraphBasedSlamComponent::isUsableGnssFix(const sensor_msgs::msg::NavSatFix & msg) const
 {
-  if (!std::isfinite(msg.latitude) || !std::isfinite(msg.longitude) ||
-    !std::isfinite(msg.altitude))
-  {
-    return false;
-  }
-  if (msg.latitude < -90.0 || msg.latitude > 90.0) {
-    return false;
-  }
-  if (msg.longitude < -180.0 || msg.longitude > 180.0) {
-    return false;
-  }
-  if (std::abs(msg.latitude) < 1e-6 && std::abs(msg.longitude) < 1e-6) {
-    return false;
-  }
-  return true;
+  return detail::isUsableGeodeticFix(msg.latitude, msg.longitude, msg.altitude);
 }
 
 void GraphBasedSlamComponent::tryInitializeGnssOrigin(double lat, double lon, double alt)
@@ -1958,47 +1945,15 @@ void GraphBasedSlamComponent::tryInitializeGnssOrigin(double lat, double lon, do
 double GraphBasedSlamComponent::approximateGeodeticDistanceMeters(
   double lat0, double lon0, double lat1, double lon1) const
 {
-  constexpr double kEarthRadiusM = 6378137.0;
-  auto toRad = [](double deg) {return deg * M_PI / 180.0;};
-
-  const double lat0_rad = toRad(lat0);
-  const double lat1_rad = toRad(lat1);
-  const double dlat = lat1_rad - lat0_rad;
-  const double dlon = toRad(lon1 - lon0);
-  const double x = dlon * std::cos((lat0_rad + lat1_rad) * 0.5);
-  const double y = dlat;
-  return std::sqrt(x * x + y * y) * kEarthRadiusM;
+  return detail::approximateGeodeticDistanceMeters(lat0, lon0, lat1, lon1);
 }
 
 Eigen::Vector3d GraphBasedSlamComponent::geodeticToEnu(
   double lat, double lon, double alt) const
 {
-  // WGS84 parameters
-  constexpr double a = 6378137.0;              // semi-major axis [m]
-  constexpr double f = 1.0 / 298.257223563;    // flattening
-  constexpr double e2 = 2 * f - f * f;         // eccentricity squared
-
-  auto toRad = [](double deg) {return deg * M_PI / 180.0;};
-
-  double lat0 = toRad(gnss_origin_lat_);
-  double lon0 = toRad(gnss_origin_lon_);
-  double lat1 = toRad(lat);
-  double lon1 = toRad(lon);
-
-  double dlat = lat1 - lat0;
-  double dlon = lon1 - lon0;
-  double dalt = alt - gnss_origin_alt_;
-
-  double sin_lat0 = std::sin(lat0);
-  double N = a / std::sqrt(1.0 - e2 * sin_lat0 * sin_lat0);
-  double M = a * (1.0 - e2) / std::pow(1.0 - e2 * sin_lat0 * sin_lat0, 1.5);
-
-  // ENU: East = dlon * N * cos(lat), North = dlat * M, Up = dalt
-  double east = dlon * N * std::cos(lat0);
-  double north = dlat * M;
-  double up = dalt;
-
-  return Eigen::Vector3d(east, north, up);
+  const detail::GeodeticOrigin origin {
+    gnss_origin_lat_, gnss_origin_lon_, gnss_origin_alt_};
+  return detail::geodeticToEnu(lat, lon, alt, origin);
 }
 
 void GraphBasedSlamComponent::receiveImu(const sensor_msgs::msg::Imu & msg)

--- a/graph_based_slam/test/test_gnss_geometry.cpp
+++ b/graph_based_slam/test/test_gnss_geometry.cpp
@@ -1,0 +1,77 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <limits>
+
+#include <gtest/gtest.h>
+
+#include "graph_based_slam/gnss_geometry.hpp"
+
+namespace graphslam
+{
+namespace detail
+{
+namespace
+{
+
+TEST(GnssGeometry, ValidatesFiniteCoordinatesAndRanges)
+{
+  EXPECT_TRUE(isUsableGeodeticFix(35.681236, 139.767125, 12.0));
+  EXPECT_FALSE(isUsableGeodeticFix(0.0, 0.0, 0.0));
+  EXPECT_FALSE(isUsableGeodeticFix(91.0, 139.0, 0.0));
+  EXPECT_FALSE(isUsableGeodeticFix(
+    std::numeric_limits<double>::quiet_NaN(), 139.0, 0.0));
+}
+
+TEST(GnssGeometry, ComputesShortGeodeticDistanceSymmetrically)
+{
+  const double forward = approximateGeodeticDistanceMeters(35.0, 139.0, 35.001, 139.002);
+  const double reverse = approximateGeodeticDistanceMeters(35.001, 139.002, 35.0, 139.0);
+  EXPECT_NEAR(forward, 213.5, 1.0);
+  EXPECT_NEAR(reverse, forward, 1e-9);
+}
+
+TEST(GnssGeometry, ConvertsOriginToZeroEnu)
+{
+  const GeodeticOrigin origin {35.0, 139.0, 42.0};
+  EXPECT_TRUE(geodeticToEnu(35.0, 139.0, 42.0, origin).isZero(1e-12));
+}
+
+TEST(GnssGeometry, ConvertsLocalOffsetsToEastNorthUp)
+{
+  const GeodeticOrigin origin {35.0, 139.0, 10.0};
+  const Eigen::Vector3d enu = geodeticToEnu(35.001, 139.001, 15.0, origin);
+  EXPECT_NEAR(enu.x(), 91.29, 0.1);
+  EXPECT_NEAR(enu.y(), 110.94, 0.1);
+  EXPECT_DOUBLE_EQ(enu.z(), 5.0);
+}
+
+}  // namespace
+}  // namespace detail
+}  // namespace graphslam

--- a/graph_based_slam/test/test_gnss_geometry.cpp
+++ b/graph_based_slam/test/test_gnss_geometry.cpp
@@ -27,9 +27,9 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include <limits>
-
 #include <gtest/gtest.h>
+
+#include <limits>
 
 #include "graph_based_slam/gnss_geometry.hpp"
 
@@ -45,8 +45,9 @@ TEST(GnssGeometry, ValidatesFiniteCoordinatesAndRanges)
   EXPECT_TRUE(isUsableGeodeticFix(35.681236, 139.767125, 12.0));
   EXPECT_FALSE(isUsableGeodeticFix(0.0, 0.0, 0.0));
   EXPECT_FALSE(isUsableGeodeticFix(91.0, 139.0, 0.0));
-  EXPECT_FALSE(isUsableGeodeticFix(
-    std::numeric_limits<double>::quiet_NaN(), 139.0, 0.0));
+  EXPECT_FALSE(
+    isUsableGeodeticFix(
+      std::numeric_limits<double>::quiet_NaN(), 139.0, 0.0));
 }
 
 TEST(GnssGeometry, ComputesShortGeodeticDistanceSymmetrically)


### PR DESCRIPTION
## What changed

- add pure GNSS geometry helpers for fix validation, short geodetic distance, and WGS84-to-ENU conversion
- delegate the existing component methods to the extracted helpers without changing the ROS-facing API
- add focused C++ unit tests and register them with CMake

## Why

`graph_based_slam_component.cpp` mixed reusable geodetic calculations with ROS node state and callbacks. Moving the pure calculations into a small header makes the behavior directly testable and reduces the component's responsibility while preserving runtime behavior.

## Validation

- Jazzy `colcon build --packages-up-to graph_based_slam --cmake-args -DBUILD_TESTING=ON`
- GNSS CTest through `colcon test --packages-select graph_based_slam --ctest-args -R test_gnss_geometry --output-on-failure` (5 tests, 0 failures)
- standalone GNSS geometry gtest (4 tests passed)
- `git diff --check origin/develop...HEAD`
