### PR TITLE
Measure held-out colored map accuracy

### DIFF
--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -517,6 +517,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_heldout_point_colors
+    test/test_heldout_point_colors.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_gaussian_splatting_render
     test/test_gaussian_splatting_render.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_heldout_point_colors.py
+++ b/graph_based_slam/test/test_heldout_point_colors.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for held-out camera-coloured point-map evaluation."""
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    'evaluate_heldout_point_colors',
+    REPO_ROOT / 'scripts' / 'evaluate_heldout_point_colors.py')
+hpc = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(hpc)
+
+
+def _camera():
+    return np.eye(4), np.array([
+        [10.0, 0.0, 5.0], [0.0, 10.0, 5.0], [0.0, 0.0, 1.0]])
+
+
+def test_visible_point_samples_keeps_nearest_per_pixel():
+    vm, K = _camera()
+    points = np.array([[0.0, 0.0, 5.0], [0.0, 0.0, 2.0],
+                       [0.2, 0.0, 2.0]])
+    ids, _, _ = hpc.visible_point_samples(points, vm, K, 10, 10)
+    assert ids.tolist() == [1, 2]
+
+
+def test_visible_point_samples_ignores_non_finite_projections():
+    vm, K = _camera()
+    points = np.array([[0.0, 0.0, 0.0], [np.nan, 0.0, 2.0],
+                       [0.0, 0.0, 2.0]])
+    ids, _, _ = hpc.visible_point_samples(points, vm, K, 10, 10)
+    assert ids.tolist() == [2]
+
+
+def test_score_heldout_view_zero_for_matching_color():
+    vm, K = _camera()
+    points = np.array([[0.0, 0.0, 2.0]])
+    colors = np.array([[10, 20, 30]], dtype=np.uint8)
+    image = np.zeros((10, 10, 3), dtype=np.uint8)
+    image[5, 5] = colors[0]
+    errors, visible = hpc.score_heldout_view(
+        points, colors, np.array([True]), vm, K, image)
+    assert visible == 1
+    np.testing.assert_allclose(errors, [0.0])
+
+
+def test_score_heldout_view_excludes_training_unseen_points():
+    vm, K = _camera()
+    points = np.array([[0.0, 0.0, 2.0]])
+    errors, visible = hpc.score_heldout_view(
+        points, np.zeros((1, 3), dtype=np.uint8), np.array([False]),
+        vm, K, np.zeros((10, 10, 3), dtype=np.uint8))
+    assert visible == 1
+    assert errors.size == 0
+
+
+def test_exposure_scales_are_clamped():
+    images = [np.full((4, 4, 3), 10, dtype=np.uint8),
+              np.full((4, 4, 3), 100, dtype=np.uint8),
+              np.full((4, 4, 3), 200, dtype=np.uint8)]
+    scales = hpc.exposure_scales(images, limit=1.5)
+    np.testing.assert_allclose(scales, [1.5, 1.0, 2.0 / 3.0])

--- a/scripts/evaluate_heldout_point_colors.py
+++ b/scripts/evaluate_heldout_point_colors.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Evaluate camera-coloured points on camera views excluded from colouring."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
+if str(TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOL_DIR))
+
+import pointcloud_io as pcio  # noqa: E402
+import train_gsplat as tg  # noqa: E402
+
+
+def visible_point_samples(points: np.ndarray, viewmat: np.ndarray,
+                          K: np.ndarray, width: int, height: int
+                          ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return nearest point id and float pixel coordinates per occupied pixel."""
+    pts = np.asarray(points, dtype=np.float64)
+    vm = np.asarray(viewmat, dtype=np.float64)
+    cam = pts @ vm[:3, :3].T + vm[:3, 3]
+    z = cam[:, 2]
+    with np.errstate(divide='ignore', invalid='ignore'):
+        uf = K[0, 0] * cam[:, 0] / z + K[0, 2]
+        vf = K[1, 1] * cam[:, 1] / z + K[1, 2]
+    safe_uf = np.nan_to_num(uf, nan=-1.0, posinf=-1.0, neginf=-1.0)
+    safe_vf = np.nan_to_num(vf, nan=-1.0, posinf=-1.0, neginf=-1.0)
+    u = np.round(safe_uf).astype(np.int64)
+    v = np.round(safe_vf).astype(np.int64)
+    valid = (np.isfinite(uf) & np.isfinite(vf) & (z > 1e-6) &
+             (u >= 0) & (u < width) & (v >= 0) & (v < height))
+    ids = np.flatnonzero(valid)
+    if ids.size == 0:
+        empty = np.zeros(0, dtype=np.float64)
+        return ids, empty, empty
+    pixels = v[ids] * width + u[ids]
+    order = np.lexsort((z[ids], pixels))
+    sorted_pixels = pixels[order]
+    first = np.concatenate(([True], sorted_pixels[1:] != sorted_pixels[:-1]))
+    chosen = ids[order[first]]
+    return chosen, uf[chosen], vf[chosen]
+
+
+def exposure_scales(images: list[np.ndarray], limit: float = 1.5) -> np.ndarray:
+    """Return the same clamped median-luminance scales as robust colouring."""
+    if limit < 1.0:
+        raise ValueError('limit must be >= 1')
+    medians = np.asarray([pcio._median_luminance(image) for image in images])
+    valid = medians > 1e-6
+    scales = np.ones(len(images), dtype=np.float32)
+    if valid.any():
+        target = float(np.median(medians[valid]))
+        scales[valid] = np.clip(target / medians[valid], 1.0 / limit, limit)
+    return scales
+
+
+def score_heldout_view(points: np.ndarray, colors: np.ndarray, seen: np.ndarray,
+                       viewmat: np.ndarray, K: np.ndarray, image: np.ndarray,
+                       exposure_scale: float = 1.0) -> tuple[np.ndarray, int]:
+    """Return per-visible-point RGB Euclidean errors and visible count."""
+    height, width = image.shape[:2]
+    ids, uf, vf = visible_point_samples(points, viewmat, K, width, height)
+    visible_count = int(ids.size)
+    keep = seen[ids]
+    ids, uf, vf = ids[keep], uf[keep], vf[keep]
+    if ids.size == 0:
+        return np.zeros(0, dtype=np.float32), visible_count
+    observed = pcio._sample_pixels(
+        image, uf, vf, width, height, 'edge-aware', 48.0)
+    observed = np.clip(observed * exposure_scale, 0.0, 255.0)
+    delta = colors[ids].astype(np.float32) - observed
+    return np.linalg.norm(delta, axis=1), visible_count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--pointcloud', type=Path, required=True)
+    parser.add_argument('--transforms', type=Path, required=True)
+    parser.add_argument('--out', type=Path, required=True)
+    parser.add_argument('--folds', type=int, default=2)
+    parser.add_argument('--holdout-fold', type=int, default=1)
+    parser.add_argument('--view-stride', type=int, default=5)
+    args = parser.parse_args()
+    if args.folds < 2 or not 0 <= args.holdout_fold < args.folds:
+        raise SystemExit('--folds must be >= 2 and --holdout-fold must be valid')
+    if args.view_stride < 1:
+        raise SystemExit('--view-stride must be >= 1')
+
+    import imageio.v3 as iio
+    points, _ = pcio.read_ply_xyz(args.pointcloud)
+    dataset = tg.load_transforms(args.transforms)
+    viewmats = np.asarray(dataset['viewmats'], dtype=np.float64)
+    K = np.asarray(dataset['K'], dtype=np.float64)
+    images = [np.asarray(iio.imread(path)) for path in dataset['image_paths']]
+    holdout = [i for i in range(len(images)) if i % args.folds == args.holdout_fold]
+    holdout_set = set(holdout)
+    train = [i for i in range(len(images)) if i not in holdout_set]
+    colors, seen = pcio.colorize_by_projection_robust(
+        points, viewmats[train], K,
+        [images[i] for i in train], dataset['width'], dataset['height'])
+    scales = exposure_scales(images)
+    errors = []
+    visible_total = 0
+    per_view = []
+    for index in holdout[::args.view_stride]:
+        values, visible = score_heldout_view(
+            points, colors, seen, viewmats[index], K,
+            images[index], float(scales[index]))
+        errors.append(values)
+        visible_total += visible
+        per_view.append({'view_index': index, 'visible_points': visible,
+                         'scored_points': int(values.size),
+                         'median_rgb_l2': (float(np.median(values))
+                                           if values.size else None)})
+    combined = np.concatenate(errors) if errors else np.zeros(0)
+    if combined.size == 0:
+        raise SystemExit('no held-out points could be scored')
+    report = {
+        'train_views': len(train), 'heldout_views': len(holdout),
+        'heldout_views_scored': len(per_view),
+        'visible_points': visible_total, 'scored_points': int(combined.size),
+        'training_coverage': float(seen.mean()),
+        'heldout_scored_fraction': float(combined.size / visible_total),
+        'rgb_l2_mean': float(np.mean(combined)),
+        'rgb_l2_median': float(np.median(combined)),
+        'rgb_l2_p90': float(np.percentile(combined, 90)),
+        'rgb_l2_inlier_20': float(np.mean(combined <= 20.0)),
+        'per_view': per_view,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2) + '\n')
+    print(json.dumps({key: value for key, value in report.items()
+                      if key != 'per_view'}, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/gaussian_splatting/README.md
+++ b/tools/gaussian_splatting/README.md
@@ -31,6 +31,7 @@ photorealistic map / novel-view 成果物を後処理で再構成するための
 | `build_lidar_init.py` | bag のスキャンを SLAM 軌跡で world 系に蓄積 → **LiDAR-primed init 点群** PLY。per-point timestampがあれば1ms pose binで自動deskew（`--no-deskew` で比較可能）。FILE-compressed(zstd) bag 対応。`--color-transforms` でposed画像を投影して着色。 | rosbag2_py（実行時のみ）| 同上（`transform_points` / `deskew_points` 等の純粋部）|
 | `colored_map_pipeline.py` | bag + TUM軌跡 + camera extrinsic から、posed画像抽出 → 遮蔽対応の複数view着色map生成を一括実行。既存成果物の再利用、`--dry-run`、段階別forceに対応。 | 上記2ツールと同じ | `test_colored_map_pipeline.py` |
 | `../../scripts/evaluate_lidar_camera_alignment.py` | LiDAR depth境界とcamera画像edgeの距離を測り、外部校正をpixel単位で評価。 | numpy, imageio | `test_lidar_camera_alignment.py` |
+| `../../scripts/evaluate_heldout_point_colors.py` | 偶数viewだけで点群を着色し、除外した奇数viewへのRGB再投影誤差を評価。 | numpy, imageio | `test_heldout_point_colors.py` |
 | `train_gsplat.py` | `transforms.json` + 画像で gsplat 学習 → INRIA 標準 `.ply` 出力。OpenGL c2w を OpenCV w2c に変換。`--init-ply` で **LiDAR-primed init**（位置＋色 seed）、`--densify` で gsplat `DefaultStrategy` の adaptive density control、`--ssim-lambda`（既定 0.2）で INRIA 標準 **L1+D-SSIM 損失**、`--knn-scale-init` で点群の局所密度から per-Gaussian スケール seed、`--sh-degree D` で **視点依存カラー（SH 次数 D、INRIA 標準 f_dc+f_rest 出力）**、`--antialiased` で gsplat の antialiased rasterize mode、`--mcmc`（+`--mcmc-cap`）で MCMCStrategy（LiDAR-primed init では DefaultStrategy 優位＝既定）、`--optimize-extrinsic` で共有 6-DoF extrinsic の photometric 自己校正。学習終了時に全ビューの PSNR/SSIM を出力。 | torch, gsplat (CUDA) | `test_gaussian_splatting_train.py`（20、純粋部）|
 | `selftest_gpu.py` | opt-in GPU セルフテスト。合成シーンを描画→`transforms.json`→学習→`.ply` の全鎖を検証。 | torch, gsplat (CUDA) | 手動実行（CI 非対象）|
 | `render_path.py` | 学習済み `.ply` + `transforms.json` から**フライスルー動画（mp4/GIF）**を描画する CLI。INRIA `.ply` の読み戻し、学習視点を通る SLERP+box-smooth カメラパス、`--ping-pong` ループ、`--scale` 縮小描画、`--rotate` 横倒しカメラ補正。 | torch, gsplat (CUDA)（純粋部は numpy のみ）| `test_gaussian_splatting_render.py`（13、ply 読み戻し/パス/回転/intrinsics の純粋部）|
@@ -103,6 +104,22 @@ python3 scripts/evaluate_lidar_camera_alignment.py \
   --transforms output/<run>/posed_images/transforms.json \
   --out output/<run>/lidar_camera_alignment.json
 ```
+
+着色に使っていない画像への再投影誤差も測定できる。既定では偶数viewのみで着色し、
+奇数viewをheld-out検証に使うため、入力画像を覚えただけの色一致を避けられる。
+
+```bash
+python3 scripts/evaluate_heldout_point_colors.py \
+  --pointcloud output/<run>/colored_map.ply \
+  --transforms output/<run>/posed_images/transforms.json \
+  --out output/<run>/heldout_point_colors.json
+```
+
+HILTI 2022 exp04のdeskew + density guard済み点群では、126枚で着色して未使用126枚中
+26枚を評価した結果、training coverage 99.86%、held-out scored fraction 99.99%、
+RGB L2中央値36.37、20以内inlier率35.36%だった。P90は225.33であり、色そのものに加え
+未モデル化の動体、遮蔽境界、時刻同期、camera--LiDAR外部校正の残差も含む厳しい
+end-to-end回帰指標として扱う。
 
 SLAM推定軌跡による着色地図の検証出力（RTK-SLAM Construction Hall 1、全60 m loop）:
 


### PR DESCRIPTION
## What changed

- add a CPU-only held-out view evaluator for camera-coloured point clouds
- colour points from one camera-view fold and score RGB reprojection error on the excluded fold
- report coverage, scored fraction, RGB L2 distribution, inlier rate, and per-view medians as JSON
- register focused tests and document the workflow plus HILTI 2022 exp04 baseline

## Why

Training-view coverage alone cannot distinguish genuine colour consistency from reusing the same input images. A held-out metric gives the coloured-map pipeline an end-to-end regression signal that includes colour fusion, visibility, trajectory, timing, and camera-LiDAR calibration effects.

## Validation

- `44 passed` across held-out colour and point-cloud tests with warnings treated as errors
- `ament_flake8`
- `ament_copyright`
- `ament_lint_cmake`
- `git diff --check`
- HILTI 2022 exp04: 99.86% training coverage, 99.99% held-out scored fraction, RGB L2 median 36.37, <=20 inlier rate 35.36%
