### PR TITLE
Extract GNSS origin accumulation from graph SLAM component

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -133,6 +133,13 @@ if(BUILD_TESTING)
     target_include_directories(test_gnss_geometry PRIVATE include ${EIGEN3_INCLUDE_DIR})
   endif()
   ament_add_gtest(
+    test_gnss_origin_accumulator
+    test/test_gnss_origin_accumulator.cpp
+  )
+  if(TARGET test_gnss_origin_accumulator)
+    target_include_directories(test_gnss_origin_accumulator PRIVATE include ${EIGEN3_INCLUDE_DIR})
+  endif()
+  ament_add_gtest(
     test_adjacent_edge_auto_scale
     test/test_adjacent_edge_auto_scale.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/gnss_origin_accumulator.hpp
+++ b/graph_based_slam/include/graph_based_slam/gnss_origin_accumulator.hpp
@@ -1,24 +1,30 @@
-// Copyright 2026 Ryohei Sasaki
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
 //
 // Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
+// modification, are permitted provided that the following conditions
+// are met:
 //
-// 1. Redistributions of source code must retain the above copyright notice,
-//    this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef GRAPH_BASED_SLAM__GNSS_ORIGIN_ACCUMULATOR_HPP_

--- a/graph_based_slam/include/graph_based_slam/gnss_origin_accumulator.hpp
+++ b/graph_based_slam/include/graph_based_slam/gnss_origin_accumulator.hpp
@@ -1,0 +1,128 @@
+// Copyright 2026 Ryohei Sasaki
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__GNSS_ORIGIN_ACCUMULATOR_HPP_
+#define GRAPH_BASED_SLAM__GNSS_ORIGIN_ACCUMULATOR_HPP_
+
+#include <algorithm>
+#include <cstddef>
+#include <vector>
+
+#include "graph_based_slam/gnss_geometry.hpp"
+
+namespace graphslam
+{
+namespace detail
+{
+
+struct GnssOriginUpdate
+{
+  bool reset_after_jump {false};
+  bool restarted_after_inconsistency {false};
+  bool initialized {false};
+  double deviation_m {0.0};
+  std::size_t accepted_samples {0};
+  GeodeticOrigin origin;
+};
+
+class GnssOriginAccumulator
+{
+public:
+  void configure(int min_samples, double consistency_threshold_m)
+  {
+    min_samples_ = std::max(1, min_samples);
+    consistency_threshold_m_ = consistency_threshold_m;
+    candidates_.clear();
+  }
+
+  GnssOriginUpdate add(double latitude_deg, double longitude_deg, double altitude_m)
+  {
+    GnssOriginUpdate update;
+    const GeodeticOrigin sample {latitude_deg, longitude_deg, altitude_m};
+
+    if (!candidates_.empty()) {
+      const GeodeticOrigin mean = meanOrigin();
+      update.deviation_m = approximateGeodeticDistanceMeters(
+        mean.latitude_deg, mean.longitude_deg, latitude_deg, longitude_deg);
+      if (update.deviation_m > consistency_threshold_m_) {
+        candidates_.clear();
+        update.reset_after_jump = true;
+      }
+    }
+
+    candidates_.push_back(sample);
+    update.accepted_samples = candidates_.size();
+    if (static_cast<int>(candidates_.size()) < min_samples_) {
+      return update;
+    }
+
+    const GeodeticOrigin mean = meanOrigin();
+    double max_deviation_m = 0.0;
+    for (const auto & candidate : candidates_) {
+      max_deviation_m = std::max(
+        max_deviation_m,
+        approximateGeodeticDistanceMeters(
+          mean.latitude_deg, mean.longitude_deg,
+          candidate.latitude_deg, candidate.longitude_deg));
+    }
+    update.deviation_m = max_deviation_m;
+
+    if (max_deviation_m > consistency_threshold_m_) {
+      candidates_.assign(1, sample);
+      update.restarted_after_inconsistency = true;
+      update.accepted_samples = candidates_.size();
+      return update;
+    }
+
+    update.initialized = true;
+    update.origin = mean;
+    update.accepted_samples = candidates_.size();
+    candidates_.clear();
+    return update;
+  }
+
+private:
+  GeodeticOrigin meanOrigin() const
+  {
+    GeodeticOrigin mean;
+    for (const auto & candidate : candidates_) {
+      mean.latitude_deg += candidate.latitude_deg;
+      mean.longitude_deg += candidate.longitude_deg;
+      mean.altitude_m += candidate.altitude_m;
+    }
+    const double count = static_cast<double>(candidates_.size());
+    mean.latitude_deg /= count;
+    mean.longitude_deg /= count;
+    mean.altitude_m /= count;
+    return mean;
+  }
+
+  int min_samples_ {1};
+  double consistency_threshold_m_ {20.0};
+  std::vector<GeodeticOrigin> candidates_;
+};
+
+}  // namespace detail
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__GNSS_ORIGIN_ACCUMULATOR_HPP_

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -123,6 +123,7 @@ extern "C" {
 #include "graph_based_slam/backend_core.hpp"
 #include "graph_based_slam/candidate_aggregator.hpp"
 #include "graph_based_slam/degeneracy_report_summary.hpp"
+#include "graph_based_slam/gnss_origin_accumulator.hpp"
 #include "graph_based_slam/registration_factory.hpp"
 #include "graph_based_slam/gnss_weighting.hpp"
 #include "graph_based_slam/scan_context.hpp"
@@ -472,14 +473,8 @@ private:
       bool rtk_like;
       double horizontal_stddev_m;
     };
-    struct GnssOriginSample
-    {
-      double lat;
-      double lon;
-      double alt;
-    };
     std::vector < GnssEnu > gnss_buffer_;
-    std::vector < GnssOriginSample > gnss_origin_candidates_;
+    detail::GnssOriginAccumulator gnss_origin_accumulator_;
     std::mutex gnss_mtx_;
     bool gnss_origin_set_ {false};
     double gnss_origin_lat_ {0.0};
@@ -488,11 +483,6 @@ private:
     void receiveNavSatFix(const sensor_msgs::msg::NavSatFix & msg);
     bool isUsableGnssFix(const sensor_msgs::msg::NavSatFix & msg) const;
     void tryInitializeGnssOrigin(double lat, double lon, double alt);
-    double approximateGeodeticDistanceMeters(
-      double lat0,
-      double lon0,
-      double lat1,
-      double lon1) const;
     Eigen::Vector3d geodeticToEnu(double lat, double lon, double alt) const;
 
     // IMU preintegration

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -415,6 +415,8 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       gnss_origin_consistency_threshold_m_);
     gnss_origin_consistency_threshold_m_ = 20.0;
   }
+  gnss_origin_accumulator_.configure(
+    gnss_origin_min_samples_, gnss_origin_consistency_threshold_m_);
   if (gnss_covariance_min_variance_m2_ <= 0.0) {
     RCLCPP_WARN(
       get_logger(),
@@ -1868,84 +1870,31 @@ bool GraphBasedSlamComponent::isUsableGnssFix(const sensor_msgs::msg::NavSatFix 
 
 void GraphBasedSlamComponent::tryInitializeGnssOrigin(double lat, double lon, double alt)
 {
-  GnssOriginSample sample {lat, lon, alt};
-
-  if (!gnss_origin_candidates_.empty()) {
-    double mean_lat = 0.0;
-    double mean_lon = 0.0;
-    double mean_alt = 0.0;
-    for (const auto & candidate : gnss_origin_candidates_) {
-      mean_lat += candidate.lat;
-      mean_lon += candidate.lon;
-      mean_alt += candidate.alt;
-    }
-    mean_lat /= gnss_origin_candidates_.size();
-    mean_lon /= gnss_origin_candidates_.size();
-    mean_alt /= gnss_origin_candidates_.size();
-
-    const double jump_m = approximateGeodeticDistanceMeters(mean_lat, mean_lon, lat, lon);
-    if (jump_m > gnss_origin_consistency_threshold_m_) {
-      RCLCPP_WARN(
-        get_logger(),
-        "Resetting GNSS origin initialization after %.1f m jump in candidate fixes",
-        jump_m);
-      gnss_origin_candidates_.clear();
-    }
+  const detail::GnssOriginUpdate update = gnss_origin_accumulator_.add(lat, lon, alt);
+  if (update.reset_after_jump) {
+    RCLCPP_WARN(
+      get_logger(),
+      "Resetting GNSS origin initialization after %.1f m jump in candidate fixes",
+      update.deviation_m);
   }
-
-  gnss_origin_candidates_.push_back(sample);
-
-  if (static_cast<int>(gnss_origin_candidates_.size()) < gnss_origin_min_samples_) {
-    return;
-  }
-
-  double mean_lat = 0.0;
-  double mean_lon = 0.0;
-  double mean_alt = 0.0;
-  for (const auto & candidate : gnss_origin_candidates_) {
-    mean_lat += candidate.lat;
-    mean_lon += candidate.lon;
-    mean_alt += candidate.alt;
-  }
-  mean_lat /= gnss_origin_candidates_.size();
-  mean_lon /= gnss_origin_candidates_.size();
-  mean_alt /= gnss_origin_candidates_.size();
-
-  double max_deviation_m = 0.0;
-  for (const auto & candidate : gnss_origin_candidates_) {
-    const double deviation_m = approximateGeodeticDistanceMeters(
-      mean_lat, mean_lon, candidate.lat, candidate.lon);
-    if (deviation_m > max_deviation_m) {
-      max_deviation_m = deviation_m;
-    }
-  }
-
-  if (max_deviation_m > gnss_origin_consistency_threshold_m_) {
-    const GnssOriginSample latest = gnss_origin_candidates_.back();
-    gnss_origin_candidates_.clear();
-    gnss_origin_candidates_.push_back(latest);
+  if (update.restarted_after_inconsistency) {
     RCLCPP_WARN(
       get_logger(),
       "GNSS origin candidates were inconsistent (max deviation %.1f m), restarting accumulation",
-      max_deviation_m);
+      update.deviation_m);
+  }
+  if (!update.initialized) {
     return;
   }
 
-  gnss_origin_lat_ = mean_lat;
-  gnss_origin_lon_ = mean_lon;
-  gnss_origin_alt_ = mean_alt;
+  gnss_origin_lat_ = update.origin.latitude_deg;
+  gnss_origin_lon_ = update.origin.longitude_deg;
+  gnss_origin_alt_ = update.origin.altitude_m;
   gnss_origin_set_ = true;
-  gnss_origin_candidates_.clear();
   RCLCPP_INFO(
     get_logger(),
     "GNSS origin set from %d consistent fixes: lat=%.8f, lon=%.8f, alt=%.2f",
     gnss_origin_min_samples_, gnss_origin_lat_, gnss_origin_lon_, gnss_origin_alt_);
-}
-
-double GraphBasedSlamComponent::approximateGeodeticDistanceMeters(
-  double lat0, double lon0, double lat1, double lon1) const
-{
-  return detail::approximateGeodeticDistanceMeters(lat0, lon0, lat1, lon1);
 }
 
 Eigen::Vector3d GraphBasedSlamComponent::geodeticToEnu(

--- a/graph_based_slam/test/test_gnss_origin_accumulator.cpp
+++ b/graph_based_slam/test/test_gnss_origin_accumulator.cpp
@@ -1,0 +1,81 @@
+// Copyright 2026 Ryohei Sasaki
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include "graph_based_slam/gnss_origin_accumulator.hpp"
+
+namespace graphslam
+{
+namespace detail
+{
+namespace
+{
+
+TEST(GnssOriginAccumulator, InitializesFromConsistentFixes)
+{
+  GnssOriginAccumulator accumulator;
+  accumulator.configure(3, 20.0);
+
+  EXPECT_FALSE(accumulator.add(35.0, 139.0, 10.0).initialized);
+  EXPECT_FALSE(accumulator.add(35.00001, 139.00001, 12.0).initialized);
+  const GnssOriginUpdate update = accumulator.add(35.00002, 139.00002, 14.0);
+
+  EXPECT_TRUE(update.initialized);
+  EXPECT_EQ(update.accepted_samples, 3U);
+  EXPECT_NEAR(update.origin.latitude_deg, 35.00001, 1e-12);
+  EXPECT_NEAR(update.origin.longitude_deg, 139.00001, 1e-12);
+  EXPECT_NEAR(update.origin.altitude_m, 12.0, 1e-12);
+}
+
+TEST(GnssOriginAccumulator, RestartsAfterLargeJump)
+{
+  GnssOriginAccumulator accumulator;
+  accumulator.configure(3, 20.0);
+  accumulator.add(35.0, 139.0, 10.0);
+
+  const GnssOriginUpdate update = accumulator.add(35.01, 139.01, 20.0);
+
+  EXPECT_TRUE(update.reset_after_jump);
+  EXPECT_FALSE(update.initialized);
+  EXPECT_EQ(update.accepted_samples, 1U);
+  EXPECT_GT(update.deviation_m, 20.0);
+}
+
+TEST(GnssOriginAccumulator, SupportsSingleSampleInitialization)
+{
+  GnssOriginAccumulator accumulator;
+  accumulator.configure(1, 20.0);
+
+  const GnssOriginUpdate update = accumulator.add(35.0, 139.0, 10.0);
+
+  EXPECT_TRUE(update.initialized);
+  EXPECT_EQ(update.accepted_samples, 1U);
+  EXPECT_DOUBLE_EQ(update.origin.latitude_deg, 35.0);
+  EXPECT_DOUBLE_EQ(update.origin.longitude_deg, 139.0);
+  EXPECT_DOUBLE_EQ(update.origin.altitude_m, 10.0);
+}
+
+}  // namespace
+}  // namespace detail
+}  // namespace graphslam

--- a/graph_based_slam/test/test_gnss_origin_accumulator.cpp
+++ b/graph_based_slam/test/test_gnss_origin_accumulator.cpp
@@ -1,24 +1,30 @@
-// Copyright 2026 Ryohei Sasaki
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
 //
 // Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
+// modification, are permitted provided that the following conditions
+// are met:
 //
-// 1. Redistributions of source code must retain the above copyright notice,
-//    this list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
## What changed

- add a testable `GnssOriginAccumulator` for candidate averaging and consistency checks
- delegate GNSS origin initialization from the ROS component to the accumulator
- remove the component-owned candidate vector and obsolete distance wrapper
- add focused tests for consistent fixes, large jumps, and single-sample configuration

## Why

GNSS origin initialization mixed state management, geodetic calculations, logging, and ROS component concerns in one large method. Isolating the state machine reduces component size and makes reset and initialization behavior directly testable.

## Impact

Runtime behavior and log messages are preserved. The component now applies accumulator results while the reusable helper owns candidate state.

## Validation

- Jazzy `colcon build --packages-up-to graph_based_slam --cmake-args -DBUILD_TESTING=ON`
- focused GNSS, cpplint, and uncrustify tests
- `colcon test-result --verbose`: 1577 tests, 0 errors, 0 failures