### PR TITLE
Integrate trajectory densification into colored maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,18 @@ the same SLAM poses.
 The sequence is from the RTK-SLAM dataset (CC-BY 4.0). Its total-station
 checkpoints are also used by the [accuracy gate](#accuracy).
 
-If graph optimization outputs sparse keyframes, propagate their corrections
-onto the dense SLAM pose stream before building the coloured map:
+If graph optimization outputs sparse keyframes, the coloured-map pipeline can
+propagate their corrections onto the dense SLAM pose stream automatically:
 
 ```bash
-python3 scripts/densify_corrected_trajectory.py \
-  --raw output/<run>/traj_raw.tum \
-  --corrected output/<run>/traj_corrected.tum \
-  --output output/<run>/traj_corrected_dense.tum
+python3 tools/gaussian_splatting/colored_map_pipeline.py \
+  <bag> output/<run>/traj_corrected.tum output/<run>/colored_map \
+  --raw-traj output/<run>/traj_raw.tum \
+  --extrinsic configs/gaussian_splatting/<lidar_camera_extrinsic>.yaml
 ```
+
+The generated `dense_corrected_trajectory.tum` is reused on later runs. Use
+`--force-trajectory` after either input trajectory changes.
 
 ## Accuracy
 

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -58,6 +58,44 @@ def test_build_commands_connects_extract_to_robust_map(tmp_path):
     assert '--color-robust' in build
 
 
+def test_raw_trajectory_adds_densification_and_connects_dense_output(tmp_path):
+    args = _args(tmp_path, '--raw-traj', str(tmp_path / 'raw.tum'))
+    commands = cmp.build_commands(args)
+    assert [name for name, _ in commands] == [
+        'dense corrected trajectory', 'posed images', 'coloured map']
+    densify, extract, build = [command for _, command in commands]
+    dense = str(tmp_path / 'out' / 'dense_corrected_trajectory.tum')
+    assert densify[densify.index('--raw') + 1] == str(tmp_path / 'raw.tum')
+    assert densify[densify.index('--corrected') + 1] == str(
+        tmp_path / 'traj.tum')
+    assert densify[densify.index('--output') + 1] == dense
+    assert extract[extract.index('--traj') + 1] == dense
+    assert build[build.index('--traj') + 1] == dense
+
+
+def test_existing_dense_trajectory_and_outputs_are_reused(tmp_path):
+    out = tmp_path / 'out'
+    (out / 'posed_images').mkdir(parents=True)
+    (out / 'dense_corrected_trajectory.tum').write_text('dense\n')
+    (out / 'posed_images' / 'transforms.json').write_text('{}')
+    (out / 'colored_map.ply').write_text('ply\n')
+    args = _args(tmp_path, '--raw-traj', str(tmp_path / 'raw.tum'))
+    assert cmp.build_commands(args) == []
+
+
+def test_force_trajectory_rebuilds_all_dependent_stages(tmp_path):
+    out = tmp_path / 'out'
+    (out / 'posed_images').mkdir(parents=True)
+    (out / 'dense_corrected_trajectory.tum').write_text('dense\n')
+    (out / 'posed_images' / 'transforms.json').write_text('{}')
+    (out / 'colored_map.ply').write_text('ply\n')
+    args = _args(
+        tmp_path, '--raw-traj', str(tmp_path / 'raw.tum'),
+        '--force-trajectory')
+    assert [name for name, _ in cmp.build_commands(args)] == [
+        'dense corrected trajectory', 'posed images', 'coloured map']
+
+
 def test_build_commands_reuses_existing_outputs(tmp_path):
     out = tmp_path / 'out'
     (out / 'posed_images').mkdir(parents=True)

--- a/tools/gaussian_splatting/README.md
+++ b/tools/gaussian_splatting/README.md
@@ -64,14 +64,11 @@ python3 tools/gaussian_splatting/colored_map_pipeline.py \
   --points-topic /livox/points --camera-topic /image \
   --camera-info-topic /camera_info
 
-# Kalibr camchain + 別LiDAR calibration（HILTI形式）はextrinsicを自動合成
-python3 scripts/densify_corrected_trajectory.py \
-  --raw output/<run>/traj_raw.tum \
-  --corrected output/<run>/traj_corrected.tum \
-  --output output/<run>/traj_corrected_dense.tum
-
+# Kalibr camchain + 別LiDAR calibration（HILTI形式）はextrinsicを自動合成。
+# 疎な補正軌跡は --raw-traj の高密度軌跡へ自動伝播してから着色する
 python3 tools/gaussian_splatting/colored_map_pipeline.py \
-  <bag> output/<run>/traj_corrected_dense.tum output/<run>/colored_map \
+  <bag> output/<run>/traj_corrected.tum output/<run>/colored_map \
+  --raw-traj output/<run>/traj_raw.tum \
   --kalibr-camchain calibration/camchain-imucam.yaml \
   --lidar-calibration calibration/lidar_calibration.yaml \
   --intrinsics-yaml calibration/camchain-imucam.yaml \
@@ -80,7 +77,8 @@ python3 tools/gaussian_splatting/colored_map_pipeline.py \
 
 この形式ではcamera pose用の `body <- camera` と、点群積算用の
 `body <- LiDAR` をそれぞれ校正ファイルから適用する。`traj` にはscanを補間できる
-dense SLAM軌跡を渡すこと。疎なpose-graph keyframe列は既定で検出・拒否される。
+dense SLAM軌跡を渡すこと。疎なpose-graph keyframe列を使う場合は `--raw-traj` に
+補正前のdense軌跡を渡すと、補正を全poseへ伝播した軌跡が出力先に保存・再利用される。
 
 SLAM推定軌跡による着色地図の検証出力（RTK-SLAM Construction Hall 1、全60 m loop）:
 

--- a/tools/gaussian_splatting/colored_map_pipeline.py
+++ b/tools/gaussian_splatting/colored_map_pipeline.py
@@ -46,6 +46,14 @@ from typing import Sequence
 
 
 TOOL_DIR = Path(__file__).resolve().parent
+REPO_ROOT = TOOL_DIR.parents[1]
+
+
+def effective_trajectory(args) -> Path:
+    """Return the trajectory consumed by image and map generation."""
+    if args.raw_traj is None:
+        return Path(args.traj)
+    return Path(args.out) / 'dense_corrected_trajectory.tum'
 
 
 def validate_trajectory_density(path: Path, max_gap: float) -> None:
@@ -76,12 +84,25 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
     extrinsic_path = (Path(args.extrinsic) if args.extrinsic is not None else
                       out_dir / 'generated_body_camera_extrinsic.json')
     commands = []
+    trajectory = effective_trajectory(args)
 
-    rebuild_images = args.force_images or not transforms.is_file()
+    rebuild_trajectory = (args.raw_traj is not None and
+                          (args.force_trajectory or not trajectory.is_file()))
+    if rebuild_trajectory:
+        commands.append(('dense corrected trajectory', [
+            sys.executable,
+            str(REPO_ROOT / 'scripts' / 'densify_corrected_trajectory.py'),
+            '--raw', str(args.raw_traj), '--corrected', str(args.traj),
+            '--output', str(trajectory),
+            '--max-anchor-offset', str(args.max_anchor_offset),
+        ]))
+
+    rebuild_images = (rebuild_trajectory or args.force_images or
+                      not transforms.is_file())
     if rebuild_images:
         extract = [
             sys.executable, str(TOOL_DIR / 'extract_posed_images.py'),
-            '--bag', str(args.bag), '--traj', str(args.traj),
+            '--bag', str(args.bag), '--traj', str(trajectory),
             '--camera-topic', args.camera_topic,
             '--camera-info-topic', args.camera_info_topic,
             '--extrinsic', str(extrinsic_path), '--out', str(posed_dir),
@@ -99,7 +120,7 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
     if rebuild_images or args.force_map or not colored_map.is_file():
         build = [
             sys.executable, str(TOOL_DIR / 'build_lidar_init.py'),
-            '--bag', str(args.bag), '--traj', str(args.traj),
+            '--bag', str(args.bag), '--traj', str(trajectory),
             '--points-topic', args.points_topic, '--out', str(colored_map),
             '--voxel', str(args.voxel), '--max-points', str(args.max_points),
             '--min-range', str(args.min_range), '--max-range', str(args.max_range),
@@ -122,8 +143,6 @@ def run_pipeline(args) -> dict:
     if args.kalibr_camchain is not None and args.lidar_calibration is None:
         raise ValueError('--kalibr-camchain requires --lidar-calibration')
     if not args.dry_run:
-        validate_trajectory_density(args.traj, args.max_trajectory_gap)
-    if not args.dry_run:
         out_dir.mkdir(parents=True, exist_ok=True)
         if args.kalibr_camchain is not None:
             from extract_posed_images import load_kalibr_body_camera_extrinsic
@@ -133,22 +152,39 @@ def run_pipeline(args) -> dict:
             generated = out_dir / 'generated_body_camera_extrinsic.json'
             generated.write_text(json.dumps({'matrix': matrix.tolist()}, indent=2))
     commands = build_commands(args)
+    trajectory = effective_trajectory(args)
+    trajectory_validated = False
     for name, command in commands:
+        if (not args.dry_run and name != 'dense corrected trajectory' and
+                not trajectory_validated):
+            validate_trajectory_density(
+                trajectory, args.max_trajectory_gap)
+            trajectory_validated = True
         print(f'[{name}]', ' '.join(command))
         if not args.dry_run:
             subprocess.run(command, check=True)
+    if not args.dry_run and not trajectory_validated:
+        validate_trajectory_density(trajectory, args.max_trajectory_gap)
     return {
         'stages': [name for name, _ in commands],
         'transforms': out_dir / 'posed_images' / 'transforms.json',
         'colored_map': out_dir / 'colored_map.ply',
+        'trajectory': trajectory,
     }
 
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument('bag', type=Path, help='rosbag2 directory')
-    p.add_argument('traj', type=Path, help='SLAM trajectory (TUM, world<-body)')
+    p.add_argument('traj', type=Path,
+                   help='corrected SLAM trajectory (TUM, world<-body)')
     p.add_argument('out', type=Path, help='output directory')
+    p.add_argument('--raw-traj', type=Path,
+                   help='dense pre-optimization TUM trajectory; propagate the '
+                        'corrections from traj before colouring')
+    p.add_argument('--max-anchor-offset', type=float, default=0.2,
+                   help='allowed corrected-anchor extrapolation into the raw '
+                        'trajectory (s)')
     calibration = p.add_mutually_exclusive_group(required=True)
     calibration.add_argument('--extrinsic', type=Path,
                              help='body<-camera YAML/JSON or vlcal calib.json')
@@ -179,6 +215,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--no-undistort', action='store_true')
     p.add_argument('--force-images', action='store_true')
     p.add_argument('--force-map', action='store_true')
+    p.add_argument('--force-trajectory', action='store_true')
     p.add_argument('--dry-run', action='store_true')
     return p
 
@@ -190,6 +227,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         print('completed stages:', ', '.join(summary['stages']))
     else:
         print('everything is up to date; nothing to do')
+    print('trajectory:', summary['trajectory'])
     print('coloured map:', summary['colored_map'])
     return 0
 


### PR DESCRIPTION
## What changed

- add `--raw-traj` to propagate sparse pose-graph corrections automatically
- feed the generated dense corrected trajectory to both posed-image extraction and LiDAR map accumulation
- reuse the generated trajectory by default and add `--force-trajectory` for explicit regeneration
- document the one-command HILTI/colored-map workflow

## Why

Sparse optimized graph nodes cannot register every LiDAR scan or camera frame directly. Users previously had to invoke the densification script separately and manually connect its output to the coloring pipeline. This makes that safe trajectory handoff a first-class pipeline stage.

## Validation

- `37 passed` across colored-map pipeline, densification, and posed-image tests
- `ament_flake8` passed for the modified Python files
- synthetic TUM end-to-end densification generated the expected dense output
- `git diff --check` passed