### PR TITLE
Deskew colored maps with point timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ The generated `dense_corrected_trajectory.tum` is reused on later runs. Use
 newer trajectory and posed-image inputs and automatically rebuilds downstream
 artifacts, preventing stale coloured maps from being silently reused.
 
+When a `PointCloud2` scan carries per-point `timestamp`, `time`, or `t`, map
+accumulation deskews the scan against the dense trajectory in 1 ms pose bins.
+Use `--no-deskew` on `build_lidar_init.py` only for an explicit A/B baseline.
+On HILTI 2022 exp04 this reduced mean plane thickness from 8.89 cm to 6.25 cm
+and increased planar coverage from 21.38% to 48.16%.
+
 ## Accuracy
 
 Current numbers from the release-gate profiles (`scripts/release_profiles.yaml`).

--- a/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
+++ b/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
@@ -141,6 +141,44 @@ def test_compose_world_lidar_applies_rig_extrinsic_before_body_pose():
     np.testing.assert_allclose(out, [[10.0, 3.0, 0.0]], atol=1e-9)
 
 
+def test_deskew_points_compensates_body_motion_during_scan():
+    import posed_images as pi
+    samples = [
+        pi.TrajectorySample(0.0, np.array([0.0, 0.0, 0.0]),
+                            np.array([0.0, 0.0, 0.0, 1.0])),
+        pi.TrajectorySample(0.1, np.array([1.0, 0.0, 0.0]),
+                            np.array([0.0, 0.0, 0.0, 1.0])),
+    ]
+    # A static object at world x=10 is observed at LiDAR x=10 then x=9 as the
+    # body translates by one metre during the scan.
+    points = np.array([[10.0, 0.0, 0.0], [9.0, 0.0, 0.0]])
+    out = bli.deskew_points(
+        points, np.array([0.0, 0.1]), samples, np.eye(4),
+        bin_seconds=0.001, max_extrapolation=0.0)
+    np.testing.assert_allclose(out, [[10.0, 0.0, 0.0],
+                                     [10.0, 0.0, 0.0]], atol=1e-6)
+
+
+def test_deskew_points_applies_lidar_extrinsic_and_validates_inputs():
+    import posed_images as pi
+    samples = [
+        pi.TrajectorySample(1.0, np.zeros(3),
+                            np.array([0.0, 0.0, 0.0, 1.0])),
+        pi.TrajectorySample(2.0, np.zeros(3),
+                            np.array([0.0, 0.0, 0.0, 1.0])),
+    ]
+    extrinsic = np.eye(4)
+    extrinsic[:3, 3] = [1.0, 2.0, 3.0]
+    out = bli.deskew_points(
+        np.array([[0.0, 0.0, 0.0]]), np.array([1.5]), samples, extrinsic)
+    np.testing.assert_allclose(out, [[1.0, 2.0, 3.0]], atol=1e-6)
+    with np.testing.assert_raises(ValueError):
+        bli.deskew_points(np.zeros((2, 3)), np.zeros(1), samples, extrinsic)
+    with np.testing.assert_raises(ValueError):
+        bli.deskew_points(np.zeros((1, 3)), np.zeros(1), samples, extrinsic,
+                          bin_seconds=0.0)
+
+
 # --------------------------------------------------------------------------- #
 # colorize_by_projection
 # --------------------------------------------------------------------------- #

--- a/tools/gaussian_splatting/README.md
+++ b/tools/gaussian_splatting/README.md
@@ -28,7 +28,7 @@ photorealistic map / novel-view 成果物を後処理で再構成するための
 | `posed_images.py` | GPU/ROS 非依存コア。TUM 軌跡パース、SLERP ポーズ補間、外部標定合成、Nerfstudio `transforms.json` 出力。 | numpy のみ | `test_gaussian_splatting_posed_images.py`（19）|
 | `extract_posed_images.py` | rosbag2 から画像 + `camera_info` を取り出し、各画像の `world<-camera` を解決して `transforms.json` + 画像を書き出す CLI。`sensor_msgs/Image` は **numpy で生復号**（cv_bridge 非依存）、`rosbag2_py` は遅延 import。 | rosbag2_py（実行時のみ）| `test_gaussian_splatting_extract.py`（17、ポーズ/外部標定/復号ロジックは ROS 非依存）|
 | `pointcloud_io.py` | 最小 PLY 入出力（xyz[+rgb]）＋ voxel 間引き＋ **画像投影による点群着色**（`colorize_by_projection`）。 | numpy のみ | `test_gaussian_splatting_pointcloud.py`（12）|
-| `build_lidar_init.py` | bag のスキャンを SLAM 軌跡で world 系に蓄積 → **LiDAR-primed init 点群** PLY。FILE-compressed(zstd) bag 対応。`--color-transforms` で transforms.json の posed 画像を投影して着色（品質中立だが検査用に有用）。 | rosbag2_py（実行時のみ）| 同上（`transform_points` 等の純粋部）|
+| `build_lidar_init.py` | bag のスキャンを SLAM 軌跡で world 系に蓄積 → **LiDAR-primed init 点群** PLY。per-point timestampがあれば1ms pose binで自動deskew（`--no-deskew` で比較可能）。FILE-compressed(zstd) bag 対応。`--color-transforms` でposed画像を投影して着色。 | rosbag2_py（実行時のみ）| 同上（`transform_points` / `deskew_points` 等の純粋部）|
 | `colored_map_pipeline.py` | bag + TUM軌跡 + camera extrinsic から、posed画像抽出 → 遮蔽対応の複数view着色map生成を一括実行。既存成果物の再利用、`--dry-run`、段階別forceに対応。 | 上記2ツールと同じ | `test_colored_map_pipeline.py` |
 | `train_gsplat.py` | `transforms.json` + 画像で gsplat 学習 → INRIA 標準 `.ply` 出力。OpenGL c2w を OpenCV w2c に変換。`--init-ply` で **LiDAR-primed init**（位置＋色 seed）、`--densify` で gsplat `DefaultStrategy` の adaptive density control、`--ssim-lambda`（既定 0.2）で INRIA 標準 **L1+D-SSIM 損失**、`--knn-scale-init` で点群の局所密度から per-Gaussian スケール seed、`--sh-degree D` で **視点依存カラー（SH 次数 D、INRIA 標準 f_dc+f_rest 出力）**、`--antialiased` で gsplat の antialiased rasterize mode、`--mcmc`（+`--mcmc-cap`）で MCMCStrategy（LiDAR-primed init では DefaultStrategy 優位＝既定）、`--optimize-extrinsic` で共有 6-DoF extrinsic の photometric 自己校正。学習終了時に全ビューの PSNR/SSIM を出力。 | torch, gsplat (CUDA) | `test_gaussian_splatting_train.py`（20、純粋部）|
 | `selftest_gpu.py` | opt-in GPU セルフテスト。合成シーンを描画→`transforms.json`→学習→`.ply` の全鎖を検証。 | torch, gsplat (CUDA) | 手動実行（CI 非対象）|
@@ -88,6 +88,8 @@ robust着色は1ピクセル単位のz-bufferで遮蔽を判定し、隣接ピ�
 強い色境界では実画素へ切り替え、前景色と背景色のにじみを抑える。
 画像間の露出正規化は倍率を `1/1.5`〜`1.5` に制限し、実際に明るい壁や暗い区間を
 全画面medianの差だけで白飛び・黒潰れさせない。
+HILTI 2022 exp04ではper-point timestamp deskewにより、平面厚RMS meanが
+8.89 cmから6.25 cmへ改善し、planar coverageは21.38%から48.16%へ増加した。
 
 SLAM推定軌跡による着色地図の検証出力（RTK-SLAM Construction Hall 1、全60 m loop）:
 

--- a/tools/gaussian_splatting/build_lidar_init.py
+++ b/tools/gaussian_splatting/build_lidar_init.py
@@ -37,14 +37,66 @@ def compose_world_lidar(world_T_body: np.ndarray,
             np.asarray(body_T_lidar, dtype=np.float64))
 
 
-def _read_pointcloud_xyz(msg) -> np.ndarray:
-    """Extract finite XYZ (N,3) from a sensor_msgs/PointCloud2 message."""
+def _read_pointcloud_xyz_time(msg) -> tuple[np.ndarray, Optional[np.ndarray]]:
+    """Extract finite XYZ and optional absolute per-point timestamps."""
     from sensor_msgs_py import point_cloud2
 
-    pts = point_cloud2.read_points_numpy(msg, field_names=('x', 'y', 'z'),
-                                         skip_nans=True)
-    pts = np.asarray(pts, dtype=np.float32).reshape(-1, 3)
-    return pts[np.isfinite(pts).all(axis=1)]
+    field_names = {field.name for field in msg.fields}
+    time_name = next((name for name in ('timestamp', 'time', 't')
+                      if name in field_names), None)
+    if time_name is None:
+        pts = point_cloud2.read_points_numpy(
+            msg, field_names=('x', 'y', 'z'), skip_nans=True)
+        pts = np.asarray(pts, dtype=np.float32).reshape(-1, 3)
+        return pts[np.isfinite(pts).all(axis=1)], None
+
+    records = point_cloud2.read_points(
+        msg, field_names=('x', 'y', 'z', time_name), skip_nans=False)
+    pts = np.stack([records['x'], records['y'], records['z']], axis=1)
+    raw_time = np.asarray(records[time_name], dtype=np.float64)
+    finite = np.isfinite(pts).all(axis=1) & np.isfinite(raw_time)
+    pts = pts[finite].astype(np.float32)
+    raw_time = raw_time[finite]
+    header_time = msg.header.stamp.sec + msg.header.stamp.nanosec * 1e-9
+    # HILTI stores Unix seconds; common ROS drivers instead store seconds from
+    # the scan header. Unknown large integer tick formats safely fall back to a
+    # rigid scan rather than guessing their unit.
+    if raw_time.size == 0:
+        return pts, None
+    if float(np.median(np.abs(raw_time))) > 1.0e8:
+        timestamps = raw_time
+    elif float(np.max(np.abs(raw_time))) <= 10.0:
+        timestamps = header_time + raw_time
+    else:
+        return pts, None
+    if float(np.ptp(timestamps)) > 1.0:
+        return pts, None
+    return pts, timestamps
+
+
+def deskew_points(points: np.ndarray, timestamps: np.ndarray,
+                  samples: Sequence[pi.TrajectorySample],
+                  body_T_lidar: np.ndarray, *, bin_seconds: float = 0.001,
+                  max_extrapolation: float = 0.1) -> np.ndarray:
+    """Transform points at acquisition time using binned trajectory poses."""
+    pts = np.asarray(points, dtype=np.float64)
+    stamps = np.asarray(timestamps, dtype=np.float64)
+    if pts.ndim != 2 or pts.shape[1] != 3 or stamps.shape != (len(pts),):
+        raise ValueError('points must be Nx3 and timestamps must be length N')
+    if bin_seconds <= 0.0:
+        raise ValueError('bin_seconds must be > 0')
+    if len(pts) == 0:
+        return np.empty((0, 3), dtype=np.float32)
+    bins = np.floor((stamps - stamps.min()) / bin_seconds).astype(np.int64)
+    world = np.empty_like(pts)
+    for bin_id in np.unique(bins):
+        selected = bins == bin_id
+        stamp = float(np.mean(stamps[selected]))
+        world_T_body = pi.interpolate_pose(
+            samples, stamp, max_extrapolation=max_extrapolation)
+        world_T_lidar = compose_world_lidar(world_T_body, body_T_lidar)
+        world[selected] = transform_points(pts[selected], world_T_lidar)
+    return world.astype(np.float32)
 
 
 def build(args: argparse.Namespace) -> dict:
@@ -67,6 +119,7 @@ def build(args: argparse.Namespace) -> dict:
 
     chunks: list[np.ndarray] = []
     used = 0
+    deskewed = 0
     skipped = 0
     seen = 0
     t0 = None
@@ -93,19 +146,28 @@ def build(args: argparse.Namespace) -> dict:
         except ValueError:
             skipped += 1
             continue
-        pts = _read_pointcloud_xyz(msg)
+        pts, point_timestamps = _read_pointcloud_xyz_time(msg)
         if args.max_range > 0 or args.min_range > 0:
             rng = np.linalg.norm(pts, axis=1)
             keep = rng >= args.min_range
             if args.max_range > 0:
                 keep &= rng <= args.max_range
             pts = pts[keep]
+            if point_timestamps is not None:
+                point_timestamps = point_timestamps[keep]
         # PointCloud2 XYZ is expressed in the LiDAR frame, while the SLAM TUM
         # trajectory is world <- body/IMU. Compose both transforms explicitly;
         # treating raw LiDAR points as body-frame points rotates every scan
         # around the wrong axes on rigs such as HILTI's PandarXT-32.
-        world_T_lidar = compose_world_lidar(world_T_body, body_T_lidar)
-        world_pts = transform_points(pts, world_T_lidar).astype(np.float32)
+        if args.deskew and point_timestamps is not None:
+            world_pts = deskew_points(
+                pts, point_timestamps, samples, body_T_lidar,
+                bin_seconds=args.deskew_bin_ms * 1e-3,
+                max_extrapolation=args.max_extrapolation)
+            deskewed += 1
+        else:
+            world_T_lidar = compose_world_lidar(world_T_body, body_T_lidar)
+            world_pts = transform_points(pts, world_T_lidar).astype(np.float32)
         # Downsample each scan before accumulating so peak memory is bounded by
         # the downsampled cloud, not the sum of every raw scan (a long bag is
         # tens of millions of points before any reduction).
@@ -130,7 +192,7 @@ def build(args: argparse.Namespace) -> dict:
         rgb, seen = _colorize(world, args.color_transforms, robust=args.color_robust)
         colored = int(seen.sum())
     out = pcio.write_ply(args.out, world, rgb)
-    return {'scans_used': used, 'scans_skipped': skipped,
+    return {'scans_used': used, 'scans_deskewed': deskewed, 'scans_skipped': skipped,
             'points': int(world.shape[0]), 'colored': colored, 'out': str(out)}
 
 
@@ -166,6 +228,11 @@ def build_parser() -> argparse.ArgumentParser:
                         'training as a fog tube on the camera path)')
     p.add_argument('--max-points', type=int, default=300000, help='cap final point count')
     p.add_argument('--max-extrapolation', type=float, default=0.1)
+    p.add_argument('--no-deskew', action='store_false', dest='deskew',
+                   help='ignore per-point timestamps and transform each scan '
+                        'at its header time')
+    p.add_argument('--deskew-bin-ms', type=float, default=1.0,
+                   help='pose bin width for per-point deskew (default 1 ms)')
     p.add_argument('--stride', type=int, default=1, help='use every Nth scan')
     p.add_argument('--start-time', type=float, default=0.0,
                    help='use scans at/after this many seconds from bag start')
@@ -192,7 +259,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = build_parser().parse_args(argv)
     summary = build(args)
     print(f"accumulated {summary['scans_used']} scans "
-          f"({summary['scans_skipped']} skipped) -> "
+          f"({summary['scans_deskewed']} deskewed, "
+          f"{summary['scans_skipped']} skipped) -> "
           f"{summary['points']} points "
           f"({summary['colored']} coloured) -> {summary['out']}")
     return 0


### PR DESCRIPTION
## What changed

- read optional `timestamp`, `time`, or `t` fields alongside PointCloud2 XYZ
- recognize absolute Unix seconds and relative-second point times conservatively
- interpolate the dense SLAM trajectory in 1 ms pose bins and transform each point at acquisition time
- preserve rigid-scan fallback when timestamps are absent or use an unknown unit
- add `--no-deskew` for explicit A/B baselines and `--deskew-bin-ms` tuning
- report how many scans were deskewed
- add pure geometry/validation regression tests and documentation

## Root cause

The HILTI Pandar scan spans about 100 ms and contains an absolute float64 timestamp for every point. The colored-map builder previously discarded that field and transformed all 57,456 points at the scan header pose, thickening walls and duplicating moving-view geometry.

## HILTI 2022 exp04 validation

- 1,257 scans deskewed, 1 final out-of-trajectory scan skipped
- 300,000-point deterministic output
- plane thickness RMS mean: 0.0889 m -> 0.0625 m (-29.6%)
- plane thickness RMS p95: 0.1285 m -> 0.1109 m (-13.7%)
- planar coverage: 0.2138 -> 0.4816 (2.25x)
- MME valid fraction: 0.7983 -> 0.8879
- final robust camera coloring: 299,422 / 300,000 points (99.81%)

External artifacts:
- `hilti_exp04_deskew_geometry/deskewed_map.ply`
- `hilti_exp04_deskew_geometry/deskewed_colored_map.ply`

## Checks

- 60 focused tests passed
- ament_flake8 passed
- Python compile check passed
- real 13 GB HILTI bag processed end to end
- corrected PLY map-quality evaluator used for before/after metrics
- git diff whitespace check passed