### PR TITLE
Gate colored map quality end to end

### DIFF
--- a/configs/colored_map_quality_profiles/hilti_exp04_report_only.yaml
+++ b/configs/colored_map_quality_profiles/hilti_exp04_report_only.yaml
@@ -1,0 +1,13 @@
+colored_map_quality_profile:
+  name: hilti_exp04_baseline
+  enforcement: report_only
+  thresholds:
+    ape_rmse_max_m: 0.10
+    thickness_rms_mean_max_m: 0.07
+    thickness_rms_p95_max_m: 0.12
+    planar_coverage_min: 0.50
+    alignment_median_max_px: 7.0
+    alignment_inlier_2px_min: 0.25
+    heldout_rgb_median_max: 40.0
+    heldout_rgb_inlier_20_min: 0.30
+    heldout_scored_fraction_min: 0.95

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -522,6 +522,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_colored_map_quality_gate
+    test/test_colored_map_quality_gate.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_gaussian_splatting_render
     test/test_gaussian_splatting_render.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_colored_map_quality_gate.py
+++ b/graph_based_slam/test/test_colored_map_quality_gate.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Tests for the integrated coloured-map quality gate."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    'check_colored_map_quality',
+    REPO_ROOT / 'scripts' / 'check_colored_map_quality.py')
+gate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(gate)
+
+
+def _reports():
+    return {
+        'trajectory': {'evo': {'ape': {'rmse': 0.07}}},
+        'geometry': {'map_quality_report': {'plane_metrics': {
+            'thickness_rms_mean_m': 0.06,
+            'thickness_rms_p95_m': 0.11,
+            'planar_coverage': 0.54}}},
+        'alignment': {'weighted_median_px': 6.7,
+                      'weighted_inlier_2px': 0.26},
+        'colour': {'rgb_l2_median': 36.4, 'rgb_l2_inlier_20': 0.35,
+                   'heldout_scored_fraction': 0.999},
+    }
+
+
+def _profile(enforcement='blocking'):
+    return {'colored_map_quality_profile': {
+        'name': 'test', 'enforcement': enforcement, 'thresholds': {
+            'ape_rmse_max_m': 0.1,
+            'thickness_rms_mean_max_m': 0.07,
+            'planar_coverage_min': 0.5,
+            'alignment_median_max_px': 7.0,
+            'heldout_rgb_median_max': 40.0,
+            'heldout_scored_fraction_min': 0.95}}}
+
+
+def test_all_quality_domains_pass():
+    result = gate.evaluate(_reports(), _profile())
+    assert result['overall'] == 'OK'
+    assert result['violations'] == 0
+    assert {row['source'] for row in result['checks']} == {
+        'trajectory', 'geometry', 'alignment', 'colour'}
+
+
+def test_blocking_profile_fails_a_regression():
+    reports = _reports()
+    reports['colour']['rgb_l2_median'] = 50.0
+    result = gate.evaluate(reports, _profile())
+    assert result['overall'] == 'FAILED'
+    assert result['violations'] == 1
+
+
+def test_report_only_records_violation_without_failure():
+    reports = _reports()
+    reports['trajectory']['evo']['ape']['rmse'] = 1.0
+    result = gate.evaluate(reports, _profile('report_only'))
+    assert result['overall'] == 'REPORT_ONLY'
+    assert result['violations'] == 1
+
+
+def test_missing_metric_is_actionable():
+    reports = _reports()
+    del reports['alignment']['weighted_median_px']
+    with pytest.raises(gate.QualityGateError, match='weighted_median_px'):
+        gate.evaluate(reports, _profile())

--- a/scripts/check_colored_map_quality.py
+++ b/scripts/check_colored_map_quality.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Gate trajectory, geometry, calibration, and held-out colour reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+METRICS = {
+    'ape_rmse_max_m': ('trajectory', ('evo', 'ape', 'rmse'), 'max'),
+    'thickness_rms_mean_max_m': (
+        'geometry', ('map_quality_report', 'plane_metrics',
+                     'thickness_rms_mean_m'), 'max'),
+    'thickness_rms_p95_max_m': (
+        'geometry', ('map_quality_report', 'plane_metrics',
+                     'thickness_rms_p95_m'), 'max'),
+    'planar_coverage_min': (
+        'geometry', ('map_quality_report', 'plane_metrics',
+                     'planar_coverage'), 'min'),
+    'alignment_median_max_px': (
+        'alignment', ('weighted_median_px',), 'max'),
+    'alignment_inlier_2px_min': (
+        'alignment', ('weighted_inlier_2px',), 'min'),
+    'heldout_rgb_median_max': (
+        'colour', ('rgb_l2_median',), 'max'),
+    'heldout_rgb_inlier_20_min': (
+        'colour', ('rgb_l2_inlier_20',), 'min'),
+    'heldout_scored_fraction_min': (
+        'colour', ('heldout_scored_fraction',), 'min'),
+}
+
+
+class QualityGateError(Exception):
+    """A user-facing report or profile error."""
+
+
+def load_mapping(path: Path) -> dict[str, Any]:
+    """Load a JSON or YAML mapping."""
+    try:
+        data = yaml.safe_load(path.read_text(encoding='utf-8'))
+    except (OSError, yaml.YAMLError) as exc:
+        raise QualityGateError(f'cannot read {path}: {exc}') from exc
+    if not isinstance(data, dict):
+        raise QualityGateError(f'expected mapping in {path}')
+    return data
+
+
+def nested_number(data: dict[str, Any], path: tuple[str, ...]) -> float:
+    """Read one finite numeric value from a nested mapping."""
+    value: Any = data
+    for key in path:
+        if not isinstance(value, dict) or key not in value:
+            raise QualityGateError(f'missing metric: {".".join(path)}')
+        value = value[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise QualityGateError(f'metric {".".join(path)} must be numeric')
+    number = float(value)
+    if number != number or abs(number) == float('inf'):
+        raise QualityGateError(f'metric {".".join(path)} must be finite')
+    return number
+
+
+def evaluate(reports: dict[str, dict[str, Any]],
+             profile_document: dict[str, Any]) -> dict[str, Any]:
+    """Evaluate all configured thresholds and return a JSON-ready result."""
+    profile = profile_document.get('colored_map_quality_profile')
+    if not isinstance(profile, dict):
+        raise QualityGateError('profile needs colored_map_quality_profile')
+    name = profile.get('name')
+    enforcement = profile.get('enforcement')
+    thresholds = profile.get('thresholds')
+    if not isinstance(name, str) or not name:
+        raise QualityGateError('profile name must be a non-empty string')
+    if enforcement not in ('blocking', 'report_only'):
+        raise QualityGateError('enforcement must be blocking or report_only')
+    if not isinstance(thresholds, dict) or not thresholds:
+        raise QualityGateError('profile thresholds must be a non-empty mapping')
+    unknown = sorted(set(thresholds) - set(METRICS))
+    if unknown:
+        raise QualityGateError(f'unknown thresholds: {", ".join(unknown)}')
+
+    checks = []
+    violations = 0
+    for key, limit_value in thresholds.items():
+        if isinstance(limit_value, bool) or not isinstance(limit_value, (int, float)):
+            raise QualityGateError(f'threshold {key} must be numeric')
+        report_name, metric_path, comparison = METRICS[key]
+        value = nested_number(reports[report_name], metric_path)
+        limit = float(limit_value)
+        passed = value <= limit if comparison == 'max' else value >= limit
+        violations += int(not passed)
+        checks.append({'name': key, 'source': report_name,
+                       'metric': '.'.join(metric_path), 'value': value,
+                       'comparison': comparison, 'limit': limit,
+                       'verdict': 'PASS' if passed else 'VIOLATION'})
+    if enforcement == 'report_only':
+        overall = 'REPORT_ONLY'
+    else:
+        overall = 'FAILED' if violations else 'OK'
+    return {'profile': name, 'enforcement': enforcement, 'overall': overall,
+            'violations': violations, 'checks': checks}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--trajectory-report', type=Path, required=True)
+    parser.add_argument('--geometry-report', type=Path, required=True)
+    parser.add_argument('--alignment-report', type=Path, required=True)
+    parser.add_argument('--colour-report', type=Path, required=True)
+    parser.add_argument('--profile', type=Path, required=True)
+    parser.add_argument('--out', type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        reports = {
+            'trajectory': load_mapping(args.trajectory_report),
+            'geometry': load_mapping(args.geometry_report),
+            'alignment': load_mapping(args.alignment_report),
+            'colour': load_mapping(args.colour_report),
+        }
+        result = evaluate(reports, load_mapping(args.profile))
+    except QualityGateError as exc:
+        parser.error(str(exc))
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(result, indent=2) + '\n', encoding='utf-8')
+    for check in result['checks']:
+        operator = '<=' if check['comparison'] == 'max' else '>='
+        print(f"{check['verdict']:9} {check['name']}: "
+              f"{check['value']:.6g} {operator} {check['limit']:.6g}")
+    print(f"COLORED_MAP_QUALITY_{result['overall']}: "
+          f"{result['violations']} violation(s)")
+    return 1 if result['overall'] == 'FAILED' else 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/gaussian_splatting/README.md
+++ b/tools/gaussian_splatting/README.md
@@ -32,6 +32,7 @@ photorealistic map / novel-view 成果物を後処理で再構成するための
 | `colored_map_pipeline.py` | bag + TUM軌跡 + camera extrinsic から、posed画像抽出 → 遮蔽対応の複数view着色map生成を一括実行。既存成果物の再利用、`--dry-run`、段階別forceに対応。 | 上記2ツールと同じ | `test_colored_map_pipeline.py` |
 | `../../scripts/evaluate_lidar_camera_alignment.py` | LiDAR depth境界とcamera画像edgeの距離を測り、外部校正をpixel単位で評価。 | numpy, imageio | `test_lidar_camera_alignment.py` |
 | `../../scripts/evaluate_heldout_point_colors.py` | 偶数viewだけで点群を着色し、除外した奇数viewへのRGB再投影誤差を評価。 | numpy, imageio | `test_heldout_point_colors.py` |
+| `../../scripts/check_colored_map_quality.py` | 軌跡APE、点群形状、外部校正、held-out着色の4レポートをprofile閾値で一括判定。 | PyYAML | `test_colored_map_quality_gate.py` |
 | `train_gsplat.py` | `transforms.json` + 画像で gsplat 学習 → INRIA 標準 `.ply` 出力。OpenGL c2w を OpenCV w2c に変換。`--init-ply` で **LiDAR-primed init**（位置＋色 seed）、`--densify` で gsplat `DefaultStrategy` の adaptive density control、`--ssim-lambda`（既定 0.2）で INRIA 標準 **L1+D-SSIM 損失**、`--knn-scale-init` で点群の局所密度から per-Gaussian スケール seed、`--sh-degree D` で **視点依存カラー（SH 次数 D、INRIA 標準 f_dc+f_rest 出力）**、`--antialiased` で gsplat の antialiased rasterize mode、`--mcmc`（+`--mcmc-cap`）で MCMCStrategy（LiDAR-primed init では DefaultStrategy 優位＝既定）、`--optimize-extrinsic` で共有 6-DoF extrinsic の photometric 自己校正。学習終了時に全ビューの PSNR/SSIM を出力。 | torch, gsplat (CUDA) | `test_gaussian_splatting_train.py`（20、純粋部）|
 | `selftest_gpu.py` | opt-in GPU セルフテスト。合成シーンを描画→`transforms.json`→学習→`.ply` の全鎖を検証。 | torch, gsplat (CUDA) | 手動実行（CI 非対象）|
 | `render_path.py` | 学習済み `.ply` + `transforms.json` から**フライスルー動画（mp4/GIF）**を描画する CLI。INRIA `.ply` の読み戻し、学習視点を通る SLERP+box-smooth カメラパス、`--ping-pong` ループ、`--scale` 縮小描画、`--rotate` 横倒しカメラ補正。 | torch, gsplat (CUDA)（純粋部は numpy のみ）| `test_gaussian_splatting_render.py`（13、ply 読み戻し/パス/回転/intrinsics の純粋部）|
@@ -120,6 +121,22 @@ HILTI 2022 exp04のdeskew + density guard済み点群では、126枚で着色し
 RGB L2中央値36.37、20以内inlier率35.36%だった。P90は225.33であり、色そのものに加え
 未モデル化の動体、遮蔽境界、時刻同期、camera--LiDAR外部校正の残差も含む厳しい
 end-to-end回帰指標として扱う。
+
+4領域をまとめて確認する場合は統合gateを使う。結果は人向けの一覧と機械可読JSONの
+両方へ出力され、`blocking` profileの違反時は終了コード1になる。
+
+```bash
+python3 scripts/check_colored_map_quality.py \
+  --trajectory-report output/<run>/metrics.json \
+  --geometry-report output/<run>/map_quality_report.yaml \
+  --alignment-report output/<run>/lidar_camera_alignment.json \
+  --colour-report output/<run>/heldout_point_colors.json \
+  --profile configs/colored_map_quality_profiles/hilti_exp04_report_only.yaml \
+  --out output/<run>/colored_map_quality_gate.json
+```
+
+付属HILTI profileは同じexp04測定から定めた初期baselineなので`report_only`である。
+別走行を含む再現試験で閾値を固定してから`blocking`へ昇格する。
 
 SLAM推定軌跡による着色地図の検証出力（RTK-SLAM Construction Hall 1、全60 m loop）:
 


### PR DESCRIPTION
## What changed

- add one CPU-only command that gates trajectory, point-cloud geometry, camera-LiDAR alignment, and held-out colour reports together
- support explicit `blocking` and `report_only` YAML profiles
- emit a readable per-metric verdict and a machine-readable JSON summary
- add a report-only HILTI 2022 exp04 baseline profile and document the complete workflow

## Why

The coloured-map pipeline now measures all four major error sources, but separate reports make regressions easy to miss. This gate gives CI and operators one deterministic verdict while keeping dataset-specific thresholds outside the code.

The bundled HILTI profile remains report-only because its thresholds were derived from the initial exp04 baseline. It should become blocking only after validation on independent runs.

## User impact

Operators can identify whether a regression comes from trajectory accuracy, LiDAR geometry, camera-LiDAR calibration, or colour projection without inspecting four report formats manually. Blocking profiles return exit code 1 when any configured limit is violated.

## Validation

- 23 related tests passed with warnings treated as errors
- `ament_flake8`
- `ament_copyright`
- `ament_lint_cmake`
- `git diff --check`
- HILTI 2022 exp04: all 9 report-only baseline checks passed
