### PR TITLE
Complete Graph SLAM component PImpl boundary

### DIFF
--- a/graph_based_slam/CHANGELOG.rst
+++ b/graph_based_slam/CHANGELOG.rst
@@ -14,6 +14,9 @@ Forthcoming
 * Hide ``BackendCore``, registration, voxel filtering, and 3D-BBS state behind
   an implementation-only workspace, keeping g2o, pclomp, and descriptor
   database headers out of the public ROS component interface.
+* Complete the component PImpl boundary: ROS subscriptions, configuration,
+  graph state, and sensor/cache implementation details now live in a private
+  source header, reducing the installed component header from 518 to 78 lines.
 
 0.6.0 (2026-06-12)
 ------------------

--- a/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
+++ b/graph_based_slam/include/graph_based_slam/graph_based_slam_component.h
@@ -10,9 +10,9 @@
 //  * Redistributions of source code must retain the above copyright
 //    notice, this list of conditions and the following disclaimer.
 //  * Redistributions in binary form must reproduce the above
-//    copyright notice, this list of conditions and the following
-//    disclaimer in the documentation and/or other materials provided
-//    with the distribution.
+//    copyright notice, this list of conditions and the following disclaimer
+//    in the documentation and/or other materials provided with the
+//    distribution.
 //
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -30,12 +30,10 @@
 #ifndef GRAPH_BASED_SLAM__GRAPH_BASED_SLAM_COMPONENT_H_
 #define GRAPH_BASED_SLAM__GRAPH_BASED_SLAM_COMPONENT_H_
 
-#if __cplusplus
-extern "C" {
-#endif
+#include <memory>
 
-// The below macros are taken from https://gcc.gnu.org/wiki/Visibility and from
-// demos/composition/include/composition/visibility_control.h at https://github.com/ros2/demos
+#include <rclcpp/rclcpp.hpp>
+
 #if defined _WIN32 || defined __CYGWIN__
   #ifdef __GNUC__
     #define GS_GBS_EXPORT __attribute__ ((dllexport))
@@ -49,64 +47,19 @@ extern "C" {
   #else
     #define GS_GBS_PUBLIC GS_GBS_IMPORT
   #endif
-  #define GS_GBS_PUBLIC_TYPE GS_GBS_PUBLIC
-  #define GS_GBS_LOCAL
 #else
   #define GS_GBS_EXPORT __attribute__ ((visibility("default")))
   #define GS_GBS_IMPORT
   #if __GNUC__ >= 4
     #define GS_GBS_PUBLIC __attribute__ ((visibility("default")))
-    #define GS_GBS_LOCAL  __attribute__ ((visibility("hidden")))
   #else
     #define GS_GBS_PUBLIC
-    #define GS_GBS_LOCAL
   #endif
-  #define GS_GBS_PUBLIC_TYPE
 #endif
-
-#if __cplusplus
-}  // extern "C"
-#endif
-
-#include <Eigen/Core>  // NOLINT(build/include_order)
-#include <Eigen/Geometry>  // NOLINT(build/include_order)
-#include <pcl/point_cloud.h>  // NOLINT(build/include_order)
-#include <pcl/point_types.h>  // NOLINT(build/include_order)
-#include <tf2_ros/buffer.h>  // NOLINT(build/include_order)
-#include <tf2_ros/transform_broadcaster.h>  // NOLINT(build/include_order)
-#include <tf2_ros/transform_listener.h>  // NOLINT(build/include_order)
-
-#include <fstream>
-#include <functional>
-#include <memory>
-#include <mutex>
-#include <string>
-#include <utility>
-#include <vector>
-
-#include <rclcpp/rclcpp.hpp>
-
-#include <geometry_msgs/msg/point.hpp>
-#include <geometry_msgs/msg/pose_stamped.hpp>
-#include <geometry_msgs/msg/transform.hpp>
-#include <geometry_msgs/msg/transform_stamped.hpp>
-#include <lidarslam_msgs/msg/map_array.hpp>
-#include <message_filters/subscriber.h>  // NOLINT(build/include_order)
-#include <message_filters/sync_policies/approximate_time.h>  // NOLINT(build/include_order)
-#include <message_filters/synchronizer.h>  // NOLINT(build/include_order)
-#include <nav_msgs/msg/odometry.hpp>
-#include <nav_msgs/msg/path.hpp>
-#include <sensor_msgs/msg/imu.hpp>
-#include <sensor_msgs/msg/nav_sat_fix.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <std_srvs/srv/empty.hpp>
-#include "graph_based_slam/degeneracy_report_summary.hpp"
-#include "graph_based_slam/gnss_origin_accumulator.hpp"
-#include "graph_based_slam/graph_state_store.hpp"
-#include "graph_based_slam/serialized_work_drain.hpp"
 
 namespace graphslam
 {
+
   class GraphBasedSlamComponent: public rclcpp::Node  // NOLINT(runtime/indentation_namespace)
   {
 public:
@@ -116,403 +69,10 @@ public:
     ~GraphBasedSlamComponent() override;
 
 private:
-    struct BackendWorkspace;
-
-    rclcpp::Clock clock_;
-    tf2_ros::Buffer tfbuffer_;
-    tf2_ros::TransformListener listener_;
-    tf2_ros::TransformBroadcaster broadcaster_;
-
-    // Compiler firewall for the ROS-free backend, registration engine,
-    // voxel filter and 3D-BBS verifier. Their PCL/pclomp/descriptor headers
-    // stay in the component implementation translation unit.
-    std::unique_ptr < BackendWorkspace > backend_;
-    // BackendWorkspace is single-threaded by contract. Keep that contract
-    // when hosted by a MultiThreadedExecutor, while coalescing arrivals
-    // during a long search.
-    scheduling::SerializedWorkDrain backend_work_drain_;
-    // Serializes ordered input staging (cloud conversion / PCD writes) but
-    // never blocks GraphStateStore snapshots during that I/O.
-    std::mutex submap_ingest_mtx_;
-    GraphStateStore graph_state_;
-
-    rclcpp::Subscription < lidarslam_msgs::msg::MapArray > ::SharedPtr map_array_sub_;
-    rclcpp::Publisher < lidarslam_msgs::msg::MapArray > ::SharedPtr modified_map_array_pub_;
-    rclcpp::Publisher < nav_msgs::msg::Path > ::SharedPtr modified_path_pub_;
-    rclcpp::Publisher < sensor_msgs::msg::PointCloud2 > ::SharedPtr modified_map_pub_;
-    rclcpp::Service < std_srvs::srv::Empty > ::SharedPtr map_save_srv_;
-
-    using LoopEdge = GraphStateStore::LoopEdge;
-    using LoopEdges = GraphStateStore::LoopEdges;
-    using PointCloud = pcl::PointCloud < pcl::PointXYZI >;
-    using PointCloudPtr = PointCloud::Ptr;
-    using LocalSubmapProvider = std::function < PointCloudPtr(int) >;
-    using MapSaveRequestHeader = std::shared_ptr < rmw_request_id_t >;
-    using MapSaveRequest = std::shared_ptr < std_srvs::srv::Empty::Request >;
-    using MapSaveResponse = std::shared_ptr < std_srvs::srv::Empty::Response >;
-
-    void initializePubSub();
-    void handleMapSaveRequest(
-      const MapSaveRequestHeader request_header,
-      const MapSaveRequest request,
-      const MapSaveResponse response);
-    // Event-driven scheduling (docs/roadmap/v0.6.md, Phase 2): drain every
-    // submap not yet used as a loop-search query, in arrival order, each
-    // against exactly the map state [0..q] so the result is a function of
-    // the data, not of how the executor batched arrivals.
-    void runEventDrivenLoopSearch();
-    void drainEventDrivenLoopSearch();
-    // Per-query loop search body shared by the event-driven drain.
-    void searchLoopForLatest(
-      const lidarslam_msgs::msg::MapArray & map_array_msg,
-      LoopEdges & loop_edges,
-      int num_submaps,
-      int latest_idx);
-    // Voxel-filtered local aggregate of a submap and its recent neighbors;
-    // the returned provider borrows map_array_msg and must not outlive it.
-    LocalSubmapProvider makeFilteredLocalSubmapProvider(
-      const lidarslam_msgs::msg::MapArray & map_array_msg);
-    bool snapshotGraphState(
-      lidarslam_msgs::msg::MapArray & map_array_msg,
-      LoopEdges & loop_edges);
-    void snapshotLoopEdges(LoopEdges & loop_edges);
-    bool upsertLoopEdge(const LoopEdge & loop_edge);
-    void doPoseAdjustment(
-      lidarslam_msgs::msg::MapArray map_array_msg,
-      const LoopEdges & loop_edges,
-      bool do_save_map);
-    void publishMapAndPose();
-
-    // loop search parameter
-    double threshold_loop_closure_score_;
-    double scan_context_loop_closure_score_threshold_ {-1.0};
-    double distance_loop_closure_;
-    double range_of_searching_loop_closure_;
-    int search_submap_num_;
-    int loop_search_query_stride_ {1};
-    int max_loop_candidate_count_ {3};
-    int loop_edge_dedup_index_window_ {8};
-    double loop_max_translation_delta_ {15.0};
-    double loop_max_rotation_delta_deg_ {45.0};
-    double loop_min_overlap_ratio_ {0.0};
-    double loop_min_overlap_ratio_large_correction_ {0.0};
-    double loop_overlap_large_correction_translation_m_ {0.0};
-    double loop_overlap_max_distance_m_ {0.5};
-    // Per-source overrides for descriptor-based candidates (TRIANGLE,
-    // SCAN_CONTEXT, BEV, SOLID). When positive, replace the generic caps
-    // above for those sources only — DISTANCE keeps the strict default.
-    // -1.0 = disabled / fall back to the generic cap.
-    double loop_max_translation_delta_descriptor_ {-1.0};
-    double loop_max_rotation_delta_deg_descriptor_ {-1.0};
-    int last_searched_submap_idx_ {-1};
-    // Event-driven loop search (the only scheduling semantics since v0.7
-    // Phase 0): loop search runs once per submap arrival in arrival order,
-    // each query seeing exactly the map state up to itself. The legacy
-    // wall-clock timer path and the retired deterministic_loop_scheduling
-    // parameter (v0.4 D1) are gone.
-
-    // pose graph optimization parameter
-    int num_adjacent_pose_cnstraints_;
-    bool use_save_map_in_loop_ {true};
-    double adjacent_edge_info_weight_ {1000.0};
-    double loop_edge_info_weight_ {100.0};
-    double loop_edge_robust_kernel_delta_ {1.0};
-    std::string loop_edge_robust_kernel_type_ {"huber"};
-
-    // Auto-scaling for adjacent_edge_info_weight (Level 1: NIS median tracking).
-    // When enabled, the post-optimisation chi-squared of adjacent edges is
-    // monitored and adjacent_edge_info_weight_ is mixed toward
-    // current * target_nis / median_chi2 via EMA, clamped to [min, max].
-    bool adjacent_edge_info_auto_scale_ {false};
-    double adjacent_edge_info_auto_scale_target_nis_ {6.0};
-    double adjacent_edge_info_auto_scale_ema_alpha_ {0.3};
-    double adjacent_edge_info_auto_scale_min_ {1.0};
-    double adjacent_edge_info_auto_scale_max_ {1.0e6};
-    // Level 2: split the adjacent edge Information matrix into translation /
-    // rotation blocks (block-diag with weights w_trans, w_rot on I_3 each) so
-    // the auto-scaler can balance translation residuals and rotation residuals
-    // independently. When split mode is off the legacy single-scalar shape is
-    // used. Targets default to 3.0 (3 DoF per block, vs 6 for the unified
-    // mode); the EMA / min / max defaults are shared with Level 1.
-    bool adjacent_edge_info_auto_scale_split_trans_rot_ {false};
-    double adjacent_edge_info_weight_trans_ {-1.0};
-    double adjacent_edge_info_weight_rot_ {-1.0};
-    double adjacent_edge_info_auto_scale_target_nis_trans_ {3.0};
-    double adjacent_edge_info_auto_scale_target_nis_rot_ {3.0};
-
-    int previous_submaps_num_ {0};
-
-    bool debug_flag_ {false};
-
-    // Scan Context loop detection
-    bool use_scan_context_ {false};
-    double scan_context_threshold_ {0.3};
-    int scan_context_query_stride_ {1};
-    int scan_context_exclude_recent_ {50};
-    bool prefer_scan_context_candidates_ {false};
-    bool use_bev_descriptor_ {false};
-    double bev_descriptor_threshold_ {0.20};
-    double bev_descriptor_grid_size_m_ {80.0};
-    int bev_descriptor_grid_cells_ {40};
-    int bev_descriptor_yaw_bins_ {24};
-    int bev_descriptor_sequence_window_ {0};
-    double bev_descriptor_sequence_threshold_ {-1.0};
-    double bev_descriptor_pose_consistency_threshold_m_ {-1.0};
-    double bev_descriptor_max_euclidean_distance_m_ {-1.0};
-    double bev_descriptor_rerank_weight_m_ {100.0};
-    // FOV-aware (mutual-visibility) distance for the BEV descriptor. Default
-    // off so the cosine-distance baseline stays unchanged on 360° LiDAR.
-    bool bev_use_mutual_visibility_ {false};
-    double bev_mutual_visibility_min_overlap_ratio_ {0.05};
-    double bev_mutual_visibility_occupancy_eps_ {0.5};
-    // Triangle (STD/BTC-style) descriptor place-recognition path. Built on the
-    // BSD-2 primitives in graph_based_slam/triangle_descriptor*. Default off
-    // so the existing default workflow stays unchanged.
-    bool use_triangle_descriptor_ {false};
-    // Tuned 2026-05-18 on NTU VIRAL tnp_01 ablation v4. The earlier loose
-    // defaults (60 cells, 0.3 m salience, 80 keypoints, 1.0 m edge bin)
-    // produced false-positive vote buckets where one stale submap collected
-    // every triangle match; this triggered randomly-rotating SE(3) outputs
-    // that NDT could not refine. The tighter values below caused triangle
-    // to vote across distinct submap ids (32 / 40 / 17 / 9) and produced
-    // the first triangle-sourced accepted loop closure (32 <-> 95, 0.49 m
-    // / 1.06 deg correction).
-    double triangle_descriptor_grid_size_m_ {60.0};
-    int triangle_descriptor_grid_cells_ {100};
-    int triangle_descriptor_max_keypoints_ {40};
-    double triangle_descriptor_min_salience_m_ {0.8};
-    double triangle_descriptor_min_edge_m_ {2.0};
-    double triangle_descriptor_max_edge_m_ {50.0};
-    int triangle_descriptor_max_triangles_ {3000};
-    double triangle_descriptor_edge_bin_m_ {0.5};
-    // Quad-hash 4th-point feature bin (m). 0 = disabled (legacy 3-edge hash).
-    // When > 0, the bucket key also includes the quantized distance from the
-    // triangle centroid to the nearest non-vertex keypoint, which makes the
-    // hash 4-dim and rejects wrong-but-agreeing triangle pairs in repeated
-    // geometry (corridor / parking-row / parallel column rows).
-    double triangle_descriptor_quad_feature_bin_m_ {0.0};
-    // Keypoint extractor mode. "bev_max_height" is the original outdoor-only
-    // extractor; "edge_3d" enables PCA-edgeness keypoints that survive in
-    // narrow-FOV / indoor scenes (MID-360, Newer College math_hard) where
-    // BEV max-height keypoint repeatability collapses.
-    std::string triangle_descriptor_keypoint_mode_ {"bev_max_height"};
-    double triangle_descriptor_edge_voxel_size_m_ {0.4};
-    double triangle_descriptor_edge_neighbor_radius_m_ {1.0};
-    int triangle_descriptor_edge_min_neighbors_ {6};
-    double triangle_descriptor_edge_min_edgeness_ {0.5};
-    double triangle_descriptor_edge_nms_radius_m_ {2.0};
-    // 5-inlier floor would have killed the only accepted loop in v4 (id=32
-    // emitted with 4 inliers), so settle on 4 as the compromise between
-    // recall and noise. Votes can stay loose because the tighter keypoint
-    // / hash params suppress most false buckets on their own.
-    int triangle_descriptor_min_votes_ {6};
-    int triangle_descriptor_min_inliers_ {4};
-    // Companion to min_inliers expressed as inliers / eval_n. Zero disables.
-    // Lets the operator combine a low absolute count with a meaningful
-    // relative-density floor (e.g. 4 inliers / max_pairs 64 = 6% vs the
-    // same 4 inliers / max_pairs 20 = 20%).
-    double triangle_descriptor_min_inlier_ratio_ {0.0};
-    // Cap on triangle pairs evaluated inside the RANSAC consensus check.
-    // Lower numbers make min_inlier_ratio more informative; default 64 keeps
-    // the previous behaviour.
-    int triangle_descriptor_max_pairs_ {64};
-    // 4-point consensus: after the 3-point RANSAC picks a winning SE(3),
-    // optionally project every query keypoint by that transform and require
-    // this many to fall within `fourth_point_max_distance_m` of some
-    // database keypoint in the chosen submap. Three points uniquely
-    // determine SE(3), so even a strong 3-point consensus can be fooled by
-    // repeated structure; the 4-point gate adds an independent constraint.
-    // Default 0 disables the gate.
-    int triangle_descriptor_min_4th_point_agreements_ {0};
-    double triangle_descriptor_fourth_point_max_distance_m_ {2.0};
-    // After the 3-point RANSAC picks the winning SE(3), re-estimate it by
-    // pooling the 3 * N_inliers point correspondences and running a single
-    // N-point Umeyama least-squares. Reduces translation noise by √N versus
-    // keeping the single 3-point hypothesis.
-    bool triangle_descriptor_refine_se3_with_all_inliers_ {false};
-    // Diagnostic-only: when true, run accumulateVotes (and submap_id selection)
-    // but skip the RANSAC findLoopCandidate inner loop. Used to isolate
-    // "executor scheduling cost of enabling triangle pipeline" from
-    // "RANSAC compute cost" when investigating APE drift on tuned configs.
-    // Default false (production).
-    bool triangle_descriptor_skip_ransac_ {false};
-    double triangle_descriptor_inlier_translation_m_ {2.0};
-    double triangle_descriptor_inlier_rotation_deg_ {5.0};
-    int triangle_descriptor_exclude_recent_ {4};
-    // Cross-verification: when both use_triangle_descriptor and
-    // use_bev_descriptor are true, gate the triangle candidate by also
-    // requiring the BEV mutual-visibility distance to clear an upper bound.
-    // Helps filter false positives caused by repeated geometry (corridors,
-    // facades) at the cost of triangle-only recall.
-    bool triangle_verify_with_bev_ {false};
-    double triangle_verify_bev_max_distance_ {0.30};
-    bool use_solid_descriptor_ {false};
-    double solid_descriptor_min_similarity_ {0.70};
-    int solid_descriptor_sequence_window_ {0};
-    double solid_descriptor_sequence_min_similarity_ {-1.0};
-    double solid_descriptor_pose_consistency_threshold_m_ {-1.0};
-    double solid_descriptor_max_euclidean_distance_m_ {-1.0};
-    bool use_3d_bbs_for_scan_context_ {false};
-    double three_d_bbs_min_level_res_ {1.0};
-    int three_d_bbs_max_level_ {3};
-    double three_d_bbs_score_threshold_percentage_ {0.25};
-    int three_d_bbs_timeout_msec_ {50};
-    int three_d_bbs_num_threads_ {0};
-    double three_d_bbs_voxel_leaf_size_ {1.0};
-    int three_d_bbs_source_submap_num_ {2};
-    int three_d_bbs_target_submap_radius_ {1};
-    double three_d_bbs_translation_search_margin_m_ {15.0};
-    double three_d_bbs_roll_pitch_search_deg_ {10.0};
-    double three_d_bbs_yaw_search_deg_ {180.0};
-    bool use_dynamic_object_filter_ {false};
-    double dynamic_object_filter_voxel_size_ {0.3};
-    int dynamic_object_filter_min_observations_ {2};
-    int dynamic_object_filter_temporal_window_ {5};
-    double dynamic_object_filter_max_range_from_sensor_m_ {30.0};
-    bool use_planar_map_filter_ {false};
-    double planar_map_filter_voxel_size_ {0.1};
-    int planar_map_filter_min_neighbors_ {3};
-    double planar_map_filter_max_small_eigenvalue_ratio_ {0.24};
-    double planar_map_filter_min_middle_eigenvalue_ratio_ {0.0};
-    double planar_map_filter_min_retained_ratio_ {0.90};
-
-    // PCD disk cache for memory-efficient submap storage
-    std::string pcd_cache_dir_;
-    bool use_pcd_cache_ {false};
-    std::mutex pcd_cache_mtx_;
-    void stageMapArrayCloudCache(lidarslam_msgs::msg::MapArray & map_array_msg);
-    bool saveSubmapToPCD(
-      int idx,
-      const pcl::PointCloud < pcl::PointXYZI > ::Ptr & cloud);
-    bool saveSubmapToPCDUnlocked(
-      int idx,
-      const pcl::PointCloud < pcl::PointXYZI > ::Ptr & cloud);
-    pcl::PointCloud < pcl::PointXYZI > ::Ptr loadSubmapFromPCD(int idx);
-    pcl::PointCloud < pcl::PointXYZI > ::Ptr loadSubmapCloud(
-      const lidarslam_msgs::msg::MapArray & map_array_msg, int idx);
-
-    // Autoware-compatible grid-divided PCD map output
-    std::string map_save_dir_ {"."};
-    std::string save_pose_graph_path_ {"pose_graph.g2o"};
-    double map_grid_size_x_ {20.0};
-    double map_grid_size_y_ {20.0};
-    double map_leaf_size_ {0.2};
-    void saveGridDividedMap(
-      const pcl::PointCloud < pcl::PointXYZI > ::Ptr & map);
-    void writeMapBundleArtifacts(
-      const lidarslam_msgs::msg::MapArray & map_array_msg,
-      const LoopEdges & loop_edges,
-      const std::vector < Eigen::Isometry3d > &optimized_poses);
-
-    // Direct odometry + cloud input mode (for LIO frontends). The two
-    // streams are stamp-synchronized (message_filters ApproximateTime) so
-    // the submap pose/cloud pairing no longer depends on executor timing
-    // (v0.6 Phase 1; see docs/research/determinism-variance-attribution.md).
-    bool use_odom_input_ {false};
-    double submap_distance_threshold_ {1.5};
-    int odom_cloud_sync_queue_size_ {100};
-    std::shared_ptr < message_filters::Subscriber < nav_msgs::msg::Odometry >> odom_sync_sub_;
-    std::shared_ptr < message_filters::Subscriber <
-    sensor_msgs::msg::PointCloud2 >> cloud_sync_sub_;
-    using OdomCloudSyncPolicy = message_filters::sync_policies::ApproximateTime <
-      nav_msgs::msg::Odometry, sensor_msgs::msg::PointCloud2 >;
-    std::shared_ptr < message_filters::Synchronizer < OdomCloudSyncPolicy >> odom_cloud_sync_;
-    Eigen::Vector3d last_submap_position_ {0, 0, 0};
-    bool last_submap_position_valid_ {false};
-    double accumulated_distance_ {0.0};
-    bool first_synced_input_logged_ {false};
-    void receiveSyncedOdomCloud(
-      const nav_msgs::msg::Odometry::ConstSharedPtr & odom_msg,
-      const sensor_msgs::msg::PointCloud2::ConstSharedPtr & cloud_msg);
-    void tryCreateSubmap(
-      const nav_msgs::msg::Odometry & odom_msg,
-      const sensor_msgs::msg::PointCloud2 & cloud_msg);
-
-    // v0.8 Phase 1 (docs/roadmap/v0.8.md §5): opt-in, report-only per-scan
-    // degeneracy diagnostics on the use_odom_input path. The received
-    // Odometry pose.covariance (filled anisotropically by the
-    // Thirdparty/rko_lio diagnostic patch) is classified per scan via
-    // localizability_analysis.hpp; when degeneracy_diagnostics_csv_path is
-    // non-empty a per-scan CSV row is appended, and when
-    // save_degeneracy_report is true a degeneracy_report.yaml summary joins
-    // the map bundle at /map_save time (best-effort, like the other bundle
-    // artifacts). Both default off: default behavior (and determinism) is
-    // unchanged, and nothing here feeds back into any pose or edge weight.
-    std::string degeneracy_diagnostics_csv_path_;
-    bool save_degeneracy_report_ {false};
-    std::mutex degeneracy_mtx_;
-    std::ofstream degeneracy_csv_ofs_;
-    degeneracy::DegeneracyReportAccumulator degeneracy_accumulator_;
-    void recordScanDegeneracy(const nav_msgs::msg::Odometry & odom_msg);
-    void writeDegeneracyReport();
-
-    // GNSS constraints for georeferenced mapping
-    bool use_gnss_ {false};
-    bool gnss_align_yaw_ {true};
-    int gnss_yaw_alignment_min_anchors_ {10};
-    double gnss_yaw_alignment_min_baseline_m_ {5.0};
-    std::string gnss_topic_ {"/gnss/fix"};
-    double gnss_info_weight_ {1.0};
-    bool gnss_use_covariance_weighting_ {true};
-    double gnss_covariance_min_variance_m2_ {0.01};
-    double gnss_covariance_max_variance_m2_ {25.0};
-    double gnss_rtk_fix_max_horizontal_stddev_m_ {0.3};
-    double gnss_rtk_fix_weight_scale_ {3.0};
-    double gnss_non_rtk_weight_scale_ {1.0};
-    double gnss_header_stamp_max_skew_sec_ {30.0};
-    int gnss_origin_min_samples_ {3};
-    double gnss_origin_consistency_threshold_m_ {20.0};
-    rclcpp::Subscription < sensor_msgs::msg::NavSatFix > ::SharedPtr gnss_sub_;
-    struct GnssEnu
-    {
-      double stamp;
-      double x;
-      double y;
-      double z;  // ENU coordinates relative to origin
-      double info_x;
-      double info_y;
-      double info_z;
-      bool covariance_valid;
-      bool rtk_like;
-      double horizontal_stddev_m;
-    };
-    std::vector < GnssEnu > gnss_buffer_;
-    detail::GnssOriginAccumulator gnss_origin_accumulator_;
-    std::mutex gnss_mtx_;
-    bool gnss_origin_set_ {false};
-    double gnss_origin_lat_ {0.0};
-    double gnss_origin_lon_ {0.0};
-    double gnss_origin_alt_ {0.0};
-    void receiveNavSatFix(const sensor_msgs::msg::NavSatFix & msg);
-    bool isUsableGnssFix(const sensor_msgs::msg::NavSatFix & msg) const;
-    void tryInitializeGnssOrigin(double lat, double lon, double alt);
-    Eigen::Vector3d geodeticToEnu(double lat, double lon, double alt) const;
-
-    // IMU preintegration
-    bool use_imu_preintegration_ {false};
-    double imu_rotation_info_roll_pitch_ {100.0};
-    double imu_rotation_info_yaw_ {10.0};
-    rclcpp::Subscription < sensor_msgs::msg::Imu > ::SharedPtr imu_sub_;
-    struct StampedImu
-    {
-      double stamp;
-      double ax;
-      double ay;
-      double az;
-      double gx;
-      double gy;
-      double gz;
-      double qx;
-      double qy;
-      double qz;
-      double qw;
-    };
-    std::vector < StampedImu > imu_buffer_;
-    std::mutex imu_mtx_;
-    static constexpr size_t kMaxImuBufferSize = 50000;
-    void receiveImu(const sensor_msgs::msg::Imu & msg);
-    Eigen::Quaterniond integrateImuRotation(double t0, double t1) const;
+    class Impl;
+    std::unique_ptr < Impl > impl_;
   };
+
 }  // namespace graphslam
 
 #endif  // GRAPH_BASED_SLAM__GRAPH_BASED_SLAM_COMPONENT_H_

--- a/graph_based_slam/src/graph_based_slam_component.cpp
+++ b/graph_based_slam/src/graph_based_slam_component.cpp
@@ -27,7 +27,7 @@
 // ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "graph_based_slam/graph_based_slam_component.h"
+#include "graph_based_slam_component_impl.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -67,7 +67,7 @@ using namespace std::chrono_literals;
 
 namespace graphslam
 {
-struct GraphBasedSlamComponent::BackendWorkspace
+struct GraphBasedSlamComponent::Impl::BackendWorkspace
 {
   backend_core::BackendCore core;
   boost::shared_ptr<pcl::Registration<pcl::PointXYZI, pcl::PointXYZI>> registration;
@@ -77,100 +77,110 @@ struct GraphBasedSlamComponent::BackendWorkspace
 
 GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & options)
 : Node("graph_based_slam", options),
+  impl_(std::make_unique<Impl>(*this))
+{
+}
+
+GraphBasedSlamComponent::~GraphBasedSlamComponent() = default;
+
+GraphBasedSlamComponent::Impl::Impl(GraphBasedSlamComponent & node)
+: node_(node),
   clock_(RCL_ROS_TIME),
   tfbuffer_(std::make_shared<rclcpp::Clock>(clock_)),
   listener_(tfbuffer_),
-  broadcaster_(this),
+  broadcaster_(&node_),
   backend_(std::make_unique<BackendWorkspace>())
 {
-  RCLCPP_INFO(get_logger(), "initialization start");
+  RCLCPP_INFO(node_.get_logger(), "initialization start");
   std::string registration_method;
   double voxel_leaf_size;
   double ndt_resolution;
   int ndt_num_threads;
 
-  declare_parameter("registration_method", "NDT");
-  get_parameter("registration_method", registration_method);
-  declare_parameter("voxel_leaf_size", 0.2);
-  get_parameter("voxel_leaf_size", voxel_leaf_size);
-  declare_parameter("ndt_resolution", 5.0);
-  get_parameter("ndt_resolution", ndt_resolution);
-  declare_parameter("ndt_num_threads", 0);
-  get_parameter("ndt_num_threads", ndt_num_threads);
-  declare_parameter("threshold_loop_closure_score", 1.0);
-  get_parameter("threshold_loop_closure_score", threshold_loop_closure_score_);
-  declare_parameter("scan_context_loop_closure_score_threshold", -1.0);
-  get_parameter(
+  node_.declare_parameter("registration_method", "NDT");
+  node_.get_parameter("registration_method", registration_method);
+  node_.declare_parameter("voxel_leaf_size", 0.2);
+  node_.get_parameter("voxel_leaf_size", voxel_leaf_size);
+  node_.declare_parameter("ndt_resolution", 5.0);
+  node_.get_parameter("ndt_resolution", ndt_resolution);
+  node_.declare_parameter("ndt_num_threads", 0);
+  node_.get_parameter("ndt_num_threads", ndt_num_threads);
+  node_.declare_parameter("threshold_loop_closure_score", 1.0);
+  node_.get_parameter("threshold_loop_closure_score", threshold_loop_closure_score_);
+  node_.declare_parameter("scan_context_loop_closure_score_threshold", -1.0);
+  node_.get_parameter(
     "scan_context_loop_closure_score_threshold",
     scan_context_loop_closure_score_threshold_);
-  declare_parameter("distance_loop_closure", 20.0);
-  get_parameter("distance_loop_closure", distance_loop_closure_);
-  declare_parameter("range_of_searching_loop_closure", 20.0);
-  get_parameter("range_of_searching_loop_closure", range_of_searching_loop_closure_);
-  declare_parameter("search_submap_num", 3);
-  get_parameter("search_submap_num", search_submap_num_);
-  declare_parameter("loop_search_query_stride", 1);
-  get_parameter("loop_search_query_stride", loop_search_query_stride_);
-  declare_parameter("max_loop_candidate_count", 3);
-  get_parameter("max_loop_candidate_count", max_loop_candidate_count_);
-  declare_parameter("loop_edge_dedup_index_window", 8);
-  get_parameter("loop_edge_dedup_index_window", loop_edge_dedup_index_window_);
-  declare_parameter("loop_max_translation_delta", 15.0);
-  get_parameter("loop_max_translation_delta", loop_max_translation_delta_);
-  declare_parameter("loop_max_rotation_delta_deg", 45.0);
-  get_parameter("loop_max_rotation_delta_deg", loop_max_rotation_delta_deg_);
-  declare_parameter("loop_min_overlap_ratio", 0.0);
-  get_parameter("loop_min_overlap_ratio", loop_min_overlap_ratio_);
-  declare_parameter("loop_min_overlap_ratio_large_correction", 0.0);
-  get_parameter(
+  node_.declare_parameter("distance_loop_closure", 20.0);
+  node_.get_parameter("distance_loop_closure", distance_loop_closure_);
+  node_.declare_parameter("range_of_searching_loop_closure", 20.0);
+  node_.get_parameter("range_of_searching_loop_closure", range_of_searching_loop_closure_);
+  node_.declare_parameter("search_submap_num", 3);
+  node_.get_parameter("search_submap_num", search_submap_num_);
+  node_.declare_parameter("loop_search_query_stride", 1);
+  node_.get_parameter("loop_search_query_stride", loop_search_query_stride_);
+  node_.declare_parameter("max_loop_candidate_count", 3);
+  node_.get_parameter("max_loop_candidate_count", max_loop_candidate_count_);
+  node_.declare_parameter("loop_edge_dedup_index_window", 8);
+  node_.get_parameter("loop_edge_dedup_index_window", loop_edge_dedup_index_window_);
+  node_.declare_parameter("loop_max_translation_delta", 15.0);
+  node_.get_parameter("loop_max_translation_delta", loop_max_translation_delta_);
+  node_.declare_parameter("loop_max_rotation_delta_deg", 45.0);
+  node_.get_parameter("loop_max_rotation_delta_deg", loop_max_rotation_delta_deg_);
+  node_.declare_parameter("loop_min_overlap_ratio", 0.0);
+  node_.get_parameter("loop_min_overlap_ratio", loop_min_overlap_ratio_);
+  node_.declare_parameter("loop_min_overlap_ratio_large_correction", 0.0);
+  node_.get_parameter(
     "loop_min_overlap_ratio_large_correction",
     loop_min_overlap_ratio_large_correction_);
-  declare_parameter("loop_overlap_large_correction_translation_m", 0.0);
-  get_parameter(
+  node_.declare_parameter("loop_overlap_large_correction_translation_m", 0.0);
+  node_.get_parameter(
     "loop_overlap_large_correction_translation_m",
     loop_overlap_large_correction_translation_m_);
-  declare_parameter("loop_overlap_max_distance_m", 0.5);
-  get_parameter("loop_overlap_max_distance_m", loop_overlap_max_distance_m_);
-  declare_parameter("loop_max_translation_delta_descriptor", -1.0);
-  get_parameter("loop_max_translation_delta_descriptor", loop_max_translation_delta_descriptor_);
-  declare_parameter("loop_max_rotation_delta_deg_descriptor", -1.0);
-  get_parameter("loop_max_rotation_delta_deg_descriptor", loop_max_rotation_delta_deg_descriptor_);
-  declare_parameter("num_adjacent_pose_cnstraints", 5);
-  get_parameter("num_adjacent_pose_cnstraints", num_adjacent_pose_cnstraints_);
-  declare_parameter("use_save_map_in_loop", true);
-  get_parameter("use_save_map_in_loop", use_save_map_in_loop_);
-  declare_parameter("debug_flag", false);
-  get_parameter("debug_flag", debug_flag_);
-  declare_parameter("adjacent_edge_info_weight", 1000.0);
-  get_parameter("adjacent_edge_info_weight", adjacent_edge_info_weight_);
-  declare_parameter("adjacent_edge_info_auto_scale", false);
-  get_parameter("adjacent_edge_info_auto_scale", adjacent_edge_info_auto_scale_);
-  declare_parameter("adjacent_edge_info_auto_scale_target_nis", 6.0);
-  get_parameter(
+  node_.declare_parameter("loop_overlap_max_distance_m", 0.5);
+  node_.get_parameter("loop_overlap_max_distance_m", loop_overlap_max_distance_m_);
+  node_.declare_parameter("loop_max_translation_delta_descriptor", -1.0);
+  node_.get_parameter(
+    "loop_max_translation_delta_descriptor", loop_max_translation_delta_descriptor_);
+  node_.declare_parameter("loop_max_rotation_delta_deg_descriptor", -1.0);
+  node_.get_parameter(
+    "loop_max_rotation_delta_deg_descriptor", loop_max_rotation_delta_deg_descriptor_);
+  node_.declare_parameter("num_adjacent_pose_cnstraints", 5);
+  node_.get_parameter("num_adjacent_pose_cnstraints", num_adjacent_pose_cnstraints_);
+  node_.declare_parameter("use_save_map_in_loop", true);
+  node_.get_parameter("use_save_map_in_loop", use_save_map_in_loop_);
+  node_.declare_parameter("debug_flag", false);
+  node_.get_parameter("debug_flag", debug_flag_);
+  node_.declare_parameter("adjacent_edge_info_weight", 1000.0);
+  node_.get_parameter("adjacent_edge_info_weight", adjacent_edge_info_weight_);
+  node_.declare_parameter("adjacent_edge_info_auto_scale", false);
+  node_.get_parameter("adjacent_edge_info_auto_scale", adjacent_edge_info_auto_scale_);
+  node_.declare_parameter("adjacent_edge_info_auto_scale_target_nis", 6.0);
+  node_.get_parameter(
     "adjacent_edge_info_auto_scale_target_nis",
     adjacent_edge_info_auto_scale_target_nis_);
-  declare_parameter("adjacent_edge_info_auto_scale_ema_alpha", 0.3);
-  get_parameter(
+  node_.declare_parameter("adjacent_edge_info_auto_scale_ema_alpha", 0.3);
+  node_.get_parameter(
     "adjacent_edge_info_auto_scale_ema_alpha",
     adjacent_edge_info_auto_scale_ema_alpha_);
-  declare_parameter("adjacent_edge_info_auto_scale_min", 1.0);
-  get_parameter("adjacent_edge_info_auto_scale_min", adjacent_edge_info_auto_scale_min_);
-  declare_parameter("adjacent_edge_info_auto_scale_max", 1.0e6);
-  get_parameter("adjacent_edge_info_auto_scale_max", adjacent_edge_info_auto_scale_max_);
-  declare_parameter("adjacent_edge_info_auto_scale_split_trans_rot", false);
-  get_parameter(
+  node_.declare_parameter("adjacent_edge_info_auto_scale_min", 1.0);
+  node_.get_parameter("adjacent_edge_info_auto_scale_min", adjacent_edge_info_auto_scale_min_);
+  node_.declare_parameter("adjacent_edge_info_auto_scale_max", 1.0e6);
+  node_.get_parameter("adjacent_edge_info_auto_scale_max", adjacent_edge_info_auto_scale_max_);
+  node_.declare_parameter("adjacent_edge_info_auto_scale_split_trans_rot", false);
+  node_.get_parameter(
     "adjacent_edge_info_auto_scale_split_trans_rot",
     adjacent_edge_info_auto_scale_split_trans_rot_);
-  declare_parameter("adjacent_edge_info_weight_trans", -1.0);
-  get_parameter("adjacent_edge_info_weight_trans", adjacent_edge_info_weight_trans_);
-  declare_parameter("adjacent_edge_info_weight_rot", -1.0);
-  get_parameter("adjacent_edge_info_weight_rot", adjacent_edge_info_weight_rot_);
-  declare_parameter("adjacent_edge_info_auto_scale_target_nis_trans", 3.0);
-  get_parameter(
+  node_.declare_parameter("adjacent_edge_info_weight_trans", -1.0);
+  node_.get_parameter("adjacent_edge_info_weight_trans", adjacent_edge_info_weight_trans_);
+  node_.declare_parameter("adjacent_edge_info_weight_rot", -1.0);
+  node_.get_parameter("adjacent_edge_info_weight_rot", adjacent_edge_info_weight_rot_);
+  node_.declare_parameter("adjacent_edge_info_auto_scale_target_nis_trans", 3.0);
+  node_.get_parameter(
     "adjacent_edge_info_auto_scale_target_nis_trans",
     adjacent_edge_info_auto_scale_target_nis_trans_);
-  declare_parameter("adjacent_edge_info_auto_scale_target_nis_rot", 3.0);
-  get_parameter(
+  node_.declare_parameter("adjacent_edge_info_auto_scale_target_nis_rot", 3.0);
+  node_.get_parameter(
     "adjacent_edge_info_auto_scale_target_nis_rot",
     adjacent_edge_info_auto_scale_target_nis_rot_);
   // Trans/rot weights default to the unified weight when negative (i.e., user
@@ -183,289 +193,290 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   if (adjacent_edge_info_weight_rot_ <= 0.0) {
     adjacent_edge_info_weight_rot_ = adjacent_edge_info_weight_;
   }
-  declare_parameter("loop_edge_info_weight", 100.0);
-  get_parameter("loop_edge_info_weight", loop_edge_info_weight_);
-  declare_parameter("loop_edge_robust_kernel_delta", 1.0);
-  get_parameter("loop_edge_robust_kernel_delta", loop_edge_robust_kernel_delta_);
-  declare_parameter("loop_edge_robust_kernel_type", std::string("huber"));
-  get_parameter("loop_edge_robust_kernel_type", loop_edge_robust_kernel_type_);
-  declare_parameter("use_scan_context", false);
-  get_parameter("use_scan_context", use_scan_context_);
-  declare_parameter("use_bev_descriptor", false);
-  get_parameter("use_bev_descriptor", use_bev_descriptor_);
-  declare_parameter("use_solid_descriptor", false);
-  get_parameter("use_solid_descriptor", use_solid_descriptor_);
-  declare_parameter("use_triangle_descriptor", false);
-  get_parameter("use_triangle_descriptor", use_triangle_descriptor_);
-  declare_parameter("triangle_descriptor_grid_size_m", 60.0);
-  get_parameter("triangle_descriptor_grid_size_m", triangle_descriptor_grid_size_m_);
-  declare_parameter("triangle_descriptor_grid_cells", 100);
-  get_parameter("triangle_descriptor_grid_cells", triangle_descriptor_grid_cells_);
-  declare_parameter("triangle_descriptor_max_keypoints", 40);
-  get_parameter("triangle_descriptor_max_keypoints", triangle_descriptor_max_keypoints_);
-  declare_parameter("triangle_descriptor_min_salience_m", 0.8);
-  get_parameter("triangle_descriptor_min_salience_m", triangle_descriptor_min_salience_m_);
-  declare_parameter("triangle_descriptor_min_edge_m", 2.0);
-  get_parameter("triangle_descriptor_min_edge_m", triangle_descriptor_min_edge_m_);
-  declare_parameter("triangle_descriptor_max_edge_m", 50.0);
-  get_parameter("triangle_descriptor_max_edge_m", triangle_descriptor_max_edge_m_);
-  declare_parameter("triangle_descriptor_max_triangles", 3000);
-  get_parameter("triangle_descriptor_max_triangles", triangle_descriptor_max_triangles_);
-  declare_parameter("triangle_descriptor_edge_bin_m", 0.5);
-  get_parameter("triangle_descriptor_edge_bin_m", triangle_descriptor_edge_bin_m_);
-  declare_parameter("triangle_descriptor_quad_feature_bin_m", 0.0);
-  get_parameter(
+  node_.declare_parameter("loop_edge_info_weight", 100.0);
+  node_.get_parameter("loop_edge_info_weight", loop_edge_info_weight_);
+  node_.declare_parameter("loop_edge_robust_kernel_delta", 1.0);
+  node_.get_parameter("loop_edge_robust_kernel_delta", loop_edge_robust_kernel_delta_);
+  node_.declare_parameter("loop_edge_robust_kernel_type", std::string("huber"));
+  node_.get_parameter("loop_edge_robust_kernel_type", loop_edge_robust_kernel_type_);
+  node_.declare_parameter("use_scan_context", false);
+  node_.get_parameter("use_scan_context", use_scan_context_);
+  node_.declare_parameter("use_bev_descriptor", false);
+  node_.get_parameter("use_bev_descriptor", use_bev_descriptor_);
+  node_.declare_parameter("use_solid_descriptor", false);
+  node_.get_parameter("use_solid_descriptor", use_solid_descriptor_);
+  node_.declare_parameter("use_triangle_descriptor", false);
+  node_.get_parameter("use_triangle_descriptor", use_triangle_descriptor_);
+  node_.declare_parameter("triangle_descriptor_grid_size_m", 60.0);
+  node_.get_parameter("triangle_descriptor_grid_size_m", triangle_descriptor_grid_size_m_);
+  node_.declare_parameter("triangle_descriptor_grid_cells", 100);
+  node_.get_parameter("triangle_descriptor_grid_cells", triangle_descriptor_grid_cells_);
+  node_.declare_parameter("triangle_descriptor_max_keypoints", 40);
+  node_.get_parameter("triangle_descriptor_max_keypoints", triangle_descriptor_max_keypoints_);
+  node_.declare_parameter("triangle_descriptor_min_salience_m", 0.8);
+  node_.get_parameter("triangle_descriptor_min_salience_m", triangle_descriptor_min_salience_m_);
+  node_.declare_parameter("triangle_descriptor_min_edge_m", 2.0);
+  node_.get_parameter("triangle_descriptor_min_edge_m", triangle_descriptor_min_edge_m_);
+  node_.declare_parameter("triangle_descriptor_max_edge_m", 50.0);
+  node_.get_parameter("triangle_descriptor_max_edge_m", triangle_descriptor_max_edge_m_);
+  node_.declare_parameter("triangle_descriptor_max_triangles", 3000);
+  node_.get_parameter("triangle_descriptor_max_triangles", triangle_descriptor_max_triangles_);
+  node_.declare_parameter("triangle_descriptor_edge_bin_m", 0.5);
+  node_.get_parameter("triangle_descriptor_edge_bin_m", triangle_descriptor_edge_bin_m_);
+  node_.declare_parameter("triangle_descriptor_quad_feature_bin_m", 0.0);
+  node_.get_parameter(
     "triangle_descriptor_quad_feature_bin_m",
     triangle_descriptor_quad_feature_bin_m_);
-  declare_parameter<std::string>(
+  node_.declare_parameter<std::string>(
     "triangle_descriptor_keypoint_mode", triangle_descriptor_keypoint_mode_);
-  get_parameter("triangle_descriptor_keypoint_mode", triangle_descriptor_keypoint_mode_);
-  declare_parameter("triangle_descriptor_edge_voxel_size_m", 0.4);
-  get_parameter(
+  node_.get_parameter("triangle_descriptor_keypoint_mode", triangle_descriptor_keypoint_mode_);
+  node_.declare_parameter("triangle_descriptor_edge_voxel_size_m", 0.4);
+  node_.get_parameter(
     "triangle_descriptor_edge_voxel_size_m", triangle_descriptor_edge_voxel_size_m_);
-  declare_parameter("triangle_descriptor_edge_neighbor_radius_m", 1.0);
-  get_parameter(
+  node_.declare_parameter("triangle_descriptor_edge_neighbor_radius_m", 1.0);
+  node_.get_parameter(
     "triangle_descriptor_edge_neighbor_radius_m",
     triangle_descriptor_edge_neighbor_radius_m_);
-  declare_parameter("triangle_descriptor_edge_min_neighbors", 6);
-  get_parameter(
+  node_.declare_parameter("triangle_descriptor_edge_min_neighbors", 6);
+  node_.get_parameter(
     "triangle_descriptor_edge_min_neighbors", triangle_descriptor_edge_min_neighbors_);
-  declare_parameter("triangle_descriptor_edge_min_edgeness", 0.5);
-  get_parameter(
+  node_.declare_parameter("triangle_descriptor_edge_min_edgeness", 0.5);
+  node_.get_parameter(
     "triangle_descriptor_edge_min_edgeness", triangle_descriptor_edge_min_edgeness_);
-  declare_parameter("triangle_descriptor_edge_nms_radius_m", 2.0);
-  get_parameter(
+  node_.declare_parameter("triangle_descriptor_edge_nms_radius_m", 2.0);
+  node_.get_parameter(
     "triangle_descriptor_edge_nms_radius_m", triangle_descriptor_edge_nms_radius_m_);
-  declare_parameter("triangle_descriptor_min_votes", 6);
-  get_parameter("triangle_descriptor_min_votes", triangle_descriptor_min_votes_);
-  declare_parameter("triangle_descriptor_min_inliers", 4);
-  get_parameter("triangle_descriptor_min_inliers", triangle_descriptor_min_inliers_);
-  declare_parameter("triangle_descriptor_min_inlier_ratio", 0.0);
-  get_parameter(
+  node_.declare_parameter("triangle_descriptor_min_votes", 6);
+  node_.get_parameter("triangle_descriptor_min_votes", triangle_descriptor_min_votes_);
+  node_.declare_parameter("triangle_descriptor_min_inliers", 4);
+  node_.get_parameter("triangle_descriptor_min_inliers", triangle_descriptor_min_inliers_);
+  node_.declare_parameter("triangle_descriptor_min_inlier_ratio", 0.0);
+  node_.get_parameter(
     "triangle_descriptor_min_inlier_ratio",
     triangle_descriptor_min_inlier_ratio_);
-  declare_parameter("triangle_descriptor_max_pairs", 64);
-  get_parameter("triangle_descriptor_max_pairs", triangle_descriptor_max_pairs_);
-  declare_parameter("triangle_descriptor_min_4th_point_agreements", 0);
-  get_parameter(
+  node_.declare_parameter("triangle_descriptor_max_pairs", 64);
+  node_.get_parameter("triangle_descriptor_max_pairs", triangle_descriptor_max_pairs_);
+  node_.declare_parameter("triangle_descriptor_min_4th_point_agreements", 0);
+  node_.get_parameter(
     "triangle_descriptor_min_4th_point_agreements",
     triangle_descriptor_min_4th_point_agreements_);
-  declare_parameter("triangle_descriptor_fourth_point_max_distance_m", 2.0);
-  get_parameter(
+  node_.declare_parameter("triangle_descriptor_fourth_point_max_distance_m", 2.0);
+  node_.get_parameter(
     "triangle_descriptor_fourth_point_max_distance_m",
     triangle_descriptor_fourth_point_max_distance_m_);
-  declare_parameter("triangle_descriptor_refine_se3_with_all_inliers", false);
-  get_parameter(
+  node_.declare_parameter("triangle_descriptor_refine_se3_with_all_inliers", false);
+  node_.get_parameter(
     "triangle_descriptor_refine_se3_with_all_inliers",
     triangle_descriptor_refine_se3_with_all_inliers_);
-  declare_parameter("triangle_descriptor_skip_ransac", false);
-  get_parameter(
+  node_.declare_parameter("triangle_descriptor_skip_ransac", false);
+  node_.get_parameter(
     "triangle_descriptor_skip_ransac",
     triangle_descriptor_skip_ransac_);
-  declare_parameter("triangle_descriptor_inlier_translation_m", 2.0);
-  get_parameter(
+  node_.declare_parameter("triangle_descriptor_inlier_translation_m", 2.0);
+  node_.get_parameter(
     "triangle_descriptor_inlier_translation_m",
     triangle_descriptor_inlier_translation_m_);
-  declare_parameter("triangle_descriptor_inlier_rotation_deg", 5.0);
-  get_parameter(
+  node_.declare_parameter("triangle_descriptor_inlier_rotation_deg", 5.0);
+  node_.get_parameter(
     "triangle_descriptor_inlier_rotation_deg",
     triangle_descriptor_inlier_rotation_deg_);
-  declare_parameter("triangle_descriptor_exclude_recent", 4);
-  get_parameter("triangle_descriptor_exclude_recent", triangle_descriptor_exclude_recent_);
-  declare_parameter("triangle_verify_with_bev", false);
-  get_parameter("triangle_verify_with_bev", triangle_verify_with_bev_);
-  declare_parameter("triangle_verify_bev_max_distance", 0.30);
-  get_parameter("triangle_verify_bev_max_distance", triangle_verify_bev_max_distance_);
-  declare_parameter("use_pcd_cache", false);
-  get_parameter("use_pcd_cache", use_pcd_cache_);
-  declare_parameter("pcd_cache_dir", std::string("/tmp/graph_slam_pcd_cache"));
-  get_parameter("pcd_cache_dir", pcd_cache_dir_);
+  node_.declare_parameter("triangle_descriptor_exclude_recent", 4);
+  node_.get_parameter("triangle_descriptor_exclude_recent", triangle_descriptor_exclude_recent_);
+  node_.declare_parameter("triangle_verify_with_bev", false);
+  node_.get_parameter("triangle_verify_with_bev", triangle_verify_with_bev_);
+  node_.declare_parameter("triangle_verify_bev_max_distance", 0.30);
+  node_.get_parameter("triangle_verify_bev_max_distance", triangle_verify_bev_max_distance_);
+  node_.declare_parameter("use_pcd_cache", false);
+  node_.get_parameter("use_pcd_cache", use_pcd_cache_);
+  node_.declare_parameter("pcd_cache_dir", std::string("/tmp/graph_slam_pcd_cache"));
+  node_.get_parameter("pcd_cache_dir", pcd_cache_dir_);
   if (use_pcd_cache_) {
     std::filesystem::create_directories(pcd_cache_dir_);
     std::cout << "pcd_cache_dir:" << pcd_cache_dir_ << std::endl;
   }
-  declare_parameter("scan_context_threshold", 0.3);
-  get_parameter("scan_context_threshold", scan_context_threshold_);
-  declare_parameter("scan_context_query_stride", 1);
-  get_parameter("scan_context_query_stride", scan_context_query_stride_);
-  declare_parameter("scan_context_exclude_recent", ScanContext::EXCLUDE_RECENT);
-  get_parameter("scan_context_exclude_recent", scan_context_exclude_recent_);
-  declare_parameter("bev_descriptor_threshold", 0.20);
-  get_parameter("bev_descriptor_threshold", bev_descriptor_threshold_);
-  declare_parameter("bev_descriptor_grid_size_m", 80.0);
-  get_parameter("bev_descriptor_grid_size_m", bev_descriptor_grid_size_m_);
-  declare_parameter("bev_descriptor_grid_cells", 40);
-  get_parameter("bev_descriptor_grid_cells", bev_descriptor_grid_cells_);
-  declare_parameter("bev_descriptor_yaw_bins", 24);
-  get_parameter("bev_descriptor_yaw_bins", bev_descriptor_yaw_bins_);
-  declare_parameter("bev_descriptor_sequence_window", 0);
-  get_parameter("bev_descriptor_sequence_window", bev_descriptor_sequence_window_);
-  declare_parameter("bev_descriptor_sequence_threshold", -1.0);
-  get_parameter("bev_descriptor_sequence_threshold", bev_descriptor_sequence_threshold_);
-  declare_parameter("bev_descriptor_pose_consistency_threshold_m", -1.0);
-  get_parameter(
+  node_.declare_parameter("scan_context_threshold", 0.3);
+  node_.get_parameter("scan_context_threshold", scan_context_threshold_);
+  node_.declare_parameter("scan_context_query_stride", 1);
+  node_.get_parameter("scan_context_query_stride", scan_context_query_stride_);
+  node_.declare_parameter("scan_context_exclude_recent", ScanContext::EXCLUDE_RECENT);
+  node_.get_parameter("scan_context_exclude_recent", scan_context_exclude_recent_);
+  node_.declare_parameter("bev_descriptor_threshold", 0.20);
+  node_.get_parameter("bev_descriptor_threshold", bev_descriptor_threshold_);
+  node_.declare_parameter("bev_descriptor_grid_size_m", 80.0);
+  node_.get_parameter("bev_descriptor_grid_size_m", bev_descriptor_grid_size_m_);
+  node_.declare_parameter("bev_descriptor_grid_cells", 40);
+  node_.get_parameter("bev_descriptor_grid_cells", bev_descriptor_grid_cells_);
+  node_.declare_parameter("bev_descriptor_yaw_bins", 24);
+  node_.get_parameter("bev_descriptor_yaw_bins", bev_descriptor_yaw_bins_);
+  node_.declare_parameter("bev_descriptor_sequence_window", 0);
+  node_.get_parameter("bev_descriptor_sequence_window", bev_descriptor_sequence_window_);
+  node_.declare_parameter("bev_descriptor_sequence_threshold", -1.0);
+  node_.get_parameter("bev_descriptor_sequence_threshold", bev_descriptor_sequence_threshold_);
+  node_.declare_parameter("bev_descriptor_pose_consistency_threshold_m", -1.0);
+  node_.get_parameter(
     "bev_descriptor_pose_consistency_threshold_m",
     bev_descriptor_pose_consistency_threshold_m_);
-  declare_parameter("bev_descriptor_max_euclidean_distance_m", -1.0);
-  get_parameter(
+  node_.declare_parameter("bev_descriptor_max_euclidean_distance_m", -1.0);
+  node_.get_parameter(
     "bev_descriptor_max_euclidean_distance_m",
     bev_descriptor_max_euclidean_distance_m_);
-  declare_parameter("bev_descriptor_rerank_weight_m", 100.0);
-  get_parameter("bev_descriptor_rerank_weight_m", bev_descriptor_rerank_weight_m_);
-  declare_parameter("bev_use_mutual_visibility", false);
-  get_parameter("bev_use_mutual_visibility", bev_use_mutual_visibility_);
-  declare_parameter("bev_mutual_visibility_min_overlap_ratio", 0.05);
-  get_parameter(
+  node_.declare_parameter("bev_descriptor_rerank_weight_m", 100.0);
+  node_.get_parameter("bev_descriptor_rerank_weight_m", bev_descriptor_rerank_weight_m_);
+  node_.declare_parameter("bev_use_mutual_visibility", false);
+  node_.get_parameter("bev_use_mutual_visibility", bev_use_mutual_visibility_);
+  node_.declare_parameter("bev_mutual_visibility_min_overlap_ratio", 0.05);
+  node_.get_parameter(
     "bev_mutual_visibility_min_overlap_ratio",
     bev_mutual_visibility_min_overlap_ratio_);
-  declare_parameter("bev_mutual_visibility_occupancy_eps", 0.5);
-  get_parameter(
+  node_.declare_parameter("bev_mutual_visibility_occupancy_eps", 0.5);
+  node_.get_parameter(
     "bev_mutual_visibility_occupancy_eps",
     bev_mutual_visibility_occupancy_eps_);
-  declare_parameter("solid_descriptor_min_similarity", 0.70);
-  get_parameter("solid_descriptor_min_similarity", solid_descriptor_min_similarity_);
-  declare_parameter("solid_descriptor_sequence_window", 0);
-  get_parameter("solid_descriptor_sequence_window", solid_descriptor_sequence_window_);
-  declare_parameter("solid_descriptor_sequence_min_similarity", -1.0);
-  get_parameter(
+  node_.declare_parameter("solid_descriptor_min_similarity", 0.70);
+  node_.get_parameter("solid_descriptor_min_similarity", solid_descriptor_min_similarity_);
+  node_.declare_parameter("solid_descriptor_sequence_window", 0);
+  node_.get_parameter("solid_descriptor_sequence_window", solid_descriptor_sequence_window_);
+  node_.declare_parameter("solid_descriptor_sequence_min_similarity", -1.0);
+  node_.get_parameter(
     "solid_descriptor_sequence_min_similarity",
     solid_descriptor_sequence_min_similarity_);
-  declare_parameter("solid_descriptor_pose_consistency_threshold_m", -1.0);
-  get_parameter(
+  node_.declare_parameter("solid_descriptor_pose_consistency_threshold_m", -1.0);
+  node_.get_parameter(
     "solid_descriptor_pose_consistency_threshold_m",
     solid_descriptor_pose_consistency_threshold_m_);
-  declare_parameter("solid_descriptor_max_euclidean_distance_m", -1.0);
-  get_parameter(
+  node_.declare_parameter("solid_descriptor_max_euclidean_distance_m", -1.0);
+  node_.get_parameter(
     "solid_descriptor_max_euclidean_distance_m",
     solid_descriptor_max_euclidean_distance_m_);
-  declare_parameter("prefer_scan_context_candidates", false);
-  get_parameter("prefer_scan_context_candidates", prefer_scan_context_candidates_);
-  declare_parameter("use_3d_bbs_for_scan_context", false);
-  get_parameter("use_3d_bbs_for_scan_context", use_3d_bbs_for_scan_context_);
-  declare_parameter("three_d_bbs_min_level_res", 1.0);
-  get_parameter("three_d_bbs_min_level_res", three_d_bbs_min_level_res_);
-  declare_parameter("three_d_bbs_max_level", 3);
-  get_parameter("three_d_bbs_max_level", three_d_bbs_max_level_);
-  declare_parameter("three_d_bbs_score_threshold_percentage", 0.25);
-  get_parameter(
+  node_.declare_parameter("prefer_scan_context_candidates", false);
+  node_.get_parameter("prefer_scan_context_candidates", prefer_scan_context_candidates_);
+  node_.declare_parameter("use_3d_bbs_for_scan_context", false);
+  node_.get_parameter("use_3d_bbs_for_scan_context", use_3d_bbs_for_scan_context_);
+  node_.declare_parameter("three_d_bbs_min_level_res", 1.0);
+  node_.get_parameter("three_d_bbs_min_level_res", three_d_bbs_min_level_res_);
+  node_.declare_parameter("three_d_bbs_max_level", 3);
+  node_.get_parameter("three_d_bbs_max_level", three_d_bbs_max_level_);
+  node_.declare_parameter("three_d_bbs_score_threshold_percentage", 0.25);
+  node_.get_parameter(
     "three_d_bbs_score_threshold_percentage",
     three_d_bbs_score_threshold_percentage_);
-  declare_parameter("three_d_bbs_timeout_msec", 50);
-  get_parameter("three_d_bbs_timeout_msec", three_d_bbs_timeout_msec_);
-  declare_parameter("three_d_bbs_num_threads", 0);
-  get_parameter("three_d_bbs_num_threads", three_d_bbs_num_threads_);
-  declare_parameter("three_d_bbs_voxel_leaf_size", 1.0);
-  get_parameter("three_d_bbs_voxel_leaf_size", three_d_bbs_voxel_leaf_size_);
-  declare_parameter("three_d_bbs_source_submap_num", 2);
-  get_parameter("three_d_bbs_source_submap_num", three_d_bbs_source_submap_num_);
-  declare_parameter("three_d_bbs_target_submap_radius", 1);
-  get_parameter("three_d_bbs_target_submap_radius", three_d_bbs_target_submap_radius_);
-  declare_parameter("three_d_bbs_translation_search_margin_m", 15.0);
-  get_parameter(
+  node_.declare_parameter("three_d_bbs_timeout_msec", 50);
+  node_.get_parameter("three_d_bbs_timeout_msec", three_d_bbs_timeout_msec_);
+  node_.declare_parameter("three_d_bbs_num_threads", 0);
+  node_.get_parameter("three_d_bbs_num_threads", three_d_bbs_num_threads_);
+  node_.declare_parameter("three_d_bbs_voxel_leaf_size", 1.0);
+  node_.get_parameter("three_d_bbs_voxel_leaf_size", three_d_bbs_voxel_leaf_size_);
+  node_.declare_parameter("three_d_bbs_source_submap_num", 2);
+  node_.get_parameter("three_d_bbs_source_submap_num", three_d_bbs_source_submap_num_);
+  node_.declare_parameter("three_d_bbs_target_submap_radius", 1);
+  node_.get_parameter("three_d_bbs_target_submap_radius", three_d_bbs_target_submap_radius_);
+  node_.declare_parameter("three_d_bbs_translation_search_margin_m", 15.0);
+  node_.get_parameter(
     "three_d_bbs_translation_search_margin_m",
     three_d_bbs_translation_search_margin_m_);
-  declare_parameter("three_d_bbs_roll_pitch_search_deg", 10.0);
-  get_parameter(
+  node_.declare_parameter("three_d_bbs_roll_pitch_search_deg", 10.0);
+  node_.get_parameter(
     "three_d_bbs_roll_pitch_search_deg",
     three_d_bbs_roll_pitch_search_deg_);
-  declare_parameter("three_d_bbs_yaw_search_deg", 180.0);
-  get_parameter("three_d_bbs_yaw_search_deg", three_d_bbs_yaw_search_deg_);
-  declare_parameter("use_dynamic_object_filter", false);
-  get_parameter("use_dynamic_object_filter", use_dynamic_object_filter_);
-  declare_parameter("dynamic_object_filter_voxel_size", 0.3);
-  get_parameter("dynamic_object_filter_voxel_size", dynamic_object_filter_voxel_size_);
-  declare_parameter("dynamic_object_filter_min_observations", 2);
-  get_parameter(
+  node_.declare_parameter("three_d_bbs_yaw_search_deg", 180.0);
+  node_.get_parameter("three_d_bbs_yaw_search_deg", three_d_bbs_yaw_search_deg_);
+  node_.declare_parameter("use_dynamic_object_filter", false);
+  node_.get_parameter("use_dynamic_object_filter", use_dynamic_object_filter_);
+  node_.declare_parameter("dynamic_object_filter_voxel_size", 0.3);
+  node_.get_parameter("dynamic_object_filter_voxel_size", dynamic_object_filter_voxel_size_);
+  node_.declare_parameter("dynamic_object_filter_min_observations", 2);
+  node_.get_parameter(
     "dynamic_object_filter_min_observations",
     dynamic_object_filter_min_observations_);
-  declare_parameter("dynamic_object_filter_temporal_window", 5);
-  get_parameter(
+  node_.declare_parameter("dynamic_object_filter_temporal_window", 5);
+  node_.get_parameter(
     "dynamic_object_filter_temporal_window",
     dynamic_object_filter_temporal_window_);
-  declare_parameter("dynamic_object_filter_max_range_from_sensor_m", 30.0);
-  get_parameter(
+  node_.declare_parameter("dynamic_object_filter_max_range_from_sensor_m", 30.0);
+  node_.get_parameter(
     "dynamic_object_filter_max_range_from_sensor_m",
     dynamic_object_filter_max_range_from_sensor_m_);
-  declare_parameter("use_planar_map_filter", false);
-  get_parameter("use_planar_map_filter", use_planar_map_filter_);
-  declare_parameter("planar_map_filter_voxel_size", 0.1);
-  get_parameter("planar_map_filter_voxel_size", planar_map_filter_voxel_size_);
-  declare_parameter("planar_map_filter_min_neighbors", 3);
-  get_parameter("planar_map_filter_min_neighbors", planar_map_filter_min_neighbors_);
-  declare_parameter("planar_map_filter_max_small_eigenvalue_ratio", 0.24);
-  get_parameter(
+  node_.declare_parameter("use_planar_map_filter", false);
+  node_.get_parameter("use_planar_map_filter", use_planar_map_filter_);
+  node_.declare_parameter("planar_map_filter_voxel_size", 0.1);
+  node_.get_parameter("planar_map_filter_voxel_size", planar_map_filter_voxel_size_);
+  node_.declare_parameter("planar_map_filter_min_neighbors", 3);
+  node_.get_parameter("planar_map_filter_min_neighbors", planar_map_filter_min_neighbors_);
+  node_.declare_parameter("planar_map_filter_max_small_eigenvalue_ratio", 0.24);
+  node_.get_parameter(
     "planar_map_filter_max_small_eigenvalue_ratio",
     planar_map_filter_max_small_eigenvalue_ratio_);
-  declare_parameter("planar_map_filter_min_middle_eigenvalue_ratio", 0.0);
-  get_parameter(
+  node_.declare_parameter("planar_map_filter_min_middle_eigenvalue_ratio", 0.0);
+  node_.get_parameter(
     "planar_map_filter_min_middle_eigenvalue_ratio",
     planar_map_filter_min_middle_eigenvalue_ratio_);
-  declare_parameter("planar_map_filter_min_retained_ratio", 0.90);
-  get_parameter("planar_map_filter_min_retained_ratio", planar_map_filter_min_retained_ratio_);
-  declare_parameter("map_save_dir", std::string("."));
-  get_parameter("map_save_dir", map_save_dir_);
+  node_.declare_parameter("planar_map_filter_min_retained_ratio", 0.90);
+  node_.get_parameter(
+    "planar_map_filter_min_retained_ratio", planar_map_filter_min_retained_ratio_);
+  node_.declare_parameter("map_save_dir", std::string("."));
+  node_.get_parameter("map_save_dir", map_save_dir_);
   // The launch files have always passed this; until v0.6 Phase 1 it was
   // silently ignored and the graph went to the CWD. The default keeps the
   // historical CWD behaviour.
-  declare_parameter("save_pose_graph_path", std::string("pose_graph.g2o"));
-  get_parameter("save_pose_graph_path", save_pose_graph_path_);
-  declare_parameter("map_grid_size_x", 20.0);
-  get_parameter("map_grid_size_x", map_grid_size_x_);
-  declare_parameter("map_grid_size_y", 20.0);
-  get_parameter("map_grid_size_y", map_grid_size_y_);
-  declare_parameter("map_leaf_size", 0.2);
-  get_parameter("map_leaf_size", map_leaf_size_);
-  declare_parameter("use_gnss", false);
-  get_parameter("use_gnss", use_gnss_);
-  declare_parameter("gnss_topic", std::string("/gnss/fix"));
-  get_parameter("gnss_topic", gnss_topic_);
-  declare_parameter("gnss_info_weight", 1.0);
-  get_parameter("gnss_info_weight", gnss_info_weight_);
-  declare_parameter("gnss_use_covariance_weighting", true);
-  get_parameter("gnss_use_covariance_weighting", gnss_use_covariance_weighting_);
-  declare_parameter("gnss_covariance_min_variance_m2", 0.01);
-  get_parameter("gnss_covariance_min_variance_m2", gnss_covariance_min_variance_m2_);
-  declare_parameter("gnss_covariance_max_variance_m2", 25.0);
-  get_parameter("gnss_covariance_max_variance_m2", gnss_covariance_max_variance_m2_);
-  declare_parameter("gnss_rtk_fix_max_horizontal_stddev_m", 0.3);
-  get_parameter(
+  node_.declare_parameter("save_pose_graph_path", std::string("pose_graph.g2o"));
+  node_.get_parameter("save_pose_graph_path", save_pose_graph_path_);
+  node_.declare_parameter("map_grid_size_x", 20.0);
+  node_.get_parameter("map_grid_size_x", map_grid_size_x_);
+  node_.declare_parameter("map_grid_size_y", 20.0);
+  node_.get_parameter("map_grid_size_y", map_grid_size_y_);
+  node_.declare_parameter("map_leaf_size", 0.2);
+  node_.get_parameter("map_leaf_size", map_leaf_size_);
+  node_.declare_parameter("use_gnss", false);
+  node_.get_parameter("use_gnss", use_gnss_);
+  node_.declare_parameter("gnss_topic", std::string("/gnss/fix"));
+  node_.get_parameter("gnss_topic", gnss_topic_);
+  node_.declare_parameter("gnss_info_weight", 1.0);
+  node_.get_parameter("gnss_info_weight", gnss_info_weight_);
+  node_.declare_parameter("gnss_use_covariance_weighting", true);
+  node_.get_parameter("gnss_use_covariance_weighting", gnss_use_covariance_weighting_);
+  node_.declare_parameter("gnss_covariance_min_variance_m2", 0.01);
+  node_.get_parameter("gnss_covariance_min_variance_m2", gnss_covariance_min_variance_m2_);
+  node_.declare_parameter("gnss_covariance_max_variance_m2", 25.0);
+  node_.get_parameter("gnss_covariance_max_variance_m2", gnss_covariance_max_variance_m2_);
+  node_.declare_parameter("gnss_rtk_fix_max_horizontal_stddev_m", 0.3);
+  node_.get_parameter(
     "gnss_rtk_fix_max_horizontal_stddev_m",
     gnss_rtk_fix_max_horizontal_stddev_m_);
-  declare_parameter("gnss_rtk_fix_weight_scale", 3.0);
-  get_parameter("gnss_rtk_fix_weight_scale", gnss_rtk_fix_weight_scale_);
-  declare_parameter("gnss_non_rtk_weight_scale", 1.0);
-  get_parameter("gnss_non_rtk_weight_scale", gnss_non_rtk_weight_scale_);
-  declare_parameter("gnss_header_stamp_max_skew_sec", 30.0);
-  get_parameter("gnss_header_stamp_max_skew_sec", gnss_header_stamp_max_skew_sec_);
-  declare_parameter("gnss_align_yaw", true);
-  get_parameter("gnss_align_yaw", gnss_align_yaw_);
-  declare_parameter("gnss_yaw_alignment_min_anchors", 10);
-  get_parameter("gnss_yaw_alignment_min_anchors", gnss_yaw_alignment_min_anchors_);
-  declare_parameter("gnss_yaw_alignment_min_baseline_m", 5.0);
-  get_parameter("gnss_yaw_alignment_min_baseline_m", gnss_yaw_alignment_min_baseline_m_);
-  declare_parameter("gnss_origin_min_samples", 3);
-  get_parameter("gnss_origin_min_samples", gnss_origin_min_samples_);
-  declare_parameter("gnss_origin_consistency_threshold_m", 20.0);
-  get_parameter(
+  node_.declare_parameter("gnss_rtk_fix_weight_scale", 3.0);
+  node_.get_parameter("gnss_rtk_fix_weight_scale", gnss_rtk_fix_weight_scale_);
+  node_.declare_parameter("gnss_non_rtk_weight_scale", 1.0);
+  node_.get_parameter("gnss_non_rtk_weight_scale", gnss_non_rtk_weight_scale_);
+  node_.declare_parameter("gnss_header_stamp_max_skew_sec", 30.0);
+  node_.get_parameter("gnss_header_stamp_max_skew_sec", gnss_header_stamp_max_skew_sec_);
+  node_.declare_parameter("gnss_align_yaw", true);
+  node_.get_parameter("gnss_align_yaw", gnss_align_yaw_);
+  node_.declare_parameter("gnss_yaw_alignment_min_anchors", 10);
+  node_.get_parameter("gnss_yaw_alignment_min_anchors", gnss_yaw_alignment_min_anchors_);
+  node_.declare_parameter("gnss_yaw_alignment_min_baseline_m", 5.0);
+  node_.get_parameter("gnss_yaw_alignment_min_baseline_m", gnss_yaw_alignment_min_baseline_m_);
+  node_.declare_parameter("gnss_origin_min_samples", 3);
+  node_.get_parameter("gnss_origin_min_samples", gnss_origin_min_samples_);
+  node_.declare_parameter("gnss_origin_consistency_threshold_m", 20.0);
+  node_.get_parameter(
     "gnss_origin_consistency_threshold_m",
     gnss_origin_consistency_threshold_m_);
-  declare_parameter("use_imu_preintegration", false);
-  get_parameter("use_imu_preintegration", use_imu_preintegration_);
-  declare_parameter("imu_rotation_info_roll_pitch", 100.0);
-  get_parameter("imu_rotation_info_roll_pitch", imu_rotation_info_roll_pitch_);
-  declare_parameter("imu_rotation_info_yaw", 10.0);
-  get_parameter("imu_rotation_info_yaw", imu_rotation_info_yaw_);
+  node_.declare_parameter("use_imu_preintegration", false);
+  node_.get_parameter("use_imu_preintegration", use_imu_preintegration_);
+  node_.declare_parameter("imu_rotation_info_roll_pitch", 100.0);
+  node_.get_parameter("imu_rotation_info_roll_pitch", imu_rotation_info_roll_pitch_);
+  node_.declare_parameter("imu_rotation_info_yaw", 10.0);
+  node_.get_parameter("imu_rotation_info_yaw", imu_rotation_info_yaw_);
 
   if (gnss_origin_min_samples_ < 1) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "gnss_origin_min_samples must be >= 1, clamping %d to 1",
       gnss_origin_min_samples_);
     gnss_origin_min_samples_ = 1;
   }
   if (gnss_origin_consistency_threshold_m_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "gnss_origin_consistency_threshold_m must be positive, resetting %.3f to 20.0",
       gnss_origin_consistency_threshold_m_);
     gnss_origin_consistency_threshold_m_ = 20.0;
@@ -474,70 +485,70 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     gnss_origin_min_samples_, gnss_origin_consistency_threshold_m_);
   if (gnss_covariance_min_variance_m2_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "gnss_covariance_min_variance_m2 must be positive, resetting %.6f to 0.01",
       gnss_covariance_min_variance_m2_);
     gnss_covariance_min_variance_m2_ = 0.01;
   }
   if (gnss_covariance_max_variance_m2_ < gnss_covariance_min_variance_m2_) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "gnss_covariance_max_variance_m2 must be >= min variance, resetting %.6f to %.6f",
       gnss_covariance_max_variance_m2_, gnss_covariance_min_variance_m2_);
     gnss_covariance_max_variance_m2_ = gnss_covariance_min_variance_m2_;
   }
   if (gnss_rtk_fix_max_horizontal_stddev_m_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "gnss_rtk_fix_max_horizontal_stddev_m must be positive, resetting %.3f to 0.3",
       gnss_rtk_fix_max_horizontal_stddev_m_);
     gnss_rtk_fix_max_horizontal_stddev_m_ = 0.3;
   }
   if (gnss_rtk_fix_weight_scale_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "gnss_rtk_fix_weight_scale must be positive, resetting %.3f to 3.0",
       gnss_rtk_fix_weight_scale_);
     gnss_rtk_fix_weight_scale_ = 3.0;
   }
   if (gnss_non_rtk_weight_scale_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "gnss_non_rtk_weight_scale must be positive, resetting %.3f to 1.0",
       gnss_non_rtk_weight_scale_);
     gnss_non_rtk_weight_scale_ = 1.0;
   }
   if (gnss_header_stamp_max_skew_sec_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "gnss_header_stamp_max_skew_sec must be positive, resetting %.3f to 30.0",
       gnss_header_stamp_max_skew_sec_);
     gnss_header_stamp_max_skew_sec_ = 30.0;
   }
   if (search_submap_num_ < 1) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "search_submap_num must be >= 1, clamping %d to 1",
       search_submap_num_);
     search_submap_num_ = 1;
   }
   if (loop_search_query_stride_ < 1) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "loop_search_query_stride must be >= 1, clamping %d to 1",
       loop_search_query_stride_);
     loop_search_query_stride_ = 1;
   }
   if (max_loop_candidate_count_ < 1) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "max_loop_candidate_count must be >= 1, clamping %d to 1",
       max_loop_candidate_count_);
     max_loop_candidate_count_ = 1;
   }
   if (loop_edge_dedup_index_window_ < 0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "loop_edge_dedup_index_window must be >= 0, clamping %d to 0",
       loop_edge_dedup_index_window_);
     loop_edge_dedup_index_window_ = 0;
@@ -545,21 +556,21 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   graph_state_.configureLoopEdgeDedupWindow(loop_edge_dedup_index_window_);
   if (loop_max_translation_delta_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "loop_max_translation_delta must be positive, resetting %.3f to 15.0",
       loop_max_translation_delta_);
     loop_max_translation_delta_ = 15.0;
   }
   if (loop_max_rotation_delta_deg_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "loop_max_rotation_delta_deg must be positive, resetting %.3f to 45.0",
       loop_max_rotation_delta_deg_);
     loop_max_rotation_delta_deg_ = 45.0;
   }
   if (loop_min_overlap_ratio_ < 0.0 || loop_min_overlap_ratio_ > 1.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "loop_min_overlap_ratio must be in [0, 1], resetting %.3f to 0 (disabled)",
       loop_min_overlap_ratio_);
     loop_min_overlap_ratio_ = 0.0;
@@ -569,7 +580,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     loop_min_overlap_ratio_large_correction_ > 1.0)
   {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "loop_min_overlap_ratio_large_correction must be in [0, 1], "
       "resetting %.3f to 0 (disabled)",
       loop_min_overlap_ratio_large_correction_);
@@ -577,7 +588,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   }
   if (loop_overlap_large_correction_translation_m_ < 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "loop_overlap_large_correction_translation_m must be non-negative, "
       "resetting %.3f to 0 (disabled)",
       loop_overlap_large_correction_translation_m_);
@@ -585,7 +596,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   }
   if (loop_overlap_max_distance_m_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "loop_overlap_max_distance_m must be positive, resetting %.3f to 0.5",
       loop_overlap_max_distance_m_);
     loop_overlap_max_distance_m_ = 0.5;
@@ -598,7 +609,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     loop_max_translation_delta_descriptor_ != -1.0)
   {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "loop_max_translation_delta_descriptor must be > 0 (override) or -1 "
       "(disabled); resetting %.3f to -1",
       loop_max_translation_delta_descriptor_);
@@ -608,7 +619,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     loop_max_rotation_delta_deg_descriptor_ != -1.0)
   {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "loop_max_rotation_delta_deg_descriptor must be > 0 (override) or -1 "
       "(disabled); resetting %.3f to -1",
       loop_max_rotation_delta_deg_descriptor_);
@@ -616,14 +627,14 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   }
   if (num_adjacent_pose_cnstraints_ < 1) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "num_adjacent_pose_cnstraints must be >= 1, clamping %d to 1",
       num_adjacent_pose_cnstraints_);
     num_adjacent_pose_cnstraints_ = 1;
   }
   if (adjacent_edge_info_weight_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "adjacent_edge_info_weight must be positive, resetting %.3f to 1000.0",
       adjacent_edge_info_weight_);
     adjacent_edge_info_weight_ = 1000.0;
@@ -642,49 +653,49 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   }
   if (loop_edge_info_weight_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "loop_edge_info_weight must be positive, resetting %.3f to 100.0",
       loop_edge_info_weight_);
     loop_edge_info_weight_ = 100.0;
   }
   if (loop_edge_robust_kernel_delta_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "loop_edge_robust_kernel_delta must be positive, resetting %.3f to 1.0",
       loop_edge_robust_kernel_delta_);
     loop_edge_robust_kernel_delta_ = 1.0;
   }
   if (bev_descriptor_threshold_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "bev_descriptor_threshold must be positive, resetting %.3f to 0.20",
       bev_descriptor_threshold_);
     bev_descriptor_threshold_ = 0.20;
   }
   if (bev_descriptor_grid_size_m_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "bev_descriptor_grid_size_m must be positive, resetting %.3f to 80.0",
       bev_descriptor_grid_size_m_);
     bev_descriptor_grid_size_m_ = 80.0;
   }
   if (bev_descriptor_grid_cells_ < 8) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "bev_descriptor_grid_cells must be >= 8, clamping %d to 8",
       bev_descriptor_grid_cells_);
     bev_descriptor_grid_cells_ = 8;
   }
   if (bev_descriptor_yaw_bins_ < 1) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "bev_descriptor_yaw_bins must be >= 1, clamping %d to 1",
       bev_descriptor_yaw_bins_);
     bev_descriptor_yaw_bins_ = 1;
   }
   if (bev_descriptor_sequence_window_ < 0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "bev_descriptor_sequence_window must be >= 0, clamping %d to 0",
       bev_descriptor_sequence_window_);
     bev_descriptor_sequence_window_ = 0;
@@ -694,14 +705,14 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   }
   if (bev_descriptor_rerank_weight_m_ < 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "bev_descriptor_rerank_weight_m must be >= 0.0, clamping %.3f to 0.0",
       bev_descriptor_rerank_weight_m_);
     bev_descriptor_rerank_weight_m_ = 0.0;
   }
   if (bev_descriptor_pose_consistency_threshold_m_ == 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "bev_descriptor_pose_consistency_threshold_m must be negative (disabled) or positive, "
       "resetting 0.0 to disabled");
     bev_descriptor_pose_consistency_threshold_m_ = -1.0;
@@ -710,7 +721,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     triangle_descriptor_keypoint_mode_ != "edge_3d")
   {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "triangle_descriptor_keypoint_mode must be 'bev_max_height' or 'edge_3d', "
       "got '%s'; falling back to 'bev_max_height'",
       triangle_descriptor_keypoint_mode_.c_str());
@@ -735,21 +746,21 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   }
   if (triangle_descriptor_grid_size_m_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "triangle_descriptor_grid_size_m must be positive, resetting %.3f to 60.0",
       triangle_descriptor_grid_size_m_);
     triangle_descriptor_grid_size_m_ = 60.0;
   }
   if (triangle_descriptor_grid_cells_ < 8) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "triangle_descriptor_grid_cells must be >= 8, clamping %d to 8",
       triangle_descriptor_grid_cells_);
     triangle_descriptor_grid_cells_ = 8;
   }
   if (triangle_descriptor_max_keypoints_ < 4) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "triangle_descriptor_max_keypoints must be >= 4, clamping %d to 4",
       triangle_descriptor_max_keypoints_);
     triangle_descriptor_max_keypoints_ = 4;
@@ -759,7 +770,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   }
   if (triangle_descriptor_max_edge_m_ <= triangle_descriptor_min_edge_m_) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "triangle_descriptor_max_edge_m (%.3f) must exceed min_edge_m (%.3f); using min*5",
       triangle_descriptor_max_edge_m_, triangle_descriptor_min_edge_m_);
     triangle_descriptor_max_edge_m_ = triangle_descriptor_min_edge_m_ * 5.0;
@@ -772,7 +783,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   }
   if (triangle_descriptor_quad_feature_bin_m_ < 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "triangle_descriptor_quad_feature_bin_m must be >= 0 (0 = disabled); "
       "resetting %.3f to 0",
       triangle_descriptor_quad_feature_bin_m_);
@@ -788,14 +799,14 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     triangle_descriptor_min_inlier_ratio_ = 0.0;
   } else if (triangle_descriptor_min_inlier_ratio_ > 1.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "triangle_descriptor_min_inlier_ratio must be in [0, 1]; clamping %.3f to 1.0",
       triangle_descriptor_min_inlier_ratio_);
     triangle_descriptor_min_inlier_ratio_ = 1.0;
   }
   if (triangle_descriptor_max_pairs_ < 3) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "triangle_descriptor_max_pairs must be >= 3; clamping %d to 3",
       triangle_descriptor_max_pairs_);
     triangle_descriptor_max_pairs_ = 3;
@@ -823,14 +834,14 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     solid_descriptor_min_similarity_ > 1.0)
   {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "solid_descriptor_min_similarity must be in (-1, 1], resetting %.3f to 0.70",
       solid_descriptor_min_similarity_);
     solid_descriptor_min_similarity_ = 0.70;
   }
   if (solid_descriptor_sequence_window_ < 0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "solid_descriptor_sequence_window must be >= 0, clamping %d to 0",
       solid_descriptor_sequence_window_);
     solid_descriptor_sequence_window_ = 0;
@@ -843,112 +854,112 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   }
   if (solid_descriptor_pose_consistency_threshold_m_ == 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "solid_descriptor_pose_consistency_threshold_m must be negative (disabled) or positive, "
       "resetting 0.0 to disabled");
     solid_descriptor_pose_consistency_threshold_m_ = -1.0;
   }
   if (three_d_bbs_min_level_res_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "three_d_bbs_min_level_res must be positive, resetting %.3f to 1.0",
       three_d_bbs_min_level_res_);
     three_d_bbs_min_level_res_ = 1.0;
   }
   if (three_d_bbs_max_level_ < 1) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "three_d_bbs_max_level must be >= 1, clamping %d to 1",
       three_d_bbs_max_level_);
     three_d_bbs_max_level_ = 1;
   }
   if (three_d_bbs_score_threshold_percentage_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "three_d_bbs_score_threshold_percentage must be positive, resetting %.3f to 0.25",
       three_d_bbs_score_threshold_percentage_);
     three_d_bbs_score_threshold_percentage_ = 0.25;
   }
   if (three_d_bbs_voxel_leaf_size_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "three_d_bbs_voxel_leaf_size must be positive, resetting %.3f to 1.0",
       three_d_bbs_voxel_leaf_size_);
     three_d_bbs_voxel_leaf_size_ = 1.0;
   }
   if (three_d_bbs_source_submap_num_ < 1) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "three_d_bbs_source_submap_num must be >= 1, clamping %d to 1",
       three_d_bbs_source_submap_num_);
     three_d_bbs_source_submap_num_ = 1;
   }
   if (three_d_bbs_target_submap_radius_ < 0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "three_d_bbs_target_submap_radius must be >= 0, clamping %d to 0",
       three_d_bbs_target_submap_radius_);
     three_d_bbs_target_submap_radius_ = 0;
   }
   if (three_d_bbs_translation_search_margin_m_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "three_d_bbs_translation_search_margin_m must be positive, resetting %.3f to 15.0",
       three_d_bbs_translation_search_margin_m_);
     three_d_bbs_translation_search_margin_m_ = 15.0;
   }
   if (three_d_bbs_roll_pitch_search_deg_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "three_d_bbs_roll_pitch_search_deg must be positive, resetting %.3f to 10.0",
       three_d_bbs_roll_pitch_search_deg_);
     three_d_bbs_roll_pitch_search_deg_ = 10.0;
   }
   if (three_d_bbs_yaw_search_deg_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "three_d_bbs_yaw_search_deg must be positive, resetting %.3f to 180.0",
       three_d_bbs_yaw_search_deg_);
     three_d_bbs_yaw_search_deg_ = 180.0;
   }
   if (dynamic_object_filter_voxel_size_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "dynamic_object_filter_voxel_size must be positive, resetting %.3f to 0.3",
       dynamic_object_filter_voxel_size_);
     dynamic_object_filter_voxel_size_ = 0.3;
   }
   if (dynamic_object_filter_min_observations_ < 1) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "dynamic_object_filter_min_observations must be >= 1, clamping %d to 1",
       dynamic_object_filter_min_observations_);
     dynamic_object_filter_min_observations_ = 1;
   }
   if (dynamic_object_filter_temporal_window_ < 0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "dynamic_object_filter_temporal_window must be >= 0, clamping %d to 0",
       dynamic_object_filter_temporal_window_);
     dynamic_object_filter_temporal_window_ = 0;
   }
   if (dynamic_object_filter_max_range_from_sensor_m_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "dynamic_object_filter_max_range_from_sensor_m must be positive, resetting %.3f to 30.0",
       dynamic_object_filter_max_range_from_sensor_m_);
     dynamic_object_filter_max_range_from_sensor_m_ = 30.0;
   }
   if (planar_map_filter_voxel_size_ <= 0.0) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "planar_map_filter_voxel_size must be positive, resetting %.3f to 0.1",
       planar_map_filter_voxel_size_);
     planar_map_filter_voxel_size_ = 0.1;
   }
   if (planar_map_filter_min_neighbors_ < 3) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "planar_map_filter_min_neighbors must be >= 3, clamping %d to 3",
       planar_map_filter_min_neighbors_);
     planar_map_filter_min_neighbors_ = 3;
@@ -1162,18 +1173,18 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
     std::cout << "planar_map_filter_min_retained_ratio:" <<
       planar_map_filter_min_retained_ratio_ << std::endl;
   }
-  declare_parameter("use_odom_input", false);
-  get_parameter("use_odom_input", use_odom_input_);
-  declare_parameter("submap_distance_threshold", 1.5);
-  get_parameter("submap_distance_threshold", submap_distance_threshold_);
-  declare_parameter("odom_cloud_sync_queue_size", 100);
-  get_parameter("odom_cloud_sync_queue_size", odom_cloud_sync_queue_size_);
+  node_.declare_parameter("use_odom_input", false);
+  node_.get_parameter("use_odom_input", use_odom_input_);
+  node_.declare_parameter("submap_distance_threshold", 1.5);
+  node_.get_parameter("submap_distance_threshold", submap_distance_threshold_);
+  node_.declare_parameter("odom_cloud_sync_queue_size", 100);
+  node_.get_parameter("odom_cloud_sync_queue_size", odom_cloud_sync_queue_size_);
   // v0.8 Phase 1 report-only degeneracy diagnostics (opt-in, default off:
   // empty path / false flag leaves default behavior untouched).
-  declare_parameter("degeneracy_diagnostics_csv_path", std::string(""));
-  get_parameter("degeneracy_diagnostics_csv_path", degeneracy_diagnostics_csv_path_);
-  declare_parameter("save_degeneracy_report", false);
-  get_parameter("save_degeneracy_report", save_degeneracy_report_);
+  node_.declare_parameter("degeneracy_diagnostics_csv_path", std::string(""));
+  node_.get_parameter("degeneracy_diagnostics_csv_path", degeneracy_diagnostics_csv_path_);
+  node_.declare_parameter("save_degeneracy_report", false);
+  node_.get_parameter("save_degeneracy_report", save_degeneracy_report_);
   std::cout << "use_odom_input:" << std::boolalpha << use_odom_input_ << std::endl;
   if (use_odom_input_) {
     std::cout << "submap_distance_threshold[m]:" << submap_distance_threshold_ << std::endl;
@@ -1190,7 +1201,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
       degeneracy_csv_ofs_ << degeneracy::degeneracyDiagnosticsCsvHeaderLine() << "\n";
     } else {
       RCLCPP_WARN(
-        get_logger(), "failed to open degeneracy_diagnostics_csv_path: %s (CSV disabled)",
+        node_.get_logger(), "failed to open degeneracy_diagnostics_csv_path: %s (CSV disabled)",
         degeneracy_diagnostics_csv_path_.c_str());
       degeneracy_diagnostics_csv_path_.clear();
     }
@@ -1224,7 +1235,7 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
   backend_->registration =
     backend_core::makeLoopRegistration(registration_method, ndt_resolution, ndt_num_threads);
   if (!backend_->registration) {
-    RCLCPP_ERROR(get_logger(), "invalid registration_method");
+    RCLCPP_ERROR(node_.get_logger(), "invalid registration_method");
     exit(1);
   }
 
@@ -1261,21 +1272,21 @@ GraphBasedSlamComponent::GraphBasedSlamComponent(const rclcpp::NodeOptions & opt
 
   initializePubSub();
 
-  map_save_srv_ = create_service<std_srvs::srv::Empty>(
+  map_save_srv_ = node_.create_service<std_srvs::srv::Empty>(
     "map_save",
     std::bind(
-      &GraphBasedSlamComponent::handleMapSaveRequest,
+      &GraphBasedSlamComponent::Impl::handleMapSaveRequest,
       this,
       std::placeholders::_1,
       std::placeholders::_2,
       std::placeholders::_3));
 }  // NOLINT(readability/fn_size)
 
-GraphBasedSlamComponent::~GraphBasedSlamComponent() = default;
+GraphBasedSlamComponent::Impl::~Impl() = default;
 
-void GraphBasedSlamComponent::initializePubSub()
+void GraphBasedSlamComponent::Impl::initializePubSub()
 {
-  RCLCPP_INFO(get_logger(), "initialize Publishers and Subscribers");
+  RCLCPP_INFO(node_.get_logger(), "initialize Publishers and Subscribers");
 
   auto map_array_callback =
     [this](const typename lidarslam_msgs::msg::MapArray::SharedPtr msg_ptr) -> void
@@ -1295,7 +1306,7 @@ void GraphBasedSlamComponent::initializePubSub()
     };
 
   map_array_sub_ =
-    create_subscription<lidarslam_msgs::msg::MapArray>(
+    node_.create_subscription<lidarslam_msgs::msg::MapArray>(
     "map_array", rclcpp::QoS(rclcpp::KeepLast(1)).reliable(), map_array_callback);
 
   if (use_odom_input_) {
@@ -1310,27 +1321,28 @@ void GraphBasedSlamComponent::initializePubSub()
     rmw_qos_profile_t cloud_qos = rmw_qos_profile_sensor_data;
     cloud_qos.depth = sync_depth;
     odom_sync_sub_ = std::make_shared<message_filters::Subscriber<nav_msgs::msg::Odometry>>(
-      this, "odom_input", odom_qos);
+      &node_, "odom_input", odom_qos);
     cloud_sync_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::PointCloud2>>(
-      this, "cloud_input", cloud_qos);
+      &node_, "cloud_input", cloud_qos);
     odom_cloud_sync_ = std::make_shared<message_filters::Synchronizer<OdomCloudSyncPolicy>>(
       OdomCloudSyncPolicy(static_cast<uint32_t>(sync_depth)), *odom_sync_sub_, *cloud_sync_sub_);
     odom_cloud_sync_->registerCallback(
       std::bind(
-        &GraphBasedSlamComponent::receiveSyncedOdomCloud, this, std::placeholders::_1,
+        &GraphBasedSlamComponent::Impl::receiveSyncedOdomCloud, this, std::placeholders::_1,
         std::placeholders::_2));
     RCLCPP_INFO(
-      get_logger(), "Direct odom+cloud input mode enabled (stamp-synced, queue %zu)", sync_depth);
+      node_.get_logger(), "Direct odom+cloud input mode enabled (stamp-synced, queue %zu)",
+      sync_depth);
   }
 
-  modified_map_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
+  modified_map_pub_ = node_.create_publisher<sensor_msgs::msg::PointCloud2>(
     "modified_map",
     rclcpp::QoS(10));
 
-  modified_map_array_pub_ = create_publisher<lidarslam_msgs::msg::MapArray>(
+  modified_map_array_pub_ = node_.create_publisher<lidarslam_msgs::msg::MapArray>(
     "modified_map_array", rclcpp::QoS(10));
 
-  modified_path_pub_ = create_publisher<nav_msgs::msg::Path>(
+  modified_path_pub_ = node_.create_publisher<nav_msgs::msg::Path>(
     "modified_path",
     rclcpp::QoS(10));
 
@@ -1340,25 +1352,25 @@ void GraphBasedSlamComponent::initializePubSub()
       {
         receiveImu(*msg);
       };
-    imu_sub_ = create_subscription<sensor_msgs::msg::Imu>(
+    imu_sub_ = node_.create_subscription<sensor_msgs::msg::Imu>(
       "/imu", rclcpp::SensorDataQoS(), imu_callback);
-    RCLCPP_INFO(get_logger(), "IMU preintegration enabled, subscribed to /imu");
+    RCLCPP_INFO(node_.get_logger(), "IMU preintegration enabled, subscribed to /imu");
   }
 
   if (use_gnss_) {
-    gnss_sub_ = create_subscription<sensor_msgs::msg::NavSatFix>(
+    gnss_sub_ = node_.create_subscription<sensor_msgs::msg::NavSatFix>(
       gnss_topic_, rclcpp::SensorDataQoS(),
       [this](const sensor_msgs::msg::NavSatFix::SharedPtr msg) {receiveNavSatFix(*msg);});
     RCLCPP_INFO(
-      get_logger(),
+      node_.get_logger(),
       "GNSS constraints enabled, subscribed to %s",
       gnss_topic_.c_str());
   }
 
-  RCLCPP_INFO(get_logger(), "initialization end");
+  RCLCPP_INFO(node_.get_logger(), "initialization end");
 }
 
-void GraphBasedSlamComponent::handleMapSaveRequest(
+void GraphBasedSlamComponent::Impl::handleMapSaveRequest(
   const MapSaveRequestHeader request_header,
   const MapSaveRequest request,
   const MapSaveResponse response)
@@ -1377,24 +1389,24 @@ void GraphBasedSlamComponent::handleMapSaveRequest(
   doPoseAdjustment(map_array_msg, loop_edges, true);
 }
 
-bool GraphBasedSlamComponent::snapshotGraphState(
+bool GraphBasedSlamComponent::Impl::snapshotGraphState(
   lidarslam_msgs::msg::MapArray & map_array_msg,
   LoopEdges & loop_edges)
 {
   return graph_state_.snapshot(map_array_msg, loop_edges);
 }
 
-void GraphBasedSlamComponent::snapshotLoopEdges(LoopEdges & loop_edges)
+void GraphBasedSlamComponent::Impl::snapshotLoopEdges(LoopEdges & loop_edges)
 {
   loop_edges = graph_state_.snapshotLoopEdges();
 }
 
-bool GraphBasedSlamComponent::upsertLoopEdge(const LoopEdge & loop_edge)
+bool GraphBasedSlamComponent::Impl::upsertLoopEdge(const LoopEdge & loop_edge)
 {
   return graph_state_.upsertLoopEdge(loop_edge);
 }
-GraphBasedSlamComponent::LocalSubmapProvider
-GraphBasedSlamComponent::makeFilteredLocalSubmapProvider(
+GraphBasedSlamComponent::Impl::LocalSubmapProvider
+GraphBasedSlamComponent::Impl::makeFilteredLocalSubmapProvider(
   const lidarslam_msgs::msg::MapArray & map_array_msg)
 {
   return [this, &map_array_msg](int ref_idx) -> pcl::PointCloud<pcl::PointXYZI>::Ptr {
@@ -1430,14 +1442,14 @@ GraphBasedSlamComponent::makeFilteredLocalSubmapProvider(
          };
 }
 
-void GraphBasedSlamComponent::runEventDrivenLoopSearch()
+void GraphBasedSlamComponent::Impl::runEventDrivenLoopSearch()
 {
   // A component may be hosted by a MultiThreadedExecutor. Elect one callback
   // to own BackendCore and coalesce notifications that arrive while it drains.
   backend_work_drain_.request([this]() {drainEventDrivenLoopSearch();});
 }
 
-void GraphBasedSlamComponent::drainEventDrivenLoopSearch()
+void GraphBasedSlamComponent::Impl::drainEventDrivenLoopSearch()
 {
   while (rclcpp::ok()) {
     lidarslam_msgs::msg::MapArray map_array_msg;
@@ -1449,7 +1461,7 @@ void GraphBasedSlamComponent::drainEventDrivenLoopSearch()
     if (query_idx < 1) {query_idx = 1;}
     if (query_idx >= num_submaps) {return;}
     if (map_array_msg.cloud_coordinate != map_array_msg.LOCAL) {
-      RCLCPP_WARN(get_logger(), "cloud_coordinate should be local, but it's not local.");
+      RCLCPP_WARN(node_.get_logger(), "cloud_coordinate should be local, but it's not local.");
     }
     const auto build_filtered_local_submap = makeFilteredLocalSubmapProvider(map_array_msg);
     // One immutable snapshot serves the whole currently available batch.
@@ -1458,7 +1470,7 @@ void GraphBasedSlamComponent::drainEventDrivenLoopSearch()
     for (; query_idx < num_submaps && rclcpp::ok(); ++query_idx) {
       if (debug_flag_) {
         RCLCPP_INFO(
-          get_logger(), "event-driven loop search, query submap %d of %d", query_idx,
+          node_.get_logger(), "event-driven loop search, query submap %d of %d", query_idx,
           num_submaps);
       }
       backend_->core.ingestDescriptors(query_idx + 1, build_filtered_local_submap);
@@ -1466,7 +1478,7 @@ void GraphBasedSlamComponent::drainEventDrivenLoopSearch()
         searchLoopForLatest(map_array_msg, loop_edges, query_idx + 1, query_idx);
       } else if (debug_flag_) {
         RCLCPP_INFO(
-          get_logger(), "loop search registration skipped for query submap %d by stride %d",
+          node_.get_logger(), "loop search registration skipped for query submap %d by stride %d",
           query_idx, loop_search_query_stride_);
       }
       last_searched_submap_idx_ = query_idx;
@@ -1474,7 +1486,7 @@ void GraphBasedSlamComponent::drainEventDrivenLoopSearch()
   }
 }
 
-void GraphBasedSlamComponent::searchLoopForLatest(
+void GraphBasedSlamComponent::Impl::searchLoopForLatest(
   const lidarslam_msgs::msg::MapArray & map_array_msg,
   LoopEdges & loop_edges,
   int num_submaps,
@@ -1592,7 +1604,7 @@ void GraphBasedSlamComponent::searchLoopForLatest(
 
   for (const auto & line : search_output.logs) {
     if (line.via_logger) {
-      RCLCPP_INFO(get_logger(), "%s", line.text.c_str());
+      RCLCPP_INFO(node_.get_logger(), "%s", line.text.c_str());
     } else {
       std::cout << line.text << std::endl;
     }
@@ -1620,7 +1632,7 @@ void GraphBasedSlamComponent::searchLoopForLatest(
   doPoseAdjustment(std::move(query_prefix), loop_edges, use_save_map_in_loop_);
 }
 
-void GraphBasedSlamComponent::doPoseAdjustment(
+void GraphBasedSlamComponent::Impl::doPoseAdjustment(
   lidarslam_msgs::msg::MapArray map_array_msg,
   const LoopEdges & loop_edges,
   bool do_save_map)
@@ -1664,7 +1676,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
     }
     if (debug_flag_) {
       RCLCPP_INFO(
-        get_logger(), "Added %zu IMU rotation constraint edges", imu_constraints.size());
+        node_.get_logger(), "Added %zu IMU rotation constraint edges", imu_constraints.size());
     }
   }
 
@@ -1714,7 +1726,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
     }
     if (debug_flag_) {
       RCLCPP_INFO(
-        get_logger(),
+        node_.get_logger(),
         "Added %zu GNSS position constraint edges (%d RTK-like by covariance)",
         gnss_constraints.size(), gnss_rtk_like_edges_added);
     }
@@ -1749,13 +1761,13 @@ void GraphBasedSlamComponent::doPoseAdjustment(
       }
       fix_first_vertex = false;
       RCLCPP_INFO(
-        get_logger(),
+        node_.get_logger(),
         "GNSS yaw alignment applied: yaw=%.2f deg, baseline=%.1f m, rms=%.2f m; "
         "vertex-0 gauge released, graph moves to the ENU frame",
         alignment.yaw_rad * 180.0 / M_PI, alignment.baseline_m, alignment.rms_residual_m);
     } else if (debug_flag_) {
       RCLCPP_INFO(
-        get_logger(),
+        node_.get_logger(),
         "GNSS yaw alignment not applied (pairs=%zu, baseline=%.1f m); keeping the "
         "vertex-0 gauge",
         odom_xy.size(), alignment.baseline_m);
@@ -1805,7 +1817,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
       std::filesystem::copy_options::overwrite_existing, copy_error);
     if (copy_error) {
       RCLCPP_WARN(
-        get_logger(), "failed to copy pose graph to configured path %s: %s",
+        node_.get_logger(), "failed to copy pose graph to configured path %s: %s",
         save_pose_graph_path_.c_str(), copy_error.message().c_str());
     }
   }
@@ -1836,7 +1848,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
         graphslam::detail::nextScale(prev_w_rot, median_chi2_rot, cfg);
 
       RCLCPP_INFO(
-        get_logger(),
+        node_.get_logger(),
         "[auto_scale_split] trans median_chi2=%.3f target=%.3f w_trans=%.3f -> %.3f | "
         "rot median_chi2=%.3f target=%.3f w_rot=%.3f -> %.3f (n=%zu)",
         median_chi2_trans, adjacent_edge_info_auto_scale_target_nis_trans_,
@@ -1853,7 +1865,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
         graphslam::detail::nextScale(prev_weight, median_chi2, cfg);
 
       RCLCPP_INFO(
-        get_logger(),
+        node_.get_logger(),
         "[auto_scale] median_chi2=%.3f (n=%zu) target=%.3f weight=%.3f -> %.3f",
         median_chi2, opt_result.adjacent_chi2.size(), cfg.target_nis, prev_weight,
         adjacent_edge_info_weight_);
@@ -1930,7 +1942,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
         map_to_save = filter_result.cloud;
       }
       RCLCPP_INFO(
-        get_logger(),
+        node_.get_logger(),
         "Dynamic object filter: input_points %zu, kept %zu/%zu candidate voxels, "
         "removed %zu, always_keep %zu, output_points %zu",
         filter_result.stats.input_points,
@@ -1946,7 +1958,7 @@ void GraphBasedSlamComponent::doPoseAdjustment(
   }
 }
 
-void GraphBasedSlamComponent::receiveNavSatFix(const sensor_msgs::msg::NavSatFix & msg)
+void GraphBasedSlamComponent::Impl::receiveNavSatFix(const sensor_msgs::msg::NavSatFix & msg)
 {
   if (msg.status.status < sensor_msgs::msg::NavSatStatus::STATUS_FIX) {
     return;  // No valid fix
@@ -1976,7 +1988,7 @@ void GraphBasedSlamComponent::receiveNavSatFix(const sensor_msgs::msg::NavSatFix
   weighting_config.non_rtk_weight_scale = gnss_non_rtk_weight_scale_;
   const detail::GnssConstraintWeights gnss_weights =
     detail::computeGnssConstraintWeights(msg, weighting_config);
-  const double receive_time_sec = get_clock()->now().seconds();
+  const double receive_time_sec = node_.get_clock()->now().seconds();
   const double header_time_sec = rclcpp::Time(msg.header.stamp).seconds();
   const detail::GnssTimestampResolution stamp_resolution =
     detail::resolveGnssMeasurementStamp(
@@ -1996,8 +2008,8 @@ void GraphBasedSlamComponent::receiveNavSatFix(const sensor_msgs::msg::NavSatFix
 
   if (debug_flag_ && stamp_resolution.used_fallback) {
     RCLCPP_WARN_THROTTLE(
-      get_logger(),
-      *get_clock(),
+      node_.get_logger(),
+      *node_.get_clock(),
       5000,
       "GNSS header stamp %.3f s differs from receive time %.3f s by more than "
       "%.3f s; using receive time",
@@ -2006,8 +2018,8 @@ void GraphBasedSlamComponent::receiveNavSatFix(const sensor_msgs::msg::NavSatFix
 
   if (debug_flag_ && gnss_weights.covariance_valid) {
     RCLCPP_INFO_THROTTLE(
-      get_logger(),
-      *get_clock(),
+      node_.get_logger(),
+      *node_.get_clock(),
       5000,
       "GNSS covariance weighting: horizontal_stddev=%.3f m, class=%s, info=(%.3f, %.3f, %.3f)",
       gnss_weights.horizontal_stddev_m,
@@ -2021,23 +2033,23 @@ void GraphBasedSlamComponent::receiveNavSatFix(const sensor_msgs::msg::NavSatFix
   }
 }
 
-bool GraphBasedSlamComponent::isUsableGnssFix(const sensor_msgs::msg::NavSatFix & msg) const
+bool GraphBasedSlamComponent::Impl::isUsableGnssFix(const sensor_msgs::msg::NavSatFix & msg) const
 {
   return detail::isUsableGeodeticFix(msg.latitude, msg.longitude, msg.altitude);
 }
 
-void GraphBasedSlamComponent::tryInitializeGnssOrigin(double lat, double lon, double alt)
+void GraphBasedSlamComponent::Impl::tryInitializeGnssOrigin(double lat, double lon, double alt)
 {
   const detail::GnssOriginUpdate update = gnss_origin_accumulator_.add(lat, lon, alt);
   if (update.reset_after_jump) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "Resetting GNSS origin initialization after %.1f m jump in candidate fixes",
       update.deviation_m);
   }
   if (update.restarted_after_inconsistency) {
     RCLCPP_WARN(
-      get_logger(),
+      node_.get_logger(),
       "GNSS origin candidates were inconsistent (max deviation %.1f m), restarting accumulation",
       update.deviation_m);
   }
@@ -2050,12 +2062,12 @@ void GraphBasedSlamComponent::tryInitializeGnssOrigin(double lat, double lon, do
   gnss_origin_alt_ = update.origin.altitude_m;
   gnss_origin_set_ = true;
   RCLCPP_INFO(
-    get_logger(),
+    node_.get_logger(),
     "GNSS origin set from %d consistent fixes: lat=%.8f, lon=%.8f, alt=%.2f",
     gnss_origin_min_samples_, gnss_origin_lat_, gnss_origin_lon_, gnss_origin_alt_);
 }
 
-Eigen::Vector3d GraphBasedSlamComponent::geodeticToEnu(
+Eigen::Vector3d GraphBasedSlamComponent::Impl::geodeticToEnu(
   double lat, double lon, double alt) const
 {
   const detail::GeodeticOrigin origin {
@@ -2063,7 +2075,7 @@ Eigen::Vector3d GraphBasedSlamComponent::geodeticToEnu(
   return detail::geodeticToEnu(lat, lon, alt, origin);
 }
 
-void GraphBasedSlamComponent::receiveImu(const sensor_msgs::msg::Imu & msg)
+void GraphBasedSlamComponent::Impl::receiveImu(const sensor_msgs::msg::Imu & msg)
 {
   std::lock_guard<std::mutex> lock(imu_mtx_);
   StampedImu imu;
@@ -2084,7 +2096,7 @@ void GraphBasedSlamComponent::receiveImu(const sensor_msgs::msg::Imu & msg)
   }
 }
 
-Eigen::Quaterniond GraphBasedSlamComponent::integrateImuRotation(double t0, double t1) const
+Eigen::Quaterniond GraphBasedSlamComponent::Impl::integrateImuRotation(double t0, double t1) const
 {
   // Integrate gyroscope measurements between t0 and t1
   Eigen::Quaterniond delta_q = Eigen::Quaterniond::Identity();
@@ -2119,7 +2131,7 @@ Eigen::Quaterniond GraphBasedSlamComponent::integrateImuRotation(double t0, doub
   return delta_q;
 }
 
-void GraphBasedSlamComponent::receiveSyncedOdomCloud(
+void GraphBasedSlamComponent::Impl::receiveSyncedOdomCloud(
   const nav_msgs::msg::Odometry::ConstSharedPtr & odom_msg,
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr & cloud_msg)
 {
@@ -2132,14 +2144,14 @@ void GraphBasedSlamComponent::receiveSyncedOdomCloud(
   if (debug_flag_ && !first_synced_input_logged_) {
     first_synced_input_logged_ = true;
     RCLCPP_INFO(
-      get_logger(), "First synced odom+cloud pair: (%.2f, %.2f, %.2f), %zu bytes", pos.x(),
+      node_.get_logger(), "First synced odom+cloud pair: (%.2f, %.2f, %.2f), %zu bytes", pos.x(),
       pos.y(), pos.z(), cloud_msg->data.size());
   }
   recordScanDegeneracy(*odom_msg);
   tryCreateSubmap(*odom_msg, *cloud_msg);
 }
 
-void GraphBasedSlamComponent::recordScanDegeneracy(const nav_msgs::msg::Odometry & odom_msg)
+void GraphBasedSlamComponent::Impl::recordScanDegeneracy(const nav_msgs::msg::Odometry & odom_msg)
 {
   // Opt-in, report-only (v0.8 Phase 1): compute nothing at all unless one of
   // the two diagnostics outputs was requested, so the default path stays
@@ -2162,7 +2174,7 @@ void GraphBasedSlamComponent::recordScanDegeneracy(const nav_msgs::msg::Odometry
   }
 }
 
-void GraphBasedSlamComponent::writeDegeneracyReport()
+void GraphBasedSlamComponent::Impl::writeDegeneracyReport()
 {
   if (!save_degeneracy_report_) {
     return;
@@ -2178,7 +2190,7 @@ void GraphBasedSlamComponent::writeDegeneracyReport()
   const std::string report_path = map_save_dir_ + "/degeneracy_report.yaml";
   std::ofstream report(report_path);
   if (!report.is_open()) {
-    RCLCPP_WARN(get_logger(), "failed to write degeneracy report: %s", report_path.c_str());
+    RCLCPP_WARN(node_.get_logger(), "failed to write degeneracy report: %s", report_path.c_str());
     return;
   }
   const std::vector<std::string> lines = degeneracy::degeneracyReportYamlLines(summary);
@@ -2188,7 +2200,7 @@ void GraphBasedSlamComponent::writeDegeneracyReport()
   std::cout << "Degeneracy report: " << report_path << std::endl;
 }
 
-void GraphBasedSlamComponent::tryCreateSubmap(
+void GraphBasedSlamComponent::Impl::tryCreateSubmap(
   const nav_msgs::msg::Odometry & odom_msg,
   const sensor_msgs::msg::PointCloud2 & cloud_msg)
 {
@@ -2230,13 +2242,15 @@ void GraphBasedSlamComponent::tryCreateSubmap(
   ingest_lock.unlock();
 
   if (n % 50 == 0) {
-    RCLCPP_INFO(get_logger(), "Odom input: %d submaps, distance: %.1fm", n, accumulated_distance_);
+    RCLCPP_INFO(
+      node_.get_logger(), "Odom input: %d submaps, distance: %.1fm", n,
+      accumulated_distance_);
   }
 
   runEventDrivenLoopSearch();
 }
 
-void GraphBasedSlamComponent::stageMapArrayCloudCache(
+void GraphBasedSlamComponent::Impl::stageMapArrayCloudCache(
   lidarslam_msgs::msg::MapArray & map_array_msg)
 {
   // Treat a full MapArray cache refresh as one repository transaction so
@@ -2255,7 +2269,7 @@ void GraphBasedSlamComponent::stageMapArrayCloudCache(
   }
 }
 
-bool GraphBasedSlamComponent::saveSubmapToPCD(
+bool GraphBasedSlamComponent::Impl::saveSubmapToPCD(
   int idx,
   const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud)
 {
@@ -2263,7 +2277,7 @@ bool GraphBasedSlamComponent::saveSubmapToPCD(
   return saveSubmapToPCDUnlocked(idx, cloud);
 }
 
-bool GraphBasedSlamComponent::saveSubmapToPCDUnlocked(
+bool GraphBasedSlamComponent::Impl::saveSubmapToPCDUnlocked(
   int idx,
   const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud)
 {
@@ -2271,22 +2285,22 @@ bool GraphBasedSlamComponent::saveSubmapToPCDUnlocked(
   if (pcl::io::savePCDFileBinaryCompressed(path, *cloud) == 0) {
     return true;
   }
-  RCLCPP_WARN(get_logger(), "Failed to save PCD: %s", path.c_str());
+  RCLCPP_WARN(node_.get_logger(), "Failed to save PCD: %s", path.c_str());
   return false;
 }
 
-pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::loadSubmapFromPCD(int idx)
+pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::Impl::loadSubmapFromPCD(int idx)
 {
   std::lock_guard<std::mutex> cache_lock(pcd_cache_mtx_);
   auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZI>>();
   std::string path = map_saver::submapCachePath(pcd_cache_dir_, idx);
   if (pcl::io::loadPCDFile(path, *cloud) == -1) {
-    RCLCPP_WARN(get_logger(), "Failed to load PCD: %s", path.c_str());
+    RCLCPP_WARN(node_.get_logger(), "Failed to load PCD: %s", path.c_str());
   }
   return cloud;
 }
 
-pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::loadSubmapCloud(
+pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::Impl::loadSubmapCloud(
   const lidarslam_msgs::msg::MapArray & map_array_msg,
   int idx)
 {
@@ -2304,7 +2318,7 @@ pcl::PointCloud<pcl::PointXYZI>::Ptr GraphBasedSlamComponent::loadSubmapCloud(
   return cloud;
 }
 
-void GraphBasedSlamComponent::writeMapBundleArtifacts(
+void GraphBasedSlamComponent::Impl::writeMapBundleArtifacts(
   const lidarslam_msgs::msg::MapArray & map_array_msg,
   const LoopEdges & loop_edges,
   const std::vector<Eigen::Isometry3d> & optimized_poses)
@@ -2314,7 +2328,8 @@ void GraphBasedSlamComponent::writeMapBundleArtifacts(
   const std::string trajectory_path = map_save_dir_ + "/trajectory_optimized.tum";
   std::ofstream trajectory(trajectory_path);
   if (!trajectory.is_open()) {
-    RCLCPP_WARN(get_logger(), "failed to write optimized trajectory: %s", trajectory_path.c_str());
+    RCLCPP_WARN(
+      node_.get_logger(), "failed to write optimized trajectory: %s", trajectory_path.c_str());
   } else {
     const std::size_t count = std::min(map_array_msg.submaps.size(), optimized_poses.size());
     for (std::size_t i = 0; i < count; ++i) {
@@ -2336,7 +2351,7 @@ void GraphBasedSlamComponent::writeMapBundleArtifacts(
   const std::string loop_edges_path = map_save_dir_ + "/loop_edges.csv";
   std::ofstream loop_csv(loop_edges_path);
   if (!loop_csv.is_open()) {
-    RCLCPP_WARN(get_logger(), "failed to write loop edges: %s", loop_edges_path.c_str());
+    RCLCPP_WARN(node_.get_logger(), "failed to write loop edges: %s", loop_edges_path.c_str());
   } else {
     loop_csv << map_saver::loopEdgesCsvHeader() << "\n";
     for (const auto & edge : loop_edges) {
@@ -2376,17 +2391,18 @@ void GraphBasedSlamComponent::writeMapBundleArtifacts(
   const std::string manifest_path = map_save_dir_ + "/map_bundle.yaml";
   std::ofstream manifest_file(manifest_path);
   if (!manifest_file.is_open()) {
-    RCLCPP_WARN(get_logger(), "failed to write map bundle manifest: %s", manifest_path.c_str());
+    RCLCPP_WARN(
+      node_.get_logger(), "failed to write map bundle manifest: %s", manifest_path.c_str());
   } else {
     manifest_file << map_saver::bundleManifestYaml(manifest);
   }
 
   RCLCPP_INFO(
-    get_logger(), "Map bundle artifacts: trajectory=%s loops=%s manifest=%s",
+    node_.get_logger(), "Map bundle artifacts: trajectory=%s loops=%s manifest=%s",
     trajectory_path.c_str(), loop_edges_path.c_str(), manifest_path.c_str());
 }
 
-void GraphBasedSlamComponent::saveGridDividedMap(
+void GraphBasedSlamComponent::Impl::saveGridDividedMap(
   const pcl::PointCloud<pcl::PointXYZI>::Ptr & map)
 {
   if (map->empty()) {
@@ -2431,7 +2447,7 @@ void GraphBasedSlamComponent::saveGridDividedMap(
     const auto filter_result = buildPlanarMapFilteredMap(downsampled, filter_config);
     downsampled = filter_result.cloud;
     RCLCPP_INFO(
-      get_logger(),
+      node_.get_logger(),
       "Planar map filter: input_points %zu, finite %zu, planar_voxels %zu/%zu, "
       "supported_points %zu, output_points %zu, fallback %s",
       filter_result.stats.input_points,

--- a/graph_based_slam/src/graph_based_slam_component_impl.hpp
+++ b/graph_based_slam/src/graph_based_slam_component_impl.hpp
@@ -1,0 +1,481 @@
+// Copyright 2026 Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD 2-Clause Simplified License)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef GRAPH_BASED_SLAM_COMPONENT_IMPL_HPP_
+#define GRAPH_BASED_SLAM_COMPONENT_IMPL_HPP_
+
+#include "graph_based_slam/graph_based_slam_component.h"
+
+#include <Eigen/Core>  // NOLINT(build/include_order)
+#include <Eigen/Geometry>  // NOLINT(build/include_order)
+#include <pcl/point_cloud.h>  // NOLINT(build/include_order)
+#include <pcl/point_types.h>  // NOLINT(build/include_order)
+#include <tf2_ros/buffer.h>  // NOLINT(build/include_order)
+#include <tf2_ros/transform_broadcaster.h>  // NOLINT(build/include_order)
+#include <tf2_ros/transform_listener.h>  // NOLINT(build/include_order)
+
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/transform.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <lidarslam_msgs/msg/map_array.hpp>
+#include <message_filters/subscriber.h>  // NOLINT(build/include_order)
+#include <message_filters/sync_policies/approximate_time.h>  // NOLINT(build/include_order)
+#include <message_filters/synchronizer.h>  // NOLINT(build/include_order)
+#include <nav_msgs/msg/odometry.hpp>
+#include <nav_msgs/msg/path.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_srvs/srv/empty.hpp>
+#include "graph_based_slam/degeneracy_report_summary.hpp"
+#include "graph_based_slam/gnss_origin_accumulator.hpp"
+#include "graph_based_slam/graph_state_store.hpp"
+#include "graph_based_slam/serialized_work_drain.hpp"
+
+namespace graphslam
+{
+class GraphBasedSlamComponent::Impl    // NOLINT(runtime/indentation_namespace)
+{
+public:
+  explicit Impl(GraphBasedSlamComponent & node);
+  ~Impl();
+
+private:
+  struct BackendWorkspace;
+
+  GraphBasedSlamComponent & node_;
+  rclcpp::Clock clock_;
+  tf2_ros::Buffer tfbuffer_;
+  tf2_ros::TransformListener listener_;
+  tf2_ros::TransformBroadcaster broadcaster_;
+
+    // Compiler firewall for the ROS-free backend, registration engine,
+    // voxel filter and 3D-BBS verifier. Their PCL/pclomp/descriptor headers
+    // stay in the component implementation translation unit.
+  std::unique_ptr<BackendWorkspace> backend_;
+    // BackendWorkspace is single-threaded by contract. Keep that contract
+    // when hosted by a MultiThreadedExecutor, while coalescing arrivals
+    // during a long search.
+  scheduling::SerializedWorkDrain backend_work_drain_;
+    // Serializes ordered input staging (cloud conversion / PCD writes) but
+    // never blocks GraphStateStore snapshots during that I/O.
+  std::mutex submap_ingest_mtx_;
+  GraphStateStore graph_state_;
+
+  rclcpp::Subscription<lidarslam_msgs::msg::MapArray>::SharedPtr map_array_sub_;
+  rclcpp::Publisher<lidarslam_msgs::msg::MapArray>::SharedPtr modified_map_array_pub_;
+  rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr modified_path_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr modified_map_pub_;
+  rclcpp::Service<std_srvs::srv::Empty>::SharedPtr map_save_srv_;
+
+  using LoopEdge = GraphStateStore::LoopEdge;
+  using LoopEdges = GraphStateStore::LoopEdges;
+  using PointCloud = pcl::PointCloud<pcl::PointXYZI>;
+  using PointCloudPtr = PointCloud::Ptr;
+  using LocalSubmapProvider = std::function<PointCloudPtr(int)>;
+  using MapSaveRequestHeader = std::shared_ptr<rmw_request_id_t>;
+  using MapSaveRequest = std::shared_ptr<std_srvs::srv::Empty::Request>;
+  using MapSaveResponse = std::shared_ptr<std_srvs::srv::Empty::Response>;
+
+  void initializePubSub();
+  void handleMapSaveRequest(
+    const MapSaveRequestHeader request_header,
+    const MapSaveRequest request,
+    const MapSaveResponse response);
+    // Event-driven scheduling (docs/roadmap/v0.6.md, Phase 2): drain every
+    // submap not yet used as a loop-search query, in arrival order, each
+    // against exactly the map state [0..q] so the result is a function of
+    // the data, not of how the executor batched arrivals.
+  void runEventDrivenLoopSearch();
+  void drainEventDrivenLoopSearch();
+    // Per-query loop search body shared by the event-driven drain.
+  void searchLoopForLatest(
+    const lidarslam_msgs::msg::MapArray & map_array_msg,
+    LoopEdges & loop_edges,
+    int num_submaps,
+    int latest_idx);
+    // Voxel-filtered local aggregate of a submap and its recent neighbors;
+    // the returned provider borrows map_array_msg and must not outlive it.
+  LocalSubmapProvider makeFilteredLocalSubmapProvider(
+    const lidarslam_msgs::msg::MapArray & map_array_msg);
+  bool snapshotGraphState(
+    lidarslam_msgs::msg::MapArray & map_array_msg,
+    LoopEdges & loop_edges);
+  void snapshotLoopEdges(LoopEdges & loop_edges);
+  bool upsertLoopEdge(const LoopEdge & loop_edge);
+  void doPoseAdjustment(
+    lidarslam_msgs::msg::MapArray map_array_msg,
+    const LoopEdges & loop_edges,
+    bool do_save_map);
+  void publishMapAndPose();
+
+    // loop search parameter
+  double threshold_loop_closure_score_;
+  double scan_context_loop_closure_score_threshold_ {-1.0};
+  double distance_loop_closure_;
+  double range_of_searching_loop_closure_;
+  int search_submap_num_;
+  int loop_search_query_stride_ {1};
+  int max_loop_candidate_count_ {3};
+  int loop_edge_dedup_index_window_ {8};
+  double loop_max_translation_delta_ {15.0};
+  double loop_max_rotation_delta_deg_ {45.0};
+  double loop_min_overlap_ratio_ {0.0};
+  double loop_min_overlap_ratio_large_correction_ {0.0};
+  double loop_overlap_large_correction_translation_m_ {0.0};
+  double loop_overlap_max_distance_m_ {0.5};
+    // Per-source overrides for descriptor-based candidates (TRIANGLE,
+    // SCAN_CONTEXT, BEV, SOLID). When positive, replace the generic caps
+    // above for those sources only — DISTANCE keeps the strict default.
+    // -1.0 = disabled / fall back to the generic cap.
+  double loop_max_translation_delta_descriptor_ {-1.0};
+  double loop_max_rotation_delta_deg_descriptor_ {-1.0};
+  int last_searched_submap_idx_ {-1};
+    // Event-driven loop search (the only scheduling semantics since v0.7
+    // Phase 0): loop search runs once per submap arrival in arrival order,
+    // each query seeing exactly the map state up to itself. The legacy
+    // wall-clock timer path and the retired deterministic_loop_scheduling
+    // parameter (v0.4 D1) are gone.
+
+    // pose graph optimization parameter
+  int num_adjacent_pose_cnstraints_;
+  bool use_save_map_in_loop_ {true};
+  double adjacent_edge_info_weight_ {1000.0};
+  double loop_edge_info_weight_ {100.0};
+  double loop_edge_robust_kernel_delta_ {1.0};
+  std::string loop_edge_robust_kernel_type_ {"huber"};
+
+    // Auto-scaling for adjacent_edge_info_weight (Level 1: NIS median tracking).
+    // When enabled, the post-optimisation chi-squared of adjacent edges is
+    // monitored and adjacent_edge_info_weight_ is mixed toward
+    // current * target_nis / median_chi2 via EMA, clamped to [min, max].
+  bool adjacent_edge_info_auto_scale_ {false};
+  double adjacent_edge_info_auto_scale_target_nis_ {6.0};
+  double adjacent_edge_info_auto_scale_ema_alpha_ {0.3};
+  double adjacent_edge_info_auto_scale_min_ {1.0};
+  double adjacent_edge_info_auto_scale_max_ {1.0e6};
+    // Level 2: split the adjacent edge Information matrix into translation /
+    // rotation blocks (block-diag with weights w_trans, w_rot on I_3 each) so
+    // the auto-scaler can balance translation residuals and rotation residuals
+    // independently. When split mode is off the legacy single-scalar shape is
+    // used. Targets default to 3.0 (3 DoF per block, vs 6 for the unified
+    // mode); the EMA / min / max defaults are shared with Level 1.
+  bool adjacent_edge_info_auto_scale_split_trans_rot_ {false};
+  double adjacent_edge_info_weight_trans_ {-1.0};
+  double adjacent_edge_info_weight_rot_ {-1.0};
+  double adjacent_edge_info_auto_scale_target_nis_trans_ {3.0};
+  double adjacent_edge_info_auto_scale_target_nis_rot_ {3.0};
+
+  int previous_submaps_num_ {0};
+
+  bool debug_flag_ {false};
+
+    // Scan Context loop detection
+  bool use_scan_context_ {false};
+  double scan_context_threshold_ {0.3};
+  int scan_context_query_stride_ {1};
+  int scan_context_exclude_recent_ {50};
+  bool prefer_scan_context_candidates_ {false};
+  bool use_bev_descriptor_ {false};
+  double bev_descriptor_threshold_ {0.20};
+  double bev_descriptor_grid_size_m_ {80.0};
+  int bev_descriptor_grid_cells_ {40};
+  int bev_descriptor_yaw_bins_ {24};
+  int bev_descriptor_sequence_window_ {0};
+  double bev_descriptor_sequence_threshold_ {-1.0};
+  double bev_descriptor_pose_consistency_threshold_m_ {-1.0};
+  double bev_descriptor_max_euclidean_distance_m_ {-1.0};
+  double bev_descriptor_rerank_weight_m_ {100.0};
+    // FOV-aware (mutual-visibility) distance for the BEV descriptor. Default
+    // off so the cosine-distance baseline stays unchanged on 360° LiDAR.
+  bool bev_use_mutual_visibility_ {false};
+  double bev_mutual_visibility_min_overlap_ratio_ {0.05};
+  double bev_mutual_visibility_occupancy_eps_ {0.5};
+    // Triangle (STD/BTC-style) descriptor place-recognition path. Built on the
+    // BSD-2 primitives in graph_based_slam/triangle_descriptor*. Default off
+    // so the existing default workflow stays unchanged.
+  bool use_triangle_descriptor_ {false};
+    // Tuned 2026-05-18 on NTU VIRAL tnp_01 ablation v4. The earlier loose
+    // defaults (60 cells, 0.3 m salience, 80 keypoints, 1.0 m edge bin)
+    // produced false-positive vote buckets where one stale submap collected
+    // every triangle match; this triggered randomly-rotating SE(3) outputs
+    // that NDT could not refine. The tighter values below caused triangle
+    // to vote across distinct submap ids (32 / 40 / 17 / 9) and produced
+    // the first triangle-sourced accepted loop closure (32 <-> 95, 0.49 m
+    // / 1.06 deg correction).
+  double triangle_descriptor_grid_size_m_ {60.0};
+  int triangle_descriptor_grid_cells_ {100};
+  int triangle_descriptor_max_keypoints_ {40};
+  double triangle_descriptor_min_salience_m_ {0.8};
+  double triangle_descriptor_min_edge_m_ {2.0};
+  double triangle_descriptor_max_edge_m_ {50.0};
+  int triangle_descriptor_max_triangles_ {3000};
+  double triangle_descriptor_edge_bin_m_ {0.5};
+    // Quad-hash 4th-point feature bin (m). 0 = disabled (legacy 3-edge hash).
+    // When > 0, the bucket key also includes the quantized distance from the
+    // triangle centroid to the nearest non-vertex keypoint, which makes the
+    // hash 4-dim and rejects wrong-but-agreeing triangle pairs in repeated
+    // geometry (corridor / parking-row / parallel column rows).
+  double triangle_descriptor_quad_feature_bin_m_ {0.0};
+    // Keypoint extractor mode. "bev_max_height" is the original outdoor-only
+    // extractor; "edge_3d" enables PCA-edgeness keypoints that survive in
+    // narrow-FOV / indoor scenes (MID-360, Newer College math_hard) where
+    // BEV max-height keypoint repeatability collapses.
+  std::string triangle_descriptor_keypoint_mode_ {"bev_max_height"};
+  double triangle_descriptor_edge_voxel_size_m_ {0.4};
+  double triangle_descriptor_edge_neighbor_radius_m_ {1.0};
+  int triangle_descriptor_edge_min_neighbors_ {6};
+  double triangle_descriptor_edge_min_edgeness_ {0.5};
+  double triangle_descriptor_edge_nms_radius_m_ {2.0};
+    // 5-inlier floor would have killed the only accepted loop in v4 (id=32
+    // emitted with 4 inliers), so settle on 4 as the compromise between
+    // recall and noise. Votes can stay loose because the tighter keypoint
+    // / hash params suppress most false buckets on their own.
+  int triangle_descriptor_min_votes_ {6};
+  int triangle_descriptor_min_inliers_ {4};
+    // Companion to min_inliers expressed as inliers / eval_n. Zero disables.
+    // Lets the operator combine a low absolute count with a meaningful
+    // relative-density floor (e.g. 4 inliers / max_pairs 64 = 6% vs the
+    // same 4 inliers / max_pairs 20 = 20%).
+  double triangle_descriptor_min_inlier_ratio_ {0.0};
+    // Cap on triangle pairs evaluated inside the RANSAC consensus check.
+    // Lower numbers make min_inlier_ratio more informative; default 64 keeps
+    // the previous behaviour.
+  int triangle_descriptor_max_pairs_ {64};
+    // 4-point consensus: after the 3-point RANSAC picks a winning SE(3),
+    // optionally project every query keypoint by that transform and require
+    // this many to fall within `fourth_point_max_distance_m` of some
+    // database keypoint in the chosen submap. Three points uniquely
+    // determine SE(3), so even a strong 3-point consensus can be fooled by
+    // repeated structure; the 4-point gate adds an independent constraint.
+    // Default 0 disables the gate.
+  int triangle_descriptor_min_4th_point_agreements_ {0};
+  double triangle_descriptor_fourth_point_max_distance_m_ {2.0};
+    // After the 3-point RANSAC picks the winning SE(3), re-estimate it by
+    // pooling the 3 * N_inliers point correspondences and running a single
+    // N-point Umeyama least-squares. Reduces translation noise by √N versus
+    // keeping the single 3-point hypothesis.
+  bool triangle_descriptor_refine_se3_with_all_inliers_ {false};
+    // Diagnostic-only: when true, run accumulateVotes (and submap_id selection)
+    // but skip the RANSAC findLoopCandidate inner loop. Used to isolate
+    // "executor scheduling cost of enabling triangle pipeline" from
+    // "RANSAC compute cost" when investigating APE drift on tuned configs.
+    // Default false (production).
+  bool triangle_descriptor_skip_ransac_ {false};
+  double triangle_descriptor_inlier_translation_m_ {2.0};
+  double triangle_descriptor_inlier_rotation_deg_ {5.0};
+  int triangle_descriptor_exclude_recent_ {4};
+    // Cross-verification: when both use_triangle_descriptor and
+    // use_bev_descriptor are true, gate the triangle candidate by also
+    // requiring the BEV mutual-visibility distance to clear an upper bound.
+    // Helps filter false positives caused by repeated geometry (corridors,
+    // facades) at the cost of triangle-only recall.
+  bool triangle_verify_with_bev_ {false};
+  double triangle_verify_bev_max_distance_ {0.30};
+  bool use_solid_descriptor_ {false};
+  double solid_descriptor_min_similarity_ {0.70};
+  int solid_descriptor_sequence_window_ {0};
+  double solid_descriptor_sequence_min_similarity_ {-1.0};
+  double solid_descriptor_pose_consistency_threshold_m_ {-1.0};
+  double solid_descriptor_max_euclidean_distance_m_ {-1.0};
+  bool use_3d_bbs_for_scan_context_ {false};
+  double three_d_bbs_min_level_res_ {1.0};
+  int three_d_bbs_max_level_ {3};
+  double three_d_bbs_score_threshold_percentage_ {0.25};
+  int three_d_bbs_timeout_msec_ {50};
+  int three_d_bbs_num_threads_ {0};
+  double three_d_bbs_voxel_leaf_size_ {1.0};
+  int three_d_bbs_source_submap_num_ {2};
+  int three_d_bbs_target_submap_radius_ {1};
+  double three_d_bbs_translation_search_margin_m_ {15.0};
+  double three_d_bbs_roll_pitch_search_deg_ {10.0};
+  double three_d_bbs_yaw_search_deg_ {180.0};
+  bool use_dynamic_object_filter_ {false};
+  double dynamic_object_filter_voxel_size_ {0.3};
+  int dynamic_object_filter_min_observations_ {2};
+  int dynamic_object_filter_temporal_window_ {5};
+  double dynamic_object_filter_max_range_from_sensor_m_ {30.0};
+  bool use_planar_map_filter_ {false};
+  double planar_map_filter_voxel_size_ {0.1};
+  int planar_map_filter_min_neighbors_ {3};
+  double planar_map_filter_max_small_eigenvalue_ratio_ {0.24};
+  double planar_map_filter_min_middle_eigenvalue_ratio_ {0.0};
+  double planar_map_filter_min_retained_ratio_ {0.90};
+
+    // PCD disk cache for memory-efficient submap storage
+  std::string pcd_cache_dir_;
+  bool use_pcd_cache_ {false};
+  std::mutex pcd_cache_mtx_;
+  void stageMapArrayCloudCache(lidarslam_msgs::msg::MapArray & map_array_msg);
+  bool saveSubmapToPCD(
+    int idx,
+    const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud);
+  bool saveSubmapToPCDUnlocked(
+    int idx,
+    const pcl::PointCloud<pcl::PointXYZI>::Ptr & cloud);
+  pcl::PointCloud<pcl::PointXYZI>::Ptr loadSubmapFromPCD(int idx);
+  pcl::PointCloud<pcl::PointXYZI>::Ptr loadSubmapCloud(
+    const lidarslam_msgs::msg::MapArray & map_array_msg, int idx);
+
+    // Autoware-compatible grid-divided PCD map output
+  std::string map_save_dir_ {"."};
+  std::string save_pose_graph_path_ {"pose_graph.g2o"};
+  double map_grid_size_x_ {20.0};
+  double map_grid_size_y_ {20.0};
+  double map_leaf_size_ {0.2};
+  void saveGridDividedMap(
+    const pcl::PointCloud<pcl::PointXYZI>::Ptr & map);
+  void writeMapBundleArtifacts(
+    const lidarslam_msgs::msg::MapArray & map_array_msg,
+    const LoopEdges & loop_edges,
+    const std::vector<Eigen::Isometry3d> & optimized_poses);
+
+    // Direct odometry + cloud input mode (for LIO frontends). The two
+    // streams are stamp-synchronized (message_filters ApproximateTime) so
+    // the submap pose/cloud pairing no longer depends on executor timing
+    // (v0.6 Phase 1; see docs/research/determinism-variance-attribution.md).
+  bool use_odom_input_ {false};
+  double submap_distance_threshold_ {1.5};
+  int odom_cloud_sync_queue_size_ {100};
+  std::shared_ptr<message_filters::Subscriber<nav_msgs::msg::Odometry>> odom_sync_sub_;
+  std::shared_ptr<message_filters::Subscriber<
+      sensor_msgs::msg::PointCloud2>> cloud_sync_sub_;
+  using OdomCloudSyncPolicy = message_filters::sync_policies::ApproximateTime<
+    nav_msgs::msg::Odometry, sensor_msgs::msg::PointCloud2>;
+  std::shared_ptr<message_filters::Synchronizer<OdomCloudSyncPolicy>> odom_cloud_sync_;
+  Eigen::Vector3d last_submap_position_ {0, 0, 0};
+  bool last_submap_position_valid_ {false};
+  double accumulated_distance_ {0.0};
+  bool first_synced_input_logged_ {false};
+  void receiveSyncedOdomCloud(
+    const nav_msgs::msg::Odometry::ConstSharedPtr & odom_msg,
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & cloud_msg);
+  void tryCreateSubmap(
+    const nav_msgs::msg::Odometry & odom_msg,
+    const sensor_msgs::msg::PointCloud2 & cloud_msg);
+
+    // v0.8 Phase 1 (docs/roadmap/v0.8.md §5): opt-in, report-only per-scan
+    // degeneracy diagnostics on the use_odom_input path. The received
+    // Odometry pose.covariance (filled anisotropically by the
+    // Thirdparty/rko_lio diagnostic patch) is classified per scan via
+    // localizability_analysis.hpp; when degeneracy_diagnostics_csv_path is
+    // non-empty a per-scan CSV row is appended, and when
+    // save_degeneracy_report is true a degeneracy_report.yaml summary joins
+    // the map bundle at /map_save time (best-effort, like the other bundle
+    // artifacts). Both default off: default behavior (and determinism) is
+    // unchanged, and nothing here feeds back into any pose or edge weight.
+  std::string degeneracy_diagnostics_csv_path_;
+  bool save_degeneracy_report_ {false};
+  std::mutex degeneracy_mtx_;
+  std::ofstream degeneracy_csv_ofs_;
+  degeneracy::DegeneracyReportAccumulator degeneracy_accumulator_;
+  void recordScanDegeneracy(const nav_msgs::msg::Odometry & odom_msg);
+  void writeDegeneracyReport();
+
+    // GNSS constraints for georeferenced mapping
+  bool use_gnss_ {false};
+  bool gnss_align_yaw_ {true};
+  int gnss_yaw_alignment_min_anchors_ {10};
+  double gnss_yaw_alignment_min_baseline_m_ {5.0};
+  std::string gnss_topic_ {"/gnss/fix"};
+  double gnss_info_weight_ {1.0};
+  bool gnss_use_covariance_weighting_ {true};
+  double gnss_covariance_min_variance_m2_ {0.01};
+  double gnss_covariance_max_variance_m2_ {25.0};
+  double gnss_rtk_fix_max_horizontal_stddev_m_ {0.3};
+  double gnss_rtk_fix_weight_scale_ {3.0};
+  double gnss_non_rtk_weight_scale_ {1.0};
+  double gnss_header_stamp_max_skew_sec_ {30.0};
+  int gnss_origin_min_samples_ {3};
+  double gnss_origin_consistency_threshold_m_ {20.0};
+  rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr gnss_sub_;
+  struct GnssEnu
+  {
+    double stamp;
+    double x;
+    double y;
+    double z;    // ENU coordinates relative to origin
+    double info_x;
+    double info_y;
+    double info_z;
+    bool covariance_valid;
+    bool rtk_like;
+    double horizontal_stddev_m;
+  };
+  std::vector<GnssEnu> gnss_buffer_;
+  detail::GnssOriginAccumulator gnss_origin_accumulator_;
+  std::mutex gnss_mtx_;
+  bool gnss_origin_set_ {false};
+  double gnss_origin_lat_ {0.0};
+  double gnss_origin_lon_ {0.0};
+  double gnss_origin_alt_ {0.0};
+  void receiveNavSatFix(const sensor_msgs::msg::NavSatFix & msg);
+  bool isUsableGnssFix(const sensor_msgs::msg::NavSatFix & msg) const;
+  void tryInitializeGnssOrigin(double lat, double lon, double alt);
+  Eigen::Vector3d geodeticToEnu(double lat, double lon, double alt) const;
+
+    // IMU preintegration
+  bool use_imu_preintegration_ {false};
+  double imu_rotation_info_roll_pitch_ {100.0};
+  double imu_rotation_info_yaw_ {10.0};
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
+  struct StampedImu
+  {
+    double stamp;
+    double ax;
+    double ay;
+    double az;
+    double gx;
+    double gy;
+    double gz;
+    double qx;
+    double qy;
+    double qz;
+    double qw;
+  };
+  std::vector<StampedImu> imu_buffer_;
+  std::mutex imu_mtx_;
+  static constexpr size_t kMaxImuBufferSize = 50000;
+  void receiveImu(const sensor_msgs::msg::Imu & msg);
+  Eigen::Quaterniond integrateImuRotation(double t0, double t1) const;
+};
+}  // namespace graphslam
+
+#endif  // GRAPH_BASED_SLAM_COMPONENT_IMPL_HPP_


### PR DESCRIPTION
## Summary

- move all private ROS, configuration, graph, sensor, and cache state into `GraphBasedSlamComponent::Impl`
- keep the implementation declaration in a non-installed source header
- reduce the installed component header from 518 lines to 78 lines
- document the completed compiler firewall in the changelog

## Why

The public component header still exposed most implementation dependencies and private state after the backend workspace extraction. That made downstream compilation depend on PCL, TF, message filters, message types, and internal graph helpers even though none of them are part of the component API.

This completes the PImpl boundary so downstream users only see the ROS node interface and a stable implementation pointer. Runtime behavior and parameters remain unchanged.

## Validation

- `colcon build --packages-select graph_based_slam --symlink-install`
- Graph SLAM runtime startup smoke test
- Graph SLAM package tests: 153/153 passed
- default CI: 2387 tests, 0 errors, 0 failures, 111 skipped
- `git diff --check`