### PR TITLE
Add dense corrected trajectory propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ the same SLAM poses.
 The sequence is from the RTK-SLAM dataset (CC-BY 4.0). Its total-station
 checkpoints are also used by the [accuracy gate](#accuracy).
 
+If graph optimization outputs sparse keyframes, propagate their corrections
+onto the dense SLAM pose stream before building the coloured map:
+
+```bash
+python3 scripts/densify_corrected_trajectory.py \
+  --raw output/<run>/traj_raw.tum \
+  --corrected output/<run>/traj_corrected.tum \
+  --output output/<run>/traj_corrected_dense.tum
+```
+
 ## Accuracy
 
 Current numbers from the release-gate profiles (`scripts/release_profiles.yaml`).

--- a/graph_based_slam/test/test_densify_corrected_trajectory.py
+++ b/graph_based_slam/test/test_densify_corrected_trajectory.py
@@ -1,0 +1,74 @@
+"""Tests for dense propagation of sparse pose-graph corrections."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+if str(TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOL_DIR))
+
+import posed_images as pi  # noqa: E402
+
+SPEC = importlib.util.spec_from_file_location(
+    'densify_corrected_trajectory',
+    REPO_ROOT / 'scripts' / 'densify_corrected_trajectory.py')
+dct = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = dct
+SPEC.loader.exec_module(dct)
+
+
+def _sample(stamp, x, quat=(0.0, 0.0, 0.0, 1.0)):
+    return pi.TrajectorySample(
+        stamp=float(stamp),
+        translation=np.array([x, 0.0, 0.0], dtype=float),
+        quat_xyzw=np.asarray(quat, dtype=float),
+    )
+
+
+def test_dense_translation_correction_matches_anchors_and_interpolates():
+    raw = [_sample(0, 0), _sample(1, 1), _sample(2, 2)]
+    corrected = [_sample(0, 10), _sample(2, 14)]
+    dense = dct.densify_trajectory(raw, corrected)
+    np.testing.assert_allclose(
+        [sample.translation[0] for sample in dense], [10, 12, 14],
+        atol=1e-12)
+    assert [sample.stamp for sample in dense] == [0, 1, 2]
+
+
+def test_world_side_rotation_correction_uses_slerp():
+    raw = [_sample(0, 0), _sample(1, 0), _sample(2, 0)]
+    half_turn_z = (0.0, 0.0, 1.0, 0.0)
+    corrected = [_sample(0, 0), _sample(2, 0, half_turn_z)]
+    dense = dct.densify_trajectory(raw, corrected)
+    rotated_x = pi.quat_to_matrix(dense[1].quat_xyzw) @ np.array([1, 0, 0])
+    np.testing.assert_allclose(rotated_x, [0, 1, 0], atol=1e-9)
+
+
+def test_correction_clamps_before_and_after_graph_anchor_range():
+    raw = [_sample(0, 0), _sample(1, 1), _sample(2, 2), _sample(3, 3)]
+    corrected = [_sample(1, 11), _sample(2, 12)]
+    dense = dct.densify_trajectory(raw, corrected)
+    np.testing.assert_allclose(
+        [sample.translation[0] for sample in dense], [10, 11, 12, 13],
+        atol=1e-12)
+
+
+def test_write_and_read_tum_round_trip(tmp_path):
+    samples = [_sample(1.25, 3.5), _sample(1.35, 4.5)]
+    path = dct.write_tum(tmp_path / 'dense.tum', samples)
+    loaded = pi.read_tum_trajectory(path)
+    assert len(loaded) == 2
+    np.testing.assert_allclose(loaded[1].translation, [4.5, 0, 0])
+
+
+def test_matrix_to_quaternion_round_trip_for_half_turn():
+    quaternion = np.array([1.0, 0.0, 0.0, 0.0])
+    recovered = dct.matrix_to_quat_xyzw(pi.quat_to_matrix(quaternion))
+    np.testing.assert_allclose(
+        pi.quat_to_matrix(recovered), pi.quat_to_matrix(quaternion), atol=1e-12)

--- a/graph_based_slam/test/test_densify_corrected_trajectory.py
+++ b/graph_based_slam/test/test_densify_corrected_trajectory.py
@@ -1,3 +1,32 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 """Tests for dense propagation of sparse pose-graph corrections."""
 
 from __future__ import annotations

--- a/scripts/densify_corrected_trajectory.py
+++ b/scripts/densify_corrected_trajectory.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Propagate sparse pose-graph corrections onto a dense SLAM trajectory."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+from typing import Sequence
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+if str(TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOL_DIR))
+
+import posed_images as pi  # noqa: E402
+
+
+@dataclass(frozen=True)
+class CorrectionAnchor:
+    """One world-side pose correction at a graph keyframe timestamp."""
+
+    stamp: float
+    translation: np.ndarray
+    quat_xyzw: np.ndarray
+
+
+def matrix_to_quat_xyzw(rotation: np.ndarray) -> np.ndarray:
+    """Convert a 3x3 rotation matrix to a normalized xyzw quaternion."""
+    matrix = np.asarray(rotation, dtype=np.float64)
+    if matrix.shape != (3, 3):
+        raise ValueError(f'rotation must be 3x3, got {matrix.shape}')
+    # Shepperd's method selects the best-conditioned branch.
+    trace = float(np.trace(matrix))
+    if trace > 0.0:
+        scale = 2.0 * np.sqrt(trace + 1.0)
+        quat = np.array([
+            (matrix[2, 1] - matrix[1, 2]) / scale,
+            (matrix[0, 2] - matrix[2, 0]) / scale,
+            (matrix[1, 0] - matrix[0, 1]) / scale,
+            0.25 * scale,
+        ])
+    else:
+        axis = int(np.argmax(np.diag(matrix)))
+        if axis == 0:
+            scale = 2.0 * np.sqrt(1.0 + matrix[0, 0] -
+                                  matrix[1, 1] - matrix[2, 2])
+            quat = np.array([
+                0.25 * scale,
+                (matrix[0, 1] + matrix[1, 0]) / scale,
+                (matrix[0, 2] + matrix[2, 0]) / scale,
+                (matrix[2, 1] - matrix[1, 2]) / scale,
+            ])
+        elif axis == 1:
+            scale = 2.0 * np.sqrt(1.0 + matrix[1, 1] -
+                                  matrix[0, 0] - matrix[2, 2])
+            quat = np.array([
+                (matrix[0, 1] + matrix[1, 0]) / scale,
+                0.25 * scale,
+                (matrix[1, 2] + matrix[2, 1]) / scale,
+                (matrix[0, 2] - matrix[2, 0]) / scale,
+            ])
+        else:
+            scale = 2.0 * np.sqrt(1.0 + matrix[2, 2] -
+                                  matrix[0, 0] - matrix[1, 1])
+            quat = np.array([
+                (matrix[0, 2] + matrix[2, 0]) / scale,
+                (matrix[1, 2] + matrix[2, 1]) / scale,
+                0.25 * scale,
+                (matrix[1, 0] - matrix[0, 1]) / scale,
+            ])
+    return pi.quat_normalize(quat)
+
+
+def build_correction_anchors(
+    raw: Sequence[pi.TrajectorySample],
+    corrected: Sequence[pi.TrajectorySample],
+    *,
+    max_anchor_offset: float = 0.2,
+) -> list[CorrectionAnchor]:
+    """Compute ``corrected @ inverse(raw)`` at each graph timestamp."""
+    if not raw:
+        raise ValueError('raw trajectory is empty')
+    if not corrected:
+        raise ValueError('corrected trajectory is empty')
+    anchors = []
+    for sample in corrected:
+        raw_pose = pi.interpolate_pose(
+            raw, sample.stamp, max_extrapolation=max_anchor_offset)
+        correction = sample.matrix() @ np.linalg.inv(raw_pose)
+        anchors.append(CorrectionAnchor(
+            stamp=sample.stamp,
+            translation=correction[:3, 3].copy(),
+            quat_xyzw=matrix_to_quat_xyzw(correction[:3, :3]),
+        ))
+    return anchors
+
+
+def interpolate_correction(anchors: Sequence[CorrectionAnchor],
+                           stamp: float) -> np.ndarray:
+    """Interpolate a world-side correction, clamping outside anchor range."""
+    if not anchors:
+        raise ValueError('correction anchors are empty')
+    if stamp <= anchors[0].stamp:
+        anchor = anchors[0]
+        return pi.make_transform(anchor.translation, anchor.quat_xyzw)
+    if stamp >= anchors[-1].stamp:
+        anchor = anchors[-1]
+        return pi.make_transform(anchor.translation, anchor.quat_xyzw)
+
+    lo, hi = 0, len(anchors) - 1
+    while hi - lo > 1:
+        mid = (lo + hi) // 2
+        if anchors[mid].stamp <= stamp:
+            lo = mid
+        else:
+            hi = mid
+    left, right = anchors[lo], anchors[hi]
+    span = right.stamp - left.stamp
+    alpha = 0.0 if span <= 0.0 else (stamp - left.stamp) / span
+    translation = ((1.0 - alpha) * left.translation +
+                   alpha * right.translation)
+    quat = pi.quat_slerp(left.quat_xyzw, right.quat_xyzw, alpha)
+    return pi.make_transform(translation, quat)
+
+
+def densify_trajectory(
+    raw: Sequence[pi.TrajectorySample],
+    corrected: Sequence[pi.TrajectorySample],
+    *,
+    max_anchor_offset: float = 0.2,
+) -> list[pi.TrajectorySample]:
+    """Apply interpolated graph corrections to every dense raw pose."""
+    anchors = build_correction_anchors(
+        raw, corrected, max_anchor_offset=max_anchor_offset)
+    dense = []
+    for sample in raw:
+        pose = interpolate_correction(anchors, sample.stamp) @ sample.matrix()
+        dense.append(pi.TrajectorySample(
+            stamp=sample.stamp,
+            translation=pose[:3, 3].copy(),
+            quat_xyzw=matrix_to_quat_xyzw(pose[:3, :3]),
+        ))
+    return dense
+
+
+def write_tum(path: str | Path,
+              samples: Sequence[pi.TrajectorySample]) -> Path:
+    """Write trajectory samples in TUM timestamp/translation/xyzw format."""
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for sample in samples:
+        values = [sample.stamp, *sample.translation, *sample.quat_xyzw]
+        lines.append(' '.join(f'{float(value):.17g}' for value in values))
+    target.write_text('\n'.join(lines) + ('\n' if lines else ''))
+    return target
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--raw', type=Path, required=True,
+                        help='dense pre-optimization TUM trajectory')
+    parser.add_argument('--corrected', type=Path, required=True,
+                        help='sparse optimized graph-node TUM trajectory')
+    parser.add_argument('--output', type=Path, required=True,
+                        help='output dense corrected TUM trajectory')
+    parser.add_argument('--max-anchor-offset', type=float, default=0.2,
+                        help='allowed corrected-anchor extrapolation (s)')
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Generate and write the dense corrected trajectory."""
+    args = build_parser().parse_args(argv)
+    raw = pi.read_tum_trajectory(args.raw)
+    corrected = pi.read_tum_trajectory(args.corrected)
+    dense = densify_trajectory(
+        raw, corrected, max_anchor_offset=args.max_anchor_offset)
+    output = write_tum(args.output, dense)
+    print(f'wrote {len(dense)} dense corrected poses from '
+          f'{len(corrected)} graph anchors -> {output}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/gaussian_splatting/README.md
+++ b/tools/gaussian_splatting/README.md
@@ -65,8 +65,13 @@ python3 tools/gaussian_splatting/colored_map_pipeline.py \
   --camera-info-topic /camera_info
 
 # Kalibr camchain + 別LiDAR calibration（HILTI形式）はextrinsicを自動合成
+python3 scripts/densify_corrected_trajectory.py \
+  --raw output/<run>/traj_raw.tum \
+  --corrected output/<run>/traj_corrected.tum \
+  --output output/<run>/traj_corrected_dense.tum
+
 python3 tools/gaussian_splatting/colored_map_pipeline.py \
-  <bag> output/<run>/traj_corrected.tum output/<run>/colored_map \
+  <bag> output/<run>/traj_corrected_dense.tum output/<run>/colored_map \
   --kalibr-camchain calibration/camchain-imucam.yaml \
   --lidar-calibration calibration/lidar_calibration.yaml \
   --intrinsics-yaml calibration/camchain-imucam.yaml \


### PR DESCRIPTION
## What changed

- add `scripts/densify_corrected_trajectory.py`
- compute each graph anchor's world-side correction as `corrected_pose @ inverse(raw_pose)`
- interpolate correction translation linearly and rotation with quaternion SLERP
- apply the interpolated correction to every dense raw SLAM pose
- clamp the first/last correction outside the graph-anchor time span
- document the coloured-map workflow in the main and tool READMEs

## Why

Pose-graph output can contain only optimized graph keyframes, while camera images and LiDAR scans arrive at a much higher rate. Direct interpolation across a sparse corrected trajectory produced gaps up to 12.799 seconds on HILTI exp04 and distorted the accumulated map. This tool preserves the dense raw timestamps while propagating loop-closure corrections across the complete trajectory.

## Real-data validation

HILTI 2022 exp04, same RKO-LIO/graph SLAM run used for coloured-map validation:

- 42 sparse graph anchors
- 1,258 dense corrected output poses
- maximum dense pose gap: 0.102 s
- graph-anchor agreement: `4.1e-15 m` maximum translation error and `3.7e-8 rad` maximum rotation error
- coloured-map pipeline accepted the dense result and accumulated 251 scans into 300,000 points
- 230,706 points received camera observations

The measured graph correction in this particular exp04 run was effectively zero; non-zero translation and rotation propagation are covered by synthetic tests.

## Checks

- focused Python suite: 34 passed
- CLI help/compile check: passed
- `git diff --check`: passed
- HILTI exp04 dense corrected trajectory generation: passed
- HILTI exp04 coloured-map end-to-end run: passed

The unrelated local BIM/export files are not included.
