### PR TITLE
Rebuild stale colored map artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ python3 tools/gaussian_splatting/colored_map_pipeline.py \
 ```
 
 The generated `dense_corrected_trajectory.tum` is reused on later runs. Use
-`--force-trajectory` after either input trajectory changes.
+`--force-trajectory` to regenerate it explicitly. The pipeline also detects
+newer trajectory and posed-image inputs and automatically rebuilds downstream
+artifacts, preventing stale coloured maps from being silently reused.
 
 ## Accuracy
 

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -29,6 +29,7 @@
 
 """Tests for the user-facing coloured-map pipeline command composition."""
 
+import os
 from pathlib import Path
 import sys
 
@@ -38,6 +39,12 @@ if str(TOOL_DIR) not in sys.path:
     sys.path.insert(0, str(TOOL_DIR))
 
 import colored_map_pipeline as cmp  # noqa: E402
+
+
+def _write_at(path, text, stamp_ns):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    os.utime(path, ns=(stamp_ns, stamp_ns))
 
 
 def _args(tmp_path, *extra):
@@ -94,6 +101,36 @@ def test_force_trajectory_rebuilds_all_dependent_stages(tmp_path):
         '--force-trajectory')
     assert [name for name, _ in cmp.build_commands(args)] == [
         'dense corrected trajectory', 'posed images', 'coloured map']
+
+
+def test_newer_trajectory_input_rebuilds_all_dependent_stages(tmp_path):
+    out = tmp_path / 'out'
+    _write_at(out / 'dense_corrected_trajectory.tum', 'dense\n', 2)
+    _write_at(out / 'posed_images' / 'transforms.json', '{}', 3)
+    _write_at(out / 'colored_map.ply', 'ply\n', 4)
+    _write_at(tmp_path / 'raw.tum', 'raw\n', 5)
+    _write_at(tmp_path / 'traj.tum', 'corrected\n', 1)
+    args = _args(tmp_path, '--raw-traj', str(tmp_path / 'raw.tum'))
+    assert [name for name, _ in cmp.build_commands(args)] == [
+        'dense corrected trajectory', 'posed images', 'coloured map']
+
+
+def test_newer_direct_trajectory_rebuilds_images_and_map(tmp_path):
+    out = tmp_path / 'out'
+    _write_at(out / 'posed_images' / 'transforms.json', '{}', 2)
+    _write_at(out / 'colored_map.ply', 'ply\n', 3)
+    _write_at(tmp_path / 'traj.tum', 'dense\n', 4)
+    assert [name for name, _ in cmp.build_commands(_args(tmp_path))] == [
+        'posed images', 'coloured map']
+
+
+def test_newer_posed_images_rebuild_only_map(tmp_path):
+    out = tmp_path / 'out'
+    _write_at(tmp_path / 'traj.tum', 'dense\n', 1)
+    _write_at(out / 'colored_map.ply', 'ply\n', 2)
+    _write_at(out / 'posed_images' / 'transforms.json', '{}', 3)
+    assert [name for name, _ in cmp.build_commands(_args(tmp_path))] == [
+        'coloured map']
 
 
 def test_build_commands_reuses_existing_outputs(tmp_path):

--- a/tools/gaussian_splatting/README.md
+++ b/tools/gaussian_splatting/README.md
@@ -79,6 +79,7 @@ python3 tools/gaussian_splatting/colored_map_pipeline.py \
 `body <- LiDAR` をそれぞれ校正ファイルから適用する。`traj` にはscanを補間できる
 dense SLAM軌跡を渡すこと。疎なpose-graph keyframe列を使う場合は `--raw-traj` に
 補正前のdense軌跡を渡すと、補正を全poseへ伝播した軌跡が出力先に保存・再利用される。
+入力軌跡やposed画像が成果物より新しい場合は、依存する後段だけ自動再生成される。
 
 SLAM推定軌跡による着色地図の検証出力（RTK-SLAM Construction Hall 1、全60 m loop）:
 

--- a/tools/gaussian_splatting/colored_map_pipeline.py
+++ b/tools/gaussian_splatting/colored_map_pipeline.py
@@ -56,6 +56,15 @@ def effective_trajectory(args) -> Path:
     return Path(args.out) / 'dense_corrected_trajectory.tum'
 
 
+def is_stale(output: Path, inputs: Sequence[Path]) -> bool:
+    """Return whether an existing output predates any available input."""
+    if not output.is_file():
+        return True
+    output_mtime = output.stat().st_mtime_ns
+    return any(path.is_file() and path.stat().st_mtime_ns > output_mtime
+               for path in inputs)
+
+
 def validate_trajectory_density(path: Path, max_gap: float) -> None:
     """Reject sparse graph keyframes that cannot register individual scans."""
     if max_gap <= 0:
@@ -86,8 +95,9 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
     commands = []
     trajectory = effective_trajectory(args)
 
-    rebuild_trajectory = (args.raw_traj is not None and
-                          (args.force_trajectory or not trajectory.is_file()))
+    rebuild_trajectory = (args.raw_traj is not None and (
+        args.force_trajectory or is_stale(
+            trajectory, [Path(args.raw_traj), Path(args.traj)])))
     if rebuild_trajectory:
         commands.append(('dense corrected trajectory', [
             sys.executable,
@@ -98,7 +108,7 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
         ]))
 
     rebuild_images = (rebuild_trajectory or args.force_images or
-                      not transforms.is_file())
+                      is_stale(transforms, [trajectory]))
     if rebuild_images:
         extract = [
             sys.executable, str(TOOL_DIR / 'extract_posed_images.py'),
@@ -117,7 +127,8 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
             extract.extend(['--intrinsics-yaml', str(args.intrinsics_yaml)])
         commands.append(('posed images', extract))
 
-    if rebuild_images or args.force_map or not colored_map.is_file():
+    if (rebuild_images or args.force_map or
+            is_stale(colored_map, [trajectory, transforms])):
         build = [
             sys.executable, str(TOOL_DIR / 'build_lidar_init.py'),
             '--bag', str(args.bag), '--traj', str(trajectory),


### PR DESCRIPTION
## What changed

- detect generated outputs that predate their trajectory inputs
- regenerate dense corrections when raw or optimized trajectories change
- rebuild posed images when their effective trajectory changes
- rebuild the colored map when its trajectory or posed-image transforms change
- document automatic downstream invalidation

## Why

The pipeline previously reused outputs based only on file existence. Updating an input trajectory could therefore silently retain a stale colored map unless the user remembered the correct force flags.

## Validation

- `40 passed` across colored-map, trajectory-densification, and posed-image tests
- added coverage for each dependency boundary and selective rebuild behavior
- `ament_flake8` passed
- `git diff --check` passed