### PR TITLE
Improve colored-map quality and validation

### DIFF
--- a/configs/colored_map_quality_profiles/rtkslam_seq1_report_only.yaml
+++ b/configs/colored_map_quality_profiles/rtkslam_seq1_report_only.yaml
@@ -1,0 +1,22 @@
+colored_map_quality_profile:
+  name: rtkslam_construction_seq1_colored_map
+  enforcement: report_only
+  thresholds:
+    # Calibrated on the 480--545 s construction_seq1 A/B/D comparison in
+    # rtkslam_seq1_colored_map_20260718. D is the adopted margin=140,
+    # min_samples=3 configuration. Keep report-only until another colour rig
+    # establishes run-to-run variation.
+    alignment_median_max_px: 8.0
+    alignment_inlier_2px_min: 0.20
+    heldout_rgb_median_max: 42.0
+    heldout_rgb_inlier_20_min: 0.28
+    heldout_scored_fraction_min: 0.70
+    appearance_coverage_min: 0.70
+    appearance_roughness_median_max: 6.0
+    appearance_roughness_p90_max: 22.0
+    appearance_chroma_retention_min: 0.90
+    # PCA-planar voxels amplify pepper regressions: A/B/D/I p90 scores are
+    # 25.89 / 28.12 / 23.75 / 23.50. The pipeline enables this metric
+    # automatically when these thresholds are present.
+    appearance_planar_roughness_median_max: 7.6
+    appearance_planar_roughness_p90_max: 25.0

--- a/graph_based_slam/test/test_colored_map_appearance.py
+++ b/graph_based_slam/test/test_colored_map_appearance.py
@@ -139,3 +139,30 @@ def test_evaluate_mono_images_disable_retention():
     mono = np.full((8, 8), 90, dtype=np.uint8)
     report = app.evaluate(xyz, rgb, images=[mono])
     assert report['chroma_retention'] is None
+
+
+def test_planar_roughness_is_optional_and_detects_planar_pepper():
+    rng = np.random.default_rng(7)
+    xy = rng.uniform(0.0, 0.07, (80, 2))
+    xyz = np.column_stack([xy, rng.normal(0.0, 0.0002, 80)])
+    rgb = np.full((80, 3), 100, dtype=np.uint8)
+    rgb[:8] = 240
+    ordinary = app.evaluate(xyz, rgb, voxel=0.08)
+    planar = app.evaluate(
+        xyz, rgb, voxel=0.08, planar_roughness=True,
+        planar_min_points=10)
+    assert 'planar_roughness' not in ordinary
+    assert planar['planar_points'] == 80
+    assert planar['planar_fraction'] == pytest.approx(1.0)
+    assert planar['planar_roughness']['roughness_p90'] > 30.0
+
+
+def test_planar_roughness_rejects_line_like_voxel():
+    xyz = np.column_stack([
+        np.linspace(0.0, 0.07, 20), np.zeros(20), np.zeros(20)])
+    rgb = np.full((20, 3), 100, dtype=np.uint8)
+    report = app.evaluate(
+        xyz, rgb, voxel=0.08, planar_roughness=True,
+        planar_min_points=10)
+    assert report['planar_points'] == 0
+    assert report['planar_roughness']['voxels_scored'] == 0

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -300,27 +300,34 @@ def test_quality_profile_adds_two_evaluators_and_gate(tmp_path):
         'out/heldout_point_colors.json')
 
 
-def test_quality_profile_requires_external_reports_before_running(tmp_path):
-    import pytest
+def test_quality_profile_allows_appearance_and_colour_only(tmp_path):
     args = _args(
         tmp_path, '--quality-profile', str(tmp_path / 'profile.yaml'),
         '--dry-run')
-    with pytest.raises(ValueError, match='trajectory-report.*geometry-report'):
-        cmp.run_pipeline(args)
+    commands = cmp.build_commands(args)
+    gate = dict(commands)['quality gate']
+    assert '--trajectory-report' not in gate
+    assert '--geometry-report' not in gate
+    assert '--alignment-report' in gate
+    assert '--colour-report' in gate
+    assert '--appearance-report' in gate
 
 
 def test_vignette_and_confidence_options_reach_map_builder(tmp_path):
     commands = cmp.build_commands(_args(
-        tmp_path, '--color-image-margin', '140', '--color-min-samples', '3'))
+        tmp_path, '--color-image-margin', '140', '--color-min-samples', '3',
+        '--color-vignette-gain-limit', '2.5'))
     build = commands[1][1]
     assert build[build.index('--color-image-margin') + 1] == '140'
     assert build[build.index('--color-min-samples') + 1] == '3'
+    assert build[build.index('--color-vignette-gain-limit') + 1] == '2.5'
 
 
 def test_vignette_and_confidence_defaults_are_off(tmp_path):
     build = cmp.build_commands(_args(tmp_path))[1][1]
     assert build[build.index('--color-image-margin') + 1] == '0'
     assert build[build.index('--color-min-samples') + 1] == '1'
+    assert build[build.index('--color-vignette-gain-limit') + 1] == '1.0'
 
 
 def test_quality_profile_adds_appearance_stage_and_gate_wiring(tmp_path):
@@ -338,3 +345,21 @@ def test_quality_profile_adds_appearance_stage_and_gate_wiring(tmp_path):
     gate_cmd = dict(commands)['quality gate']
     assert gate_cmd[gate_cmd.index('--appearance-report') + 1].endswith(
         'colored_map_appearance.json')
+
+
+def test_planar_roughness_option_reaches_appearance_evaluator(tmp_path):
+    commands = cmp.build_commands(_args(
+        tmp_path, '--quality-profile', str(tmp_path / 'profile.yaml'),
+        '--appearance-planar-roughness'))
+    assert '--planar-roughness' in dict(commands)['appearance']
+
+
+def test_planar_roughness_profile_enables_evaluator_automatically(tmp_path):
+    profile = tmp_path / 'profile.yaml'
+    profile.write_text(
+        'colored_map_quality_profile:\n'
+        '  thresholds:\n'
+        '    appearance_planar_roughness_p90_max: 25.0\n')
+    commands = cmp.build_commands(_args(
+        tmp_path, '--quality-profile', str(profile)))
+    assert '--planar-roughness' in dict(commands)['appearance']

--- a/graph_based_slam/test/test_colored_map_quality_gate.py
+++ b/graph_based_slam/test/test_colored_map_quality_gate.py
@@ -115,6 +115,19 @@ def test_appearance_domain_gates_pepper_and_coverage():
     assert result['violations'] == 2
 
 
+def test_planar_appearance_thresholds_use_dedicated_report_section():
+    reports = _reports()
+    reports['appearance']['planar_roughness'] = {
+        'roughness_median': 1.5, 'roughness_p90': 9.0}
+    profile = {'colored_map_quality_profile': {
+        'name': 'planar', 'enforcement': 'blocking', 'thresholds': {
+            'appearance_planar_roughness_median_max': 2.0,
+            'appearance_planar_roughness_p90_max': 10.0}}}
+    assert gate.evaluate(reports, profile)['overall'] == 'OK'
+    reports['appearance']['planar_roughness']['roughness_p90'] = 11.0
+    assert gate.evaluate(reports, profile)['overall'] == 'FAILED'
+
+
 def test_appearance_threshold_without_report_is_actionable():
     reports = _reports()
     del reports['appearance']
@@ -123,3 +136,38 @@ def test_appearance_threshold_without_report_is_actionable():
             'appearance_coverage_min': 0.95}}}
     with pytest.raises(gate.QualityGateError, match='appearance-report'):
         gate.evaluate(reports, profile)
+
+
+def test_rtkslam_profile_accepts_d_and_rejects_ab_regressions():
+    profile = gate.load_mapping(
+        REPO_ROOT / 'configs' / 'colored_map_quality_profiles' /
+        'rtkslam_seq1_report_only.yaml')
+
+    def reports(heldout_median, heldout_inlier, coverage, roughness_p90,
+                planar_median, planar_p90):
+        return {
+            'alignment': {'weighted_median_px': 7.477,
+                          'weighted_inlier_2px': 0.227},
+            'colour': {'rgb_l2_median': heldout_median,
+                       'rgb_l2_inlier_20': heldout_inlier,
+                       'heldout_scored_fraction': 0.725},
+            'appearance': {
+                'coverage': coverage, 'chroma_retention': 1.0,
+                'roughness': {'roughness_median': 5.4,
+                              'roughness_p90': roughness_p90},
+                'planar_roughness': {'roughness_median': planar_median,
+                                     'roughness_p90': planar_p90}},
+        }
+
+    adopted_d = gate.evaluate(
+        reports(40.308, 0.2945, 0.728, 20.127, 7.504, 23.755), profile)
+    no_margin_a = gate.evaluate(
+        reports(43.499, 0.2568, 0.908, 20.617, 7.203, 25.894), profile)
+    margin_b = gate.evaluate(
+        reports(40.096, 0.2963, 0.832, 23.172, 7.682, 28.119), profile)
+    vignette_i = gate.evaluate(
+        reports(41.114, 0.2862, 0.748, 19.973, 7.156, 23.502), profile)
+    assert adopted_d['violations'] == 0
+    assert no_margin_a['violations'] == 3
+    assert margin_b['violations'] == 3
+    assert vignette_i['violations'] == 0

--- a/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
+++ b/graph_based_slam/test/test_gaussian_splatting_pointcloud.py
@@ -680,3 +680,31 @@ def test_colorize_robust_image_margin_validation():
         with np.testing.assert_raises(ValueError):
             pcio.colorize_by_projection_robust(
                 np.zeros((1, 3)), vms, K, [img], W, H, image_margin=margin)
+
+
+def test_radial_vignette_gain_recovers_dark_border_and_is_default_off():
+    vms, K, W, H = _cam()
+    yy, xx = np.mgrid[:H, :W]
+    radius = np.hypot(xx - 50.0, yy - 50.0) / np.hypot(50.0, 50.0)
+    image = np.clip(120.0 * (1.0 - 0.5 * radius ** 2), 0, 255)
+    image = np.repeat(image[:, :, None], 3, axis=2).astype(np.uint8)
+    points = np.array([[0.0, 0.0, 5.0], [2.25, 0.0, 5.0]])
+    baseline, _ = pcio.colorize_by_projection_robust(
+        points, vms, K, [image], W, H, normalize_exposure=False)
+    disabled, _ = pcio.colorize_by_projection_robust(
+        points, vms, K, [image], W, H, normalize_exposure=False,
+        vignette_gain_limit=1.0)
+    corrected, _ = pcio.colorize_by_projection_robust(
+        points, vms, K, [image], W, H, normalize_exposure=False,
+        vignette_gain_limit=2.5)
+    np.testing.assert_array_equal(disabled, baseline)
+    assert corrected[1, 0] > baseline[1, 0] + 15
+    assert abs(int(corrected[1, 0]) - int(corrected[0, 0])) < 10
+
+
+def test_radial_vignette_gain_validation():
+    vms, K, W, H = _cam()
+    with np.testing.assert_raises(ValueError):
+        pcio.colorize_by_projection_robust(
+            np.zeros((1, 3)), vms, K, [np.zeros((H, W, 3))], W, H,
+            vignette_gain_limit=0.9)

--- a/graph_based_slam/test/test_gaussian_splatting_render.py
+++ b/graph_based_slam/test/test_gaussian_splatting_render.py
@@ -270,6 +270,30 @@ def test_render_frames_cpu_rejects_sh_and_bad_supersample():
     with pytest.raises(ValueError):
         rp.render_frames_cpu(gaussians, viewmats, K, width, height,
                              supersample=0)
+    with pytest.raises(ValueError, match='soft_edge_px'):
+        rp.render_frames_cpu(gaussians, viewmats, K, width, height,
+                             soft_edge_px=-0.1)
+
+
+def test_render_frames_cpu_soft_edge_expands_with_fade():
+    gaussians = _point_set(
+        [[0.0, 0.0, 2.0]], [[1.0, 1.0, 1.0]], size=0.03)
+    K = np.array([[20.0, 0.0, 8.0],
+                  [0.0, 20.0, 8.0],
+                  [0.0, 0.0, 1.0]])
+    viewmats = np.eye(4)[None]
+    opaque = rp.render_frames_cpu(
+        gaussians, viewmats, K, 16, 16, supersample=2)
+    explicit_off = rp.render_frames_cpu(
+        gaussians, viewmats, K, 16, 16, supersample=2,
+        soft_edge_px=0.0)
+    softened = rp.render_frames_cpu(
+        gaussians, viewmats, K, 16, 16, supersample=2,
+        soft_edge_px=1.0)
+    assert np.count_nonzero(softened) > np.count_nonzero(opaque)
+    np.testing.assert_array_equal(explicit_off, opaque)
+    assert softened[0, 8, 8, 0] >= opaque[0, 8, 8, 0]
+    assert np.any((softened > 0) & (softened < 255))
 
 
 def test_render_frames_dispatches_cpu_device():

--- a/graph_based_slam/test/test_mesh_export.py
+++ b/graph_based_slam/test/test_mesh_export.py
@@ -61,6 +61,12 @@ def _load():
 mesh_export = _load()
 
 
+def test_cli_parser_accepts_thin_voxel():
+    args = mesh_export._build_arg_parser().parse_args(
+        ['input.ply', 'output.ply', '--thin-voxel', '0.1'])
+    assert args.thin_voxel == pytest.approx(0.1)
+
+
 def _red_sphere(n=3000):
     """Build a dense red sphere for both reconstructors."""
     sph = o3d.geometry.TriangleMesh.create_sphere(radius=1.0, resolution=20)

--- a/graph_based_slam/test/test_realtime_colored_map_evaluator.py
+++ b/graph_based_slam/test/test_realtime_colored_map_evaluator.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for realtime coloured-map packed RGB reporting."""
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    'evaluate_realtime_colored_map',
+    REPO_ROOT / 'scripts' / 'evaluate_realtime_colored_map.py')
+evaluator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(evaluator)
+
+
+def test_decode_packed_rgb_float_and_integer():
+    packed = np.array([0x00112233, 0x00A0B0C0], dtype=np.uint32)
+    expected = np.array([[0x11, 0x22, 0x33], [0xA0, 0xB0, 0xC0]])
+    np.testing.assert_array_equal(evaluator.decode_packed_rgb(packed), expected)
+    np.testing.assert_array_equal(
+        evaluator.decode_packed_rgb(packed.view(np.float32)), expected)
+
+
+def test_summarize_excludes_unconfirmed_grey():
+    report = evaluator.summarize(np.array([
+        [128, 128, 128], [200, 20, 20], [10, 30, 50]], dtype=np.uint8))
+    assert report['points'] == 3
+    assert report['confirmed'] == 2
+    assert report['coverage'] == pytest.approx(2.0 / 3.0)
+    assert report['chroma_mean'] == pytest.approx(110.0)

--- a/scripts/check_colored_map_quality.py
+++ b/scripts/check_colored_map_quality.py
@@ -67,6 +67,10 @@ METRICS = {
         'appearance', ('roughness', 'roughness_p90'), 'max'),
     'appearance_chroma_retention_min': (
         'appearance', ('chroma_retention',), 'min'),
+    'appearance_planar_roughness_median_max': (
+        'appearance', ('planar_roughness', 'roughness_median'), 'max'),
+    'appearance_planar_roughness_p90_max': (
+        'appearance', ('planar_roughness', 'roughness_p90'), 'max'),
 }
 
 
@@ -146,10 +150,10 @@ def evaluate(reports: dict[str, dict[str, Any]],
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--trajectory-report', type=Path, required=True)
-    parser.add_argument('--geometry-report', type=Path, required=True)
-    parser.add_argument('--alignment-report', type=Path, required=True)
-    parser.add_argument('--colour-report', type=Path, required=True)
+    parser.add_argument('--trajectory-report', type=Path)
+    parser.add_argument('--geometry-report', type=Path)
+    parser.add_argument('--alignment-report', type=Path)
+    parser.add_argument('--colour-report', type=Path)
     parser.add_argument('--appearance-report', type=Path, default=None,
                         help='evaluate_colored_map_appearance.py output; '
                              'required when the profile sets appearance_* '
@@ -158,14 +162,16 @@ def main() -> int:
     parser.add_argument('--out', type=Path, required=True)
     args = parser.parse_args()
     try:
-        reports = {
-            'trajectory': load_mapping(args.trajectory_report),
-            'geometry': load_mapping(args.geometry_report),
-            'alignment': load_mapping(args.alignment_report),
-            'colour': load_mapping(args.colour_report),
+        report_paths = {
+            'trajectory': args.trajectory_report,
+            'geometry': args.geometry_report,
+            'alignment': args.alignment_report,
+            'colour': args.colour_report,
+            'appearance': args.appearance_report,
         }
-        if args.appearance_report is not None:
-            reports['appearance'] = load_mapping(args.appearance_report)
+        reports = {name: load_mapping(path)
+                   for name, path in report_paths.items()
+                   if path is not None}
         result = evaluate(reports, load_mapping(args.profile))
     except QualityGateError as exc:
         parser.error(str(exc))

--- a/scripts/evaluate_colored_map_appearance.py
+++ b/scripts/evaluate_colored_map_appearance.py
@@ -138,7 +138,11 @@ def voxel_color_roughness(xyz: np.ndarray, rgb: np.ndarray,
 
 def evaluate(xyz: np.ndarray, rgb: np.ndarray, *,
              default_rgb=(128, 128, 128), voxel: float = 0.08,
-             images=None, pixel_stride: int = 4) -> dict:
+             images=None, pixel_stride: int = 4,
+             planar_roughness: bool = False,
+             planar_min_points: int = 10,
+             planar_max_ratio: float = 0.06,
+             planar_min_second_ratio: float = 0.04) -> dict:
     """Assemble the appearance report for one coloured cloud."""
     default = np.asarray(default_rgb, dtype=np.uint8)
     seen = np.any(np.asarray(rgb) != default[None, :], axis=1)
@@ -159,6 +163,23 @@ def evaluate(xyz: np.ndarray, rgb: np.ndarray, *,
         report['image_chroma_mean'] = source
         report['chroma_retention'] = (
             float(report['chroma_mean'] / source) if source >= 2.0 else None)
+    if planar_roughness:
+        coloured_xyz = np.asarray(xyz)[seen]
+        _, planar = pcio.project_planar_voxels(
+            coloured_xyz, voxel, min_points=planar_min_points,
+            max_planarity_ratio=planar_max_ratio,
+            min_second_to_first_ratio=planar_min_second_ratio,
+            max_projection_distance=float('inf'))
+        report['planar_points'] = int(planar.sum())
+        report['planar_fraction'] = (
+            float(planar.mean()) if len(planar) else 0.0)
+        report['planar_roughness'] = voxel_color_roughness(
+            coloured_xyz[planar], coloured[planar], voxel=voxel)
+        report['planar_parameters'] = {
+            'min_points': planar_min_points,
+            'max_planarity_ratio': planar_max_ratio,
+            'min_second_to_first_ratio': planar_min_second_ratio,
+        }
     return report
 
 
@@ -177,6 +198,11 @@ def main() -> int:
                         help='sample every Nth source image for image chroma')
     parser.add_argument('--default-rgb', type=int, nargs=3,
                         default=(128, 128, 128))
+    parser.add_argument('--planar-roughness', action='store_true',
+                        help='also score colour roughness in PCA-planar voxels')
+    parser.add_argument('--planar-min-points', type=int, default=10)
+    parser.add_argument('--planar-max-ratio', type=float, default=0.06)
+    parser.add_argument('--planar-min-second-ratio', type=float, default=0.04)
     args = parser.parse_args()
     if args.view_stride < 1:
         raise SystemExit('--view-stride must be >= 1')
@@ -192,7 +218,11 @@ def main() -> int:
         images = [np.asarray(iio.imread(path))
                   for path in dataset['image_paths'][::args.view_stride]]
     report = evaluate(xyz, rgb, default_rgb=tuple(args.default_rgb),
-                      voxel=args.voxel, images=images)
+                      voxel=args.voxel, images=images,
+                      planar_roughness=args.planar_roughness,
+                      planar_min_points=args.planar_min_points,
+                      planar_max_ratio=args.planar_max_ratio,
+                      planar_min_second_ratio=args.planar_min_second_ratio)
     report['pointcloud'] = str(args.pointcloud.resolve())
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(report, indent=2) + '\n')

--- a/scripts/evaluate_realtime_colored_map.py
+++ b/scripts/evaluate_realtime_colored_map.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""Capture one realtime coloured-map message and report RGB coverage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def decode_packed_rgb(values: np.ndarray) -> np.ndarray:
+    """Decode PCL packed RGB stored as float32 or uint32."""
+    packed = np.asarray(values)
+    if packed.dtype.kind == 'f':
+        packed = np.ascontiguousarray(packed, dtype=np.float32).view(np.uint32)
+    else:
+        packed = packed.astype(np.uint32, copy=False)
+    return np.stack([
+        (packed >> 16) & 0xff,
+        (packed >> 8) & 0xff,
+        packed & 0xff,
+    ], axis=1).astype(np.uint8)
+
+
+def summarize(rgb: np.ndarray, default_rgb=(128, 128, 128)) -> dict:
+    """Summarize confirmed colour coverage and chroma."""
+    colours = np.asarray(rgb, dtype=np.uint8)
+    confirmed = np.any(colours != np.asarray(default_rgb, dtype=np.uint8), axis=1)
+    chroma = np.ptp(colours[confirmed].astype(np.int16), axis=1)
+    return {
+        'points': int(len(colours)),
+        'confirmed': int(confirmed.sum()),
+        'coverage': float(confirmed.mean()) if len(confirmed) else 0.0,
+        'chroma_mean': float(chroma.mean()) if len(chroma) else 0.0,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--topic', default='/colored_map')
+    parser.add_argument('--timeout', type=float, default=15.0)
+    parser.add_argument('--out', type=Path, required=True)
+    args = parser.parse_args()
+
+    import rclpy
+    from rclpy.node import Node
+    from rclpy.qos import qos_profile_sensor_data
+    from sensor_msgs.msg import PointCloud2
+    from sensor_msgs_py import point_cloud2
+
+    rclpy.init()
+    node = Node('evaluate_realtime_colored_map')
+    result = {}
+
+    def callback(message: PointCloud2) -> None:
+        rows = point_cloud2.read_points_numpy(
+            message, field_names=('rgb',), skip_nans=False)
+        report = summarize(decode_packed_rgb(rows.reshape(-1)))
+        report.update({
+            'topic': args.topic,
+            'frame_id': message.header.frame_id,
+            'stamp': message.header.stamp.sec +
+            message.header.stamp.nanosec * 1.0e-9,
+        })
+        result.update(report)
+
+    node.create_subscription(
+        PointCloud2, args.topic, callback, qos_profile_sensor_data)
+    deadline = node.get_clock().now().nanoseconds * 1.0e-9 + args.timeout
+    while rclpy.ok() and not result:
+        rclpy.spin_once(node, timeout_sec=0.2)
+        if node.get_clock().now().nanoseconds * 1.0e-9 >= deadline:
+            break
+    node.destroy_node()
+    rclpy.shutdown()
+    if not result:
+        raise SystemExit(f'no {args.topic} message within {args.timeout:g}s')
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(result, indent=2) + '\n', encoding='utf-8')
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/colored_map/COLORING_HANDOFF.md
+++ b/tools/colored_map/COLORING_HANDOFF.md
@@ -185,3 +185,72 @@ ffmpeg -i master.mp4 -vf "fps=15,scale=600:-2:flags=lanczos" -loop 0 \
 colorize_planar_references) の先頭 bootstrap が解決する。
 tests / scripts の旧パス参照は shim で無改修動作 — 新規コードは
 `tools/colored_map/` を直接参照すること。
+
+## 10. 追記 (2026-07-18): radial vignette correction
+
+未着手候補2を実装した。`colorize_by_projection_robust` の
+`vignette_gain_limit` (`build_lidar_init.py` / pipeline では
+`--color-vignette-gain-limit`) が複数画像の半径別輝度中央値から共通gain curveを
+推定する。内周60%は厳密に1倍、外周だけ単調増加で補正し、指定値でclampする。
+default 1.0は補正なしで、従来出力と同一。
+
+RTK-SLAM construction_seq1でDと同じ4,840,318点を使い、marginを探索した。
+held-out truthは全て`--image-margin 140`。
+
+| 構成 | margin | coverage | held-out median / inlier20 | rough med / p90 | chroma |
+|---|---:|---:|---:|---:|---:|
+| D (従来採用) | 140 | 0.7280 | 40.31 / 0.2945 | 5.38 / 20.13 | 1.005 |
+| G | 40 | 0.8156 | 43.17 / 0.2650 | 5.00 / 19.04 | 1.002 |
+| H | 100 | 0.7658 | 41.75 / 0.2797 | 5.13 / 19.53 | 1.001 |
+| **I (採用候補)** | **120** | **0.7476** | **41.11 / 0.2862** | **5.22 / 19.97** | **1.002** |
+
+IはRTK report-only profileの9項目を全てPASSし、D比でcoverageを約2ポイント
+回復した。同一4視点gridでも新たな白カブリ・黒ずみ・色滲みは見られなかった。
+再現オプションは `--color-image-margin 120
+--color-vignette-gain-limit 2.5 --color-min-samples 3`。成果物は同benchmark
+directoryの`colored_I_vignette_deadzone_margin120.ply`, `app_I.json`,
+`heldout_masked_I.json`, `quality_I.json`, `test_grid_{D,I}.png`。
+
+## 11. 追記 (2026-07-18): planar-only roughness
+
+未着手候補3も実装した。`evaluate_colored_map_appearance.py
+--planar-roughness`は既存の全voxel `roughness`を残したまま、PCAで平面と判定した
+voxelだけの`planar_roughness`を追加する。default-off。品質プロファイルに
+`appearance_planar_roughness_*`閾値があればpipelineが自動で有効化する。
+
+RTK A/B/D/Iの planar median / p90 はそれぞれ 7.20/25.89,
+7.68/28.12, 7.50/23.75, 7.16/23.50。RTK profileをmedian<=7.6,
+p90<=25.0に較正した。D/IはPASSし、旧A/Bはp90で検出する。平面点率は
+約0.72%（約2.6万点、約2千voxel）なので、レポートの`planar_points`と
+`voxels_scored`も併せて監視すること。成果物は`app_planar_{A,B,D,I}.json`と
+`quality_planar_I.json`。
+
+## 12. 追記 (2026-07-18): realtime実bag A/B
+
+未着手候補5を`/home/sasaki/autoware_data/all-sensors-bag1`で実施した。
+LiDARは`/sensing/lidar/concatenated/pointcloud` (`base_link`)、camera_0は
+`/lucid_vision/camera_0/{raw_image,camera_info}` (720x465 BGR8)、optical frameは
+`camera_top/camera_optical_link`。bagには完成mapがないため、各scanをmap入力として
+TF/QoS/投影/confirmationの実データ配線を検証した。
+
+約26秒warm-up後、A (`margin=0,min_samples=1`) は138,760 voxel中22,155 confirmed
+(coverage 0.1597, chroma 26.83)、B (`margin=40,min_samples=3`) は156,547中15,075
+(coverage 0.0963, chroma 27.32)。Bは低信頼色を期待どおり降格し、TF失敗、node警告、
+crashなし。`scripts/evaluate_realtime_colored_map.py`を追加し、成果物は
+`realtime_{A,B}.json`。完成world mapでの長時間品質評価は、map topicを含むbagが
+得られた時の追加課題。
+
+## 13. 追記 (2026-07-18): CPU soft fill + export再検証
+
+未着手候補4/6を完了した。CPU rendererに`soft_edge_px`、flythrough CLIに
+`--soft-edge-px`を追加（default 0で従来とバイト同一）。初版の半透明fringeは
+手前点が奥のdiscを覆って暗い輪郭を作ったため不採用。最終版は既存の不透明pixelを
+一切変えず、黒いpixelだけを外周fadeで埋める。Iの同一2視点gridでsoft=1は
+black pixel率を41.58%から38.43%へ削減、changed fraction 7.50%、平均絶対画素差
+2.71。成果物は`test_grid_I_soft{0,1}.png`（失敗版）と
+`test_grid_I_soft1_fill_only.png`（最終版）。
+
+I点群のexportも再検証した。GIS CSV / LASを0.1m thinningして851,755点、LASは
+全点RGBあり・座標量子1mm。meshには`--thin-voxel`を追加し、0.2m thinning + BPA
+(radii 0.15/0.3/0.6m)で127,396 vertices / 109,189 triangles、vertex colourあり。
+成果物はbenchmark directoryの`exports_I/`。

--- a/tools/colored_map/README.md
+++ b/tools/colored_map/README.md
@@ -13,8 +13,8 @@ numpy ラスタライザで CUDA / torch 不要)。歴史的経緯で
 |---|---|
 | `colored_map_pipeline.py` | bag + TUM 軌跡 → posed images → 着色マップ → 品質ゲートまでの一括実行 |
 | `extract_posed_images.py` | bag から姿勢付きカメラ画像 (`transforms.json`) を抽出 |
-| `build_lidar_init.py` | スキャン蓄積 + 着色 (`--color-robust --color-image-margin --color-min-samples`) |
-| `render_map_flythrough.py` | 着色マップの三人称フライスルー動画 (`--color-mode rgb --device cpu`) |
+| `build_lidar_init.py` | スキャン蓄積 + 着色 (`--color-robust --color-image-margin --color-vignette-gain-limit --color-min-samples`) |
+| `render_map_flythrough.py` | 着色マップの三人称フライスルー動画 (`--color-mode rgb --device cpu --soft-edge-px`) |
 | `colorize_from_bag.py` | SLAM なし・静的 extrinsic での単発着色 (マルチカメラ融合対応) |
 | `map_export.py` / `las_export.py` / `mesh_export.py` | GIS delimited text / LAS 1.2 / 色付き mesh 出力 |
 | `bim_export.py` / `bim_pipeline.py` | 平面抽出 → IfcSlab/IfcWall/IfcDoor/IfcWindow/IfcSpace (IFC4) |
@@ -22,6 +22,18 @@ numpy ラスタライザで CUDA / torch 不要)。歴史的経緯で
 品質評価は `scripts/evaluate_heldout_point_colors.py --image-margin`(忠実度)、
 `scripts/evaluate_colored_map_appearance.py`(彩度保持・胡椒ノイズ・coverage)、
 `scripts/check_colored_map_quality.py`(ゲート統合)の3点セットで行う。
+RTK-SLAM construction_seq1 の較正済み report-only 閾値は
+`configs/colored_map_quality_profiles/rtkslam_seq1_report_only.yaml` にある。
+品質ゲートのレポート引数はプロファイルが参照する領域だけ指定すればよい。
+`appearance_planar_roughness_*` 閾値を持つプロファイルでは平面限定roughnessも
+パイプラインが自動計算する。
+realtime nodeの出力確認には`scripts/evaluate_realtime_colored_map.py`を使い、
+confirmed coverageとchromaをJSON保存できる。
+CPU rendererの`--soft-edge-px 1`は不透明surfaceを変えず黒い隙間だけをfadeで
+埋める。mesh exportは`--thin-voxel`でmulti-million-point入力を事前に間引ける。
+RTK-SLAMで検証済みのビネット補正は `--color-image-margin 120
+--color-vignette-gain-limit 2.5`。補正はgain limitが1のとき無効で、従来出力を
+維持する。
 
 ## 引き継ぎ文書
 

--- a/tools/colored_map/build_lidar_init.py
+++ b/tools/colored_map/build_lidar_init.py
@@ -208,6 +208,7 @@ def build(args: argparse.Namespace) -> dict:
             exposure_scale_limit=args.color_exposure_scale_limit,
             max_samples=args.color_max_samples,
             image_margin=args.color_image_margin,
+            vignette_gain_limit=args.color_vignette_gain_limit,
             min_samples=args.color_min_samples)
         colored = int(seen.sum())
     out = pcio.write_ply(args.out, world, rgb)
@@ -220,6 +221,7 @@ def _colorize(world: np.ndarray, transforms_path: str, *, robust: bool = False,
               exposure_scale_limit: float = 1.5,
               max_samples: int = 12,
               image_margin: int = 0,
+              vignette_gain_limit: float = 1.0,
               min_samples: int = 1):
     """Project ``world`` points into the posed images of a transforms.json."""
     import imageio.v3 as iio
@@ -235,6 +237,7 @@ def _colorize(world: np.ndarray, transforms_path: str, *, robust: bool = False,
         normalize_exposure=normalize_exposure,
         exposure_scale_limit=exposure_scale_limit,
         max_samples=max_samples, image_margin=image_margin,
+        vignette_gain_limit=vignette_gain_limit,
         return_counts=True)
     if min_samples > 1:
         # Colours confirmed by too few camera observations are unreliable
@@ -298,6 +301,9 @@ def build_parser() -> argparse.ArgumentParser:
                    help='ignore colour samples within this many pixels of the '
                         'image border (skips lens-vignette darkening; 0 keeps '
                         'the full frame)')
+    p.add_argument('--color-vignette-gain-limit', type=float, default=1.0,
+                   help='estimate and apply a shared radial luminance gain, '
+                        'clamped to this value (1 disables correction)')
     p.add_argument('--min-neighbors', type=int, default=2,
                    help='drop points whose 3x3x3 voxel neighbourhood (see '
                         '--sparse-voxel) holds fewer points; default 2 requires '

--- a/tools/colored_map/colored_map_pipeline.py
+++ b/tools/colored_map/colored_map_pipeline.py
@@ -45,6 +45,7 @@ import sys
 from typing import Sequence
 
 import numpy as np
+import yaml
 
 
 TOOL_DIR = Path(__file__).resolve().parent
@@ -65,6 +66,25 @@ def is_stale(output: Path, inputs: Sequence[Path]) -> bool:
     output_mtime = output.stat().st_mtime_ns
     return any(path.is_file() and path.stat().st_mtime_ns > output_mtime
                for path in inputs)
+
+
+def profile_uses_planar_roughness(path: Path) -> bool:
+    """Return whether a readable quality profile gates planar roughness."""
+    try:
+        document = yaml.safe_load(path.read_text(encoding='utf-8'))
+        thresholds = document['colored_map_quality_profile']['thresholds']
+    except (OSError, TypeError, KeyError, yaml.YAMLError):
+        return False
+    return any(str(key).startswith('appearance_planar_roughness_')
+               for key in thresholds)
+
+
+def report_has_metric(path: Path, metric: str) -> bool:
+    """Return whether an existing JSON report contains a top-level metric."""
+    try:
+        return metric in json.loads(path.read_text(encoding='utf-8'))
+    except (OSError, ValueError, TypeError):
+        return False
 
 
 def validate_trajectory_density(path: Path, max_gap: float) -> None:
@@ -178,6 +198,8 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
             '--color-exposure-scale-limit', str(args.color_exposure_scale_limit),
             '--color-max-samples', str(args.color_max_samples),
             '--color-image-margin', str(args.color_image_margin),
+            '--color-vignette-gain-limit',
+            str(args.color_vignette_gain_limit),
             '--color-min-samples', str(args.color_min_samples),
         ]
         if not args.color_normalize_exposure:
@@ -198,6 +220,9 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
         quality_report = out_dir / 'colored_map_quality_gate.json'
         rebuild_map = any(name == 'coloured map' for name, _ in commands)
         rebuild_images = any(name == 'posed images' for name, _ in commands)
+        planar_roughness = (
+            args.appearance_planar_roughness or
+            profile_uses_planar_roughness(Path(args.quality_profile)))
         if (rebuild_map or rebuild_images or args.force_quality or
                 is_stale(alignment_report, [colored_map, transforms])):
             commands.append(('camera-LiDAR alignment', [
@@ -218,34 +243,45 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                 '--out', str(colour_report),
             ]))
         if (rebuild_map or rebuild_images or args.force_quality or
-                is_stale(appearance_report, [colored_map, transforms])):
-            commands.append(('appearance', [
+                is_stale(appearance_report, [colored_map, transforms]) or
+                (planar_roughness and not report_has_metric(
+                    appearance_report, 'planar_roughness'))):
+            appearance_command = [
                 sys.executable,
                 str(REPO_ROOT / 'scripts' /
                     'evaluate_colored_map_appearance.py'),
                 '--pointcloud', str(colored_map),
                 '--transforms', str(transforms),
                 '--out', str(appearance_report),
-            ]))
-        gate_inputs = [Path(args.trajectory_report), Path(args.geometry_report),
-                       alignment_report, colour_report, appearance_report,
+            ]
+            if planar_roughness:
+                appearance_command.append('--planar-roughness')
+            commands.append(('appearance', appearance_command))
+        gate_inputs = [alignment_report, colour_report, appearance_report,
                        Path(args.quality_profile)]
+        gate_inputs.extend(Path(path) for path in
+                           (args.trajectory_report, args.geometry_report)
+                           if path is not None)
         if (args.force_quality or
                 any(name in ('camera-LiDAR alignment', 'held-out colour',
                              'appearance')
                     for name, _ in commands) or
                 is_stale(quality_report, gate_inputs)):
-            commands.append(('quality gate', [
+            gate_command = [
                 sys.executable,
                 str(REPO_ROOT / 'scripts' / 'check_colored_map_quality.py'),
-                '--trajectory-report', str(args.trajectory_report),
-                '--geometry-report', str(args.geometry_report),
                 '--alignment-report', str(alignment_report),
                 '--colour-report', str(colour_report),
                 '--appearance-report', str(appearance_report),
                 '--profile', str(args.quality_profile),
                 '--out', str(quality_report),
-            ]))
+            ]
+            for option, path in (
+                    ('--trajectory-report', args.trajectory_report),
+                    ('--geometry-report', args.geometry_report)):
+                if path is not None:
+                    gate_command.extend((option, str(path)))
+            commands.append(('quality gate', gate_command))
     return commands
 
 
@@ -254,13 +290,6 @@ def run_pipeline(args) -> dict:
     out_dir = Path(args.out)
     if args.kalibr_camchain is not None and args.lidar_calibration is None:
         raise ValueError('--kalibr-camchain requires --lidar-calibration')
-    if args.quality_profile is not None:
-        missing = [name for name in ('trajectory_report', 'geometry_report')
-                   if getattr(args, name) is None]
-        if missing:
-            options = ', '.join('--' + name.replace('_', '-')
-                                for name in missing)
-            raise ValueError(f'--quality-profile requires {options}')
     if not args.dry_run:
         out_dir.mkdir(parents=True, exist_ok=True)
         if args.kalibr_camchain is not None:
@@ -358,6 +387,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--color-image-margin', type=int, default=0,
                    help='ignore colour samples within this many pixels of the '
                         'image border (lens vignette)')
+    p.add_argument('--color-vignette-gain-limit', type=float, default=1.0,
+                   help='maximum automatic radial luminance gain; 1 disables')
     p.add_argument('--color-min-samples', type=int, default=1,
                    help='demote colours confirmed by fewer surviving camera '
                         'samples than this to unseen (1 keeps all)')
@@ -367,6 +398,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--quality-profile', type=Path,
                    help='run alignment, held-out colour, and integrated quality '
                         'checks using this profile')
+    p.add_argument('--appearance-planar-roughness', action='store_true',
+                   help='include PCA-planar voxel roughness in appearance report')
     p.add_argument('--trajectory-report', type=Path,
                    help='metrics.json containing evo.ape.rmse for quality gate')
     p.add_argument('--geometry-report', type=Path,

--- a/tools/colored_map/mesh_export.py
+++ b/tools/colored_map/mesh_export.py
@@ -126,15 +126,18 @@ def _build_arg_parser():
                    help='BPA ball radii [m] (default: from point spacing)')
     p.add_argument('--normal-radius', type=float, default=0.5,
                    help='normal-estimation search radius [m]')
+    p.add_argument('--thin-voxel', type=float, default=0.0,
+                   help='voxel-downsample input before meshing [m] (0=off)')
     return p
 
 
 def main(argv=None) -> int:
     import sys
     sys.path.insert(0, str(Path(__file__).resolve().parent))
-    from pointcloud_io import read_ply_xyz
+    from pointcloud_io import read_ply_xyz, voxel_downsample
     args = _build_arg_parser().parse_args(argv)
     xyz, rgb = read_ply_xyz(args.input)
+    xyz, rgb = voxel_downsample(xyz, args.thin_voxel, rgb)
     mesh = reconstruct_mesh(xyz, rgb, method=args.method, depth=args.depth,
                             density_quantile=args.density_quantile,
                             radii=args.radii, normal_radius=args.normal_radius)

--- a/tools/colored_map/pointcloud_io.py
+++ b/tools/colored_map/pointcloud_io.py
@@ -331,6 +331,85 @@ def _median_luminance(img: np.ndarray) -> float:
     return float(np.median(np.tensordot(arr[:, :, :3], coeff, axes=([-1], [0]))))
 
 
+def estimate_radial_vignette_gains(images, width: int, height: int, *,
+                                   cx: Optional[float] = None,
+                                   cy: Optional[float] = None,
+                                   bins: int = 32, sample_stride: int = 8,
+                                   gain_limit: float = 2.5) -> np.ndarray:
+    """Estimate one robust radial luminance correction shared by all views.
+
+    Each image is normalised by its central luminance before annular profiles
+    are combined, which separates per-view exposure from a lens-fixed radial
+    falloff. The returned curve only brightens, is monotonically non-decreasing,
+    and is clamped by ``gain_limit``. It therefore cannot amplify dark corners
+    without a caller explicitly choosing a limit above one.
+    """
+    if bins < 4:
+        raise ValueError('bins must be >= 4')
+    if sample_stride < 1:
+        raise ValueError('sample_stride must be >= 1')
+    if gain_limit < 1.0:
+        raise ValueError('gain_limit must be >= 1')
+    if len(images) == 0:
+        return np.ones(bins, dtype=np.float32)
+    centre_x = (width - 1) * 0.5 if cx is None else float(cx)
+    centre_y = (height - 1) * 0.5 if cy is None else float(cy)
+    ys = np.arange(0, height, sample_stride, dtype=np.float32)
+    xs = np.arange(0, width, sample_stride, dtype=np.float32)
+    xx, yy = np.meshgrid(xs, ys)
+    corner_radius = max(
+        np.hypot(x - centre_x, y - centre_y)
+        for x in (0.0, width - 1.0) for y in (0.0, height - 1.0))
+    radius = np.hypot(xx - centre_x, yy - centre_y) / max(corner_radius, 1.0)
+    bin_ids = np.minimum((radius * bins).astype(np.intp), bins - 1)
+    central = radius <= 0.2
+    profiles = []
+    coeff = np.asarray([0.299, 0.587, 0.114], dtype=np.float32)
+    for image in images:
+        arr = np.asarray(image, dtype=np.float32)
+        if arr.shape[:2] != (height, width):
+            raise ValueError('all images must match width and height')
+        if arr.ndim == 2:
+            lum = arr
+        elif arr.ndim == 3 and arr.shape[2] == 1:
+            lum = arr[:, :, 0]
+        elif arr.ndim == 3 and arr.shape[2] >= 3:
+            lum = np.tensordot(arr[:, :, :3], coeff, axes=([-1], [0]))
+        else:
+            raise ValueError(f'image must be HxW or HxWxC, got {arr.shape}')
+        sampled = lum[::sample_stride, ::sample_stride]
+        reference = float(np.median(sampled[central]))
+        if reference <= 1.0e-6:
+            continue
+        profile = np.asarray([
+            np.median(sampled[bin_ids == index]) / reference
+            if np.any(bin_ids == index) else np.nan
+            for index in range(bins)
+        ], dtype=np.float32)
+        valid_bins = np.flatnonzero(np.isfinite(profile))
+        if valid_bins.size:
+            profile = np.interp(
+                np.arange(bins), valid_bins, profile[valid_bins]).astype(np.float32)
+        profiles.append(profile)
+    if not profiles:
+        return np.ones(bins, dtype=np.float32)
+    radial_profile = np.median(np.stack(profiles), axis=0)
+    radial_profile = np.where(
+        np.isfinite(radial_profile) & (radial_profile > 1.0e-6),
+        radial_profile, 1.0)
+    gains = 1.0 / radial_profile
+    gains = np.convolve(np.pad(gains, (1, 1), mode='edge'),
+                        np.asarray([0.25, 0.5, 0.25]), mode='valid')
+    central_gain = float(np.median(gains[:max(1, bins // 5)]))
+    gains /= max(central_gain, 1.0e-6)
+    # Lens vignetting is an outer-field effect. Pin the inner 60% to identity
+    # so scene-content outliers in a tiny central annulus cannot be propagated
+    # across the whole curve by the monotonic constraint below.
+    gains[:int(np.ceil(0.6 * bins))] = 1.0
+    gains = np.maximum.accumulate(np.clip(gains, 1.0, gain_limit))
+    return gains.astype(np.float32)
+
+
 def observed_color_medoids(samples: np.ndarray, chunk: int = 20000) -> np.ndarray:
     """Choose the observed RGB sample nearest all other samples per point.
 
@@ -367,6 +446,7 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
                                   prefer_near: bool = True,
                                   observation_mask: Optional[np.ndarray] = None,
                                   image_margin: int = 0,
+                                  vignette_gain_limit: float = 1.0,
                                   return_counts: bool = False):
     """Occlusion-aware, exposure-normalised, median-robust point colorization.
 
@@ -399,6 +479,9 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
     pixels of the image border, where lens vignetting darkens the pixels that
     per-view global exposure gains cannot repair; points near one view's border
     stay colourable from the views that see them more centrally.
+    ``vignette_gain_limit > 1`` estimates a shared radial luminance profile,
+    pins the inner 60 % of the image radius to unity, and brightens only the
+    outer field up to the requested clamp. The default 1 disables correction.
 
     Returns ``(rgb uint8 (N,3), seen bool (N,))``, or with ``return_counts`` the
     triple ``(rgb, seen, counts uint16 (N,))`` giving each point's surviving
@@ -419,6 +502,8 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
         raise ValueError('zbuf_bin must be >= 1')
     if exposure_scale_limit < 1.0:
         raise ValueError('exposure_scale_limit must be >= 1')
+    if vignette_gain_limit < 1.0:
+        raise ValueError('vignette_gain_limit must be >= 1')
     if image_margin < 0 or 2 * image_margin >= min(int(width), int(height)):
         raise ValueError('image_margin must be >= 0 and leave a usable '
                          'central image region')
@@ -429,6 +514,15 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
     samples = np.empty((n, int(max_samples), 3), dtype=np.uint8)
     # Depth stored alongside each sample so a nearer view can evict the farthest.
     sample_z = np.full((n, int(max_samples)), np.inf, dtype=np.float32)
+    vignette_gains = None
+    vignette_radius = 1.0
+    if vignette_gain_limit > 1.0:
+        vignette_gains = estimate_radial_vignette_gains(
+            images, width, height, cx=cx, cy=cy,
+            gain_limit=vignette_gain_limit)
+        vignette_radius = max(
+            np.hypot(x - cx, y - cy)
+            for x in (0.0, width - 1.0) for y in (0.0, height - 1.0))
 
     scales = np.ones(len(images), dtype=np.float32)
     if normalize_exposure:
@@ -478,6 +572,12 @@ def colorize_by_projection_robust(points: np.ndarray, viewmats: np.ndarray,
             continue
         cols = _sample_pixels(
             img, uf[cand], vf[cand], width, height, interp, edge_threshold)
+        if vignette_gains is not None:
+            radius = np.hypot(uf[cand] - cx, vf[cand] - cy) / vignette_radius
+            gain = np.interp(
+                radius, np.linspace(0.0, 1.0, len(vignette_gains)),
+                vignette_gains).astype(np.float32)
+            cols *= gain[:, None]
         cols = np.clip(cols * scales[vi], 0.0, 255.0).astype(np.uint8)
 
         # Points with room: append into the next free slot.

--- a/tools/colored_map/render_map_flythrough.py
+++ b/tools/colored_map/render_map_flythrough.py
@@ -282,7 +282,8 @@ def render_flythrough(scene: dict, args: argparse.Namespace,
         frames[k] = render_frames(merge_gaussians(culled, traj),
                                   scene['viewmats'][j][None], scene['K'],
                                   scene['width'], scene['height'],
-                                  device=args.device)[0]
+                                  device=args.device,
+                                  soft_edge_px=args.soft_edge_px)[0]
     return frames
 
 
@@ -354,6 +355,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--dry-run', action='store_true',
                    help='build the camera path, print sanity stats and exit')
     p.add_argument('--device', default='cuda')
+    p.add_argument('--soft-edge-px', type=float, default=0.0,
+                   help='CPU-only outer disc fade width in output pixels; 0 off')
     return p
 
 

--- a/tools/gaussian_splatting/render_path.py
+++ b/tools/gaussian_splatting/render_path.py
@@ -174,7 +174,8 @@ def scale_intrinsics(K: np.ndarray, width: int, height: int,
 # --------------------------------------------------------------------------- #
 def render_frames_cpu(gaussians: dict, viewmats: np.ndarray, K: np.ndarray,
                       width: int, height: int, *,
-                      supersample: int = 2) -> np.ndarray:
+                      supersample: int = 2,
+                      soft_edge_px: float = 0.0) -> np.ndarray:
     """CUDA-free rasteriser for band-0 point sets (``sh_rest`` must be None).
 
     Each Gaussian is drawn as an opaque disc whose radius matches its
@@ -183,12 +184,19 @@ def render_frames_cpu(gaussians: dict, viewmats: np.ndarray, K: np.ndarray,
     matches the gsplat look for the near-opaque flat-colour point clouds that
     ``points_to_gaussians`` produces; translucent or anisotropic Gaussian
     sets still need the CUDA path.
+
+    ``soft_edge_px`` adds a fading outer fringe only where the opaque render
+    is still black. Existing surface pixels and depth winners are untouched,
+    avoiding dark halos where a foreground fringe overlaps another disc.
     """
     if gaussians['sh_rest'] is not None:
         raise ValueError('render_frames_cpu only supports sh_rest=None sets')
     if supersample < 1:
         raise ValueError('supersample must be >= 1')
+    if soft_edge_px < 0.0:
+        raise ValueError('soft_edge_px must be >= 0')
     ss = int(supersample)
+    soft_width = int(round(float(soft_edge_px) * ss))
     w2, h2 = int(width) * ss, int(height) * ss
     means = np.asarray(gaussians['means'], dtype=np.float64)
     sigma = np.exp(np.asarray(gaussians['scales_log'], dtype=np.float64)[:, 0])
@@ -197,6 +205,7 @@ def render_frames_cpu(gaussians: dict, viewmats: np.ndarray, K: np.ndarray,
     fx, fy = float(K[0, 0]) * ss, float(K[1, 1]) * ss
     cx, cy = float(K[0, 2]) * ss, float(K[1, 2]) * ss
     max_radius = 4 * ss
+    max_draw_radius = max_radius + soft_width
     depth_shift = np.int64(1) << np.int64(24)
     no_hit = np.iinfo(np.int64).max
     frames = np.empty((len(viewmats), height, width, 3), dtype=np.uint8)
@@ -210,11 +219,13 @@ def render_frames_cpu(gaussians: dict, viewmats: np.ndarray, K: np.ndarray,
         zn = z[near]
         radius = np.clip(np.round(2.0 * sigma[near] * fx / zn).astype(np.int64),
                          1, max_radius)
-        inb = ((u >= -max_radius) & (u < w2 + max_radius) &
-               (v >= -max_radius) & (v < h2 + max_radius))
+        inb = ((u >= -max_draw_radius) & (u < w2 + max_draw_radius) &
+               (v >= -max_draw_radius) & (v < h2 + max_draw_radius))
         u, v, zn, radius = u[inb], v[inb], zn[inb], radius[inb]
         ids = np.flatnonzero(near)[inb]
         buf = np.full(w2 * h2, no_hit, dtype=np.int64)
+        fringe_buf = (np.full(w2 * h2, no_hit, dtype=np.int64)
+                      if soft_width > 0 else None)
         if len(ids):
             # One winner-take-all pass per disc offset: pack (quantized depth,
             # local index) into an int64 so np.minimum.at resolves per-pixel
@@ -227,29 +238,53 @@ def render_frames_cpu(gaussians: dict, viewmats: np.ndarray, K: np.ndarray,
             for r in np.unique(radius):
                 sel = by_radius[np.searchsorted(sorted_radius, r):
                                 np.searchsorted(sorted_radius, r, side='right')]
-                for dy in range(-int(r), int(r) + 1):
-                    for dx in range(-int(r), int(r) + 1):
-                        if dy * dy + dx * dx > r * r:
+                draw_radius = int(r) + soft_width
+                for dy in range(-draw_radius, draw_radius + 1):
+                    for dx in range(-draw_radius, draw_radius + 1):
+                        if dy * dy + dx * dx > draw_radius * draw_radius:
                             continue
                         uu = u[sel] + dx
                         vv = v[sel] + dy
                         ok = (uu >= 0) & (uu < w2) & (vv >= 0) & (vv < h2)
                         if not ok.any():
                             continue
-                        np.minimum.at(buf, vv[ok] * w2 + uu[ok], keys[sel][ok])
+                        target = (fringe_buf if soft_width > 0 and
+                                  dy * dy + dx * dx > r * r else buf)
+                        np.minimum.at(
+                            target, vv[ok] * w2 + uu[ok], keys[sel][ok])
         canvas = np.zeros((w2 * h2, 3), dtype=np.uint8)
         hit = buf != no_hit
-        canvas[hit] = colors[ids[buf[hit] % depth_shift]]
+        winners = buf[hit] % depth_shift
+        canvas[hit] = colors[ids[winners]]
+        if fringe_buf is not None:
+            fringe_hit = (~hit) & (fringe_buf != no_hit)
+            fringe_winners = fringe_buf[fringe_hit] % depth_shift
+            pixels = np.flatnonzero(fringe_hit)
+            px = pixels % w2
+            py = pixels // w2
+            distance = np.hypot(
+                px - u[fringe_winners], py - v[fringe_winners])
+            alpha = np.clip(
+                (radius[fringe_winners] + soft_width - distance) / soft_width,
+                0.0, 1.0)
+            fringe_colours = colors[ids[fringe_winners]].astype(np.float32)
+            canvas[fringe_hit] = np.round(
+                fringe_colours * alpha[:, None]).astype(np.uint8)
         frames[i] = canvas.reshape(height, ss, width, ss, 3) \
             .mean(axis=(1, 3)).astype(np.uint8)
     return frames
 
 
 def render_frames(gaussians: dict, viewmats: np.ndarray, K: np.ndarray,
-                  width: int, height: int, *, device: str = 'cuda') -> np.ndarray:
+                  width: int, height: int, *, device: str = 'cuda',
+                  soft_edge_px: float = 0.0) -> np.ndarray:
     """Rasterise every w2c view; returns uint8 frames (F, H, W, 3)."""
     if device == 'cpu':
-        return render_frames_cpu(gaussians, viewmats, K, width, height)
+        return render_frames_cpu(
+            gaussians, viewmats, K, width, height,
+            soft_edge_px=soft_edge_px)
+    if soft_edge_px != 0.0:
+        raise ValueError('soft_edge_px is only supported by the CPU renderer')
     import torch
     import torch.nn.functional as F
 


### PR DESCRIPTION
## Summary

- add an RTK-SLAM report-only colored-map quality profile and allow quality gates to consume only the reports required by active thresholds
- add planar roughness metrics and gate thresholds for color stability on locally planar surfaces
- add default-off radial vignette correction with bounded gain, plus default-off CPU soft gap filling
- add realtime colored-map evaluation for ROS bag output and preserve legacy coloring compatibility
- add mesh voxel thinning and validate GIS, LAS, and colored mesh exports

## Why

The README flythrough exposed washed-out regions, vignette-darkened samples, sparse black gaps, color bleed, and pepper noise that were not captured by the existing evaluation. Export and realtime validation also lacked a repeatable end-to-end check.

## Root cause

The previous pipeline treated image brightness as spatially uniform, reported global color metrics without planar-surface roughness, required unrelated reports even for report-only profiles, and rendered point splats with hard coverage boundaries. Realtime output and thinned mesh exports had no dedicated evaluators.

## Impact

Defaults preserve the previous output because vignette correction and soft gap filling are opt-in. On the RTK sequence, candidate I improves confirmed color coverage from 0.728 to 0.748 while passing all 11 configured gates. The soft-fill renderer reduces black pixels from 41.58% to 38.43% without overwriting opaque pixels.

## Validation

- `bash scripts/run_default_ci_checks.sh`: 4 packages, 2344 tests, 0 errors, 0 failures, 105 skipped
- focused Python suite: 180 passed
- C++ point colorizer suite: 16 passed
- actual RTK A/B/D/I quality gate: 3 / 3 / 0 / 0 violations
- all-sensors-bag1 realtime A/B evaluation completed without TF or node crash warnings
- GIS, LAS, and BPA colored-mesh export round trips validated
