### PR TITLE
Improve point cloud colorization

### DIFF
--- a/graph_based_slam/test/test_colorize_from_bag.py
+++ b/graph_based_slam/test/test_colorize_from_bag.py
@@ -1,0 +1,153 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the numpy-only helpers in colorize_from_bag (no ROS needed)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+
+
+def _load():
+    if str(TOOL_DIR) not in sys.path:
+        sys.path.insert(0, str(TOOL_DIR))
+    import colorize_from_bag
+
+    return colorize_from_bag
+
+
+cfb = _load()
+
+
+class _Vec3:
+    def __init__(self, x, y, z):
+        self.x, self.y, self.z = x, y, z
+
+
+class _Quat:
+    def __init__(self, x, y, z, w):
+        self.x, self.y, self.z, self.w = x, y, z, w
+
+
+# --------------------------------------------------------------------------- #
+# nearest_index
+# --------------------------------------------------------------------------- #
+def test_nearest_index_picks_closest():
+    stamps = [100, 200, 300, 400]
+    # 260-200=60, 300-260=40 -> index 2 wins.
+    assert cfb.nearest_index(stamps, 260) == 2
+    assert cfb.nearest_index(stamps, 240) == 1  # 40 vs 60 -> index 1
+
+
+def test_nearest_index_exact_and_ends():
+    stamps = [10, 20, 30]
+    assert cfb.nearest_index(stamps, 20) == 1
+    assert cfb.nearest_index(stamps, -5) == 0
+    assert cfb.nearest_index(stamps, 999) == 2
+
+
+def test_nearest_index_empty_raises():
+    import pytest
+    with pytest.raises(ValueError):
+        cfb.nearest_index([], 5)
+
+
+# --------------------------------------------------------------------------- #
+# transform_msg_to_matrix
+# --------------------------------------------------------------------------- #
+def test_transform_identity():
+    T = cfb.transform_msg_to_matrix(_Vec3(0, 0, 0), _Quat(0, 0, 0, 1))
+    np.testing.assert_allclose(T, np.eye(4), atol=1e-9)
+
+
+def test_transform_translation_only():
+    T = cfb.transform_msg_to_matrix(_Vec3(1, 2, 3), _Quat(0, 0, 0, 1))
+    np.testing.assert_allclose(T[:3, 3], [1, 2, 3], atol=1e-9)
+    np.testing.assert_allclose(T[:3, :3], np.eye(3), atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# merge_colorings
+# --------------------------------------------------------------------------- #
+def test_merge_single_camera_passthrough():
+    rgb = np.array([[10, 20, 30], [40, 50, 60]], dtype=np.uint8)
+    seen = np.array([True, False])
+    counts = np.array([1, 0], dtype=np.uint16)
+    out, out_seen = cfb.merge_colorings([(rgb, seen, counts)], default_rgb=(7, 7, 7))
+    np.testing.assert_array_equal(out[0], [10, 20, 30])
+    np.testing.assert_array_equal(out[1], [7, 7, 7])  # unseen -> default
+    assert out_seen.tolist() == [True, False]
+
+
+def test_merge_count_weighted_blend():
+    # Point 0: cam A (count 3) says red, cam B (count 1) says blue -> mostly red.
+    a = (np.array([[200, 0, 0]], dtype=np.uint8), np.array([True]),
+         np.array([3], dtype=np.uint16))
+    b = (np.array([[0, 0, 200]], dtype=np.uint8), np.array([True]),
+         np.array([1], dtype=np.uint16))
+    out, seen = cfb.merge_colorings([a, b])
+    assert seen[0]
+    # (3*200 + 1*0)/4 = 150 red ; (3*0 + 1*200)/4 = 50 blue
+    np.testing.assert_array_equal(out[0], [150, 0, 50])
+
+
+def test_merge_union_of_coverage():
+    # Cam A sees only point 0, cam B only point 1 -> both coloured after merge.
+    a = (np.array([[100, 0, 0], [0, 0, 0]], dtype=np.uint8),
+         np.array([True, False]), np.array([1, 0], dtype=np.uint16))
+    b = (np.array([[0, 0, 0], [0, 100, 0]], dtype=np.uint8),
+         np.array([False, True]), np.array([0, 1], dtype=np.uint16))
+    out, seen = cfb.merge_colorings([a, b], default_rgb=(9, 9, 9))
+    assert seen.tolist() == [True, True]
+    np.testing.assert_array_equal(out[0], [100, 0, 0])
+    np.testing.assert_array_equal(out[1], [0, 100, 0])
+
+
+def test_merge_empty_raises():
+    import pytest
+    with pytest.raises(ValueError):
+        cfb.merge_colorings([])
+
+
+def test_transform_optical_rotation_is_a_valid_axis_permutation():
+    # The standard camera_link<->optical quaternion (0.5,-0.5,0.5,-0.5) must
+    # produce a proper rotation (orthonormal, det +1) that maps each unit axis
+    # onto a signed unit axis. Lock in the concrete mapping as a regression.
+    T = cfb.transform_msg_to_matrix(_Vec3(0, 0, 0), _Quat(0.5, -0.5, 0.5, -0.5))
+    R = T[:3, :3]
+    np.testing.assert_allclose(R @ R.T, np.eye(3), atol=1e-9)
+    assert abs(np.linalg.det(R) - 1.0) < 1e-9
+    np.testing.assert_allclose(R @ np.array([1.0, 0.0, 0.0]), [0, -1, 0], atol=1e-9)
+    np.testing.assert_allclose(R @ np.array([0.0, 0.0, 1.0]), [1, 0, 0], atol=1e-9)

--- a/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
+++ b/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
@@ -235,6 +235,62 @@ def test_colorize_robust_rejects_bad_zbuf_bin():
                                            zbuf_bin=0)
 
 
+def test_colorize_robust_bilinear_blends_neighbouring_pixels():
+    vms, K, W, H = _cam()
+    img = np.zeros((H, W, 3), dtype=np.uint8)
+    img[50, 50] = [100, 100, 100]
+    img[50, 51] = [200, 200, 200]
+    # x = 0.02 -> u = 100*0.02/5 + 50 = 50.4 (40 % of the way to pixel 51).
+    pts = np.array([[0.02, 0.0, 5.0]])
+    rgb, seen = pcio.colorize_by_projection_robust(
+        pts, vms, K, [img], W, H, normalize_exposure=False, interp='bilinear')
+    assert seen[0]
+    # 0.6*100 + 0.4*200 = 140 on every channel.
+    np.testing.assert_array_equal(rgb[0], [140, 140, 140])
+    # Nearest snaps to pixel 50 -> the un-blended 100.
+    rgb_n, _ = pcio.colorize_by_projection_robust(
+        pts, vms, K, [img], W, H, normalize_exposure=False, interp='nearest')
+    np.testing.assert_array_equal(rgb_n[0], [100, 100, 100])
+
+
+def test_colorize_robust_prefers_nearest_views_when_full():
+    _, K, W, H = _cam()
+    red = np.full((H, W, 3), [200, 0, 0], dtype=np.uint8)     # far / wrong colour
+    green = np.full((H, W, 3), [0, 200, 0], dtype=np.uint8)   # near / true colour
+    # Same on-axis point; a per-view +z shift changes only its camera depth.
+    far, near0, near1 = np.eye(4), np.eye(4), np.eye(4)
+    far[2, 3], near0[2, 3], near1[2, 3] = 20.0, 0.0, 1.0
+    vms = np.stack([far, near0, near1])
+    pts = np.array([[0.0, 0.0, 5.0]])
+    # Budget of 2 samples, seen by 3 views: the far red view must be evicted.
+    rgb, seen = pcio.colorize_by_projection_robust(
+        pts, vms, K, [red, green, green], W, H, normalize_exposure=False,
+        max_samples=2, prefer_near=True)
+    assert seen[0]
+    np.testing.assert_array_equal(rgb[0], [0, 200, 0])
+    # Without the preference the first two (red + green) survive -> a blend.
+    rgb_fifo, _ = pcio.colorize_by_projection_robust(
+        pts, vms, K, [red, green, green], W, H, normalize_exposure=False,
+        max_samples=2, prefer_near=False)
+    assert not np.array_equal(rgb_fifo[0], [0, 200, 0])
+
+
+def test_colorize_robust_return_counts_reports_confidence():
+    vms1, K, W, H = _cam()
+    img = np.zeros((H, W, 3), dtype=np.uint8)
+    img[50, 50] = [10, 20, 30]
+    vms = np.concatenate([vms1] * 3, axis=0)
+    # One point seen by all three views, one far off-frame (never seen).
+    pts = np.array([[0.0, 0.0, 5.0], [50.0, 0.0, 5.0]])
+    out = pcio.colorize_by_projection_robust(
+        pts, vms, K, [img, img, img], W, H, normalize_exposure=False,
+        return_counts=True)
+    assert len(out) == 3
+    rgb, seen, counts = out
+    assert counts[0] == 3 and counts[1] == 0
+    assert seen[0] and not seen[1]
+
+
 # --------------------------------------------------------------------------- #
 # project_depth_maps (LiDAR depth supervision GT)
 # --------------------------------------------------------------------------- #

--- a/scanmatcher/CMakeLists.txt
+++ b/scanmatcher/CMakeLists.txt
@@ -110,6 +110,9 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_map_update_policy test/test_map_update_policy.cpp)
   target_include_directories(test_map_update_policy PRIVATE include ${EIGEN3_INCLUDE_DIR})
+
+  ament_add_gtest(test_point_colorizer test/test_point_colorizer.cpp)
+  target_include_directories(test_point_colorizer PRIVATE include ${EIGEN3_INCLUDE_DIR})
 endif()
 
 add_library(scanmatcher_component SHARED
@@ -148,6 +151,15 @@ if(small_gicp_FOUND)
   target_link_libraries(small_gicp_odom_node ${PCL_LIBRARIES})
 endif()
 
+find_package(message_filters REQUIRED)
+add_executable(pointcloud_colorization_node
+  src/pointcloud_colorization_node.cpp
+)
+target_include_directories(pointcloud_colorization_node PRIVATE include ${EIGEN3_INCLUDE_DIR})
+ament_target_dependencies(pointcloud_colorization_node
+  rclcpp sensor_msgs geometry_msgs tf2_ros tf2_eigen pcl_conversions message_filters)
+target_link_libraries(pointcloud_colorization_node ${PCL_LIBRARIES})
+
 include_directories(
     include
     ${PCL_INCLUDE_DIRS}
@@ -179,7 +191,8 @@ install(TARGETS
   RUNTIME DESTINATION bin
 )
 
-set(INSTALL_TARGETS scanmatcher_node scan_matcher_offline_runner)
+set(INSTALL_TARGETS scanmatcher_node scan_matcher_offline_runner
+  pointcloud_colorization_node)
 if(small_gicp_FOUND)
   list(APPEND INSTALL_TARGETS small_gicp_odom_node)
 endif()

--- a/scanmatcher/include/scanmatcher/point_colorizer.hpp
+++ b/scanmatcher/include/scanmatcher/point_colorizer.hpp
@@ -1,0 +1,302 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef SCANMATCHER__POINT_COLORIZER_HPP_
+#define SCANMATCHER__POINT_COLORIZER_HPP_
+
+// Pure, ROS-/OpenCV-free core for colouring a SLAM point cloud from posed
+// camera images online. It is the streaming counterpart of the offline Python
+// colorizer (tools/gaussian_splatting/pointcloud_io.colorize_by_projection_robust):
+// project a map point into the current camera, reject it if a nearer point in
+// the same image cell occludes it (a coarse per-frame z-buffer), sample the
+// pixel (nearest or bilinear), and fold the observation into a depth-weighted
+// running mean so the nearest — highest-resolution, least-foreshortened —
+// views dominate the final colour.
+//
+// The realtime ScanMatcher/colorizer node is the shell around this: it syncs
+// image + camera_info, looks up the lidar->camera extrinsic via tf, and calls
+// projectPoint / FrameZBuffer / sampleBilinear / PointColor::add per keyframe.
+// Keeping the maths here (Eigen only) lets it be unit-tested without a running
+// ROS graph, matching pose_prediction.hpp / imu_processing.hpp in this package.
+
+#include <Eigen/Core>
+
+#include <cstdint>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
+
+namespace graphslam
+{
+namespace point_colorizer
+{
+
+// Pinhole intrinsics plus image size (pixels). Matches the K / width / height a
+// sensor_msgs/CameraInfo carries.
+struct CameraIntrinsics
+{
+  float fx {0.0f};
+  float fy {0.0f};
+  float cx {0.0f};
+  float cy {0.0f};
+  int width {0};
+  int height {0};
+};
+
+// OpenCV/ROS plumb_bob distortion coefficients (k1, k2, p1, p2, k3).
+// Applying these during projection lets us sample a raw, distorted image
+// directly; a zero-initialised value is equivalent to an ideal pinhole lens.
+struct PlumbBobDistortion
+{
+  float k1 {0.0f};
+  float k2 {0.0f};
+  float p1 {0.0f};
+  float p2 {0.0f};
+  float k3 {0.0f};
+};
+
+// A borrowed, row-major image buffer (no ownership) — a thin stand-in for a
+// cv::Mat so the core needs no OpenCV. `channels` is 1 (grey) or >=3 (RGB[A]);
+// only the first three channels are read. `row_stride` is bytes per row.
+struct ImageView
+{
+  const std::uint8_t * data {nullptr};
+  int width {0};
+  int height {0};
+  int channels {0};
+  int row_stride {0};
+
+  bool valid() const
+  {
+    return data != nullptr && width > 0 && height > 0 && channels >= 1 &&
+           row_stride >= width * channels;
+  }
+
+  // Channel `c` of pixel (x, y); grey images broadcast their single channel.
+  std::uint8_t at(int x, int y, int c) const
+  {
+    const int cc = (channels >= 3) ? c : 0;
+    return data[static_cast<std::size_t>(y) * row_stride + x * channels + cc];
+  }
+};
+
+// Project a world/map point into the camera. `world_to_cam` is the OpenCV
+// convention (+z forward, world->camera) so depth is the camera-frame z. Fills
+// (u, v) in pixels and `depth` in metres; returns true only when the point is
+// in front of the camera and lands inside the image.
+inline bool projectPoint(
+  const CameraIntrinsics & intr, const Eigen::Matrix4f & world_to_cam,
+  const Eigen::Vector3f & p_world, float & u, float & v, float & depth,
+  const PlumbBobDistortion * distortion = nullptr)
+{
+  const Eigen::Vector3f cam =
+    world_to_cam.block<3, 3>(0, 0) * p_world + world_to_cam.block<3, 1>(0, 3);
+  depth = cam.z();
+  if (!(depth > 1e-6f)) {
+    return false;
+  }
+  float x = cam.x() / depth;
+  float y = cam.y() / depth;
+  if (distortion != nullptr) {
+    const float x2 = x * x;
+    const float y2 = y * y;
+    const float xy = x * y;
+    const float r2 = x2 + y2;
+    const float radial =
+      1.0f + distortion->k1 * r2 + distortion->k2 * r2 * r2 +
+      distortion->k3 * r2 * r2 * r2;
+    const float xd = x * radial + 2.0f * distortion->p1 * xy +
+      distortion->p2 * (r2 + 2.0f * x2);
+    const float yd = y * radial + distortion->p1 * (r2 + 2.0f * y2) +
+      2.0f * distortion->p2 * xy;
+    x = xd;
+    y = yd;
+  }
+  u = intr.fx * x + intr.cx;
+  v = intr.fy * y + intr.cy;
+  return u >= 0.0f && u <= static_cast<float>(intr.width - 1) &&
+         v >= 0.0f && v <= static_cast<float>(intr.height - 1);
+}
+
+// Nearest-pixel colour sample into `rgb` (3 elements). Coordinates are clamped
+// to the image, so callers may pass any in-bounds (u, v).
+inline void sampleNearest(
+  const ImageView & img, float u, float v, float rgb[3])
+{
+  const int x = std::min(std::max(static_cast<int>(std::lround(u)), 0), img.width - 1);
+  const int y = std::min(std::max(static_cast<int>(std::lround(v)), 0), img.height - 1);
+  for (int c = 0; c < 3; ++c) {
+    rgb[c] = static_cast<float>(img.at(x, y, c));
+  }
+}
+
+// Bilinear colour sample into `rgb` (3 elements): blends the four surrounding
+// pixels (edges clamp, never wrap), cutting the colour bleed nearest sampling
+// leaves along edges. Mirrors the Python `interp='bilinear'` path.
+inline void sampleBilinear(
+  const ImageView & img, float u, float v, float rgb[3])
+{
+  const float uc = std::min(std::max(u, 0.0f), static_cast<float>(img.width - 1));
+  const float vc = std::min(std::max(v, 0.0f), static_cast<float>(img.height - 1));
+  const int x0 = static_cast<int>(std::floor(uc));
+  const int y0 = static_cast<int>(std::floor(vc));
+  const int x1 = std::min(x0 + 1, img.width - 1);
+  const int y1 = std::min(y0 + 1, img.height - 1);
+  const float wx = uc - static_cast<float>(x0);
+  const float wy = vc - static_cast<float>(y0);
+  for (int c = 0; c < 3; ++c) {
+    const float top =
+      static_cast<float>(img.at(x0, y0, c)) * (1.0f - wx) +
+      static_cast<float>(img.at(x1, y0, c)) * wx;
+    const float bot =
+      static_cast<float>(img.at(x0, y1, c)) * (1.0f - wx) +
+      static_cast<float>(img.at(x1, y1, c)) * wx;
+    rgb[c] = top * (1.0f - wy) + bot * wy;
+  }
+}
+
+// Coarse per-frame z-buffer over `bin`-pixel cells. Built from the points that
+// project into this frame, it lets the colorizer skip a point whose depth sits
+// well behind the nearest surface in its cell — the online equivalent of the
+// offline z-buffer occlusion test, so points behind a wall do not steal the
+// wall's colour.
+class FrameZBuffer
+{
+public:
+  FrameZBuffer(const CameraIntrinsics & intr, int bin)
+  : bin_(std::max(bin, 1)),
+    cols_((intr.width + bin_ - 1) / bin_),
+    rows_((intr.height + bin_ - 1) / bin_),
+    buf_(static_cast<std::size_t>(cols_) * rows_,
+      std::numeric_limits<float>::infinity())
+  {
+  }
+
+  // Record a projected point's depth in its cell (keeps the nearest).
+  void insert(float u, float v, float depth)
+  {
+    const std::size_t idx = cell(u, v);
+    if (depth < buf_[idx]) {
+      buf_[idx] = depth;
+    }
+  }
+
+  // Visible if within `tol` (+2 % of range) of the nearest depth in its cell.
+  bool visible(float u, float v, float depth, float tol) const
+  {
+    return depth <= buf_[cell(u, v)] + tol + 0.02f * depth;
+  }
+
+  float nearestDepth(float u, float v) const {return buf_[cell(u, v)];}
+
+private:
+  std::size_t cell(float u, float v) const
+  {
+    int cx = static_cast<int>(u) / bin_;
+    int cy = static_cast<int>(v) / bin_;
+    cx = std::min(std::max(cx, 0), cols_ - 1);
+    cy = std::min(std::max(cy, 0), rows_ - 1);
+    return static_cast<std::size_t>(cy) * cols_ + cx;
+  }
+
+  int bin_;
+  int cols_;
+  int rows_;
+  std::vector<float> buf_;
+};
+
+// Per-point colour accumulator: a depth-weighted running mean (weight
+// 1/(depth+eps)) so nearer, sharper observations dominate — the streaming form
+// of the offline `prefer_near`. O(1) memory per point, no sample buffer.
+struct PointColor
+{
+  double sum_w {0.0};
+  double sum_wr {0.0};
+  double sum_wg {0.0};
+  double sum_wb {0.0};
+  float best_depth {std::numeric_limits<float>::infinity()};
+  std::uint16_t count {0};
+
+  void add(const float rgb[3], float depth)
+  {
+    const double w = 1.0 / (static_cast<double>(depth) + 1e-3);
+    sum_w += w;
+    sum_wr += w * rgb[0];
+    sum_wg += w * rgb[1];
+    sum_wb += w * rgb[2];
+    if (depth < best_depth) {
+      best_depth = depth;
+    }
+    if (count < std::numeric_limits<std::uint16_t>::max()) {
+      ++count;
+    }
+  }
+
+  bool seen() const {return count > 0;}
+
+  // Rounded [0,255] mean colour into `out` (3 elements). Undefined if unseen.
+  void mean(std::uint8_t out[3]) const
+  {
+    const double inv = (sum_w > 0.0) ? 1.0 / sum_w : 0.0;
+    const double vals[3] = {sum_wr * inv, sum_wg * inv, sum_wb * inv};
+    for (int c = 0; c < 3; ++c) {
+      const double v = std::min(std::max(vals[c] + 0.5, 0.0), 255.0);
+      out[c] = static_cast<std::uint8_t>(v);
+    }
+  }
+};
+
+// Median luminance (Rec.601) of an ImageView — the exposure statistic the shell
+// uses to rescale each frame toward a global median before accumulation, so
+// auto-exposure swings do not bias the colour. Returns 0 for an empty image.
+inline float medianLuminance(const ImageView & img)
+{
+  if (!img.valid()) {
+    return 0.0f;
+  }
+  std::vector<float> lum;
+  lum.reserve(static_cast<std::size_t>(img.width) * img.height);
+  for (int y = 0; y < img.height; ++y) {
+    for (int x = 0; x < img.width; ++x) {
+      lum.push_back(
+        0.299f * img.at(x, y, 0) + 0.587f * img.at(x, y, 1) +
+        0.114f * img.at(x, y, 2));
+    }
+  }
+  const std::size_t mid = lum.size() / 2;
+  std::nth_element(lum.begin(), lum.begin() + mid, lum.end());
+  return lum[mid];
+}
+
+}  // namespace point_colorizer
+}  // namespace graphslam
+
+#endif  // SCANMATCHER__POINT_COLORIZER_HPP_

--- a/scanmatcher/launch/colorization.launch.py
+++ b/scanmatcher/launch/colorization.launch.py
@@ -1,0 +1,65 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+import launch
+import launch_ros.actions
+
+
+def generate_launch_description():
+
+    colorization_param_dir = launch.substitutions.LaunchConfiguration(
+        'colorization_param_dir',
+        default=os.path.join(
+            get_package_share_directory('scanmatcher'),
+            'param',
+            'colorization.yaml'))
+
+    colorization = launch_ros.actions.Node(
+        package='scanmatcher',
+        executable='pointcloud_colorization_node',
+        parameters=[colorization_param_dir],
+        remappings=[
+            ('map', '/map'),
+            ('image_raw', '/camera/image_raw'),
+            ('camera_info', '/camera/camera_info'),
+            ('colored_map', '/colored_map'),
+        ],
+        output='screen'
+    )
+
+    return launch.LaunchDescription([
+        launch.actions.DeclareLaunchArgument(
+            'colorization_param_dir',
+            default_value=colorization_param_dir,
+            description='Full path to the colorization parameter file to load'),
+        colorization
+    ])

--- a/scanmatcher/package.xml
+++ b/scanmatcher/package.xml
@@ -21,6 +21,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_eigen</depend>
   <depend>pcl_conversions</depend>
+  <depend>message_filters</depend>
   <depend>lidarslam_msgs</depend>
   <depend>rosbag2_cpp</depend>
   <depend>ndt_omp_ros2</depend>

--- a/scanmatcher/param/colorization.yaml
+++ b/scanmatcher/param/colorization.yaml
@@ -1,0 +1,14 @@
+pointcloud_colorization:
+  ros__parameters:
+    map_frame: "map"
+    # Must be the camera OPTICAL frame (REP-103: +z forward, +x right, +y down).
+    camera_optical_frame: "camera_optical_link"
+    voxel_size: 0.1            # colour-accumulation voxel size [m]
+    zbuf_bin: 4               # per-frame z-buffer cell size [px] (occlusion)
+    depth_tolerance: 0.15     # visible if within this (+2% range) of nearest [m]
+    use_bilinear: true        # sub-pixel colour sampling (vs nearest)
+    normalize_exposure: true  # rescale each frame toward a running median luma
+    exposure_ema_alpha: 0.1   # smoothing of the exposure target
+    publish_period: 2.0       # colored_map publish period [s]
+    sync_queue_size: 10       # image/camera_info ApproximateTime queue
+    max_project_points: 2000000  # cap points projected per frame (strided)

--- a/scanmatcher/src/pointcloud_colorization_node.cpp
+++ b/scanmatcher/src/pointcloud_colorization_node.cpp
@@ -1,0 +1,414 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Realtime point-cloud colorization node.
+//
+// The ScanMatcher registration core runs on pcl::PointXYZI (no colour); this
+// node keeps that core untouched and colours the map in a decoupled layer. It
+// caches the latest SLAM map (a PointXYZI PointCloud2), and for every camera
+// image (synchronised with its CameraInfo) it looks up the map->camera_optical
+// transform via tf, projects the map points, rejects the occluded ones with a
+// coarse per-frame z-buffer, samples the pixel (bilinear), exposure-normalises
+// the frame, and folds each observation into a depth-weighted running mean per
+// voxel. A timer publishes the accumulated colours as a PointXYZRGB cloud.
+//
+// All the projection / occlusion / accumulation maths lives in the pure,
+// unit-tested scanmatcher/point_colorizer.hpp; this file is only the ROS shell
+// (topics, tf, message_filters sync, PointCloud2 <-> voxel-store plumbing). No
+// cv_bridge/OpenCV: sensor_msgs/Image already exposes a raw row-major buffer,
+// which wraps straight into point_colorizer::ImageView.
+//
+// The camera frame must be the optical frame (REP-103: +z forward, +x right,
+// +y down), matching the OpenCV convention projectPoint expects.
+
+#include <Eigen/Core>
+#include <message_filters/subscriber.h>
+#include <message_filters/synchronizer.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <cstdint>
+
+#include <cmath>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include "scanmatcher/point_colorizer.hpp"
+
+namespace graphslam
+{
+
+using point_colorizer::CameraIntrinsics;
+using point_colorizer::FrameZBuffer;
+using point_colorizer::ImageView;
+using point_colorizer::PointColor;
+using point_colorizer::PlumbBobDistortion;
+
+class PointCloudColorizationNode : public rclcpp::Node
+{
+public:
+  PointCloudColorizationNode()
+  : Node("pointcloud_colorization"),
+    tf_buffer_(this->get_clock()),
+    tf_listener_(tf_buffer_)
+  {
+    map_frame_ = declare_parameter("map_frame", std::string("map"));
+    camera_optical_frame_ =
+      declare_parameter("camera_optical_frame", std::string("camera_optical_link"));
+    const std::string map_topic = declare_parameter("map_topic", std::string("map"));
+    const std::string image_topic =
+      declare_parameter("image_topic", std::string("image_raw"));
+    const std::string camera_info_topic =
+      declare_parameter("camera_info_topic", std::string("camera_info"));
+    const std::string colored_map_topic =
+      declare_parameter("colored_map_topic", std::string("colored_map"));
+
+    voxel_size_ = declare_parameter("voxel_size", 0.1);
+    zbuf_bin_ = static_cast<int>(declare_parameter("zbuf_bin", 4));
+    depth_tol_ = declare_parameter("depth_tolerance", 0.15);
+    use_bilinear_ = declare_parameter("use_bilinear", true);
+    normalize_exposure_ = declare_parameter("normalize_exposure", true);
+    exposure_ema_alpha_ = declare_parameter("exposure_ema_alpha", 0.1);
+    tf_timeout_ = declare_parameter("tf_timeout", 0.1);
+    const double publish_period = declare_parameter("publish_period", 2.0);
+    const int sync_queue = static_cast<int>(declare_parameter("sync_queue_size", 10));
+    max_project_points_ =
+      static_cast<int>(declare_parameter("max_project_points", 2000000));
+
+    // Sensor streams (map/image/camera_info) are typically best-effort; a
+    // best-effort subscriber is compatible with both best-effort publishers
+    // (rosbag2, live drivers) and reliable ones (a latched SLAM /map), so use
+    // it everywhere to avoid silently dropping every message on a QoS mismatch.
+    map_sub_ = create_subscription<sensor_msgs::msg::PointCloud2>(
+      map_topic, rclcpp::SensorDataQoS(),
+      std::bind(&PointCloudColorizationNode::mapCallback, this, std::placeholders::_1));
+
+    image_sub_.subscribe(this, image_topic, rmw_qos_profile_sensor_data);
+    info_sub_.subscribe(this, camera_info_topic, rmw_qos_profile_sensor_data);
+    sync_ = std::make_shared<Sync>(SyncPolicy(sync_queue), image_sub_, info_sub_);
+    sync_->registerCallback(std::bind(
+      &PointCloudColorizationNode::imageCallback, this,
+      std::placeholders::_1, std::placeholders::_2));
+
+    colored_pub_ =
+      create_publisher<sensor_msgs::msg::PointCloud2>(colored_map_topic, rclcpp::QoS(1));
+
+    publish_timer_ = create_wall_timer(
+      std::chrono::duration<double>(publish_period),
+      std::bind(&PointCloudColorizationNode::publishColored, this));
+
+    RCLCPP_INFO(
+      get_logger(),
+      "colorization: map=%s image=%s info=%s -> %s (voxel=%.3f, bilinear=%d)",
+      map_topic.c_str(), image_topic.c_str(), camera_info_topic.c_str(),
+      colored_map_topic.c_str(), voxel_size_, static_cast<int>(use_bilinear_));
+  }
+
+private:
+  using SyncPolicy = message_filters::sync_policies::ApproximateTime<
+    sensor_msgs::msg::Image, sensor_msgs::msg::CameraInfo>;
+  using Sync = message_filters::Synchronizer<SyncPolicy>;
+
+  struct Voxel
+  {
+    float x {0.0f};
+    float y {0.0f};
+    float z {0.0f};
+    PointColor color;
+  };
+
+  // Quantise a point to a voxel key (three 21-bit signed fields in a 64-bit int).
+  std::int64_t voxelKey(float x, float y, float z) const
+  {
+    const auto q = [this](float v) {
+        return static_cast<std::int64_t>(std::floor(v / voxel_size_));
+      };
+    const std::int64_t mask = (1LL << 21) - 1;
+    return ((q(x) & mask) << 42) | ((q(y) & mask) << 21) | (q(z) & mask);
+  }
+
+  void mapCallback(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
+  {
+    std::vector<Eigen::Vector3f> pts;
+    pts.reserve(msg->width * msg->height);
+    sensor_msgs::PointCloud2ConstIterator<float> ix(*msg, "x");
+    sensor_msgs::PointCloud2ConstIterator<float> iy(*msg, "y");
+    sensor_msgs::PointCloud2ConstIterator<float> iz(*msg, "z");
+    for (; ix != ix.end(); ++ix, ++iy, ++iz) {
+      const float x = *ix, y = *iy, z = *iz;
+      if (!std::isfinite(x) || !std::isfinite(y) || !std::isfinite(z)) {
+        continue;
+      }
+      pts.emplace_back(x, y, z);
+    }
+    std::lock_guard<std::mutex> lock(mtx_);
+    map_points_.swap(pts);
+    // Seed geometry so far-unseen points still appear (grey) in the output.
+    for (const auto & p : map_points_) {
+      auto & vox = voxels_[voxelKey(p.x(), p.y(), p.z())];
+      vox.x = p.x();
+      vox.y = p.y();
+      vox.z = p.z();
+    }
+  }
+
+  // Wrap a sensor_msgs/Image into an ImageView; returns false for encodings we
+  // do not decode. Sets bgr when the channel order is B,G,R (swapped on sample).
+  static bool wrapImage(
+    const sensor_msgs::msg::Image & img, ImageView & view, bool & bgr)
+  {
+    const std::string & enc = img.encoding;
+    int channels = 0;
+    bgr = false;
+    if (enc == "rgb8") {
+      channels = 3;
+    } else if (enc == "bgr8") {
+      channels = 3;
+      bgr = true;
+    } else if (enc == "rgba8") {
+      channels = 4;
+    } else if (enc == "bgra8") {
+      channels = 4;
+      bgr = true;
+    } else if (enc == "mono8") {
+      channels = 1;
+    } else {
+      return false;
+    }
+    view.data = img.data.data();
+    view.width = static_cast<int>(img.width);
+    view.height = static_cast<int>(img.height);
+    view.channels = channels;
+    view.row_stride = static_cast<int>(img.step);
+    return view.valid();
+  }
+
+  void imageCallback(
+    const sensor_msgs::msg::Image::ConstSharedPtr image,
+    const sensor_msgs::msg::CameraInfo::ConstSharedPtr info)
+  {
+    ImageView view;
+    bool bgr = false;
+    if (!wrapImage(*image, view, bgr)) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "unsupported image encoding '%s'", image->encoding.c_str());
+      return;
+    }
+
+    CameraIntrinsics intr;
+    intr.fx = static_cast<float>(info->k[0]);
+    intr.fy = static_cast<float>(info->k[4]);
+    intr.cx = static_cast<float>(info->k[2]);
+    intr.cy = static_cast<float>(info->k[5]);
+    intr.width = static_cast<int>(info->width);
+    intr.height = static_cast<int>(info->height);
+    if (intr.fx <= 0.0f || intr.fy <= 0.0f || intr.width <= 0 || intr.height <= 0) {
+      return;
+    }
+
+    PlumbBobDistortion distortion;
+    const PlumbBobDistortion * distortion_ptr = nullptr;
+    if (info->distortion_model.empty() || info->distortion_model == "plumb_bob") {
+      if (info->d.size() >= 4) {
+        distortion.k1 = static_cast<float>(info->d[0]);
+        distortion.k2 = static_cast<float>(info->d[1]);
+        distortion.p1 = static_cast<float>(info->d[2]);
+        distortion.p2 = static_cast<float>(info->d[3]);
+        if (info->d.size() >= 5) {
+          distortion.k3 = static_cast<float>(info->d[4]);
+        }
+        distortion_ptr = &distortion;
+      }
+    } else {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 30000,
+        "unsupported distortion model '%s'; using pinhole projection",
+        info->distortion_model.c_str());
+    }
+
+    // map -> camera_optical at the image stamp: p_cam = T * p_map.
+    Eigen::Matrix4f world_to_cam;
+    try {
+      const auto tf = tf_buffer_.lookupTransform(
+        camera_optical_frame_, map_frame_, image->header.stamp,
+        rclcpp::Duration::from_seconds(tf_timeout_));
+      world_to_cam = tf2::transformToEigen(tf).matrix().cast<float>();
+    } catch (const tf2::TransformException & ex) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000, "tf lookup failed: %s", ex.what());
+      return;
+    }
+
+    float exposure_scale = 1.0f;
+    if (normalize_exposure_) {
+      const float med = point_colorizer::medianLuminance(view);
+      if (med > 1e-3f) {
+        if (exposure_target_ <= 0.0f) {
+          exposure_target_ = med;
+        } else {
+          exposure_target_ = static_cast<float>(
+            exposure_ema_alpha_ * med + (1.0 - exposure_ema_alpha_) * exposure_target_);
+        }
+        exposure_scale = exposure_target_ / med;
+      }
+    }
+
+    std::lock_guard<std::mutex> lock(mtx_);
+    if (map_points_.empty()) {
+      return;
+    }
+    const int stride = std::max<int>(
+      1, static_cast<int>(map_points_.size()) / std::max(1, max_project_points_));
+
+    // Pass 1: build the per-frame z-buffer from the projected points.
+    FrameZBuffer zbuf(intr, zbuf_bin_);
+    for (std::size_t i = 0; i < map_points_.size(); i += stride) {
+      float u, v, depth;
+      if (projectPoint(intr, world_to_cam, map_points_[i], u, v, depth, distortion_ptr)) {
+        zbuf.insert(u, v, depth);
+      }
+    }
+
+    // Pass 2: colour the visible points into their voxels.
+    for (std::size_t i = 0; i < map_points_.size(); i += stride) {
+      const Eigen::Vector3f & p = map_points_[i];
+      float u, v, depth;
+      if (!projectPoint(intr, world_to_cam, p, u, v, depth, distortion_ptr)) {
+        continue;
+      }
+      if (!zbuf.visible(u, v, depth, static_cast<float>(depth_tol_))) {
+        continue;
+      }
+      float rgb[3];
+      if (use_bilinear_) {
+        point_colorizer::sampleBilinear(view, u, v, rgb);
+      } else {
+        point_colorizer::sampleNearest(view, u, v, rgb);
+      }
+      if (bgr) {
+        std::swap(rgb[0], rgb[2]);
+      }
+      for (int c = 0; c < 3; ++c) {
+        rgb[c] = std::min(std::max(rgb[c] * exposure_scale, 0.0f), 255.0f);
+      }
+      voxels_[voxelKey(p.x(), p.y(), p.z())].color.add(rgb, depth);
+    }
+  }
+
+  void publishColored()
+  {
+    if (colored_pub_->get_subscription_count() == 0) {
+      return;
+    }
+    pcl::PointCloud<pcl::PointXYZRGB> cloud;
+    {
+      std::lock_guard<std::mutex> lock(mtx_);
+      cloud.reserve(voxels_.size());
+      for (const auto & kv : voxels_) {
+        const Voxel & vox = kv.second;
+        pcl::PointXYZRGB p;
+        p.x = vox.x;
+        p.y = vox.y;
+        p.z = vox.z;
+        if (vox.color.seen()) {
+          std::uint8_t rgb[3];
+          vox.color.mean(rgb);
+          p.r = rgb[0];
+          p.g = rgb[1];
+          p.b = rgb[2];
+        } else {
+          p.r = p.g = p.b = 128;  // grey for geometry not yet coloured
+        }
+        cloud.push_back(p);
+      }
+    }
+    if (cloud.empty()) {
+      return;
+    }
+    sensor_msgs::msg::PointCloud2 msg;
+    pcl::toROSMsg(cloud, msg);
+    msg.header.frame_id = map_frame_;
+    msg.header.stamp = now();
+    colored_pub_->publish(msg);
+  }
+
+  // Parameters.
+  std::string map_frame_;
+  std::string camera_optical_frame_;
+  double voxel_size_ {0.1};
+  int zbuf_bin_ {4};
+  double depth_tol_ {0.15};
+  bool use_bilinear_ {true};
+  bool normalize_exposure_ {true};
+  double exposure_ema_alpha_ {0.1};
+  double tf_timeout_ {0.1};
+  int max_project_points_ {2000000};
+
+  // State.
+  float exposure_target_ {-1.0f};
+  std::mutex mtx_;
+  std::vector<Eigen::Vector3f> map_points_;
+  std::unordered_map<std::int64_t, Voxel> voxels_;
+
+  // ROS interfaces.
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr map_sub_;
+  message_filters::Subscriber<sensor_msgs::msg::Image> image_sub_;
+  message_filters::Subscriber<sensor_msgs::msg::CameraInfo> info_sub_;
+  std::shared_ptr<Sync> sync_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr colored_pub_;
+  rclcpp::TimerBase::SharedPtr publish_timer_;
+};
+
+}  // namespace graphslam
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<graphslam::PointCloudColorizationNode>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/scanmatcher/test/test_point_colorizer.cpp
+++ b/scanmatcher/test/test_point_colorizer.cpp
@@ -1,0 +1,302 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <Eigen/Core>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include <vector>
+
+#include "scanmatcher/point_colorizer.hpp"
+
+namespace
+{
+using graphslam::point_colorizer::CameraIntrinsics;
+using graphslam::point_colorizer::FrameZBuffer;
+using graphslam::point_colorizer::ImageView;
+using graphslam::point_colorizer::PointColor;
+using graphslam::point_colorizer::PlumbBobDistortion;
+using graphslam::point_colorizer::medianLuminance;
+using graphslam::point_colorizer::projectPoint;
+using graphslam::point_colorizer::sampleBilinear;
+using graphslam::point_colorizer::sampleNearest;
+
+// 100x100 pinhole, principal point at the centre, unit focal scale of 100.
+CameraIntrinsics makeCam()
+{
+  CameraIntrinsics intr;
+  intr.fx = 100.0f;
+  intr.fy = 100.0f;
+  intr.cx = 50.0f;
+  intr.cy = 50.0f;
+  intr.width = 100;
+  intr.height = 100;
+  return intr;
+}
+
+// A backing RGB buffer wrapped as an ImageView (row-major, 3 channels).
+struct RgbImage
+{
+  int width;
+  int height;
+  std::vector<std::uint8_t> data;
+
+  RgbImage(int w, int h)
+  : width(w), height(h), data(static_cast<std::size_t>(w) * h * 3, 0)
+  {
+  }
+
+  void set(int x, int y, std::uint8_t r, std::uint8_t g, std::uint8_t b)
+  {
+    const std::size_t i = (static_cast<std::size_t>(y) * width + x) * 3;
+    data[i] = r;
+    data[i + 1] = g;
+    data[i + 2] = b;
+  }
+
+  ImageView view() const
+  {
+    ImageView v;
+    v.data = data.data();
+    v.width = width;
+    v.height = height;
+    v.channels = 3;
+    v.row_stride = width * 3;
+    return v;
+  }
+};
+
+}  // namespace
+
+// --------------------------------------------------------------------------- //
+// projectPoint
+// --------------------------------------------------------------------------- //
+TEST(PointColorizer, ProjectsOnAxisPointToPrincipalPoint)
+{
+  const CameraIntrinsics intr = makeCam();
+  const Eigen::Matrix4f w2c = Eigen::Matrix4f::Identity();
+  float u = 0.0f;
+  float v = 0.0f;
+  float depth = 0.0f;
+  ASSERT_TRUE(projectPoint(intr, w2c, Eigen::Vector3f(0.0f, 0.0f, 5.0f), u, v, depth));
+  EXPECT_NEAR(u, 50.0f, 1e-4f);
+  EXPECT_NEAR(v, 50.0f, 1e-4f);
+  EXPECT_NEAR(depth, 5.0f, 1e-4f);
+}
+
+TEST(PointColorizer, RejectsPointBehindCamera)
+{
+  const CameraIntrinsics intr = makeCam();
+  const Eigen::Matrix4f w2c = Eigen::Matrix4f::Identity();
+  float u = 0.0f;
+  float v = 0.0f;
+  float depth = 0.0f;
+  EXPECT_FALSE(projectPoint(intr, w2c, Eigen::Vector3f(0.0f, 0.0f, -5.0f), u, v, depth));
+}
+
+TEST(PointColorizer, RejectsOutOfFramePoint)
+{
+  const CameraIntrinsics intr = makeCam();
+  const Eigen::Matrix4f w2c = Eigen::Matrix4f::Identity();
+  float u = 0.0f;
+  float v = 0.0f;
+  float depth = 0.0f;
+  // u = 100*10/5 + 50 = 250 -> off image.
+  EXPECT_FALSE(projectPoint(intr, w2c, Eigen::Vector3f(10.0f, 0.0f, 5.0f), u, v, depth));
+}
+
+TEST(PointColorizer, HonoursCameraExtrinsic)
+{
+  const CameraIntrinsics intr = makeCam();
+  // Camera translated so a point 2 m ahead sits at depth 5 (offset of 3).
+  Eigen::Matrix4f w2c = Eigen::Matrix4f::Identity();
+  w2c(2, 3) = 3.0f;
+  float u = 0.0f;
+  float v = 0.0f;
+  float depth = 0.0f;
+  ASSERT_TRUE(projectPoint(intr, w2c, Eigen::Vector3f(0.0f, 0.0f, 2.0f), u, v, depth));
+  EXPECT_NEAR(depth, 5.0f, 1e-4f);
+}
+
+TEST(PointColorizer, AppliesPlumbBobRadialDistortion)
+{
+  CameraIntrinsics intr = makeCam();
+  intr.width = 200;
+  const Eigen::Matrix4f w2c = Eigen::Matrix4f::Identity();
+  PlumbBobDistortion distortion;
+  distortion.k1 = 0.2f;
+  float u = 0.0f;
+  float v = 0.0f;
+  float depth = 0.0f;
+  ASSERT_TRUE(projectPoint(
+    intr, w2c, Eigen::Vector3f(1.0f, 0.0f, 2.0f), u, v, depth, &distortion));
+  // x=0.5, r^2=0.25 -> xd=0.5*(1 + 0.2*0.25)=0.525.
+  EXPECT_NEAR(u, 102.5f, 1e-4f);
+  EXPECT_NEAR(v, 50.0f, 1e-4f);
+}
+
+TEST(PointColorizer, AppliesPlumbBobTangentialDistortion)
+{
+  CameraIntrinsics intr = makeCam();
+  intr.width = 200;
+  intr.height = 200;
+  const Eigen::Matrix4f w2c = Eigen::Matrix4f::Identity();
+  PlumbBobDistortion distortion;
+  distortion.p1 = 0.1f;
+  distortion.p2 = 0.05f;
+  float u = 0.0f;
+  float v = 0.0f;
+  float depth = 0.0f;
+  ASSERT_TRUE(projectPoint(
+    intr, w2c, Eigen::Vector3f(0.4f, 0.2f, 2.0f), u, v, depth, &distortion));
+  // x=.2, y=.1, r^2=.05: xd=.2 + .004 + .0065; yd=.1 + .007 + .002.
+  EXPECT_NEAR(u, 71.05f, 1e-4f);
+  EXPECT_NEAR(v, 60.9f, 1e-4f);
+}
+
+// --------------------------------------------------------------------------- //
+// Sampling: nearest vs bilinear
+// --------------------------------------------------------------------------- //
+TEST(PointColorizer, BilinearBlendsNeighbouringPixels)
+{
+  RgbImage img(100, 100);
+  img.set(50, 50, 100, 100, 100);
+  img.set(51, 50, 200, 200, 200);
+  float rgb[3] = {0.0f, 0.0f, 0.0f};
+  // 40 % of the way from pixel 50 to 51 -> 0.6*100 + 0.4*200 = 140.
+  sampleBilinear(img.view(), 50.4f, 50.0f, rgb);
+  for (int c = 0; c < 3; ++c) {
+    EXPECT_NEAR(rgb[c], 140.0f, 1e-3f);
+  }
+  // Nearest snaps to pixel 50 -> the un-blended 100.
+  float near_rgb[3] = {0.0f, 0.0f, 0.0f};
+  sampleNearest(img.view(), 50.4f, 50.0f, near_rgb);
+  for (int c = 0; c < 3; ++c) {
+    EXPECT_NEAR(near_rgb[c], 100.0f, 1e-3f);
+  }
+}
+
+TEST(PointColorizer, BilinearClampsAtBorder)
+{
+  RgbImage img(100, 100);
+  img.set(99, 99, 10, 20, 30);
+  float rgb[3] = {0.0f, 0.0f, 0.0f};
+  // The +1 neighbour is out of range; clamping must keep it in-bounds.
+  sampleBilinear(img.view(), 99.0f, 99.0f, rgb);
+  EXPECT_NEAR(rgb[0], 10.0f, 1e-3f);
+  EXPECT_NEAR(rgb[1], 20.0f, 1e-3f);
+  EXPECT_NEAR(rgb[2], 30.0f, 1e-3f);
+}
+
+// --------------------------------------------------------------------------- //
+// FrameZBuffer occlusion
+// --------------------------------------------------------------------------- //
+TEST(PointColorizer, ZBufferHidesOccludedPoint)
+{
+  const CameraIntrinsics intr = makeCam();
+  FrameZBuffer zbuf(intr, 4);
+  // A near surface and a far point land in the same cell (~pixel 50,50).
+  zbuf.insert(50.0f, 50.0f, 2.0f);
+  zbuf.insert(50.0f, 50.0f, 8.0f);
+  EXPECT_TRUE(zbuf.visible(50.0f, 50.0f, 2.0f, 0.15f));
+  EXPECT_FALSE(zbuf.visible(50.0f, 50.0f, 8.0f, 0.15f));
+}
+
+TEST(PointColorizer, ZBufferKeepsCoplanarPointsVisible)
+{
+  const CameraIntrinsics intr = makeCam();
+  FrameZBuffer zbuf(intr, 4);
+  zbuf.insert(50.0f, 50.0f, 5.0f);
+  zbuf.insert(51.0f, 51.0f, 5.05f);
+  // Both within tol of the cell's nearest depth -> both visible.
+  EXPECT_TRUE(zbuf.visible(50.0f, 50.0f, 5.0f, 0.15f));
+  EXPECT_TRUE(zbuf.visible(51.0f, 51.0f, 5.05f, 0.15f));
+}
+
+// --------------------------------------------------------------------------- //
+// PointColor depth-weighted mean (streaming prefer_near)
+// --------------------------------------------------------------------------- //
+TEST(PointColorizer, MeanIsUnseenBeforeAnyObservation)
+{
+  PointColor pc;
+  EXPECT_FALSE(pc.seen());
+  EXPECT_EQ(pc.count, 0);
+}
+
+TEST(PointColorizer, AveragesRepeatedObservations)
+{
+  PointColor pc;
+  const float a[3] = {10.0f, 20.0f, 30.0f};
+  const float b[3] = {30.0f, 40.0f, 50.0f};
+  pc.add(a, 5.0f);
+  pc.add(b, 5.0f);  // equal depth -> equal weight -> plain mean
+  ASSERT_TRUE(pc.seen());
+  EXPECT_EQ(pc.count, 2);
+  std::uint8_t out[3] = {0, 0, 0};
+  pc.mean(out);
+  EXPECT_EQ(out[0], 20);
+  EXPECT_EQ(out[1], 30);
+  EXPECT_EQ(out[2], 40);
+}
+
+TEST(PointColorizer, NearObservationDominatesFarOne)
+{
+  PointColor pc;
+  const float near_green[3] = {0.0f, 200.0f, 0.0f};
+  const float far_red[3] = {200.0f, 0.0f, 0.0f};
+  pc.add(near_green, 1.0f);   // weight ~1.0
+  pc.add(far_red, 50.0f);     // weight ~0.02
+  std::uint8_t out[3] = {0, 0, 0};
+  pc.mean(out);
+  // The near green view dominates; red stays small.
+  EXPECT_GT(out[1], 180);
+  EXPECT_LT(out[0], 20);
+  EXPECT_EQ(pc.best_depth, 1.0f);
+}
+
+// --------------------------------------------------------------------------- //
+// medianLuminance (exposure statistic)
+// --------------------------------------------------------------------------- //
+TEST(PointColorizer, MedianLuminanceOfFlatImage)
+{
+  RgbImage img(10, 10);
+  for (int y = 0; y < 10; ++y) {
+    for (int x = 0; x < 10; ++x) {
+      img.set(x, y, 60, 60, 60);
+    }
+  }
+  EXPECT_NEAR(medianLuminance(img.view()), 60.0f, 1e-3f);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tools/gaussian_splatting/colorize_from_bag.py
+++ b/tools/gaussian_splatting/colorize_from_bag.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Colour one real LiDAR scan from a time-matched camera image in a rosbag2.
+
+A LiDAR scan and a camera on the same rig share a *static* extrinsic, so a
+single time-matched (cloud, image) pair can be coloured by projection with no
+SLAM and no map frame: pick a cloud, pick the nearest image in time, resolve
+``camera_optical <- lidar`` from ``/tf`` + ``/tf_static`` (they are rigidly
+mounted, so the transform is time-independent), undistort the image, and hand
+the pair to the offline colorizer
+(``pointcloud_io.colorize_by_projection_robust`` — occlusion-aware, bilinear,
+depth-weighted). This is the productionised form of the real-data experiment in
+``docs`` and validates the whole colour path on real sensors.
+
+Design mirrors ``extract_posed_images.py``: the pure geometry helpers
+(``nearest_index``, ``transform_msg_to_matrix``) are numpy-only and unit-tested
+in the ament pytest harness, while the rosbag2 / tf2 / OpenCV imports are lazy
+inside ``main`` so importing this module never needs a ROS environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+import pointcloud_io as pcio
+import posed_images as pi
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers (numpy only — no ROS)
+# --------------------------------------------------------------------------- #
+def nearest_index(sorted_stamps: Sequence[int], target: int) -> int:
+    """Index of the entry in ascending ``sorted_stamps`` closest to ``target``."""
+    arr = np.asarray(sorted_stamps)
+    if arr.size == 0:
+        raise ValueError('no stamps to match against')
+    return int(np.argmin(np.abs(arr.astype(np.int64) - int(target))))
+
+
+def transform_msg_to_matrix(translation, rotation) -> np.ndarray:
+    """Build a 4x4 ``target <- source`` matrix from a geometry_msgs Transform.
+
+    ``translation`` has ``.x/.y/.z`` and ``rotation`` has ``.x/.y/.z/.w`` — the
+    fields of a ``geometry_msgs/Transform``. Reuses ``posed_images.make_transform``
+    so the maths matches the rest of the toolchain.
+    """
+    t = [translation.x, translation.y, translation.z]
+    q = [rotation.x, rotation.y, rotation.z, rotation.w]
+    return pi.make_transform(t, q)
+
+
+def merge_colorings(per_camera, default_rgb=(80, 80, 80)
+                    ) -> tuple[np.ndarray, np.ndarray]:
+    """Fuse several cameras' colourings of one cloud into a single colour.
+
+    ``per_camera`` is a list of ``(rgb uint8 (N,3), seen bool (N,), counts
+    (N,))`` — the ``return_counts=True`` output of
+    ``colorize_by_projection_robust`` for each camera. Each point's final colour
+    is the per-camera mean weighted by that camera's sample count, so a camera
+    that saw a point in more views (or at all) contributes proportionally and a
+    point seen by two overlapping cameras blends both. Points no camera saw keep
+    ``default_rgb``. Returns ``(rgb uint8 (N,3), seen bool (N,))``.
+    """
+    if not per_camera:
+        raise ValueError('need at least one camera colouring to merge')
+    n = per_camera[0][0].shape[0]
+    acc = np.zeros((n, 3), dtype=np.float64)
+    sum_w = np.zeros(n, dtype=np.float64)
+    for rgb, _seen, counts in per_camera:
+        w = np.asarray(counts, dtype=np.float64)
+        acc += w[:, None] * np.asarray(rgb, dtype=np.float64)
+        sum_w += w
+    seen = sum_w > 0
+    out = np.tile(np.asarray(default_rgb, dtype=np.uint8), (n, 1))
+    out[seen] = np.round(acc[seen] / sum_w[seen, None]).astype(np.uint8)
+    return out, seen
+
+
+# --------------------------------------------------------------------------- #
+# rosbag2 + tf2 (lazy ROS imports live inside these)
+# --------------------------------------------------------------------------- #
+def _collect(bag_path, pc_topic, cameras):
+    """One pass over the bag: tf buffer, each camera's CameraInfo, and stamps.
+
+    ``cameras`` is a list of ``(image_topic, info_topic, optical_frame)``.
+    Returns ``(buf, infos, pc_stamps, img_stamps, types)`` where ``infos`` and
+    ``img_stamps`` are keyed by info_topic / image_topic respectively.
+    """
+    from rclpy.serialization import deserialize_message
+    from rosidl_runtime_py.utilities import get_message
+    import tf2_ros
+    import rclpy.duration
+    from extract_posed_images import _open_reader
+
+    reader = _open_reader(bag_path)
+    types = {t.name: t.type for t in reader.get_all_topics_and_types()}
+    tf_cls = get_message(types['/tf'])
+    tf_static_cls = get_message(types['/tf_static'])
+    try:
+        buf = tf2_ros.BufferCore(rclpy.duration.Duration(seconds=3600))
+    except TypeError:  # older signature
+        buf = tf2_ros.BufferCore()
+
+    info_topics = {c[1] for c in cameras}
+    image_topics = {c[0] for c in cameras}
+    infos: dict = {}
+    pc_stamps: list[int] = []
+    img_stamps: dict = {t: [] for t in image_topics}
+    while reader.has_next():
+        topic, raw, bagt = reader.read_next()
+        if topic == '/tf_static':
+            for tr in deserialize_message(raw, tf_static_cls).transforms:
+                buf.set_transform_static(tr, 'bag')
+        elif topic == '/tf':
+            for tr in deserialize_message(raw, tf_cls).transforms:
+                buf.set_transform(tr, 'bag')
+        elif topic in info_topics and topic not in infos:
+            infos[topic] = deserialize_message(raw, get_message(types[topic]))
+        elif topic == pc_topic:
+            pc_stamps.append(bagt)
+        elif topic in image_topics:
+            img_stamps[topic].append(bagt)
+    for c in cameras:
+        if c[1] not in infos:
+            raise RuntimeError(f'no CameraInfo on {c[1]!r}')
+        if not img_stamps[c[0]]:
+            raise RuntimeError(f'no images on {c[0]!r}')
+    if not pc_stamps:
+        raise RuntimeError('bag has no point-cloud messages')
+    return (buf, infos, sorted(pc_stamps),
+            {t: sorted(s) for t, s in img_stamps.items()}, types)
+
+
+def _grab_messages(bag_path, wanted, types):
+    """Second pass: deserialize each ``(topic, bag_time)`` in ``wanted`` -> msg."""
+    from rclpy.serialization import deserialize_message
+    from rosidl_runtime_py.utilities import get_message
+    from extract_posed_images import _open_reader
+
+    out = {key: None for key in wanted}
+    remaining = len(wanted)
+    reader = _open_reader(bag_path)
+    while reader.has_next() and remaining > 0:
+        topic, raw, bagt = reader.read_next()
+        key = (topic, bagt)
+        if key in out and out[key] is None:
+            out[key] = deserialize_message(raw, get_message(types[topic]))
+            remaining -= 1
+    missing = [k for k, v in out.items() if v is None]
+    if missing:
+        raise RuntimeError(f'failed to re-read messages: {missing}')
+    return out
+
+
+def _image_to_rgb(img_msg, K, D, undistort):
+    """Decode an sensor_msgs/Image (rgb8/bgr8) to an RGB array, optionally undistort."""
+    enc = img_msg.encoding
+    arr = np.frombuffer(img_msg.data, dtype=np.uint8).reshape(
+        img_msg.height, img_msg.width, -1)
+    if enc == 'bgr8':
+        rgb = arr[:, :, ::-1]
+    elif enc == 'rgb8':
+        rgb = arr[:, :, :3]
+    elif enc in ('bgra8',):
+        rgb = arr[:, :, [2, 1, 0]]
+    elif enc in ('rgba8',):
+        rgb = arr[:, :, :3]
+    elif enc == 'mono8':
+        rgb = np.repeat(arr[:, :, :1], 3, axis=2)
+    else:
+        raise RuntimeError(f'unsupported image encoding {enc!r}')
+    rgb = np.ascontiguousarray(rgb)
+    if undistort and np.any(np.asarray(D) != 0.0):
+        import cv2
+        rgb = cv2.undistort(rgb, np.asarray(K, dtype=np.float64).reshape(3, 3),
+                            np.asarray(D, dtype=np.float64))
+    return rgb
+
+
+def _read_xyz(pc_msg) -> np.ndarray:
+    from sensor_msgs_py import point_cloud2 as pc2
+    pts = pc2.read_points(pc_msg, field_names=('x', 'y', 'z'), skip_nans=True)
+    return np.stack([pts['x'], pts['y'], pts['z']], axis=1).astype(np.float64)
+
+
+def _camera_list(args) -> list:
+    """Assemble the ``(image_topic, info_topic, optical_frame)`` camera list."""
+    cams = [(args.image_topic, args.camera_info_topic, args.camera_optical_frame)]
+    for extra in (args.extra_camera or []):
+        cams.append((extra[0], extra[1], extra[2]))
+    return cams
+
+
+def colorize_bag_frame(args) -> dict:
+    """Run the whole extract -> colorize -> write flow; return a summary dict."""
+    from rclpy.time import Time
+
+    cameras = _camera_list(args)
+    buf, infos, pc_stamps, img_stamps, types = _collect(
+        args.bag, args.pc_topic, cameras)
+
+    frac = min(max(args.time_frac, 0.0), 1.0)
+    pc_time = pc_stamps[min(int(len(pc_stamps) * frac), len(pc_stamps) - 1)]
+
+    # Choose each camera's nearest-in-time image and gather every message.
+    per_cam_time = {}
+    wanted = {(args.pc_topic, pc_time)}
+    for img_topic, info_topic, _frame in cameras:
+        t = img_stamps[img_topic][nearest_index(img_stamps[img_topic], pc_time)]
+        per_cam_time[img_topic] = t
+        wanted.add((img_topic, t))
+    msgs = _grab_messages(args.bag, wanted, types)
+
+    xyz = _read_xyz(msgs[(args.pc_topic, pc_time)])
+
+    per_camera = []
+    cam_stats = []
+    for img_topic, info_topic, frame in cameras:
+        info = infos[info_topic]
+        K = np.asarray(info.k, dtype=np.float64).reshape(3, 3)
+        D = np.asarray(info.d, dtype=np.float64)
+        W, H = int(info.width), int(info.height)
+        tf = buf.lookup_transform_core(frame, args.base_frame, Time().to_msg())
+        world_to_cam = transform_msg_to_matrix(
+            tf.transform.translation, tf.transform.rotation)
+        rgb_img = _image_to_rgb(
+            msgs[(img_topic, per_cam_time[img_topic])], K, D, not args.no_undistort)
+        colors, seen, counts = pcio.colorize_by_projection_robust(
+            xyz, world_to_cam[None], K, [rgb_img], W, H,
+            default_rgb=tuple(args.default_rgb),
+            normalize_exposure=args.normalize_exposure, return_counts=True)
+        per_camera.append((colors, seen, counts))
+        cam_stats.append({
+            'image_topic': img_topic, 'colored': int(seen.sum()),
+            'pair_dt_ms': abs(per_cam_time[img_topic] - pc_time) / 1e6})
+
+    colors, seen = merge_colorings(per_camera, tuple(args.default_rgb))
+    n_seen = int(seen.sum())
+
+    out_prefix = Path(args.out_prefix)
+    out_prefix.parent.mkdir(parents=True, exist_ok=True)
+    full = pcio.write_ply(out_prefix.with_name(out_prefix.name + '_full.ply'),
+                          xyz, colors)
+    seen_ply = pcio.write_ply(out_prefix.with_name(out_prefix.name + '_seen.ply'),
+                              xyz[seen], colors[seen])
+    return {
+        'pc_frames': len(pc_stamps), 'cameras': cam_stats,
+        'points': len(xyz), 'colored': n_seen,
+        'colored_frac': n_seen / max(1, len(xyz)),
+        'full_ply': str(full), 'seen_ply': str(seen_ply),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument('bag', help='rosbag2 directory')
+    p.add_argument('out_prefix', help='output path prefix (_full.ply / _seen.ply)')
+    p.add_argument('--pc-topic', default='/sensing/lidar/concatenated/pointcloud')
+    p.add_argument('--image-topic', default='/lucid_vision/camera_0/raw_image')
+    p.add_argument('--camera-info-topic',
+                   default='/lucid_vision/camera_0/camera_info')
+    p.add_argument('--base-frame', default='base_link',
+                   help='frame the point cloud is expressed in')
+    p.add_argument('--camera-optical-frame', default='camera_top/camera_optical_link',
+                   help='camera OPTICAL frame (REP-103 z-forward) to project into')
+    p.add_argument('--extra-camera', nargs=3, action='append',
+                   metavar=('IMAGE_TOPIC', 'INFO_TOPIC', 'OPTICAL_FRAME'),
+                   help='add another camera to fuse (repeatable); more coverage')
+    p.add_argument('--time-frac', type=float, default=0.6,
+                   help='pick the cloud at this fraction through the bag [0,1]')
+    p.add_argument('--no-undistort', action='store_true',
+                   help='skip plumb_bob undistortion (needs OpenCV otherwise)')
+    p.add_argument('--normalize-exposure', action='store_true',
+                   help='rescale image luminance (harmless for a single view)')
+    p.add_argument('--default-rgb', type=int, nargs=3, default=(80, 80, 80),
+                   help='colour for points no camera saw')
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    s = colorize_bag_frame(args)
+    print(f"pc_frames={s['pc_frames']}  cameras={len(s['cameras'])}")
+    for c in s['cameras']:
+        print(f"  {c['image_topic']}: {c['colored']} pts  (dt={c['pair_dt_ms']:.1f}ms)")
+    print(f"merged coloured {s['colored']}/{s['points']} "
+          f"({100.0 * s['colored_frac']:.1f}%)")
+    print(f"wrote {s['full_ply']}\n      {s['seen_ply']}")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/gaussian_splatting/pointcloud_io.py
+++ b/tools/gaussian_splatting/pointcloud_io.py
@@ -141,13 +141,44 @@ def colorize_by_projection(points: np.ndarray, viewmats: np.ndarray,
     return rgb, seen
 
 
+def _sample_pixels(img: np.ndarray, uf: np.ndarray, vf: np.ndarray,
+                   width: int, height: int, interp: str) -> np.ndarray:
+    """Sample ``img`` at float pixel coords ``(uf, vf)`` -> float32 ``(M,3)``.
+
+    ``interp='nearest'`` rounds to the pixel centre; ``'bilinear'`` blends the
+    four surrounding pixels (edge coords clamp, so the border never wraps). A
+    2-D (grayscale) image is broadcast to three channels.
+    """
+    im = np.asarray(img).astype(np.float32)
+    if im.ndim == 2:
+        im = np.repeat(im[:, :, None], 3, axis=2)
+    im = im[:, :, :3]
+    if interp == 'nearest':
+        ui = np.clip(np.round(uf).astype(np.int64), 0, width - 1)
+        vi = np.clip(np.round(vf).astype(np.int64), 0, height - 1)
+        return im[vi, ui]
+    if interp != 'bilinear':
+        raise ValueError(f"interp must be 'nearest' or 'bilinear', got {interp!r}")
+    x0 = np.clip(np.floor(uf).astype(np.int64), 0, width - 1)
+    y0 = np.clip(np.floor(vf).astype(np.int64), 0, height - 1)
+    x1 = np.minimum(x0 + 1, width - 1)
+    y1 = np.minimum(y0 + 1, height - 1)
+    wx = np.clip(uf - x0, 0.0, 1.0)[:, None].astype(np.float32)
+    wy = np.clip(vf - y0, 0.0, 1.0)[:, None].astype(np.float32)
+    top = im[y0, x0] * (1.0 - wx) + im[y0, x1] * wx
+    bot = im[y1, x0] * (1.0 - wx) + im[y1, x1] * wx
+    return top * (1.0 - wy) + bot * wy
+
+
 def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
                                   K: np.ndarray, images, width: int, height: int,
                                   default_rgb=(128, 128, 128), *,
                                   zbuf_bin: int = 4, depth_tol: float = 0.15,
                                   max_samples: int = 12,
-                                  normalize_exposure: bool = True
-                                  ) -> tuple[np.ndarray, np.ndarray]:
+                                  normalize_exposure: bool = True,
+                                  interp: str = 'bilinear',
+                                  prefer_near: bool = True,
+                                  return_counts: bool = False):
     """Occlusion-aware, exposure-normalised, median-robust point colorization.
 
     ``colorize_by_projection`` averages every view a point lands in, so points
@@ -157,17 +188,28 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
     bins) and only samples views where the point sits within ``depth_tol`` (plus
     2 % of range) of the nearest depth in its bin; each image is scaled so its
     median luminance matches the global median (``normalize_exposure``); and the
-    final colour is the per-channel median over the first ``max_samples`` valid
+    final colour is the per-channel median over up to ``max_samples`` valid
     samples, which rejects residual specular / motion-blur outliers.
 
-    Returns ``(rgb uint8 (N,3), seen bool (N,))``; unseen points get
-    ``default_rgb``.
+    Quality knobs: ``interp='bilinear'`` samples sub-pixel (blends the four
+    surrounding pixels) instead of snapping to the nearest, cutting the colour
+    bleed nearest-pixel sampling leaves along edges. ``prefer_near=True`` keeps,
+    once a point has ``max_samples`` observations, the *nearest* ones (a new
+    closer view evicts the farthest stored sample) so colour comes from the
+    highest-resolution, least-foreshortened views rather than whichever happened
+    to be visited first.
+
+    Returns ``(rgb uint8 (N,3), seen bool (N,))``, or with ``return_counts`` the
+    triple ``(rgb, seen, counts uint16 (N,))`` giving each point's surviving
+    sample count (a colour-confidence signal). Unseen points get ``default_rgb``.
     """
     points = np.asarray(points, dtype=np.float64)
     n = points.shape[0]
     rgb = np.tile(np.asarray(default_rgb, dtype=np.uint8), (n, 1))
+    counts = np.zeros(n, dtype=np.uint16)
     if n == 0 or max_samples <= 0:
-        return rgb, np.zeros(n, dtype=bool)
+        seen = np.zeros(n, dtype=bool)
+        return (rgb, seen, counts) if return_counts else (rgb, seen)
     if zbuf_bin < 1:
         raise ValueError('zbuf_bin must be >= 1')
 
@@ -175,7 +217,8 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
     zb_w = (int(width) + zbuf_bin - 1) // zbuf_bin
     zb_h = (int(height) + zbuf_bin - 1) // zbuf_bin
     samples = np.empty((n, int(max_samples), 3), dtype=np.uint8)
-    counts = np.zeros(n, dtype=np.uint16)
+    # Depth stored alongside each sample so a nearer view can evict the farthest.
+    sample_z = np.full((n, int(max_samples)), np.inf, dtype=np.float32)
 
     scales = np.ones(len(images), dtype=np.float32)
     if normalize_exposure:
@@ -193,10 +236,12 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
         cam = points @ vm[:3, :3].T + vm[:3, 3]
         z = cam[:, 2]
         with np.errstate(divide='ignore', invalid='ignore'):
-            u = np.nan_to_num(fx * cam[:, 0] / z + cx, nan=-1.0,
-                              posinf=-1.0, neginf=-1.0).astype(np.int64)
-            v = np.nan_to_num(fy * cam[:, 1] / z + cy, nan=-1.0,
-                              posinf=-1.0, neginf=-1.0).astype(np.int64)
+            uf = np.nan_to_num(fx * cam[:, 0] / z + cx, nan=-1.0,
+                               posinf=-1.0, neginf=-1.0)
+            vf = np.nan_to_num(fy * cam[:, 1] / z + cy, nan=-1.0,
+                               posinf=-1.0, neginf=-1.0)
+        u = np.round(uf).astype(np.int64)
+        v = np.round(vf).astype(np.int64)
         inb = (z > 1e-6) & (u >= 0) & (u < width) & (v >= 0) & (v < height)
         if not inb.any():
             continue
@@ -204,24 +249,40 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
         zbuf = np.full(zb_w * zb_h, np.inf, dtype=np.float32)
         np.minimum.at(zbuf, zbin, z[inb].astype(np.float32))
         visible = z[inb] <= zbuf[zbin] + depth_tol + 0.02 * z[inb]
-        idx = ids[inb][visible]
-        idx = idx[counts[idx] < max_samples]
-        if idx.size == 0:
+        cand = ids[inb][visible]  # unique point ids seen (unoccluded) this view
+        if cand.size == 0:
             continue
-        cols = np.asarray(img)[v[idx], u[idx]]
-        if cols.ndim == 1:
-            cols = np.repeat(cols[:, None], 3, axis=1)
-        cols = np.clip(cols[:, :3].astype(np.float32) * scales[vi],
-                       0.0, 255.0).astype(np.uint8)
-        samples[idx, counts[idx].astype(np.intp), :] = cols
-        counts[idx] += 1
+        cand_z = z[inb][visible].astype(np.float32)
+        cols = _sample_pixels(img, uf[cand], vf[cand], width, height, interp)
+        cols = np.clip(cols * scales[vi], 0.0, 255.0).astype(np.uint8)
+
+        # Points with room: append into the next free slot.
+        room = counts[cand] < max_samples
+        if room.any():
+            rc = cand[room]
+            slot = counts[rc].astype(np.intp)
+            samples[rc, slot, :] = cols[room]
+            sample_z[rc, slot] = cand_z[room]
+            counts[rc] += 1
+        # Full points: if enabled, evict the farthest stored sample when nearer.
+        if prefer_near and (~room).any():
+            fc = cand[~room]
+            fcz = cand_z[~room]
+            fcols = cols[~room]
+            far_slot = np.argmax(sample_z[fc], axis=1)
+            nearer = fcz < sample_z[fc, far_slot]
+            if nearer.any():
+                fb = fc[nearer]
+                sb = far_slot[nearer]
+                samples[fb, sb, :] = fcols[nearer]
+                sample_z[fb, sb] = fcz[nearer]
 
     seen = counts > 0
     seen_idx = np.flatnonzero(seen)
     for c in np.unique(counts[seen_idx]):
         group = seen_idx[counts[seen_idx] == c]
         rgb[group] = np.median(samples[group, :int(c), :], axis=1).astype(np.uint8)
-    return rgb, seen
+    return (rgb, seen, counts) if return_counts else (rgb, seen)
 
 
 def project_depth_maps(points: np.ndarray, viewmats, K: np.ndarray,


### PR DESCRIPTION
## What changed

- add a ROS 2 node that accumulates camera colours onto the live SLAM map
- add occlusion-aware, bilinear, exposure-normalized projection for online and offline workflows
- support plumb-bob lens distortion so raw-image colours stay aligned near image edges
- add rosbag2 single-frame and multi-camera colour fusion with full/visible PLY outputs
- add launch/configuration files and pure geometry regression tests

## Why

The previous projection path used nearest-pixel sampling and the realtime path ignored camera lens distortion. This caused colour bleeding at boundaries and increasing point-to-pixel misalignment toward image edges. There was also no packaged ROS 2 entry point for continuously colouring a SLAM map.

## User impact

Users can launch realtime map colourization through `scanmatcher`, or colour a selected rosbag frame offline. Occlusion filtering, near-view preference, multi-camera fusion, and distortion-aware projection improve colour coverage and alignment while retaining grey geometry for unseen points.

## Validation

- scanmatcher build on ROS 2 Jazzy
- scanmatcher test suite: 97 tests, 0 failures
- focused Python tests: 36 passed
- ament_copyright, ament_cpplint, ament_uncrustify, and ament_flake8
