### PR TITLE
Add colored map pipeline

### DIFF
--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the user-facing coloured-map pipeline command composition."""
+
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+if str(TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOL_DIR))
+
+import colored_map_pipeline as cmp  # noqa: E402
+
+
+def _args(tmp_path, *extra):
+    return cmp.build_parser().parse_args([
+        str(tmp_path / 'bag'), str(tmp_path / 'traj.tum'), str(tmp_path / 'out'),
+        '--extrinsic', str(tmp_path / 'calib.json'), *extra,
+    ])
+
+
+def test_build_commands_connects_extract_to_robust_map(tmp_path):
+    commands = cmp.build_commands(_args(tmp_path))
+    assert [name for name, _ in commands] == ['posed images', 'coloured map']
+    extract, build = commands[0][1], commands[1][1]
+    transforms = str(tmp_path / 'out' / 'posed_images' / 'transforms.json')
+    assert '--undistort' in extract
+    assert extract[extract.index('--time-offset') + 1] == 'auto'
+    assert build[build.index('--color-transforms') + 1] == transforms
+    assert '--color-robust' in build
+
+
+def test_build_commands_reuses_existing_outputs(tmp_path):
+    out = tmp_path / 'out'
+    (out / 'posed_images').mkdir(parents=True)
+    (out / 'posed_images' / 'transforms.json').write_text('{}')
+    (out / 'colored_map.ply').write_text('ply\n')
+    assert cmp.build_commands(_args(tmp_path)) == []
+
+
+def test_force_map_reuses_images_but_rebuilds_map(tmp_path):
+    posed = tmp_path / 'out' / 'posed_images'
+    posed.mkdir(parents=True)
+    (posed / 'transforms.json').write_text('{}')
+    commands = cmp.build_commands(_args(tmp_path, '--force-map'))
+    assert [name for name, _ in commands] == ['coloured map']
+
+
+def test_force_images_also_rebuilds_dependent_map(tmp_path):
+    out = tmp_path / 'out'
+    (out / 'posed_images').mkdir(parents=True)
+    (out / 'posed_images' / 'transforms.json').write_text('{}')
+    (out / 'colored_map.ply').write_text('ply\n')
+    commands = cmp.build_commands(_args(tmp_path, '--force-images'))
+    assert [name for name, _ in commands] == ['posed images', 'coloured map']
+
+
+def test_no_undistort_and_custom_topics_are_forwarded(tmp_path):
+    commands = cmp.build_commands(_args(
+        tmp_path, '--no-undistort', '--points-topic', '/points',
+        '--camera-topic', '/rgb', '--camera-info-topic', '/info'))
+    extract, build = commands[0][1], commands[1][1]
+    assert '--undistort' not in extract
+    assert extract[extract.index('--camera-topic') + 1] == '/rgb'
+    assert extract[extract.index('--camera-info-topic') + 1] == '/info'
+    assert build[build.index('--points-topic') + 1] == '/points'

--- a/graph_based_slam/test/test_gaussian_splatting_extract.py
+++ b/graph_based_slam/test/test_gaussian_splatting_extract.py
@@ -133,6 +133,14 @@ def test_parse_extrinsic_matrix():
     np.testing.assert_allclose(T, m, atol=1e-12)
 
 
+def test_parse_extrinsic_official_vlcal_result():
+    T = ex.parse_extrinsic_dict({
+        'results': {'T_lidar_camera': [1, 2, 3, 0, 0, 0, 1]},
+    })
+    np.testing.assert_allclose(T[:3, 3], [1, 2, 3], atol=1e-12)
+    np.testing.assert_allclose(T[:3, :3], np.eye(3), atol=1e-12)
+
+
 def test_parse_extrinsic_bad_matrix_shape():
     with pytest.raises(ValueError):
         ex.parse_extrinsic_dict({'matrix': [[1, 0], [0, 1]]})

--- a/tools/gaussian_splatting/README.md
+++ b/tools/gaussian_splatting/README.md
@@ -29,6 +29,7 @@ photorealistic map / novel-view 成果物を後処理で再構成するための
 | `extract_posed_images.py` | rosbag2 から画像 + `camera_info` を取り出し、各画像の `world<-camera` を解決して `transforms.json` + 画像を書き出す CLI。`sensor_msgs/Image` は **numpy で生復号**（cv_bridge 非依存）、`rosbag2_py` は遅延 import。 | rosbag2_py（実行時のみ）| `test_gaussian_splatting_extract.py`（17、ポーズ/外部標定/復号ロジックは ROS 非依存）|
 | `pointcloud_io.py` | 最小 PLY 入出力（xyz[+rgb]）＋ voxel 間引き＋ **画像投影による点群着色**（`colorize_by_projection`）。 | numpy のみ | `test_gaussian_splatting_pointcloud.py`（12）|
 | `build_lidar_init.py` | bag のスキャンを SLAM 軌跡で world 系に蓄積 → **LiDAR-primed init 点群** PLY。FILE-compressed(zstd) bag 対応。`--color-transforms` で transforms.json の posed 画像を投影して着色（品質中立だが検査用に有用）。 | rosbag2_py（実行時のみ）| 同上（`transform_points` 等の純粋部）|
+| `colored_map_pipeline.py` | bag + TUM軌跡 + camera extrinsic から、posed画像抽出 → 遮蔽対応の複数view着色map生成を一括実行。既存成果物の再利用、`--dry-run`、段階別forceに対応。 | 上記2ツールと同じ | `test_colored_map_pipeline.py` |
 | `train_gsplat.py` | `transforms.json` + 画像で gsplat 学習 → INRIA 標準 `.ply` 出力。OpenGL c2w を OpenCV w2c に変換。`--init-ply` で **LiDAR-primed init**（位置＋色 seed）、`--densify` で gsplat `DefaultStrategy` の adaptive density control、`--ssim-lambda`（既定 0.2）で INRIA 標準 **L1+D-SSIM 損失**、`--knn-scale-init` で点群の局所密度から per-Gaussian スケール seed、`--sh-degree D` で **視点依存カラー（SH 次数 D、INRIA 標準 f_dc+f_rest 出力）**、`--antialiased` で gsplat の antialiased rasterize mode、`--mcmc`（+`--mcmc-cap`）で MCMCStrategy（LiDAR-primed init では DefaultStrategy 優位＝既定）、`--optimize-extrinsic` で共有 6-DoF extrinsic の photometric 自己校正。学習終了時に全ビューの PSNR/SSIM を出力。 | torch, gsplat (CUDA) | `test_gaussian_splatting_train.py`（20、純粋部）|
 | `selftest_gpu.py` | opt-in GPU セルフテスト。合成シーンを描画→`transforms.json`→学習→`.ply` の全鎖を検証。 | torch, gsplat (CUDA) | 手動実行（CI 非対象）|
 | `render_path.py` | 学習済み `.ply` + `transforms.json` から**フライスルー動画（mp4/GIF）**を描画する CLI。INRIA `.ply` の読み戻し、学習視点を通る SLERP+box-smooth カメラパス、`--ping-pong` ループ、`--scale` 縮小描画、`--rotate` 横倒しカメラ補正。 | torch, gsplat (CUDA)（純粋部は numpy のみ）| `test_gaussian_splatting_render.py`（13、ply 読み戻し/パス/回転/intrinsics の純粋部）|
@@ -55,6 +56,13 @@ python3 tools/gaussian_splatting/build_lidar_init.py \
   --bag <bag> --traj output/<run>/traj_corrected.tum \
   --points-topic /livox/points --voxel 0.05 \
   --out output/<run>/gsplat/lidar_init.ply
+
+# 着色点群だけが目的なら、画像抽出 + robust複数view着色を一括実行
+python3 tools/gaussian_splatting/colored_map_pipeline.py \
+  <bag> output/<run>/traj_corrected.tum output/<run>/colored_map \
+  --extrinsic configs/gaussian_splatting/<lidar_camera_extrinsic>.yaml \
+  --points-topic /livox/points --camera-topic /image \
+  --camera-info-topic /camera_info
 
 # 2b) gsplat 学習 → .ply（GPU）。--init-ply で LiDAR-primed init、
 #     --densify で adaptive density control（鮮鋭化）

--- a/tools/gaussian_splatting/colored_map_pipeline.py
+++ b/tools/gaussian_splatting/colored_map_pipeline.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Build a robust coloured SLAM map from one bag and a TUM trajectory.
+
+This is the user-facing entry point over ``extract_posed_images.py`` and
+``build_lidar_init.py``. Existing posed images and maps are reused by default,
+so an interrupted or repeated run only performs missing work.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+from typing import Sequence
+
+
+TOOL_DIR = Path(__file__).resolve().parent
+
+
+def build_commands(args) -> list[tuple[str, list[str]]]:
+    """Return the missing/forced pipeline stages as ``(name, argv)`` pairs."""
+    out_dir = Path(args.out)
+    posed_dir = out_dir / 'posed_images'
+    transforms = posed_dir / 'transforms.json'
+    colored_map = out_dir / 'colored_map.ply'
+    commands = []
+
+    rebuild_images = args.force_images or not transforms.is_file()
+    if rebuild_images:
+        extract = [
+            sys.executable, str(TOOL_DIR / 'extract_posed_images.py'),
+            '--bag', str(args.bag), '--traj', str(args.traj),
+            '--camera-topic', args.camera_topic,
+            '--camera-info-topic', args.camera_info_topic,
+            '--extrinsic', str(args.extrinsic), '--out', str(posed_dir),
+            '--time-offset', args.time_offset,
+            '--clock-reference-topic', args.points_topic,
+            '--stride', str(args.image_stride),
+            '--start-time', str(args.start_time), '--end-time', str(args.end_time),
+        ]
+        if not args.no_undistort:
+            extract.append('--undistort')
+        commands.append(('posed images', extract))
+
+    if rebuild_images or args.force_map or not colored_map.is_file():
+        build = [
+            sys.executable, str(TOOL_DIR / 'build_lidar_init.py'),
+            '--bag', str(args.bag), '--traj', str(args.traj),
+            '--points-topic', args.points_topic, '--out', str(colored_map),
+            '--voxel', str(args.voxel), '--max-points', str(args.max_points),
+            '--min-range', str(args.min_range), '--max-range', str(args.max_range),
+            '--stride', str(args.scan_stride),
+            '--start-time', str(args.start_time), '--end-time', str(args.end_time),
+            '--color-transforms', str(transforms), '--color-robust',
+        ]
+        commands.append(('coloured map', build))
+    return commands
+
+
+def run_pipeline(args) -> dict:
+    """Execute missing stages and return paths plus the stages that ran."""
+    out_dir = Path(args.out)
+    if not args.dry_run:
+        out_dir.mkdir(parents=True, exist_ok=True)
+    commands = build_commands(args)
+    for name, command in commands:
+        print(f'[{name}]', ' '.join(command))
+        if not args.dry_run:
+            subprocess.run(command, check=True)
+    return {
+        'stages': [name for name, _ in commands],
+        'transforms': out_dir / 'posed_images' / 'transforms.json',
+        'colored_map': out_dir / 'colored_map.ply',
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument('bag', type=Path, help='rosbag2 directory')
+    p.add_argument('traj', type=Path, help='SLAM trajectory (TUM, world<-body)')
+    p.add_argument('out', type=Path, help='output directory')
+    p.add_argument('--extrinsic', type=Path, required=True,
+                   help='body<-camera YAML/JSON or vlcal calib.json')
+    p.add_argument('--points-topic', default='/livox/points')
+    p.add_argument('--camera-topic', default='/image')
+    p.add_argument('--camera-info-topic', default='/camera_info')
+    p.add_argument('--time-offset', default='auto',
+                   help='camera-to-trajectory clock offset or auto')
+    p.add_argument('--image-stride', type=int, default=1)
+    p.add_argument('--scan-stride', type=int, default=1)
+    p.add_argument('--voxel', type=float, default=0.1)
+    p.add_argument('--max-points', type=int, default=300000)
+    p.add_argument('--min-range', type=float, default=0.0)
+    p.add_argument('--max-range', type=float, default=80.0)
+    p.add_argument('--start-time', type=float, default=0.0)
+    p.add_argument('--end-time', type=float, default=-1.0)
+    p.add_argument('--no-undistort', action='store_true')
+    p.add_argument('--force-images', action='store_true')
+    p.add_argument('--force-map', action='store_true')
+    p.add_argument('--dry-run', action='store_true')
+    return p
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    summary = run_pipeline(args)
+    if summary['stages']:
+        print('completed stages:', ', '.join(summary['stages']))
+    else:
+        print('everything is up to date; nothing to do')
+    print('coloured map:', summary['colored_map'])
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/gaussian_splatting/extract_posed_images.py
+++ b/tools/gaussian_splatting/extract_posed_images.py
@@ -96,8 +96,16 @@ def parse_extrinsic_dict(data: dict) -> np.ndarray:
         return m
     if 'translation' in data and 'rotation_xyzw' in data:
         return pi.make_transform(data['translation'], data['rotation_xyzw'])
+    if 'results' in data and 'T_lidar_camera' in data['results']:
+        # direct_visual_lidar_calibration stores lidar/body <- camera, exactly
+        # the direction this extractor needs.
+        values = data['results']['T_lidar_camera']
+        if len(values) != 7:
+            raise ValueError('T_lidar_camera must contain 7 values')
+        return pi.make_transform(values[:3], values[3:])
     raise ValueError(
-        "extrinsic must provide 'matrix' or 'translation'+'rotation_xyzw'"
+        'extrinsic must provide matrix, translation+rotation_xyzw, or '
+        'results.T_lidar_camera'
     )
 
 


### PR DESCRIPTION
## What changed

- add a user-facing `colored_map_pipeline.py` entry point
- connect posed-image extraction and robust multi-view map colourization
- reuse existing `transforms.json` and `colored_map.ply` outputs by default
- add `--dry-run`, `--force-images`, and `--force-map`
- pass range, voxel, scan/image stride, time window, topic, and clock options through to the existing tools
- accept official `direct_visual_lidar_calibration` `calib.json` files as `body <- camera` extrinsics
- document the one-command workflow

## Why

The repository already had the geometry and multi-view colourization cores, but users had to understand and manually connect two lower-level commands with matching paths and options. The new entry point makes coloured-map generation discoverable and safely resumable without duplicating the underlying implementation.

## User impact

Users can build a robust coloured map from a rosbag2, TUM trajectory, and camera extrinsic with one command. Re-running the command skips completed stages, while explicit force flags rebuild the requested stage and its dependent map.

## Checks

- focused Python suite: 59 passed
- `ament_copyright`: passed
- `ament_flake8`: passed
- pipeline `--dry-run`: passed
- `git diff --check`: passed
