### PR TITLE
Harden graph SLAM backend architecture

### DIFF
--- a/graph_based_slam/CHANGELOG.rst
+++ b/graph_based_slam/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog for package graph_based_slam
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Serialize event-driven backend work independently of the ROS executor, so
+  composable deployments cannot concurrently mutate ``BackendCore`` or lose a
+  submap notification that arrives while loop search is finishing.
+* Move authoritative map/edge ownership into ``GraphStateStore``. PCD cache
+  writes are staged before atomic state commits, and one immutable snapshot is
+  reused across a batch of loop-search queries instead of deep-copying the
+  complete ``MapArray`` for every query.
+* Hide ``BackendCore``, registration, voxel filtering, and 3D-BBS state behind
+  an implementation-only workspace, keeping g2o, pclomp, and descriptor
+  database headers out of the public ROS component interface.
+
 0.6.0 (2026-06-12)
 ------------------
 * Deterministic core / ROS shell refactor (v0.6 roadmap): the loop-closure

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -198,6 +198,21 @@ if(BUILD_TESTING)
     target_include_directories(test_loop_search_schedule PRIVATE include)
   endif()
   ament_add_gtest(
+    test_serialized_work_drain
+    test/test_serialized_work_drain.cpp
+  )
+  if(TARGET test_serialized_work_drain)
+    target_include_directories(test_serialized_work_drain PRIVATE include)
+  endif()
+  ament_add_gtest(
+    test_graph_state_store
+    test/test_graph_state_store.cpp
+  )
+  if(TARGET test_graph_state_store)
+    target_include_directories(test_graph_state_store PRIVATE include ${EIGEN3_INCLUDE_DIR})
+    ament_target_dependencies(test_graph_state_store lidarslam_msgs)
+  endif()
+  ament_add_gtest(
     test_triangle_descriptor
     test/test_triangle_descriptor.cpp
   )

--- a/graph_based_slam/include/graph_based_slam/backend_core.hpp
+++ b/graph_based_slam/include/graph_based_slam/backend_core.hpp
@@ -57,6 +57,7 @@
 #include <pcl/registration/registration.h>  // NOLINT(build/include_order)
 
 #include "graph_based_slam/candidate_aggregator.hpp"
+#include "graph_based_slam/loop_edge_set.hpp"
 #include "graph_based_slam/loop_verifier.hpp"
 #include "graph_based_slam/scan_context.hpp"
 #include "graph_based_slam/solid_descriptor.hpp"
@@ -111,69 +112,6 @@ struct LoopEdgeProposal
   std::pair<int, int> pair_id{-1, -1};
   Eigen::Isometry3d relative_pose{Eigen::Isometry3d::Identity()};
   double fitness_score{0.0};
-};
-
-// Accepted loop edges with the nearby-pair dedup/upsert policy
-// (semantics pinned by test_backend_core.cpp). Single-threaded by
-// contract like the rest of the core; the shell serializes access.
-class LoopEdgeSet
-{
-public:
-  struct Edge
-  {
-    std::pair<int, int> pair_id{-1, -1};
-    Eigen::Isometry3d relative_pose{Eigen::Isometry3d::Identity()};
-    double fitness_score{0.0};
-  };
-
-  void configure(int dedup_index_window) {dedup_index_window_ = dedup_index_window;}
-
-  // Historical upsertLoopEdge: reject negative/self pairs, normalize the
-  // index order (swap + inverse pose), and against a nearby existing edge
-  // (both indices within the dedup window) keep the better fitness —
-  // a positive existing fitness survives unless the new edge is strictly
-  // better; a non-positive one is always replaced.
-  bool upsert(const Edge & edge)
-  {
-    if (edge.pair_id.first < 0 || edge.pair_id.second < 0) {
-      return false;
-    }
-
-    Edge normalized = edge;
-    if (normalized.pair_id.first > normalized.pair_id.second) {
-      std::swap(normalized.pair_id.first, normalized.pair_id.second);
-      normalized.relative_pose = normalized.relative_pose.inverse();
-    }
-    if (normalized.pair_id.first == normalized.pair_id.second) {
-      return false;
-    }
-
-    auto is_nearby_pair = [this](const Edge & lhs, const Edge & rhs) {
-        return std::abs(lhs.pair_id.first - rhs.pair_id.first) <= dedup_index_window_ &&
-               std::abs(lhs.pair_id.second - rhs.pair_id.second) <= dedup_index_window_;
-      };
-    for (auto & existing : edges_) {
-      if (!is_nearby_pair(existing, normalized)) {
-        continue;
-      }
-      if (existing.fitness_score > 0.0 &&
-        normalized.fitness_score >= existing.fitness_score)
-      {
-        return false;
-      }
-      existing = normalized;
-      return true;
-    }
-
-    edges_.push_back(normalized);
-    return true;
-  }
-
-  const std::vector<Edge> & edges() const {return edges_;}
-
-private:
-  int dedup_index_window_{8};
-  std::vector<Edge> edges_;
 };
 
 struct LoopSearchOutput
@@ -324,9 +262,9 @@ inline double registrationOverlapRatio(
   return registrationOverlapMetrics(aligned_source, target, max_distance_m).source_to_target;
 }
 
-// Backend-owned loop-closure state. Single-threaded by contract: the
-// caller serializes access (today the component's SingleThreadedExecutor,
-// later the shell's processing queue / the offline runner's bag loop).
+// Backend-owned loop-closure state. Single-threaded by contract: the ROS
+// shell enforces this with SerializedWorkDrain and the offline runner owns
+// the core from its bag loop.
 class BackendCore
 {
 public:

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -68,19 +68,16 @@ extern "C" {
 }  // extern "C"
 #endif
 
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Geometry>  // NOLINT(build/include_order)
+#include <pcl/point_cloud.h>  // NOLINT(build/include_order)
 #include <pcl/point_types.h>  // NOLINT(build/include_order)
-#include <pcl/io/pcd_io.h>  // NOLINT(build/include_order)
-#include <pcl/registration/gicp.h>  // NOLINT(build/include_order)
-#include <pcl/registration/ndt.h>  // NOLINT(build/include_order)
-#include <pcl_conversions/pcl_conversions.h>  // NOLINT(build/include_order)
-#include <pclomp/gicp_omp.h>  // NOLINT(build/include_order)
-#include <pclomp/ndt_omp.h>  // NOLINT(build/include_order)
-#include <pclomp/voxel_grid_covariance_omp.h>  // NOLINT(build/include_order)
 #include <tf2_ros/buffer.h>  // NOLINT(build/include_order)
 #include <tf2_ros/transform_broadcaster.h>  // NOLINT(build/include_order)
 #include <tf2_ros/transform_listener.h>  // NOLINT(build/include_order)
 
 #include <fstream>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -99,38 +96,14 @@ extern "C" {
 #include <message_filters/synchronizer.h>  // NOLINT(build/include_order)
 #include <nav_msgs/msg/odometry.hpp>
 #include <nav_msgs/msg/path.hpp>
-#include <pclomp/gicp_omp_impl.hpp>
-#include <pclomp/ndt_omp_impl.hpp>
-#include <pclomp/voxel_grid_covariance_omp_impl.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_srvs/srv/empty.hpp>
-#include <tf2_eigen/tf2_eigen.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
-
-#include "g2o/core/block_solver.h"
-#include "g2o/core/optimization_algorithm_levenberg.h"
-#include "g2o/core/sparse_optimizer.h"
-#include "g2o/solvers/eigen/linear_solver_eigen.h"
-#include "g2o/types/slam3d/edge_se3.h"
-#include "g2o/types/slam3d/edge_se3_pointxyz.h"
-#include "g2o/types/slam3d/parameter_se3_offset.h"
-#include "g2o/types/slam3d/se3quat.h"
-#include "g2o/types/slam3d/vertex_pointxyz.h"
-#include "g2o/types/slam3d/vertex_se3.h"
-#include "graph_based_slam/backend_core.hpp"
-#include "graph_based_slam/candidate_aggregator.hpp"
 #include "graph_based_slam/degeneracy_report_summary.hpp"
 #include "graph_based_slam/gnss_origin_accumulator.hpp"
-#include "graph_based_slam/registration_factory.hpp"
-#include "graph_based_slam/gnss_weighting.hpp"
-#include "graph_based_slam/scan_context.hpp"
-#include "graph_based_slam/solid_descriptor.hpp"
-#include "graph_based_slam/submap_bev_descriptor.hpp"
-#include "graph_based_slam/three_d_bbs_loop_verifier.hpp"
-#include "graph_based_slam/triangle_descriptor_database.hpp"
+#include "graph_based_slam/graph_state_store.hpp"
+#include "graph_based_slam/serialized_work_drain.hpp"
 
 namespace graphslam
 {
@@ -139,31 +112,41 @@ namespace graphslam
 public:
     GS_GBS_PUBLIC
     explicit GraphBasedSlamComponent(const rclcpp::NodeOptions & options);
+    GS_GBS_PUBLIC
+    ~GraphBasedSlamComponent() override;
 
 private:
-    std::mutex mtx_;
+    struct BackendWorkspace;
 
     rclcpp::Clock clock_;
     tf2_ros::Buffer tfbuffer_;
     tf2_ros::TransformListener listener_;
     tf2_ros::TransformBroadcaster broadcaster_;
 
-    boost::shared_ptr < pcl::Registration < pcl::PointXYZI, pcl::PointXYZI >> registration_;
-    pcl::VoxelGrid < pcl::PointXYZI > voxelgrid_;
+    // Compiler firewall for the ROS-free backend, registration engine,
+    // voxel filter and 3D-BBS verifier. Their PCL/pclomp/descriptor headers
+    // stay in the component implementation translation unit.
+    std::unique_ptr < BackendWorkspace > backend_;
+    // BackendWorkspace is single-threaded by contract. Keep that contract
+    // when hosted by a MultiThreadedExecutor, while coalescing arrivals
+    // during a long search.
+    scheduling::SerializedWorkDrain backend_work_drain_;
+    // Serializes ordered input staging (cloud conversion / PCD writes) but
+    // never blocks GraphStateStore snapshots during that I/O.
+    std::mutex submap_ingest_mtx_;
+    GraphStateStore graph_state_;
 
-    // ROS-free backend state (descriptor databases; the search and
-    // optimization orchestration migrate here across Phase 2).
-    backend_core::BackendCore backend_core_;
-
-    lidarslam_msgs::msg::MapArray map_array_msg_;
     rclcpp::Subscription < lidarslam_msgs::msg::MapArray > ::SharedPtr map_array_sub_;
     rclcpp::Publisher < lidarslam_msgs::msg::MapArray > ::SharedPtr modified_map_array_pub_;
     rclcpp::Publisher < nav_msgs::msg::Path > ::SharedPtr modified_path_pub_;
     rclcpp::Publisher < sensor_msgs::msg::PointCloud2 > ::SharedPtr modified_map_pub_;
     rclcpp::Service < std_srvs::srv::Empty > ::SharedPtr map_save_srv_;
 
-    using LoopEdge = backend_core::LoopEdgeSet::Edge;
-    using LoopEdges = std::vector < LoopEdge >;
+    using LoopEdge = GraphStateStore::LoopEdge;
+    using LoopEdges = GraphStateStore::LoopEdges;
+    using PointCloud = pcl::PointCloud < pcl::PointXYZI >;
+    using PointCloudPtr = PointCloud::Ptr;
+    using LocalSubmapProvider = std::function < PointCloudPtr(int) >;
     using MapSaveRequestHeader = std::shared_ptr < rmw_request_id_t >;
     using MapSaveRequest = std::shared_ptr < std_srvs::srv::Empty::Request >;
     using MapSaveResponse = std::shared_ptr < std_srvs::srv::Empty::Response >;
@@ -178,6 +161,7 @@ private:
     // against exactly the map state [0..q] so the result is a function of
     // the data, not of how the executor batched arrivals.
     void runEventDrivenLoopSearch();
+    void drainEventDrivenLoopSearch();
     // Per-query loop search body shared by the event-driven drain.
     void searchLoopForLatest(
       const lidarslam_msgs::msg::MapArray & map_array_msg,
@@ -186,7 +170,7 @@ private:
       int latest_idx);
     // Voxel-filtered local aggregate of a submap and its recent neighbors;
     // the returned provider borrows map_array_msg and must not outlive it.
-    backend_core::BackendCore::LocalSubmapProvider makeFilteredLocalSubmapProvider(
+    LocalSubmapProvider makeFilteredLocalSubmapProvider(
       const lidarslam_msgs::msg::MapArray & map_array_msg);
     bool snapshotGraphState(
       lidarslam_msgs::msg::MapArray & map_array_msg,
@@ -256,10 +240,7 @@ private:
     double adjacent_edge_info_auto_scale_target_nis_trans_ {3.0};
     double adjacent_edge_info_auto_scale_target_nis_rot_ {3.0};
 
-    bool initial_map_array_received_ {false};
     int previous_submaps_num_ {0};
-
-    backend_core::LoopEdgeSet loop_edge_set_;
 
     bool debug_flag_ {false};
 
@@ -267,7 +248,7 @@ private:
     bool use_scan_context_ {false};
     double scan_context_threshold_ {0.3};
     int scan_context_query_stride_ {1};
-    int scan_context_exclude_recent_ {ScanContext::EXCLUDE_RECENT};
+    int scan_context_exclude_recent_ {50};
     bool prefer_scan_context_candidates_ {false};
     bool use_bev_descriptor_ {false};
     double bev_descriptor_threshold_ {0.20};
@@ -383,8 +364,6 @@ private:
     double three_d_bbs_translation_search_margin_m_ {15.0};
     double three_d_bbs_roll_pitch_search_deg_ {10.0};
     double three_d_bbs_yaw_search_deg_ {180.0};
-    ThreeDBBSLoopVerifier three_d_bbs_loop_verifier_;
-
     bool use_dynamic_object_filter_ {false};
     double dynamic_object_filter_voxel_size_ {0.3};
     int dynamic_object_filter_min_observations_ {2};
@@ -400,10 +379,17 @@ private:
     // PCD disk cache for memory-efficient submap storage
     std::string pcd_cache_dir_;
     bool use_pcd_cache_ {false};
-    void saveSubmapToPCD(
+    std::mutex pcd_cache_mtx_;
+    void stageMapArrayCloudCache(lidarslam_msgs::msg::MapArray & map_array_msg);
+    bool saveSubmapToPCD(
+      int idx,
+      const pcl::PointCloud < pcl::PointXYZI > ::Ptr & cloud);
+    bool saveSubmapToPCDUnlocked(
       int idx,
       const pcl::PointCloud < pcl::PointXYZI > ::Ptr & cloud);
     pcl::PointCloud < pcl::PointXYZI > ::Ptr loadSubmapFromPCD(int idx);
+    pcl::PointCloud < pcl::PointXYZI > ::Ptr loadSubmapCloud(
+      const lidarslam_msgs::msg::MapArray & map_array_msg, int idx);
 
     // Autoware-compatible grid-divided PCD map output
     std::string map_save_dir_ {"."};

--- a/graph_based_slam/include/graph_based_slam/graph_state_store.hpp
+++ b/graph_based_slam/include/graph_based_slam/graph_state_store.hpp
@@ -1,0 +1,120 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__GRAPH_STATE_STORE_HPP_
+#define GRAPH_BASED_SLAM__GRAPH_STATE_STORE_HPP_
+
+#include <cstddef>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#include <lidarslam_msgs/msg/map_array.hpp>
+#include <lidarslam_msgs/msg/sub_map.hpp>
+#include <std_msgs/msg/header.hpp>
+
+#include "graph_based_slam/loop_edge_set.hpp"
+
+namespace graphslam
+{
+
+// The ROS shell's authoritative graph input state. Expensive cloud
+// conversion and cache I/O must finish before replace()/append() so readers
+// observe either the previous complete state or the next complete state.
+class GraphStateStore
+{
+public:
+  using LoopEdge = backend_core::LoopEdgeSet::Edge;
+  using LoopEdges = std::vector<LoopEdge>;
+
+  void configureLoopEdgeDedupWindow(int window)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    loop_edges_.configure(window);
+  }
+
+  void replace(lidarslam_msgs::msg::MapArray map_array)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    map_array_ = std::move(map_array);
+    initialized_ = true;
+  }
+
+  std::size_t append(
+    lidarslam_msgs::msg::SubMap submap,
+    const std_msgs::msg::Header & map_header)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    map_array_.header = map_header;
+    map_array_.submaps.push_back(std::move(submap));
+    initialized_ = true;
+    return map_array_.submaps.size();
+  }
+
+  std::size_t submapCount() const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return map_array_.submaps.size();
+  }
+
+  bool snapshot(
+    lidarslam_msgs::msg::MapArray & map_array,
+    LoopEdges & loop_edges) const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!initialized_) {
+      return false;
+    }
+    map_array = map_array_;
+    loop_edges = loop_edges_.edges();
+    return true;
+  }
+
+  LoopEdges snapshotLoopEdges() const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return loop_edges_.edges();
+  }
+
+  bool upsertLoopEdge(const LoopEdge & loop_edge)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return loop_edges_.upsert(loop_edge);
+  }
+
+private:
+  mutable std::mutex mutex_;
+  bool initialized_{false};
+  lidarslam_msgs::msg::MapArray map_array_;
+  backend_core::LoopEdgeSet loop_edges_;
+};
+
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__GRAPH_STATE_STORE_HPP_

--- a/graph_based_slam/include/graph_based_slam/loop_edge_set.hpp
+++ b/graph_based_slam/include/graph_based_slam/loop_edge_set.hpp
@@ -1,0 +1,109 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__LOOP_EDGE_SET_HPP_
+#define GRAPH_BASED_SLAM__LOOP_EDGE_SET_HPP_
+
+#include <cstdlib>
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include <Eigen/Geometry>  // NOLINT(build/include_order)
+
+namespace graphslam
+{
+namespace backend_core
+{
+
+// Accepted loop edges with the nearby-pair dedup/upsert policy. This
+// container is deliberately synchronization-free; BackendCore owns one in
+// offline mode and GraphStateStore protects one in the ROS shell.
+class LoopEdgeSet
+{
+public:
+  struct Edge
+  {
+    std::pair<int, int> pair_id{-1, -1};
+    Eigen::Isometry3d relative_pose{Eigen::Isometry3d::Identity()};
+    double fitness_score{0.0};
+  };
+
+  void configure(int dedup_index_window) {dedup_index_window_ = dedup_index_window;}
+
+  // Reject negative/self pairs, normalize index order (swap + inverse
+  // pose), and keep the better fitness for nearby duplicate pairs.
+  bool upsert(const Edge & edge)
+  {
+    if (edge.pair_id.first < 0 || edge.pair_id.second < 0) {
+      return false;
+    }
+
+    Edge normalized = edge;
+    if (normalized.pair_id.first > normalized.pair_id.second) {
+      std::swap(normalized.pair_id.first, normalized.pair_id.second);
+      normalized.relative_pose = normalized.relative_pose.inverse();
+    }
+    if (normalized.pair_id.first == normalized.pair_id.second) {
+      return false;
+    }
+
+    auto is_nearby_pair = [this](const Edge & lhs, const Edge & rhs) {
+        return std::abs(lhs.pair_id.first - rhs.pair_id.first) <= dedup_index_window_ &&
+               std::abs(lhs.pair_id.second - rhs.pair_id.second) <= dedup_index_window_;
+      };
+    for (auto & existing : edges_) {
+      if (!is_nearby_pair(existing, normalized)) {
+        continue;
+      }
+      if (existing.fitness_score > 0.0 &&
+        normalized.fitness_score >= existing.fitness_score)
+      {
+        return false;
+      }
+      existing = normalized;
+      return true;
+    }
+
+    edges_.push_back(normalized);
+    return true;
+  }
+
+  const std::vector<Edge> & edges() const {return edges_;}
+
+private:
+  int dedup_index_window_{8};
+  std::vector<Edge> edges_;
+};
+
+}  // namespace backend_core
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__LOOP_EDGE_SET_HPP_

--- a/graph_based_slam/include/graph_based_slam/serialized_work_drain.hpp
+++ b/graph_based_slam/include/graph_based_slam/serialized_work_drain.hpp
@@ -1,0 +1,97 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM__SERIALIZED_WORK_DRAIN_HPP_
+#define GRAPH_BASED_SLAM__SERIALIZED_WORK_DRAIN_HPP_
+
+#include <mutex>
+
+namespace graphslam
+{
+namespace scheduling
+{
+
+// Coalesces concurrent notifications into a single serialized drain. The
+// elected caller runs another cycle after one or more notifications arrive
+// while it owns the drain; other callers only mark work pending and return.
+//
+// Work must represent the same drain operation for every caller. It may call
+// request() recursively. Exceptions release ownership and preserve any
+// notification that arrived concurrently for a later request to retry.
+class SerializedWorkDrain
+{
+public:
+  SerializedWorkDrain() = default;
+  SerializedWorkDrain(const SerializedWorkDrain &) = delete;
+  SerializedWorkDrain & operator=(const SerializedWorkDrain &) = delete;
+
+  template<typename WorkT>
+  void request(WorkT && work)
+  {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      pending_ = true;
+      if (draining_) {
+        return;
+      }
+      draining_ = true;
+    }
+
+    try {
+      while (beginCycle()) {
+        work();
+      }
+    } catch (...) {
+      std::lock_guard<std::mutex> lock(mutex_);
+      draining_ = false;
+      throw;
+    }
+  }
+
+private:
+  bool beginCycle()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!pending_) {
+      draining_ = false;
+      return false;
+    }
+    pending_ = false;
+    return true;
+  }
+
+  std::mutex mutex_;
+  bool draining_ {false};
+  bool pending_ {false};
+};
+
+}  // namespace scheduling
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM__SERIALIZED_WORK_DRAIN_HPP_

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -36,18 +36,28 @@
 #include <fstream>
 #include <unordered_map>
 
+#include <pcl/io/pcd_io.h>  // NOLINT(build/include_order)
+#include <pcl/filters/voxel_grid.h>  // NOLINT(build/include_order)
+#include <pcl_conversions/pcl_conversions.h>  // NOLINT(build/include_order)
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
+
 #include "graph_based_slam/adjacent_edge_auto_scale.hpp"
+#include "graph_based_slam/backend_core.hpp"
 #include "graph_based_slam/bev_mutual_visibility.hpp"
 #include "graph_based_slam/candidate_aggregator.hpp"
 #include "graph_based_slam/degeneracy_diagnostics_csv.hpp"
 #include "graph_based_slam/dynamic_object_filter.hpp"
 #include "graph_based_slam/gnss_alignment.hpp"
 #include "graph_based_slam/gnss_geometry.hpp"
+#include "graph_based_slam/gnss_weighting.hpp"
 #include "graph_based_slam/loop_verifier.hpp"
 #include "graph_based_slam/loop_search_schedule.hpp"
 #include "graph_based_slam/map_saver.hpp"
 #include "graph_based_slam/planar_map_filter.hpp"
 #include "graph_based_slam/pose_graph_optimization.hpp"
+#include "graph_based_slam/registration_factory.hpp"
 #include "graph_based_slam/submap_creation.hpp"
 #include "g2o/core/robust_kernel_impl.h"
 #define GRAPH_BASED_SLAM_WITH_G2O 1
@@ -57,12 +67,21 @@ using namespace std::chrono_literals;
 
 namespace graphslam
 {
+struct GraphBasedSlamComponent::BackendWorkspace
+{
+  backend_core::BackendCore core;
+  boost::shared_ptr<pcl::Registration<pcl::PointXYZI, pcl::PointXYZI>> registration;
+  pcl::VoxelGrid<pcl::PointXYZI> voxelgrid;
+  ThreeDBBSLoopVerifier three_d_bbs_loop_verifier;
+};
+
 GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & options)
 : Node("graph_based_slam", options),
   clock_(RCL_ROS_TIME),
   tfbuffer_(std::make_shared<rclcpp::Clock>(clock_)),
   listener_(tfbuffer_),
-  broadcaster_(this)
+  broadcaster_(this),
+  backend_(std::make_unique<BackendWorkspace>())
 {
   RCLCPP_INFO(get_logger(), "initialization start");
   std::string registration_method;
@@ -523,7 +542,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       loop_edge_dedup_index_window_);
     loop_edge_dedup_index_window_ = 0;
   }
-  loop_edge_set_.configure(loop_edge_dedup_index_window_);
+  graph_state_.configureLoopEdgeDedupWindow(loop_edge_dedup_index_window_);
   if (loop_max_translation_delta_ <= 0.0) {
     RCLCPP_WARN(
       get_logger(),
@@ -1200,11 +1219,11 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   }
   std::cout << "------------------" << std::endl;
 
-  voxelgrid_.setLeafSize(voxel_leaf_size, voxel_leaf_size, voxel_leaf_size);
+  backend_->voxelgrid.setLeafSize(voxel_leaf_size, voxel_leaf_size, voxel_leaf_size);
 
-  registration_ =
+  backend_->registration =
     backend_core::makeLoopRegistration(registration_method, ndt_resolution, ndt_num_threads);
-  if (!registration_) {
+  if (!backend_->registration) {
     RCLCPP_ERROR(get_logger(), "invalid registration_method");
     exit(1);
   }
@@ -1238,7 +1257,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   descriptor_config.triangle_descriptor_edge_bin_m = triangle_descriptor_edge_bin_m_;
   descriptor_config.triangle_descriptor_quad_feature_bin_m =
     triangle_descriptor_quad_feature_bin_m_;
-  backend_core_.configure(descriptor_config);
+  backend_->core.configure(descriptor_config);
 
   initializePubSub();
 
@@ -1252,6 +1271,8 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       std::placeholders::_3));
 }  // NOLINT(readability/fn_size)
 
+GraphBasedSlamComponent::~GraphBasedSlamComponent() = default;
+
 void GraphBasedSlamComponent::initializePubSub()
 {
   RCLCPP_INFO(get_logger(), "initialize Publishers and Subscribers");
@@ -1260,23 +1281,15 @@ void GraphBasedSlamComponent::initializePubSub()
     [this](const typename lidarslam_msgs::msg::MapArray::SharedPtr msg_ptr) -> void
     {
       {
-        std::lock_guard<std::mutex> lock(mtx_);
-        map_array_msg_ = *msg_ptr;
-        // Save new submaps to PCD and clear cloud from memory
+        // Preserve input order, but stage expensive conversion and compressed
+        // PCD writes outside GraphStateStore's snapshot mutex. Readers keep
+        // seeing the previous complete graph until the move-only commit.
+        std::lock_guard<std::mutex> ingest_lock(submap_ingest_mtx_);
+        lidarslam_msgs::msg::MapArray staged_map = *msg_ptr;
         if (use_pcd_cache_) {
-          for (int i = 0; i < static_cast<int>(map_array_msg_.submaps.size()); i++) {
-            auto & sub = map_array_msg_.submaps[i];
-            if (sub.cloud.data.size() > 0) {
-              pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
-              pcl::fromROSMsg(sub.cloud, *cloud);
-              if (cloud->size() > 0) {
-                saveSubmapToPCD(i, cloud);
-                sub.cloud = sensor_msgs::msg::PointCloud2();  // Free memory
-              }
-            }
-          }
+          stageMapArrayCloudCache(staged_map);
         }
-        initial_map_array_received_ = true;
+        graph_state_.replace(std::move(staged_map));
       }
       runEventDrivenLoopSearch();
     };
@@ -1368,28 +1381,19 @@ bool GraphBasedSlamComponent::snapshotGraphState(
   lidarslam_msgs::msg::MapArray & map_array_msg,
   LoopEdges & loop_edges)
 {
-  std::lock_guard<std::mutex> lock(mtx_);
-  if (!initial_map_array_received_) {
-    return false;
-  }
-
-  map_array_msg = map_array_msg_;
-  loop_edges = loop_edge_set_.edges();
-  return true;
+  return graph_state_.snapshot(map_array_msg, loop_edges);
 }
 
 void GraphBasedSlamComponent::snapshotLoopEdges(LoopEdges & loop_edges)
 {
-  std::lock_guard<std::mutex> lock(mtx_);
-  loop_edges = loop_edge_set_.edges();
+  loop_edges = graph_state_.snapshotLoopEdges();
 }
 
 bool GraphBasedSlamComponent::upsertLoopEdge(const LoopEdge & loop_edge)
 {
-  std::lock_guard<std::mutex> lock(mtx_);
-  return loop_edge_set_.upsert(loop_edge);
+  return graph_state_.upsertLoopEdge(loop_edge);
 }
-backend_core::BackendCore::LocalSubmapProvider
+GraphBasedSlamComponent::LocalSubmapProvider
 GraphBasedSlamComponent::makeFilteredLocalSubmapProvider(
   const lidarslam_msgs::msg::MapArray & map_array_msg)
 {
@@ -1400,13 +1404,8 @@ GraphBasedSlamComponent::makeFilteredLocalSubmapProvider(
            tf2::fromMsg(map_array_msg.submaps[ref_idx].pose, reference_affine);
            for (int k = 0; k < search_submap_num_ && (ref_idx - k) >= 0; ++k) {
              const int src_idx = ref_idx - k;
-             pcl::PointCloud<pcl::PointXYZI>::Ptr cloud;
-             if (use_pcd_cache_) {
-               cloud = loadSubmapFromPCD(src_idx);
-             } else {
-               cloud.reset(new pcl::PointCloud<pcl::PointXYZI>);
-               pcl::fromROSMsg(map_array_msg.submaps[src_idx].cloud, *cloud);
-             }
+             pcl::PointCloud<pcl::PointXYZI>::Ptr cloud =
+               loadSubmapCloud(map_array_msg, src_idx);
              if (!cloud || cloud->empty()) {
                continue;
              }
@@ -1425,13 +1424,20 @@ GraphBasedSlamComponent::makeFilteredLocalSubmapProvider(
            if (aggregated_cloud->empty()) {
              return filtered_cloud;
            }
-           voxelgrid_.setInputCloud(aggregated_cloud);
-           voxelgrid_.filter(*filtered_cloud);
+           backend_->voxelgrid.setInputCloud(aggregated_cloud);
+           backend_->voxelgrid.filter(*filtered_cloud);
            return filtered_cloud;
          };
 }
 
 void GraphBasedSlamComponent::runEventDrivenLoopSearch()
+{
+  // A component may be hosted by a MultiThreadedExecutor. Elect one callback
+  // to own BackendCore and coalesce notifications that arrive while it drains.
+  backend_work_drain_.request([this]() {drainEventDrivenLoopSearch();});
+}
+
+void GraphBasedSlamComponent::drainEventDrivenLoopSearch()
 {
   while (rclcpp::ok()) {
     lidarslam_msgs::msg::MapArray map_array_msg;
@@ -1445,26 +1451,26 @@ void GraphBasedSlamComponent::runEventDrivenLoopSearch()
     if (map_array_msg.cloud_coordinate != map_array_msg.LOCAL) {
       RCLCPP_WARN(get_logger(), "cloud_coordinate should be local, but it's not local.");
     }
-    if (debug_flag_) {
-      RCLCPP_INFO(
-        get_logger(), "event-driven loop search, query submap %d of %d", query_idx,
-        num_submaps);
-    }
-    // The query for submap q runs against exactly the map state [0..q]:
-    // descriptor ingestion, candidate generation and the accepted-edge pose
-    // adjustment are functions of the data up to q, independent of how the
-    // executor batched arrivals (the v0.4 D1 nondeterminism root cause).
-    map_array_msg.submaps.resize(query_idx + 1);
     const auto build_filtered_local_submap = makeFilteredLocalSubmapProvider(map_array_msg);
-    backend_core_.ingestDescriptors(query_idx + 1, build_filtered_local_submap);
-    if (loop_search_schedule::shouldSearch(query_idx, loop_search_query_stride_)) {
-      searchLoopForLatest(map_array_msg, loop_edges, query_idx + 1, query_idx);
-    } else if (debug_flag_) {
-      RCLCPP_INFO(
-        get_logger(), "loop search registration skipped for query submap %d by stride %d",
-        query_idx, loop_search_query_stride_);
+    // One immutable snapshot serves the whole currently available batch.
+    // Each search receives an explicit prefix length, avoiding one full
+    // MapArray deep-copy per query without exposing future submaps to q.
+    for (; query_idx < num_submaps && rclcpp::ok(); ++query_idx) {
+      if (debug_flag_) {
+        RCLCPP_INFO(
+          get_logger(), "event-driven loop search, query submap %d of %d", query_idx,
+          num_submaps);
+      }
+      backend_->core.ingestDescriptors(query_idx + 1, build_filtered_local_submap);
+      if (loop_search_schedule::shouldSearch(query_idx, loop_search_query_stride_)) {
+        searchLoopForLatest(map_array_msg, loop_edges, query_idx + 1, query_idx);
+      } else if (debug_flag_) {
+        RCLCPP_INFO(
+          get_logger(), "loop search registration skipped for query submap %d by stride %d",
+          query_idx, loop_search_query_stride_);
+      }
+      last_searched_submap_idx_ = query_idx;
     }
-    last_searched_submap_idx_ = query_idx;
   }
 }
 
@@ -1474,10 +1480,13 @@ void GraphBasedSlamComponent::searchLoopForLatest(
   int num_submaps,
   int latest_idx)
 {
-  static_cast<void>(num_submaps);
+  if (num_submaps < 1 || num_submaps > static_cast<int>(map_array_msg.submaps.size())) {
+    return;
+  }
   std::vector<backend_core::SubmapMeta> submaps;
-  submaps.reserve(map_array_msg.submaps.size());
-  for (const auto & submap : map_array_msg.submaps) {
+  submaps.reserve(num_submaps);
+  for (int i = 0; i < num_submaps; ++i) {
+    const auto & submap = map_array_msg.submaps[i];
     backend_core::SubmapMeta meta;
     tf2::fromMsg(submap.pose, meta.pose);
     meta.travel_distance = submap.distance;
@@ -1486,12 +1495,7 @@ void GraphBasedSlamComponent::searchLoopForLatest(
 
   const auto raw_cloud_provider =
     [this, &map_array_msg](int idx) -> pcl::PointCloud<pcl::PointXYZI>::Ptr {
-      if (use_pcd_cache_) {
-        return loadSubmapFromPCD(idx);
-      }
-      pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
-      pcl::fromROSMsg(map_array_msg.submaps[idx].cloud, *cloud);
-      return cloud;
+      return loadSubmapCloud(map_array_msg, idx);
     };
 
   backend_core::LoopSearchConfig search_config;
@@ -1577,14 +1581,14 @@ void GraphBasedSlamComponent::searchLoopForLatest(
   gate_config.max_translation_descriptor_m = loop_max_translation_delta_descriptor_;
   gate_config.max_rotation_descriptor_deg = loop_max_rotation_delta_deg_descriptor_;
 
-  const backend_core::LoopSearchOutput search_output = backend_core_.searchLoopForSubmap(
+  const backend_core::LoopSearchOutput search_output = backend_->core.searchLoopForSubmap(
     submaps,
     latest_idx,
     search_config,
     raw_cloud_provider,
-    *registration_,
-    voxelgrid_,
-    three_d_bbs_loop_verifier_);
+    *backend_->registration,
+    backend_->voxelgrid,
+    backend_->three_d_bbs_loop_verifier);
 
   for (const auto & line : search_output.logs) {
     if (line.via_logger) {
@@ -1608,7 +1612,12 @@ void GraphBasedSlamComponent::searchLoopForLatest(
     return;
   }
   snapshotLoopEdges(loop_edges);
-  doPoseAdjustment(map_array_msg, loop_edges, use_save_map_in_loop_);
+  lidarslam_msgs::msg::MapArray query_prefix;
+  query_prefix.header = map_array_msg.header;
+  query_prefix.cloud_coordinate = map_array_msg.cloud_coordinate;
+  query_prefix.submaps.assign(
+    map_array_msg.submaps.begin(), map_array_msg.submaps.begin() + num_submaps);
+  doPoseAdjustment(std::move(query_prefix), loop_edges, use_save_map_in_loop_);
 }
 
 void GraphBasedSlamComponent::doPoseAdjustment(
@@ -1870,13 +1879,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
     Eigen::Affine3d previous_affine;
     tf2::fromMsg(map_array_msg.submaps[i].pose, previous_affine);
 
-    pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_ptr;
-    if (use_pcd_cache_) {
-      cloud_ptr = loadSubmapFromPCD(i);
-    } else {
-      cloud_ptr.reset(new pcl::PointCloud<pcl::PointXYZI>);
-      pcl::fromROSMsg(map_array_msg.submaps[i].cloud, *cloud_ptr);
-    }
+    pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_ptr = loadSubmapCloud(map_array_msg, i);
     pcl::PointCloud<pcl::PointXYZI>::Ptr transformed_cloud_ptr(
       new pcl::PointCloud<pcl::PointXYZI>());
 
@@ -2189,6 +2192,7 @@ void GraphBasedSlamComponent::tryCreateSubmap(
   const nav_msgs::msg::Odometry & odom_msg,
   const sensor_msgs::msg::PointCloud2 & cloud_msg)
 {
+  std::unique_lock<std::mutex> ingest_lock(submap_ingest_mtx_);
   Eigen::Vector3d pos(
     odom_msg.pose.pose.position.x,
     odom_msg.pose.pose.position.y,
@@ -2211,25 +2215,19 @@ void GraphBasedSlamComponent::tryCreateSubmap(
   submap.cloud = cloud_msg;
   submap.cloud.header.frame_id = odom_msg.child_frame_id;
 
-  int n;
-  {
-    std::lock_guard<std::mutex> lock(mtx_);
-    map_array_msg_.header.stamp = odom_msg.header.stamp;
-    map_array_msg_.header.frame_id = "map";
-    map_array_msg_.submaps.push_back(submap);
-    n = map_array_msg_.submaps.size();
-
-    // Save to PCD and clear cloud from memory
-    if (use_pcd_cache_) {
-      pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
-      pcl::fromROSMsg(submap.cloud, *cloud);
-      saveSubmapToPCD(n - 1, cloud);
-      // Clear cloud data from memory (keep pose and metadata)
-      map_array_msg_.submaps.back().cloud = sensor_msgs::msg::PointCloud2();
+  const int submap_idx = static_cast<int>(graph_state_.submapCount());
+  if (use_pcd_cache_) {
+    pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
+    pcl::fromROSMsg(submap.cloud, *cloud);
+    if (saveSubmapToPCD(submap_idx, cloud)) {
+      submap.cloud = sensor_msgs::msg::PointCloud2();
     }
-
-    initial_map_array_received_ = true;
   }
+  std_msgs::msg::Header map_header;
+  map_header.stamp = odom_msg.header.stamp;
+  map_header.frame_id = "map";
+  const int n = static_cast<int>(graph_state_.append(std::move(submap), map_header));
+  ingest_lock.unlock();
 
   if (n % 50 == 0) {
     RCLCPP_INFO(get_logger(), "Odom input: %d submaps, distance: %.1fm", n, accumulated_distance_);
@@ -2238,20 +2236,70 @@ void GraphBasedSlamComponent::tryCreateSubmap(
   runEventDrivenLoopSearch();
 }
 
-void GraphBasedSlamComponent::saveSubmapToPCD(
+void GraphBasedSlamComponent::stageMapArrayCloudCache(
+  lidarslam_msgs::msg::MapArray & map_array_msg)
+{
+  // Treat a full MapArray cache refresh as one repository transaction so
+  // backend readers never observe a mixture of old and newly written files.
+  std::lock_guard<std::mutex> cache_lock(pcd_cache_mtx_);
+  for (int i = 0; i < static_cast<int>(map_array_msg.submaps.size()); ++i) {
+    auto & submap = map_array_msg.submaps[i];
+    if (submap.cloud.data.empty()) {
+      continue;
+    }
+    pcl::PointCloud<pcl::PointXYZI>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZI>);
+    pcl::fromROSMsg(submap.cloud, *cloud);
+    if (!cloud->empty() && saveSubmapToPCDUnlocked(i, cloud)) {
+      submap.cloud = sensor_msgs::msg::PointCloud2();
+    }
+  }
+}
+
+bool GraphBasedSlamComponent::saveSubmapToPCD(
+  int idx,
+  const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud)
+{
+  std::lock_guard<std::mutex> cache_lock(pcd_cache_mtx_);
+  return saveSubmapToPCDUnlocked(idx, cloud);
+}
+
+bool GraphBasedSlamComponent::saveSubmapToPCDUnlocked(
   int idx,
   const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud)
 {
   std::string path = map_saver::submapCachePath(pcd_cache_dir_, idx);
-  pcl::io::savePCDFileBinaryCompressed(path, *cloud);
+  if (pcl::io::savePCDFileBinaryCompressed(path, *cloud) == 0) {
+    return true;
+  }
+  RCLCPP_WARN(get_logger(), "Failed to save PCD: %s", path.c_str());
+  return false;
 }
 
 pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::loadSubmapFromPCD(int idx)
 {
+  std::lock_guard<std::mutex> cache_lock(pcd_cache_mtx_);
   auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
   std::string path = map_saver::submapCachePath(pcd_cache_dir_, idx);
   if (pcl::io::loadPCDFile(path, *cloud) == -1) {
     RCLCPP_WARN(get_logger(), "Failed to load PCD: %s", path.c_str());
+  }
+  return cloud;
+}
+
+pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::loadSubmapCloud(
+  const lidarslam_msgs::msg::MapArray & map_array_msg,
+  int idx)
+{
+  pcl::PointCloud<pcl::PointXYZI>::Ptr cloud;
+  if (use_pcd_cache_) {
+    cloud = loadSubmapFromPCD(idx);
+    if (!cloud->empty()) {
+      return cloud;
+    }
+  }
+  cloud.reset(new pcl::PointCloud<pcl::PointXYZI>);
+  if (idx >= 0 && idx < static_cast<int>(map_array_msg.submaps.size())) {
+    pcl::fromROSMsg(map_array_msg.submaps[idx].cloud, *cloud);
   }
   return cloud;
 }

--- a/graph_based_slam/test/test_graph_state_store.cpp
+++ b/graph_based_slam/test/test_graph_state_store.cpp
@@ -1,0 +1,147 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+#include <utility>
+
+#include "graph_based_slam/graph_state_store.hpp"
+
+TEST(GraphStateStore, IsEmptyUntilTheFirstCompleteStateIsCommitted)
+{
+  graphslam::GraphStateStore store;
+  lidarslam_msgs::msg::MapArray map_array;
+  graphslam::GraphStateStore::LoopEdges loop_edges;
+
+  EXPECT_FALSE(store.snapshot(map_array, loop_edges));
+
+  store.replace(lidarslam_msgs::msg::MapArray());
+  EXPECT_TRUE(store.snapshot(map_array, loop_edges));
+  EXPECT_TRUE(map_array.submaps.empty());
+}
+
+TEST(GraphStateStore, ReplaceAndSnapshotDoNotAliasCallerOwnedMessages)
+{
+  graphslam::GraphStateStore store;
+  lidarslam_msgs::msg::MapArray input;
+  input.header.frame_id = "map";
+  input.submaps.resize(1);
+  input.submaps[0].distance = 12.5;
+  store.replace(std::move(input));
+
+  lidarslam_msgs::msg::MapArray first_snapshot;
+  graphslam::GraphStateStore::LoopEdges loop_edges;
+  ASSERT_TRUE(store.snapshot(first_snapshot, loop_edges));
+  first_snapshot.submaps[0].distance = 99.0;
+
+  lidarslam_msgs::msg::MapArray second_snapshot;
+  ASSERT_TRUE(store.snapshot(second_snapshot, loop_edges));
+  EXPECT_EQ(second_snapshot.header.frame_id, "map");
+  ASSERT_EQ(second_snapshot.submaps.size(), 1U);
+  EXPECT_DOUBLE_EQ(second_snapshot.submaps[0].distance, 12.5);
+}
+
+TEST(GraphStateStore, AppendCommitsMapHeaderAndSubmapTogether)
+{
+  graphslam::GraphStateStore store;
+  std_msgs::msg::Header header;
+  header.frame_id = "map";
+  header.stamp.sec = 42;
+  lidarslam_msgs::msg::SubMap submap;
+  submap.distance = 3.0;
+
+  EXPECT_EQ(store.append(std::move(submap), header), 1U);
+
+  lidarslam_msgs::msg::MapArray snapshot;
+  graphslam::GraphStateStore::LoopEdges loop_edges;
+  ASSERT_TRUE(store.snapshot(snapshot, loop_edges));
+  EXPECT_EQ(snapshot.header.frame_id, "map");
+  EXPECT_EQ(snapshot.header.stamp.sec, 42);
+  ASSERT_EQ(snapshot.submaps.size(), 1U);
+  EXPECT_DOUBLE_EQ(snapshot.submaps[0].distance, 3.0);
+}
+
+TEST(GraphStateStore, SnapshotKeepsMapAndAcceptedEdgesInOneCriticalSection)
+{
+  graphslam::GraphStateStore store;
+  store.configureLoopEdgeDedupWindow(0);
+  store.replace(lidarslam_msgs::msg::MapArray());
+  graphslam::GraphStateStore::LoopEdge edge;
+  edge.pair_id = {1, 4};
+  edge.fitness_score = 0.2;
+  ASSERT_TRUE(store.upsertLoopEdge(edge));
+
+  lidarslam_msgs::msg::MapArray snapshot;
+  graphslam::GraphStateStore::LoopEdges loop_edges;
+  ASSERT_TRUE(store.snapshot(snapshot, loop_edges));
+  ASSERT_EQ(loop_edges.size(), 1U);
+  EXPECT_EQ(loop_edges[0].pair_id, std::make_pair(1, 4));
+}
+
+TEST(GraphStateStore, ConcurrentAppendAndSnapshotRemainConsistent)
+{
+  graphslam::GraphStateStore store;
+  store.replace(lidarslam_msgs::msg::MapArray());
+  std::atomic<bool> writer_done{false};
+  std::atomic<bool> inconsistent_snapshot{false};
+
+  std::thread writer(
+    [&]() {
+      for (int i = 1; i <= 100; ++i) {
+        std_msgs::msg::Header header;
+        header.stamp.sec = i;
+        lidarslam_msgs::msg::SubMap submap;
+        submap.distance = static_cast<double>(i);
+        store.append(std::move(submap), header);
+      }
+      writer_done = true;
+    });
+
+  while (!writer_done.load()) {
+    lidarslam_msgs::msg::MapArray snapshot;
+    graphslam::GraphStateStore::LoopEdges loop_edges;
+    if (!store.snapshot(snapshot, loop_edges)) {
+      inconsistent_snapshot = true;
+      break;
+    }
+    if (!snapshot.submaps.empty() &&
+      snapshot.header.stamp.sec != static_cast<int32_t>(snapshot.submaps.size()))
+    {
+      inconsistent_snapshot = true;
+      break;
+    }
+  }
+  writer.join();
+
+  EXPECT_FALSE(inconsistent_snapshot.load());
+  EXPECT_EQ(store.submapCount(), 100U);
+}

--- a/graph_based_slam/test/test_serialized_work_drain.cpp
+++ b/graph_based_slam/test/test_serialized_work_drain.cpp
@@ -1,0 +1,125 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+
+#include "graph_based_slam/serialized_work_drain.hpp"
+
+using graphslam::scheduling::SerializedWorkDrain;
+
+TEST(SerializedWorkDrain, RunsOneCycleForARequest)
+{
+  SerializedWorkDrain drain;
+  int cycles = 0;
+
+  drain.request([&cycles]() {++cycles;});
+
+  EXPECT_EQ(cycles, 1);
+}
+
+TEST(SerializedWorkDrain, RecursiveRequestIsCoalescedAfterTheCurrentCycle)
+{
+  SerializedWorkDrain drain;
+  int cycles = 0;
+
+  drain.request(
+    [&]() {
+      ++cycles;
+      if (cycles == 1) {
+        drain.request([&cycles]() {++cycles;});
+      }
+    });
+
+  EXPECT_EQ(cycles, 2);
+}
+
+TEST(SerializedWorkDrain, ConcurrentRequestNeverRunsWorkConcurrentlyOrGetsLost)
+{
+  SerializedWorkDrain drain;
+  std::mutex gate_mutex;
+  std::condition_variable gate_cv;
+  bool first_cycle_started = false;
+  bool release_first_cycle = false;
+  std::atomic<int> cycles {0};
+  std::atomic<int> active_workers {0};
+  std::atomic<int> maximum_active_workers {0};
+
+  const auto work = [&]() {
+      const int active = ++active_workers;
+      int previous_maximum = maximum_active_workers.load();
+      while (
+        active > previous_maximum &&
+        !maximum_active_workers.compare_exchange_weak(previous_maximum, active)) {}
+      const int cycle = ++cycles;
+      if (cycle == 1) {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        first_cycle_started = true;
+        gate_cv.notify_all();
+        gate_cv.wait(lock, [&release_first_cycle]() {return release_first_cycle;});
+      }
+      --active_workers;
+    };
+
+  std::thread owner([&]() {drain.request(work);});
+  {
+    std::unique_lock<std::mutex> lock(gate_mutex);
+    gate_cv.wait(lock, [&first_cycle_started]() {return first_cycle_started;});
+  }
+
+  std::thread notifier([&]() {drain.request(work);});
+  notifier.join();
+  {
+    std::lock_guard<std::mutex> lock(gate_mutex);
+    release_first_cycle = true;
+  }
+  gate_cv.notify_all();
+  owner.join();
+
+  EXPECT_EQ(cycles.load(), 2);
+  EXPECT_EQ(maximum_active_workers.load(), 1);
+}
+
+TEST(SerializedWorkDrain, ExceptionReleasesOwnershipForTheNextRequest)
+{
+  SerializedWorkDrain drain;
+  EXPECT_THROW(
+    drain.request([]() {throw std::runtime_error("drain failed");}),
+    std::runtime_error);
+
+  int cycles = 0;
+  drain.request([&cycles]() {++cycles;});
+
+  EXPECT_EQ(cycles, 1);
+}


### PR DESCRIPTION
## Summary

- serialize event-driven backend work independently of ROS executor callback-group behavior
- move authoritative map and accepted-loop-edge ownership into an atomic `GraphStateStore`
- stage PCD cache updates before graph commits and reuse immutable snapshots across query batches
- hide `BackendCore`, registration, voxel filtering, 3D-BBS, g2o, pclomp, and descriptor database implementation details behind an opaque backend workspace
- add focused concurrency and state-consistency tests

## Why

The graph SLAM component previously relied on executor scheduling for backend serialization and split authoritative graph state across multiple independently locked members. That allowed architecture-level race and consistency risks under composable multi-threaded execution, while the public component header exposed heavy backend implementation dependencies.

This change makes backend execution and graph-state ownership explicit, preserves deterministic query-prefix semantics, and narrows the public compile boundary without changing the runtime algorithm.

## Validation

- `graph_based_slam`: 153/153 tests passed
- default CI: 2383 tests, 0 errors, 0 failures, 110 skipped
- `git diff --check`
