### PR TITLE
Use observed colors for robust point maps

### DIFF
--- a/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
+++ b/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
@@ -194,6 +194,31 @@ def test_colorize_averages_over_views():
 # --------------------------------------------------------------------------- #
 # colorize_by_projection_robust
 # --------------------------------------------------------------------------- #
+def test_observed_color_medoid_never_synthesizes_unseen_rgb():
+    samples = np.array([[[255, 0, 0], [0, 255, 0], [0, 0, 255]]],
+                       dtype=np.uint8)
+    out = pcio.observed_color_medoids(samples)
+    # A channel median would invent black [0, 0, 0]. Tied medoids resolve to
+    # the first real observation, deterministically.
+    np.testing.assert_array_equal(out, [[255, 0, 0]])
+
+
+def test_observed_color_medoid_rejects_single_outlier_and_chunks():
+    samples = np.array([
+        [[10, 20, 30], [11, 21, 31], [250, 0, 200]],
+        [[100, 110, 120], [101, 111, 121], [0, 255, 0]],
+    ], dtype=np.uint8)
+    out = pcio.observed_color_medoids(samples, chunk=1)
+    np.testing.assert_array_equal(out, [[11, 21, 31], [100, 110, 120]])
+
+
+def test_observed_color_medoid_validates_shape_and_chunk():
+    with np.testing.assert_raises(ValueError):
+        pcio.observed_color_medoids(np.zeros((2, 0, 3), dtype=np.uint8))
+    with np.testing.assert_raises(ValueError):
+        pcio.observed_color_medoids(np.zeros((2, 1, 3), dtype=np.uint8), chunk=0)
+
+
 def test_colorize_robust_occluded_point_is_unseen():
     vms, K, W, H = _cam()
     img = np.full((H, W, 3), 200, dtype=np.uint8)

--- a/tools/gaussian_splatting/README.md
+++ b/tools/gaussian_splatting/README.md
@@ -82,6 +82,8 @@ dense SLAM軌跡を渡すこと。疎なpose-graph keyframe列を使う場合は
 入力軌跡やposed画像が成果物より新しい場合は、依存する後段だけ自動再生成される。
 robust着色は1ピクセル単位のz-bufferで遮蔽を判定し、隣接ピクセルの前景によって
 本来見える点が未着色になる粗いbin由来の欠落を防ぐ。
+複数viewの統合にはRGB medoidを使い、チャネル別medianが実際には観測されていない
+濁った合成色を作る問題も防ぐ。
 
 SLAM推定軌跡による着色地図の検証出力（RTK-SLAM Construction Hall 1、全60 m loop）:
 

--- a/tools/gaussian_splatting/pointcloud_io.py
+++ b/tools/gaussian_splatting/pointcloud_io.py
@@ -183,6 +183,30 @@ def _median_luminance(img: np.ndarray) -> float:
     return float(np.median(np.tensordot(arr[:, :, :3], coeff, axes=([-1], [0]))))
 
 
+def observed_color_medoids(samples: np.ndarray, chunk: int = 20000) -> np.ndarray:
+    """Choose the observed RGB sample nearest all other samples per point.
+
+    A channel-wise median can synthesize a colour that no camera observed. For
+    example, red, green, and blue samples produce black. The L1 medoid retains
+    median-like outlier resistance while guaranteeing that every output row is
+    one of the input camera observations. Chunking bounds the temporary pairwise
+    distance array for large maps.
+    """
+    values = np.asarray(samples, dtype=np.uint8)
+    if values.ndim != 3 or values.shape[2] != 3 or values.shape[1] < 1:
+        raise ValueError(f'samples must be NxSx3 with S >= 1, got {values.shape}')
+    if chunk < 1:
+        raise ValueError('chunk must be >= 1')
+    out = np.empty((values.shape[0], 3), dtype=np.uint8)
+    for start in range(0, len(values), chunk):
+        block = values[start:start + chunk].astype(np.int16)
+        pairwise = np.abs(block[:, :, None, :] - block[:, None, :, :])
+        scores = pairwise.sum(axis=(2, 3), dtype=np.int32)
+        choice = np.argmin(scores, axis=1)
+        out[start:start + len(block)] = block[np.arange(len(block)), choice]
+    return out
+
+
 def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
                                   K: np.ndarray, images, width: int, height: int,
                                   default_rgb=(128, 128, 128), *,
@@ -201,8 +225,9 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
     and only samples views where the point sits within ``depth_tol`` (plus
     2 % of range) of the nearest depth in its bin; each image is scaled so its
     median luminance matches the global median (``normalize_exposure``); and the
-    final colour is the per-channel median over up to ``max_samples`` valid
-    samples, which rejects residual specular / motion-blur outliers.
+    final colour is the RGB medoid over up to ``max_samples`` valid samples,
+    which rejects residual specular / motion-blur outliers without synthesizing
+    a colour that no camera actually observed.
 
     A value above one for ``zbuf_bin`` trades memory for a coarse occlusion
     approximation. It can falsely hide a surface when an unrelated nearer point
@@ -297,7 +322,7 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
     seen_idx = np.flatnonzero(seen)
     for c in np.unique(counts[seen_idx]):
         group = seen_idx[counts[seen_idx] == c]
-        rgb[group] = np.median(samples[group, :int(c), :], axis=1).astype(np.uint8)
+        rgb[group] = observed_color_medoids(samples[group, :int(c), :])
     return (rgb, seen, counts) if return_counts else (rgb, seen)
 
 


### PR DESCRIPTION
## What changed

- replace channel-wise RGB median aggregation with an observed-color medoid
- choose the camera sample minimizing total L1 distance to the other valid views
- process points in bounded chunks to control pairwise-distance memory
- add tests for synthetic-color prevention, outlier rejection, chunking, and validation

## Root cause

Taking an independent median for R, G, and B can synthesize a color that no camera observed. Red, green, and blue samples, for example, produce black. This causes muddy colors near boundaries, reflections, and moving objects.

## HILTI exp04 validation

- retained 299,945 / 300,000 colored points (99.98%)
- changed 207,117 points (69.04%) from the channel-median result to actual observed colors
- mean absolute RGB change: 3.94 levels
- runtime: 20.8 seconds for 300,000 points and 252 views
- generated external artifact: `colored_map_pixel_zbuffer_medoid.ply`

## Checks

- 48 focused tests passed
- ament_flake8 passed
- git diff whitespace check passed