### PR TITLE
Connect colored map pipeline quality gate

### DIFF
--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -227,3 +227,31 @@ def test_dense_trajectory_passes_density_guard(tmp_path):
         '1.0 0 0 0 0 0 0 1\n'
         '1.1 0 0 0 0 0 0 1\n')
     cmp.validate_trajectory_density(traj, 0.5)
+
+
+def test_quality_profile_adds_two_evaluators_and_gate(tmp_path):
+    args = _args(
+        tmp_path, '--quality-profile', str(tmp_path / 'profile.yaml'),
+        '--trajectory-report', str(tmp_path / 'metrics.json'),
+        '--geometry-report', str(tmp_path / 'map_quality_report.yaml'))
+    commands = cmp.build_commands(args)
+    assert [name for name, _ in commands][-3:] == [
+        'camera-LiDAR alignment', 'held-out colour', 'quality gate']
+    gate = commands[-1][1]
+    assert gate[gate.index('--trajectory-report') + 1] == str(
+        tmp_path / 'metrics.json')
+    assert gate[gate.index('--geometry-report') + 1] == str(
+        tmp_path / 'map_quality_report.yaml')
+    assert gate[gate.index('--alignment-report') + 1].endswith(
+        'out/lidar_camera_alignment.json')
+    assert gate[gate.index('--colour-report') + 1].endswith(
+        'out/heldout_point_colors.json')
+
+
+def test_quality_profile_requires_external_reports_before_running(tmp_path):
+    import pytest
+    args = _args(
+        tmp_path, '--quality-profile', str(tmp_path / 'profile.yaml'),
+        '--dry-run')
+    with pytest.raises(ValueError, match='trajectory-report.*geometry-report'):
+        cmp.run_pipeline(args)

--- a/tools/gaussian_splatting/README.md
+++ b/tools/gaussian_splatting/README.md
@@ -67,6 +67,14 @@ python3 tools/gaussian_splatting/colored_map_pipeline.py \
   --points-topic /livox/points --camera-topic /image \
   --camera-info-topic /camera_info
 
+# GT付き検証では外部reportを渡し、校正・held-out色・統合gateも一括実行
+python3 tools/gaussian_splatting/colored_map_pipeline.py \
+  <bag> output/<run>/traj_corrected.tum output/<run>/colored_map \
+  --extrinsic configs/gaussian_splatting/<lidar_camera_extrinsic>.yaml \
+  --trajectory-report output/<run>/metrics.json \
+  --geometry-report output/<run>/map_quality_report.yaml \
+  --quality-profile configs/colored_map_quality_profiles/<profile>.yaml
+
 # Kalibr camchain + 別LiDAR calibration（HILTI形式）はextrinsicを自動合成。
 # 疎な補正軌跡は --raw-traj の高密度軌跡へ自動伝播してから着色する
 python3 tools/gaussian_splatting/colored_map_pipeline.py \
@@ -83,6 +91,9 @@ python3 tools/gaussian_splatting/colored_map_pipeline.py \
 dense SLAM軌跡を渡すこと。疎なpose-graph keyframe列を使う場合は `--raw-traj` に
 補正前のdense軌跡を渡すと、補正を全poseへ伝播した軌跡が出力先に保存・再利用される。
 入力軌跡やposed画像が成果物より新しい場合は、依存する後段だけ自動再生成される。
+`--quality-profile`は明示的opt-inで、`lidar_camera_alignment.json`、
+`heldout_point_colors.json`、`colored_map_quality_gate.json`も出力する。
+これらも入力より新しければ再利用し、`--force-quality`で品質3段階だけ再実行できる。
 robust着色は1ピクセル単位のz-bufferで遮蔽を判定し、隣接ピクセルの前景によって
 本来見える点が未着色になる粗いbin由来の欠落を防ぐ。
 複数viewの統合にはRGB medoidを使い、チャネル別medianが実際には観測されていない

--- a/tools/gaussian_splatting/colored_map_pipeline.py
+++ b/tools/gaussian_splatting/colored_map_pipeline.py
@@ -147,6 +147,49 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                 '--lidar-key', args.lidar_key,
             ])
         commands.append(('coloured map', build))
+
+    if args.quality_profile is not None:
+        alignment_report = out_dir / 'lidar_camera_alignment.json'
+        colour_report = out_dir / 'heldout_point_colors.json'
+        quality_report = out_dir / 'colored_map_quality_gate.json'
+        rebuild_map = any(name == 'coloured map' for name, _ in commands)
+        rebuild_images = any(name == 'posed images' for name, _ in commands)
+        if (rebuild_map or rebuild_images or args.force_quality or
+                is_stale(alignment_report, [colored_map, transforms])):
+            commands.append(('camera-LiDAR alignment', [
+                sys.executable,
+                str(REPO_ROOT / 'scripts' /
+                    'evaluate_lidar_camera_alignment.py'),
+                '--pointcloud', str(colored_map),
+                '--transforms', str(transforms),
+                '--out', str(alignment_report),
+            ]))
+        if (rebuild_map or rebuild_images or args.force_quality or
+                is_stale(colour_report, [colored_map, transforms])):
+            commands.append(('held-out colour', [
+                sys.executable,
+                str(REPO_ROOT / 'scripts' / 'evaluate_heldout_point_colors.py'),
+                '--pointcloud', str(colored_map),
+                '--transforms', str(transforms),
+                '--out', str(colour_report),
+            ]))
+        gate_inputs = [Path(args.trajectory_report), Path(args.geometry_report),
+                       alignment_report, colour_report,
+                       Path(args.quality_profile)]
+        if (args.force_quality or
+                any(name in ('camera-LiDAR alignment', 'held-out colour')
+                    for name, _ in commands) or
+                is_stale(quality_report, gate_inputs)):
+            commands.append(('quality gate', [
+                sys.executable,
+                str(REPO_ROOT / 'scripts' / 'check_colored_map_quality.py'),
+                '--trajectory-report', str(args.trajectory_report),
+                '--geometry-report', str(args.geometry_report),
+                '--alignment-report', str(alignment_report),
+                '--colour-report', str(colour_report),
+                '--profile', str(args.quality_profile),
+                '--out', str(quality_report),
+            ]))
     return commands
 
 
@@ -155,6 +198,13 @@ def run_pipeline(args) -> dict:
     out_dir = Path(args.out)
     if args.kalibr_camchain is not None and args.lidar_calibration is None:
         raise ValueError('--kalibr-camchain requires --lidar-calibration')
+    if args.quality_profile is not None:
+        missing = [name for name in ('trajectory_report', 'geometry_report')
+                   if getattr(args, name) is None]
+        if missing:
+            options = ', '.join('--' + name.replace('_', '-')
+                                for name in missing)
+            raise ValueError(f'--quality-profile requires {options}')
     if not args.dry_run:
         out_dir.mkdir(parents=True, exist_ok=True)
         if args.kalibr_camchain is not None:
@@ -234,6 +284,15 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--force-images', action='store_true')
     p.add_argument('--force-map', action='store_true')
     p.add_argument('--force-trajectory', action='store_true')
+    p.add_argument('--quality-profile', type=Path,
+                   help='run alignment, held-out colour, and integrated quality '
+                        'checks using this profile')
+    p.add_argument('--trajectory-report', type=Path,
+                   help='metrics.json containing evo.ape.rmse for quality gate')
+    p.add_argument('--geometry-report', type=Path,
+                   help='map_quality_report.yaml for quality gate')
+    p.add_argument('--force-quality', action='store_true',
+                   help='rerun quality reports even when outputs are current')
     p.add_argument('--dry-run', action='store_true')
     return p
 


### PR DESCRIPTION
## What changed

- connect the end-to-end coloured-map quality gate to the user-facing pipeline
- make quality evaluation explicit opt-in through `--quality-profile`
- generate camera-LiDAR alignment and held-out colour reports before running the integrated gate
- require external trajectory and geometry reports up front
- reuse current quality artifacts and provide `--force-quality` for targeted reruns

## Why

The individual evaluators and integrated gate existed, but operators still had to invoke and connect three commands manually. The pipeline can derive alignment and colour inputs from its own map and posed images, while trajectory ground truth and geometry reports remain explicit external inputs.

## User impact

Normal map generation is unchanged. With a quality profile, one pipeline invocation now produces `lidar_camera_alignment.json`, `heldout_point_colors.json`, and `colored_map_quality_gate.json`. Missing required reports fail before processing starts instead of silently skipping validation.

## Validation

- 72 related tests passed with warnings treated as errors
- `ament_flake8`
- `ament_copyright`
- `git diff --check`
