### PR TITLE
Filter isolated colored map returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ accumulation deskews the scan against the dense trajectory in 1 ms pose bins.
 Use `--no-deskew` on `build_lidar_init.py` only for an explicit A/B baseline.
 On HILTI 2022 exp04 this reduced mean plane thickness from 8.89 cm to 6.25 cm
 and increased planar coverage from 21.38% to 48.16%.
+The default one-neighbour density guard then removes isolated LiDAR returns
+(`--min-neighbors 2 --sparse-voxel 0.1`), retaining 81.5% of points while
+improving mean thickness to 5.99 cm and planar coverage to 53.55%.
 
 ## Accuracy
 

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -63,6 +63,8 @@ def test_build_commands_connects_extract_to_robust_map(tmp_path):
     assert extract[extract.index('--time-offset') + 1] == 'auto'
     assert build[build.index('--color-transforms') + 1] == transforms
     assert '--color-robust' in build
+    assert build[build.index('--min-neighbors') + 1] == '2'
+    assert build[build.index('--sparse-voxel') + 1] == '0.1'
 
 
 def test_raw_trajectory_adds_densification_and_connects_dense_output(tmp_path):
@@ -167,6 +169,14 @@ def test_no_undistort_and_custom_topics_are_forwarded(tmp_path):
     assert extract[extract.index('--camera-topic') + 1] == '/rgb'
     assert extract[extract.index('--camera-info-topic') + 1] == '/info'
     assert build[build.index('--points-topic') + 1] == '/points'
+
+
+def test_custom_density_filter_is_forwarded(tmp_path):
+    commands = cmp.build_commands(_args(
+        tmp_path, '--min-neighbors', '0', '--sparse-voxel', '0.2'))
+    build = commands[-1][1]
+    assert build[build.index('--min-neighbors') + 1] == '0'
+    assert build[build.index('--sparse-voxel') + 1] == '0.2'
 
 
 def test_intrinsics_yaml_is_forwarded_for_bags_without_camera_info(tmp_path):

--- a/tools/gaussian_splatting/README.md
+++ b/tools/gaussian_splatting/README.md
@@ -91,6 +91,8 @@ robust着色は1ピクセル単位のz-bufferで遮蔽を判定し、隣接ピ�
 全画面medianの差だけで白飛び・黒潰れさせない。
 HILTI 2022 exp04ではper-point timestamp deskewにより、平面厚RMS meanが
 8.89 cmから6.25 cmへ改善し、planar coverageは21.38%から48.16%へ増加した。
+既定の弱いdensity guard（0.1 m近傍に最低1支持点）を加えると、81.5%の点を保持して
+平面厚5.99 cm、planar coverage 53.55%まで改善する。`--min-neighbors 0` で無効化可能。
 
 外部校正はLiDAR depth境界と強い画像edgeの距離で診断できる。この自然scene metricは
 校正targetの代替ではなく、bag全体に対するpixel単位の回帰検査として使う。

--- a/tools/gaussian_splatting/build_lidar_init.py
+++ b/tools/gaussian_splatting/build_lidar_init.py
@@ -245,11 +245,11 @@ def build_parser() -> argparse.ArgumentParser:
                    help='use the occlusion-aware / exposure-normalised / median '
                         'colorizer instead of the plain all-view average (slower; '
                         'much cleaner colours for map flythroughs)')
-    p.add_argument('--min-neighbors', type=int, default=0,
+    p.add_argument('--min-neighbors', type=int, default=2,
                    help='drop points whose 3x3x3 voxel neighbourhood (see '
-                        '--sparse-voxel) holds fewer points; 0 disables. Removes '
-                        'isolated stray returns that render as dust')
-    p.add_argument('--sparse-voxel', type=float, default=0.08,
+                        '--sparse-voxel) holds fewer points; default 2 requires '
+                        'one supporting neighbour, 0 disables')
+    p.add_argument('--sparse-voxel', type=float, default=0.1,
                    help='voxel size (m) for the --min-neighbors density filter')
     return p
 

--- a/tools/gaussian_splatting/colored_map_pipeline.py
+++ b/tools/gaussian_splatting/colored_map_pipeline.py
@@ -135,6 +135,8 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
             '--points-topic', args.points_topic, '--out', str(colored_map),
             '--voxel', str(args.voxel), '--max-points', str(args.max_points),
             '--min-range', str(args.min_range), '--max-range', str(args.max_range),
+            '--min-neighbors', str(args.min_neighbors),
+            '--sparse-voxel', str(args.sparse_voxel),
             '--stride', str(args.scan_stride),
             '--start-time', str(args.start_time), '--end-time', str(args.end_time),
             '--color-transforms', str(transforms), '--color-robust',
@@ -221,6 +223,11 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--max-points', type=int, default=300000)
     p.add_argument('--min-range', type=float, default=0.0)
     p.add_argument('--max-range', type=float, default=80.0)
+    p.add_argument('--min-neighbors', type=int, default=2,
+                   help='minimum points in the local density neighbourhood; '
+                        'default 2 removes isolated LiDAR returns, 0 disables')
+    p.add_argument('--sparse-voxel', type=float, default=0.1,
+                   help='density-neighbourhood voxel size (m)')
     p.add_argument('--start-time', type=float, default=0.0)
     p.add_argument('--end-time', type=float, default=-1.0)
     p.add_argument('--no-undistort', action='store_true')


### PR DESCRIPTION
## What changed

- enable a conservative local density guard by default for LiDAR map construction
- require two points in the 3x3x3 neighborhood (`--min-neighbors 2`)
- use a 0.1 m density voxel matching the default map voxel
- expose both controls through the one-command colored-map pipeline
- retain `--min-neighbors 0` as an explicit disable path
- add command-forwarding regression coverage and documentation

## Why

After per-point deskew, isolated multipath and low-density returns remain as dust and thicken local surface statistics. Requiring one supporting neighbor removes those points without fitting or moving valid geometry.

## HILTI exp04 sweep

Tested neighbor thresholds 2/3/4/6 at 0.08 m and thresholds 2/3 at 0.10/0.12/0.15 m. The conservative 0.10 m / 2-point setting was selected:

- retained points: 244,542 / 300,000 (81.5%)
- plane thickness RMS mean: 0.0625 m -> 0.0599 m
- plane thickness RMS p95: 0.1109 m -> 0.1056 m
- planar coverage: 0.4816 -> 0.5355

Stronger settings improved thickness further but removed 40-98% of points, so they were rejected as defaults.

## Trajectory audit

Six retained exp04 trajectories (before/after/1CPU variants) all produced the same 0.07146 m APE RMSE. No checkpoint-fitted trajectory correction was applied because it would overfit the seven total-station samples.

## Checks

- 61 focused tests passed
- ament_flake8 passed
- full density sweep evaluated with the corrected PLY map-quality tool
- git diff whitespace check passed