### PR TITLE
Improve colored map projection coverage

### DIFF
--- a/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
+++ b/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
@@ -207,6 +207,26 @@ def test_colorize_robust_occluded_point_is_unseen():
     np.testing.assert_array_equal(rgb[1], [7, 7, 7])
 
 
+def test_colorize_robust_neighbouring_pixel_does_not_false_occlude():
+    vms, K, W, H = _cam()
+    img = np.zeros((H, W, 3), dtype=np.uint8)
+    img[50, 50] = [200, 0, 0]
+    img[50, 51] = [0, 200, 0]
+    # These land in adjacent pixels but share a 4x4 coarse bin. The near red
+    # point must not incorrectly hide the farther green surface.
+    pts = np.array([[0.0, 0.0, 2.0], [0.08, 0.0, 8.0]])
+    rgb, seen = pcio.colorize_by_projection_robust(
+        pts, vms, K, [img], W, H, normalize_exposure=False,
+        interp='nearest')
+    assert seen.tolist() == [True, True]
+    np.testing.assert_array_equal(rgb, [[200, 0, 0], [0, 200, 0]])
+
+    _, coarse_seen = pcio.colorize_by_projection_robust(
+        pts, vms, K, [img], W, H, normalize_exposure=False,
+        interp='nearest', zbuf_bin=4)
+    assert coarse_seen.tolist() == [True, False]
+
+
 def test_colorize_robust_median_rejects_outlier_view():
     vms1, K, W, H = _cam()
     imgs = []

--- a/tools/gaussian_splatting/README.md
+++ b/tools/gaussian_splatting/README.md
@@ -80,6 +80,8 @@ python3 tools/gaussian_splatting/colored_map_pipeline.py \
 dense SLAM軌跡を渡すこと。疎なpose-graph keyframe列を使う場合は `--raw-traj` に
 補正前のdense軌跡を渡すと、補正を全poseへ伝播した軌跡が出力先に保存・再利用される。
 入力軌跡やposed画像が成果物より新しい場合は、依存する後段だけ自動再生成される。
+robust着色は1ピクセル単位のz-bufferで遮蔽を判定し、隣接ピクセルの前景によって
+本来見える点が未着色になる粗いbin由来の欠落を防ぐ。
 
 SLAM推定軌跡による着色地図の検証出力（RTK-SLAM Construction Hall 1、全60 m loop）:
 

--- a/tools/gaussian_splatting/pointcloud_io.py
+++ b/tools/gaussian_splatting/pointcloud_io.py
@@ -186,7 +186,7 @@ def _median_luminance(img: np.ndarray) -> float:
 def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
                                   K: np.ndarray, images, width: int, height: int,
                                   default_rgb=(128, 128, 128), *,
-                                  zbuf_bin: int = 4, depth_tol: float = 0.15,
+                                  zbuf_bin: int = 1, depth_tol: float = 0.15,
                                   max_samples: int = 12,
                                   normalize_exposure: bool = True,
                                   interp: str = 'bilinear',
@@ -197,12 +197,17 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
     ``colorize_by_projection`` averages every view a point lands in, so points
     behind walls or machines pick up the colour of whatever occludes them and
     auto-exposure differences wash the average out. This variant first builds a
-    coarse per-view z-buffer from the point cloud itself (``zbuf_bin`` pixel
-    bins) and only samples views where the point sits within ``depth_tol`` (plus
+    per-view z-buffer from the point cloud itself (one pixel per bin by default)
+    and only samples views where the point sits within ``depth_tol`` (plus
     2 % of range) of the nearest depth in its bin; each image is scaled so its
     median luminance matches the global median (``normalize_exposure``); and the
     final colour is the per-channel median over up to ``max_samples`` valid
     samples, which rejects residual specular / motion-blur outliers.
+
+    A value above one for ``zbuf_bin`` trades memory for a coarse occlusion
+    approximation. It can falsely hide a surface when an unrelated nearer point
+    lands in a neighbouring pixel, so final map generation should keep the
+    one-pixel default.
 
     Quality knobs: ``interp='bilinear'`` samples sub-pixel (blends the four
     surrounding pixels) instead of snapping to the nearest, cutting the colour


### PR DESCRIPTION
## What changed

- make robust camera projection use an exact one-pixel z-buffer by default
- retain coarse bins as an explicit memory tradeoff
- add a regression test proving adjacent pixels cannot falsely occlude each other
- document the improved occlusion behavior

## Root cause

The previous 4x4-pixel depth bins treated every point in a bin as sharing one camera ray. A close point in one pixel could therefore hide a valid surface projected into a neighboring pixel, leaving large grey/uncolored regions.

## HILTI exp04 validation

| Metric | 4x4 bins | 1x1 pixel |
| --- | ---: | ---: |
| colored points | 230,706 / 300,000 (76.9%) | 299,945 / 300,000 (99.98%) |
| points with 2+ views | 211,168 (70.4%) | 299,781 (99.93%) |
| runtime | 16.4 s | 15.9 s |

A regenerated comparison map was written as `colored_map_pixel_zbuffer.ply` beside the external validation artifacts.

## Checks

- 45 focused tests passed
- ament_flake8 passed
- git diff whitespace check passed