### PR TITLE
Measure LiDAR camera edge alignment

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -512,6 +512,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_lidar_camera_alignment
+    test/test_lidar_camera_alignment.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_gaussian_splatting_render
     test/test_gaussian_splatting_render.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_lidar_camera_alignment.py
+++ b/graph_based_slam/test/test_lidar_camera_alignment.py
@@ -1,0 +1,87 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for LiDAR-camera depth/image edge alignment metrics."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    'evaluate_lidar_camera_alignment',
+    REPO_ROOT / 'scripts' / 'evaluate_lidar_camera_alignment.py')
+lca = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(lca)
+
+
+def test_image_edges_detects_vertical_step():
+    image = np.zeros((20, 20, 3), dtype=np.uint8)
+    image[:, 10:] = 255
+    edges = lca.image_edges(image, percentile=50)
+    assert edges[:, 9:11].any()
+    assert not edges[:, :5].any()
+
+
+def test_depth_edges_detects_supported_depth_step():
+    depth = np.full((10, 10), np.inf, dtype=np.float32)
+    depth[5, 3:5] = [2.0, 4.0]
+    edges = lca.depth_edges(depth, absolute=0.25, relative=0.0)
+    assert edges[5, 3] and edges[5, 4]
+    assert edges.sum() == 2
+
+
+def test_nearest_edge_distances_reports_alignment_and_shift():
+    query = np.zeros((20, 20), dtype=bool)
+    target = np.zeros_like(query)
+    query[5:15, 8] = True
+    target[5:15, 11] = True
+    np.testing.assert_allclose(
+        lca.nearest_edge_distances(query, target, max_distance=6), 3.0)
+    np.testing.assert_allclose(
+        lca.nearest_edge_distances(query, query, max_distance=6), 0.0)
+
+
+def test_projected_depth_keeps_nearest_point():
+    points = np.array([[0.0, 0.0, 2.0], [0.0, 0.0, 5.0]])
+    K = np.array([[10.0, 0.0, 5.0], [0.0, 10.0, 5.0], [0.0, 0.0, 1.0]])
+    depth = lca.projected_depth(points, np.eye(4), K, 10, 10)
+    assert depth[5, 5] == 2.0
+
+
+def test_score_view_handles_no_depth_edges():
+    points = np.array([[0.0, 0.0, 2.0]])
+    K = np.array([[10.0, 0.0, 5.0], [0.0, 10.0, 5.0], [0.0, 0.0, 1.0]])
+    result = lca.score_view(
+        points, np.eye(4), K, np.zeros((10, 10, 3), dtype=np.uint8))
+    assert result['edge_points'] == 0
+    assert result['median_px'] is None

--- a/scripts/evaluate_lidar_camera_alignment.py
+++ b/scripts/evaluate_lidar_camera_alignment.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Measure LiDAR depth-edge alignment against camera image edges."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+if str(TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOL_DIR))
+
+import pointcloud_io as pcio  # noqa: E402
+import train_gsplat as tg  # noqa: E402
+
+
+def image_edges(image: np.ndarray, percentile: float = 95.0) -> np.ndarray:
+    """Return a strong grayscale-gradient edge mask without OpenCV/SciPy."""
+    array = np.asarray(image, dtype=np.float32)
+    if array.ndim == 3:
+        array = array[:, :, :3] @ np.array([0.299, 0.587, 0.114])
+    if array.ndim != 2:
+        raise ValueError(f'image must be HxW or HxWxC, got {array.shape}')
+    if not 0.0 <= percentile <= 100.0:
+        raise ValueError('percentile must be between 0 and 100')
+    gx = np.zeros_like(array)
+    gy = np.zeros_like(array)
+    gx[:, 1:-1] = np.abs(array[:, 2:] - array[:, :-2])
+    gy[1:-1, :] = np.abs(array[2:, :] - array[:-2, :])
+    magnitude = np.hypot(gx, gy)
+    nonzero = magnitude[magnitude > 0.0]
+    if nonzero.size == 0:
+        return np.zeros(array.shape, dtype=bool)
+    return magnitude >= np.percentile(nonzero, percentile)
+
+
+def depth_edges(depth: np.ndarray, absolute: float = 0.25,
+                relative: float = 0.02) -> np.ndarray:
+    """Return pixels adjacent to a supported LiDAR depth discontinuity."""
+    values = np.asarray(depth, dtype=np.float32)
+    if values.ndim != 2:
+        raise ValueError(f'depth must be HxW, got {values.shape}')
+    if absolute < 0.0 or relative < 0.0:
+        raise ValueError('depth thresholds must be non-negative')
+    valid = np.isfinite(values) & (values > 0.0)
+    edges = np.zeros(values.shape, dtype=bool)
+    with np.errstate(invalid='ignore'):
+        horizontal = (valid[:, :-1] & valid[:, 1:] &
+                      (np.abs(values[:, :-1] - values[:, 1:]) >
+                       absolute + relative * np.minimum(
+                           values[:, :-1], values[:, 1:])))
+        vertical = (valid[:-1, :] & valid[1:, :] &
+                    (np.abs(values[:-1, :] - values[1:, :]) >
+                     absolute + relative * np.minimum(
+                         values[:-1, :], values[1:, :])))
+    edges[:, :-1] |= horizontal
+    edges[:, 1:] |= horizontal
+    edges[:-1, :] |= vertical
+    edges[1:, :] |= vertical
+    return edges
+
+
+def nearest_edge_distances(query: np.ndarray, target: np.ndarray,
+                           max_distance: int = 12) -> np.ndarray:
+    """Find target-edge distance for query pixels with a bounded local search."""
+    query_y, query_x = np.nonzero(query)
+    if query_y.size == 0:
+        return np.zeros(0, dtype=np.float32)
+    distances = np.full(query_y.size, float(max_distance + 1), dtype=np.float32)
+    height, width = target.shape
+    offsets = [(dy, dx) for dy in range(-max_distance, max_distance + 1)
+               for dx in range(-max_distance, max_distance + 1)
+               if dy * dy + dx * dx <= max_distance * max_distance]
+    offsets.sort(key=lambda item: item[0] * item[0] + item[1] * item[1])
+    for dy, dx in offsets:
+        distance = float(np.hypot(dy, dx))
+        pending = distances > distance
+        y = query_y + dy
+        x = query_x + dx
+        inside = pending & (y >= 0) & (y < height) & (x >= 0) & (x < width)
+        hit = np.zeros(query_y.size, dtype=bool)
+        hit[inside] = target[y[inside], x[inside]]
+        distances[hit] = distance
+    return distances
+
+
+def projected_depth(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
+                    width: int, height: int) -> np.ndarray:
+    """Project one view into an image containing sparse nearest depths."""
+    (pixels, depths), = pcio.project_depth_maps(
+        points, np.asarray(viewmat)[None], K, width, height)
+    image = np.full((height, width), np.inf, dtype=np.float32)
+    image.reshape(-1)[pixels] = depths
+    return image
+
+
+def score_view(points: np.ndarray, viewmat: np.ndarray, K: np.ndarray,
+               image: np.ndarray, *, edge_percentile: float = 95.0,
+               max_distance: int = 12) -> dict:
+    """Score one camera view and return pixel-distance alignment metrics."""
+    height, width = image.shape[:2]
+    lidar_edges = depth_edges(projected_depth(points, viewmat, K, width, height))
+    distances = nearest_edge_distances(
+        lidar_edges, image_edges(image, edge_percentile), max_distance)
+    if distances.size == 0:
+        return {'edge_points': 0, 'median_px': None, 'p90_px': None,
+                'inlier_2px': None}
+    return {'edge_points': int(distances.size),
+            'median_px': float(np.median(distances)),
+            'p90_px': float(np.percentile(distances, 90)),
+            'inlier_2px': float(np.mean(distances <= 2.0))}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--pointcloud', type=Path, required=True)
+    parser.add_argument('--transforms', type=Path, required=True)
+    parser.add_argument('--out', type=Path, required=True)
+    parser.add_argument('--view-stride', type=int, default=10)
+    parser.add_argument('--edge-percentile', type=float, default=95.0,
+                        help='retain this percentile of nonzero image gradients; '
+                             '95 focuses the metric on structural edges')
+    parser.add_argument('--max-distance', type=int, default=12)
+    args = parser.parse_args()
+    if args.view_stride < 1 or args.max_distance < 1:
+        raise SystemExit('--view-stride and --max-distance must be >= 1')
+    import imageio.v3 as iio
+    points, _ = pcio.read_ply_xyz(args.pointcloud)
+    dataset = tg.load_transforms(args.transforms)
+    per_view = []
+    for index in range(0, len(dataset['viewmats']), args.view_stride):
+        score = score_view(
+            points, dataset['viewmats'][index], dataset['K'],
+            iio.imread(dataset['image_paths'][index]),
+            edge_percentile=args.edge_percentile,
+            max_distance=args.max_distance)
+        score['view_index'] = index
+        per_view.append(score)
+    valid = [item for item in per_view if item['edge_points'] > 0]
+    if not valid:
+        raise SystemExit('no LiDAR depth edges were measurable')
+    weights = np.asarray([item['edge_points'] for item in valid], dtype=float)
+    report = {'pointcloud': str(args.pointcloud.resolve()),
+              'transforms': str(args.transforms.resolve()),
+              'views_scored': len(valid), 'edge_points': int(weights.sum())}
+    for name in ('median_px', 'p90_px', 'inlier_2px'):
+        report[f'weighted_{name}'] = float(np.average(
+            [item[name] for item in valid], weights=weights))
+    report['per_view'] = per_view
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps({key: value for key, value in report.items()
+                      if key != 'per_view'}, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/gaussian_splatting/README.md
+++ b/tools/gaussian_splatting/README.md
@@ -30,6 +30,7 @@ photorealistic map / novel-view 成果物を後処理で再構成するための
 | `pointcloud_io.py` | 最小 PLY 入出力（xyz[+rgb]）＋ voxel 間引き＋ **画像投影による点群着色**（`colorize_by_projection`）。 | numpy のみ | `test_gaussian_splatting_pointcloud.py`（12）|
 | `build_lidar_init.py` | bag のスキャンを SLAM 軌跡で world 系に蓄積 → **LiDAR-primed init 点群** PLY。FILE-compressed(zstd) bag 対応。`--color-transforms` で transforms.json の posed 画像を投影して着色（品質中立だが検査用に有用）。 | rosbag2_py（実行時のみ）| 同上（`transform_points` 等の純粋部）|
 | `colored_map_pipeline.py` | bag + TUM軌跡 + camera extrinsic から、posed画像抽出 → 遮蔽対応の複数view着色map生成を一括実行。既存成果物の再利用、`--dry-run`、段階別forceに対応。 | 上記2ツールと同じ | `test_colored_map_pipeline.py` |
+| `../../scripts/evaluate_lidar_camera_alignment.py` | LiDAR depth境界とcamera画像edgeの距離を測り、外部校正をpixel単位で評価。 | numpy, imageio | `test_lidar_camera_alignment.py` |
 | `train_gsplat.py` | `transforms.json` + 画像で gsplat 学習 → INRIA 標準 `.ply` 出力。OpenGL c2w を OpenCV w2c に変換。`--init-ply` で **LiDAR-primed init**（位置＋色 seed）、`--densify` で gsplat `DefaultStrategy` の adaptive density control、`--ssim-lambda`（既定 0.2）で INRIA 標準 **L1+D-SSIM 損失**、`--knn-scale-init` で点群の局所密度から per-Gaussian スケール seed、`--sh-degree D` で **視点依存カラー（SH 次数 D、INRIA 標準 f_dc+f_rest 出力）**、`--antialiased` で gsplat の antialiased rasterize mode、`--mcmc`（+`--mcmc-cap`）で MCMCStrategy（LiDAR-primed init では DefaultStrategy 優位＝既定）、`--optimize-extrinsic` で共有 6-DoF extrinsic の photometric 自己校正。学習終了時に全ビューの PSNR/SSIM を出力。 | torch, gsplat (CUDA) | `test_gaussian_splatting_train.py`（20、純粋部）|
 | `selftest_gpu.py` | opt-in GPU セルフテスト。合成シーンを描画→`transforms.json`→学習→`.ply` の全鎖を検証。 | torch, gsplat (CUDA) | 手動実行（CI 非対象）|
 | `render_path.py` | 学習済み `.ply` + `transforms.json` から**フライスルー動画（mp4/GIF）**を描画する CLI。INRIA `.ply` の読み戻し、学習視点を通る SLERP+box-smooth カメラパス、`--ping-pong` ループ、`--scale` 縮小描画、`--rotate` 横倒しカメラ補正。 | torch, gsplat (CUDA)（純粋部は numpy のみ）| `test_gaussian_splatting_render.py`（13、ply 読み戻し/パス/回転/intrinsics の純粋部）|
@@ -88,6 +89,16 @@ robust着色は1ピクセル単位のz-bufferで遮蔽を判定し、隣接ピ�
 強い色境界では実画素へ切り替え、前景色と背景色のにじみを抑える。
 画像間の露出正規化は倍率を `1/1.5`〜`1.5` に制限し、実際に明るい壁や暗い区間を
 全画面medianの差だけで白飛び・黒潰れさせない。
+
+外部校正はLiDAR depth境界と強い画像edgeの距離で診断できる。この自然scene metricは
+校正targetの代替ではなく、bag全体に対するpixel単位の回帰検査として使う。
+
+```bash
+python3 scripts/evaluate_lidar_camera_alignment.py \
+  --pointcloud output/<run>/colored_map.ply \
+  --transforms output/<run>/posed_images/transforms.json \
+  --out output/<run>/lidar_camera_alignment.json
+```
 
 SLAM推定軌跡による着色地図の検証出力（RTK-SLAM Construction Hall 1、全60 m loop）:
 


### PR DESCRIPTION
## What changed

- add a GPU-free LiDAR-camera alignment diagnostic
- project nearest LiDAR depths into posed camera views
- compare LiDAR depth discontinuities with the strongest structural image edges
- report weighted median/p90 pixel distance, 2 px inlier rate, and per-view details
- add five pure NumPy regression tests and usage documentation

## Why

Colored-map coverage alone cannot distinguish correct projection from a consistently miscalibrated projection. This provides a repeatable bag-wide pixel-space regression metric before changing camera-LiDAR extrinsics. It is diagnostic rather than a replacement for a calibration target.

## HILTI exp04 baseline

- 26 sampled views
- 858,065 LiDAR depth-edge points
- weighted median: 6.72 px
- weighted p90: 12.78 px
- 2 px inlier rate: 26.14%

## AIST calibration sensitivity

The dedicated calibration result improved median alignment versus its axis-aligned initialization:

- scene 1: 6.32 px -> 5.00 px; 2 px inliers 26.2% -> 31.6%
- scene 2: 6.08 px -> 5.83 px

A known 1 degree HILTI perturbation also worsened the strong-edge score. Natural-scene sensitivity remains weaker than a target-based calibration, so optimization is not enabled by this PR.

## Checks

- 42 focused tests passed with warnings treated as errors
- ament_flake8 passed
- ament_copyright passed
- ament_lint_cmake passed
- git diff whitespace check passed