### PR TITLE
Productionize LiDAR-camera spatiotemporal calibration

### DIFF
--- a/docs/research/colored-map-spatiotemporal-calibration-2026-07.md
+++ b/docs/research/colored-map-spatiotemporal-calibration-2026-07.md
@@ -22,7 +22,9 @@ For every candidate it interpolates `world <- body` from the dense TUM
 trajectory and composes it with the refined `body <- camera` transform. The
 objective is the coverage-guarded distance from projected LiDAR depth
 discontinuities to strong image gradients. Image edge masks are cached across
-the deterministic coarse-to-fine coordinate search.
+a deterministic image pyramid. Each coordinate sweep tests both one- and
+two-step moves so pixel-quantisation plateaus do not trap the search. Bounds
+that are closer than the next search step are expanded and searched again.
 
 The user-facing pipeline is deliberately staged as:
 
@@ -36,7 +38,8 @@ composition and output paths are unchanged.
 
 ## Safety and validation gates
 
-- Every Nth selected view is held out before optimization.
+- Held-out views are selected deterministically across travelled-distance
+  segments and static/translation/rotation motion strata.
 - Training loss must decrease and held-out loss must decrease independently.
 - A configurable minimum number of LiDAR depth-edge pixels is required in both
   partitions.
@@ -44,33 +47,46 @@ composition and output paths are unchanged.
 - Time, translation, and rotation corrections have independent hard bounds.
 - Source camera poses must reproduce one static extrinsic within 1 mm and 0.05
   degrees; otherwise their timestamps/conventions are treated as inconsistent.
-- Parameters that land on a search bound are listed in `boundary_axes` for
-  promotion review.
+- Parameters closer to a search bound than the next search step are listed in
+  `boundary_axes`; a production candidate cannot be promoted while any remain.
+- The observability audit runs at the finest pyramid resolution. Five samples
+  per axis provide one- and two-step centred curvatures; both must be positive
+  and the estimated stationary point must remain local.
+- Three 3x3 quadratic clock/translation surfaces must be positive definite.
+  The normalized Hessian condition number and time/translation correlations
+  are bounded, and covariance is emitted only for a positive-definite Hessian.
 - Rejected candidates export the original camera poses, never an unvalidated
   correction, and record the rejection reason in JSON.
 - Frame timestamps and original images are preserved in the corrected
   `transforms_spatiotemporal.json` dataset.
 
-## RTK-SLAM Construction Seq1 smoke result
+## RTK-SLAM Construction Seq1 production smoke result
 
-The first CPU smoke run used the existing K3 4.84 M-point map, deterministically
-sampled to 200,000 points, 13 of 260 camera views, two search rounds, and tight
-bounds of 40 ms / 4 cm / 0.5 degrees. Ten views were training data and three
-were held out.
+The production CPU smoke used the existing K3 4.84 M-point map,
+deterministically sampled to 200,000 points, 13 of 260 camera views, pyramid
+scales 0.25/0.5/1.0, and two search rounds per scale. Nine views were training
+data and four were held out by the travelled-distance/motion split. Initial
+bounds were 40 ms / 4 cm / 0.5 degrees and expanded only for axes within one
+search step of a bound.
 
 | metric | initial | refined |
 | --- | ---: | ---: |
-| training mean edge distance | 6.444 px | 6.004 px |
-| held-out mean edge distance | 6.887 px | 6.375 px |
-| held-out median edge distance | 6.325 px | 5.385 px |
-| held-out out-of-range fraction | 0.285 | 0.251 |
+| training mean edge distance | 6.539 px | 5.937 px |
+| training out-of-range fraction | 0.250 | 0.217 |
+| held-out mean edge distance | 6.522 px | 6.010 px |
+| held-out median edge distance | 6.000 px | 5.000 px |
+| held-out out-of-range fraction | 0.241 | 0.216 |
 
-The held-out mean improved by about 7.4%, so the candidate was accepted. The
-solution reached a translation bound on two axes; this establishes end-to-end
-functionality but is not a production calibration claim. Promotion requires a
-wider multi-scale search followed by rebuilding the map and running held-out
-RGB, appearance, trajectory, and geometry gates.
+Training and held-out mean loss improved by 9.20% and 7.85%, respectively. No
+axis remained near its final bound. All seven normalized Hessian eigenvalues
+were positive (0.0369 to 0.0827), the condition number was 2.24, and maximum
+absolute clock/translation correlation was 0.105. The correction therefore
+passed the production acceptance gate and was exported. This validates the
+calibration stage on Seq1; independent Seq2 and cross-rig promotion remain a
+separate dataset-level gate.
 
-The regression suite covers deterministic search, hard bounds, continuous-time
-pose recomposition, static-motion degeneracy, independent held-out rejection,
-pipeline staging, cache reuse, and unchanged default command composition.
+The regression suite covers deterministic pattern search, step-aware bounds,
+multi-scale curvature and undefined-correlation handling, stratified splitting,
+continuous-time pose recomposition, static-motion degeneracy, independent
+held-out rejection, pipeline staging, cache reuse, and unchanged opt-in command
+composition.

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -790,6 +790,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_spatiotemporal_calibration
+    test/test_spatiotemporal_calibration.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_heldout_point_colors
     test/test_heldout_point_colors.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_colored_map_pipeline.py
+++ b/graph_based_slam/test/test_colored_map_pipeline.py
@@ -104,8 +104,12 @@ def test_spatiotemporal_refinement_inserts_geometry_and_heldout_calibration(tmp_
     coloured = dict(commands)['coloured map']
     assert '--color-transforms' not in geometry
     assert '--optimize-spatiotemporal' in calibration
+    assert '--production-calibration' in calibration
     assert calibration[calibration.index('--max-time-offset') + 1] == '0.04'
     assert calibration[calibration.index('--max-points') + 1] == '300000'
+    assert calibration[calibration.index('--pyramid-scales') + 1] == \
+        '0.25,0.5,1.0'
+    assert calibration[calibration.index('--holdout-fraction') + 1] == '0.2'
     assert calibration[
         calibration.index('--minimum-heldout-improvement') + 1] == '0.02'
     refined = str(

--- a/graph_based_slam/test/test_lidar_camera_alignment.py
+++ b/graph_based_slam/test/test_lidar_camera_alignment.py
@@ -141,6 +141,47 @@ def test_write_corrected_transforms_preserves_images_and_updates_pose(tmp_path):
     assert loaded['image_paths'][0] == (images / '000.png').resolve()
 
 
+def test_write_recomposed_transforms_embeds_calibration_uncertainty(tmp_path):
+    images = tmp_path / 'source' / 'images'
+    images.mkdir(parents=True)
+    (images / '000.png').write_bytes(b'pixel')
+    source = tmp_path / 'source' / 'transforms.json'
+    source.write_text(json.dumps({
+        'fl_x': 10, 'fl_y': 10, 'cx': 5, 'cy': 5, 'w': 10, 'h': 10,
+        'frames': [{'file_path': 'images/000.png',
+                    'transform_matrix': np.eye(4).tolist()}],
+    }))
+    output = tmp_path / 'result' / 'recomposed.json'
+    calibration = {
+        'accepted': True,
+        'uncertainty_dt_s_xyz_m_rpy_rad': [0.01] * 7,
+    }
+    lca.write_recomposed_transforms(
+        source, output, np.asarray([np.eye(4)]),
+        calibration=calibration)
+    document = json.loads(output.read_text())
+    assert document['spatiotemporal_calibration'] == calibration
+    assert (lca.tg.load_transforms(output)['image_paths'][0] ==
+            (images / '000.png').resolve())
+
+
+def test_calibration_metadata_exposes_compact_fusion_contract():
+    observability = {
+        'uncertainty_dt_s_xyz_m_rpy_rad': [0.01] * 7,
+        'condition_number': 2.0,
+        'maximum_abs_time_translation_correlation': 0.1,
+    }
+    metadata = lca.calibration_metadata({
+        'accepted': True,
+        'parameters_dt_s_xyz_m_rpy_deg': [0.0] * 7,
+        'boundary_axes': [],
+        'production_calibration': {'observability': observability},
+    })
+    assert metadata['accepted']
+    assert metadata['uncertainty_dt_s_xyz_m_rpy_rad'] == [0.01] * 7
+    assert metadata['condition_number'] == 2.0
+
+
 def _moving_samples():
     return [
         lca.pi.TrajectorySample(

--- a/graph_based_slam/test/test_lidar_camera_alignment.py
+++ b/graph_based_slam/test/test_lidar_camera_alignment.py
@@ -200,6 +200,34 @@ def test_spatiotemporal_optimizer_is_deterministic_and_bounded(monkeypatch):
     assert np.all(np.abs(np.rad2deg(first[4:])) <= 0.3 + 1e-12)
 
 
+def test_production_optimizer_runs_pyramid_and_observability(monkeypatch):
+    target = np.array([0.02, -0.02, 0.0, 0.0,
+                       np.deg2rad(0.2), 0.0, 0.0])
+
+    def objective(*args, reference_edge_points=None,
+                  image_edge_masks=None, **kwargs):
+        parameters = np.asarray(args[6])
+        loss = 1.0 + float(np.sum((parameters - target) ** 2))
+        return loss, {'edge_points': 100, 'mean_px': loss,
+                      'median_px': loss, 'coverage': 1.0}
+
+    monkeypatch.setattr(lca, 'spatiotemporal_objective', objective)
+    parameters, before, after, report = \
+        lca.optimize_spatiotemporal_production(
+            np.zeros((0, 3)), _moving_samples(), np.array([1.0]),
+            np.eye(4), np.eye(3), [np.zeros((20, 20), np.uint8)],
+            scales=(0.5, 1.0), rounds_per_level=2,
+            time_step=0.02, translation_step=0.02,
+            rotation_step_deg=0.2, max_time_offset=0.1,
+            max_translation=0.1, max_rotation_deg=1.0,
+            auto_bound_expansions=0, minimum_curvature=1e-12)
+    assert after['loss'] < before['loss']
+    np.testing.assert_allclose(parameters, target, atol=0.005)
+    assert [level['scale'] for level in report['levels']] == [0.5, 1.0]
+    assert report['observability']['observable']
+    assert not report['boundary_axes']
+
+
 def test_trajectory_excitation_rejects_static_time_offset():
     static = [
         lca.pi.TrajectorySample(

--- a/graph_based_slam/test/test_spatiotemporal_calibration.py
+++ b/graph_based_slam/test/test_spatiotemporal_calibration.py
@@ -2,6 +2,30 @@
 # All rights reserved.
 #
 # Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 """Tests for production LiDAR-camera calibration policy."""
 

--- a/graph_based_slam/test/test_spatiotemporal_calibration.py
+++ b/graph_based_slam/test/test_spatiotemporal_calibration.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+
+"""Tests for production LiDAR-camera calibration policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_DIR = REPO_ROOT / 'tools' / 'colored_map'
+if str(TOOL_DIR) not in sys.path:
+    sys.path.insert(0, str(TOOL_DIR))
+
+import spatiotemporal_calibration as stc  # noqa: E402, I100
+
+
+def _pose(x: float, yaw_deg: float = 0.0) -> np.ndarray:
+    angle = np.deg2rad(yaw_deg)
+    cosine, sine = np.cos(angle), np.sin(angle)
+    result = np.eye(4)
+    result[:3, :3] = [[cosine, -sine, 0.0],
+                      [sine, cosine, 0.0], [0.0, 0.0, 1.0]]
+    result[0, 3] = x
+    return result
+
+
+def test_image_pyramid_and_intrinsics_preserve_projection_scale():
+    image = np.arange(8 * 10).reshape(8, 10)
+    reduced = stc.downsample_nearest(image, 0.5)
+    assert reduced.shape == (4, 5)
+    np.testing.assert_array_equal(reduced, image[::2, ::2])
+    K = np.array([[100.0, 0.0, 5.0],
+                  [0.0, 80.0, 4.0], [0.0, 0.0, 1.0]])
+    np.testing.assert_allclose(
+        stc.scale_intrinsics(K, 0.5),
+        [[50.0, 0.0, 2.5], [0.0, 40.0, 2.0], [0.0, 0.0, 1.0]])
+
+
+def test_stratified_split_spans_path_and_motion_regimes():
+    selected = list(range(16))
+    stamps = np.arange(16, dtype=float)
+    poses = np.asarray([
+        _pose(float(index), yaw_deg=20.0 * (index % 4 == 3))
+        for index in selected])
+    train, heldout, report = stc.stratified_view_split(
+        stamps, poses, selected, holdout_fraction=0.25, spatial_segments=4)
+    assert set(train).isdisjoint(heldout)
+    assert sorted(train + heldout) == selected
+    assert len(heldout) >= 4
+    heldout_segments = {index // 4 for index in heldout}
+    assert heldout_segments == {0, 1, 2, 3}
+    assert report['strategy'] == 'travelled_distance_x_motion'
+    assert any(item['motion'] == 'rotation' for item in report['strata'])
+
+
+def test_stratified_split_is_deterministic_for_stationary_path():
+    selected = list(range(10))
+    stamps = np.arange(10, dtype=float)
+    poses = np.repeat(np.eye(4)[None], len(selected), axis=0)
+    first = stc.stratified_view_split(stamps, poses, selected)
+    second = stc.stratified_view_split(stamps, poses, selected)
+    assert first == second
+    assert first[1]
+
+
+def test_bounded_coordinate_search_converges_and_records_history():
+    target = np.array([0.04, -0.02, 0.0])
+
+    def objective(parameters):
+        return np.sum((parameters - target) ** 2)
+
+    parameters, loss, report = stc.bounded_coordinate_search(
+        objective, np.zeros(3), np.full(3, 0.02), np.full(3, 0.1),
+        rounds=2)
+    np.testing.assert_allclose(parameters, target, atol=0.01)
+    assert loss < objective(np.zeros(3))
+    assert report['evaluations'] > 1
+    assert report['history'][-1]['loss'] == loss
+
+
+def test_boundary_axes_names_only_saturated_parameters():
+    axes = stc.boundary_axes(
+        np.array([0.1, 0.0, -0.2, 0.0, 0.0, 0.3, 0.0]),
+        np.array([0.1, 0.2, 0.2, 0.2, 0.3, 0.3, 0.3]))
+    assert axes == ['dt', 'ty', 'pitch']
+
+    near_axes = stc.boundary_axes(
+        np.array([0.091, 0.18, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        np.array([0.1, 0.2, 0.2, 0.2, 0.3, 0.3, 0.3]),
+        tolerance=np.array([0.01, 0.01, 0.01, 0.01, 0.02, 0.02, 0.02]))
+    assert near_axes == ['dt']
+
+
+def test_observability_reports_uncertainty_for_positive_quadratic():
+    diagonal = np.array([5.0, 4.0, 3.0, 2.0, 6.0, 7.0, 8.0])
+
+    def objective(parameters):
+        return 1.0 + 0.5 * np.sum(diagonal * parameters ** 2)
+
+    report = stc.finite_difference_observability(
+        objective, np.zeros(7), np.ones(7) * 0.01)
+    assert report['observable']
+    assert np.isclose(report['condition_number'], 4.0)
+    assert all(value > 0.0 for value in
+               report['uncertainty_dt_s_xyz_m_rpy_rad'])
+    assert np.isclose(
+        report['maximum_abs_time_translation_correlation'], 0.0,
+        atol=1e-12)
+
+
+def test_observability_rejects_flat_and_clock_translation_coupling():
+    def flat(parameters):
+        return 1.0 + parameters[1] ** 2
+
+    flat_report = stc.finite_difference_observability(
+        flat, np.zeros(7), np.ones(7) * 0.01)
+    assert not flat_report['observable']
+    assert 'insufficient_positive_curvature' in flat_report['rejection_reasons']
+
+    def coupled(parameters):
+        base = np.sum(parameters[2:] ** 2)
+        return 1.0 + base + (parameters[0] + parameters[1]) ** 2 + \
+            1e-4 * (parameters[0] - parameters[1]) ** 2
+
+    coupled_report = stc.finite_difference_observability(
+        coupled, np.zeros(7), np.ones(7) * 0.01,
+        maximum_condition=1e8, maximum_correlation=0.9)
+    assert not coupled_report['observable']
+    assert 'time_translation_correlation' in \
+        coupled_report['rejection_reasons']
+
+
+def test_observability_does_not_invent_correlation_for_indefinite_pair():
+    def saddle(parameters):
+        return 2.0 + np.sum(parameters[1:] ** 2) - parameters[0] ** 2
+
+    report = stc.finite_difference_observability(
+        saddle, np.zeros(7), np.ones(7) * 0.01)
+    assert not report['observable']
+    assert report['maximum_abs_time_translation_correlation'] is None
+    assert all(item['correlation'] is None for item in
+               report['time_translation_correlations'])
+    assert 'unobservable_time_translation_pair' in \
+        report['rejection_reasons']
+
+
+def test_observability_five_point_fit_rejects_nonlocal_stationary_point():
+    center = np.array([0.02, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+
+    def shifted(parameters):
+        return 1.0 + np.sum((parameters - center) ** 2)
+
+    report = stc.finite_difference_observability(
+        shifted, np.zeros(7), np.ones(7) * 0.01)
+    assert not report['observable']
+    assert 'stationary_point_outside_local_neighborhood' in \
+        report['rejection_reasons']
+    assert np.isclose(report['axis_quadratic_fits'][0][
+        'stationary_offset_steps'], 2.0)

--- a/scripts/evaluate_lidar_camera_alignment.py
+++ b/scripts/evaluate_lidar_camera_alignment.py
@@ -44,9 +44,13 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 TOOL_DIR = REPO_ROOT / 'tools' / 'gaussian_splatting'
 if str(TOOL_DIR) not in sys.path:
     sys.path.insert(0, str(TOOL_DIR))
+COLORED_MAP_DIR = REPO_ROOT / 'tools' / 'colored_map'
+if str(COLORED_MAP_DIR) not in sys.path:
+    sys.path.insert(0, str(COLORED_MAP_DIR))
 
 import pointcloud_io as pcio  # noqa: E402
 import posed_images as pi  # noqa: E402
+import spatiotemporal_calibration as stc  # noqa: E402
 import train_gsplat as tg  # noqa: E402
 
 
@@ -378,6 +382,122 @@ def optimize_spatiotemporal(
     return parameters, before, after
 
 
+def optimize_spatiotemporal_production(
+        points: np.ndarray, samples: list[pi.TrajectorySample],
+        stamps: np.ndarray, body_T_camera: np.ndarray, K: np.ndarray,
+        images: list[np.ndarray], *, scales: tuple[float, ...] = (0.25, 0.5, 1.0),
+        rounds_per_level: int = 2, time_step: float = 0.02,
+        translation_step: float = 0.02, rotation_step_deg: float = 0.2,
+        max_time_offset: float = 0.1, max_translation: float = 0.1,
+        max_rotation_deg: float = 2.0, auto_bound_expansions: int = 2,
+        bound_expansion_factor: float = 2.0, observability_scale: float = 1.0,
+        minimum_curvature: float = 1e-6, maximum_condition: float = 1e6,
+        maximum_time_translation_correlation: float = 0.98,
+        edge_percentile: float = 95.0,
+        max_distance: int = 12) -> tuple[np.ndarray, dict, dict, dict]:
+    """Optimize a pyramid and audit local identifiability before adoption."""
+    if (not scales or any(not 0.0 < scale <= 1.0 for scale in scales) or
+            tuple(sorted(scales)) != scales):
+        raise ValueError('pyramid scales must be sorted values in (0, 1]')
+    if not np.isclose(observability_scale, scales[-1]):
+        raise ValueError('observability scale must match the finest pyramid '
+                         'scale')
+    parameters = np.zeros(7, dtype=np.float64)
+    base_steps = np.array([time_step] + [translation_step] * 3 +
+                          [np.deg2rad(rotation_step_deg)] * 3)
+    bounds = np.array([max_time_offset] + [max_translation] * 3 +
+                      [np.deg2rad(max_rotation_deg)] * 3)
+    initial_bounds = bounds.copy()
+    levels = []
+
+    def level_objective(scale, reference_parameters=None):
+        level_images = [stc.downsample_nearest(image, scale)
+                        for image in images]
+        level_K = stc.scale_intrinsics(K, scale)
+        edge_masks = [image_edges(image, edge_percentile)
+                      for image in level_images]
+        reference_parameters = (parameters if reference_parameters is None
+                                else reference_parameters)
+        _, reference_metrics = spatiotemporal_objective(
+            points, samples, stamps, body_T_camera, level_K, level_images,
+            reference_parameters, edge_percentile=edge_percentile,
+            max_distance=max(2, int(round(max_distance * scale))),
+            image_edge_masks=edge_masks)
+        reference_edges = reference_metrics['edge_points']
+
+        def objective(candidate):
+            loss, _ = spatiotemporal_objective(
+                points, samples, stamps, body_T_camera, level_K, level_images,
+                candidate, edge_percentile=edge_percentile,
+                max_distance=max(2, int(round(max_distance * scale))),
+                reference_edge_points=reference_edges,
+                image_edge_masks=edge_masks)
+            return loss
+        return objective
+
+    base_loss, before = spatiotemporal_objective(
+        points, samples, stamps, body_T_camera, K, images, parameters,
+        edge_percentile=edge_percentile, max_distance=max_distance)
+    before['loss'] = base_loss
+    for scale in scales:
+        objective = level_objective(scale, np.zeros(7))
+        multiplier = max(1.0, np.sqrt(1.0 / scale))
+        parameters, loss, search = stc.bounded_coordinate_search(
+            objective, parameters, base_steps * multiplier, bounds,
+            rounds=rounds_per_level)
+        levels.append({'scale': scale, 'loss': loss, 'search': search,
+                       'bounds_dt_s_xyz_m_rpy_rad': bounds.tolist()})
+
+    expansions = []
+    boundary_tolerance = base_steps * 0.5
+    for expansion in range(auto_bound_expansions):
+        touching = stc.boundary_axes(
+            parameters, bounds, tolerance=boundary_tolerance)
+        if not touching:
+            break
+        old_bounds = bounds.copy()
+        for name in touching:
+            axis = stc.PARAMETER_NAMES.index(name)
+            bounds[axis] *= bound_expansion_factor
+        objective = level_objective(scales[-1], np.zeros(7))
+        parameters, loss, search = stc.bounded_coordinate_search(
+            objective, parameters, base_steps * 0.5, bounds,
+            rounds=rounds_per_level)
+        expansions.append({
+            'iteration': expansion + 1, 'trigger_axes': touching,
+            'old_bounds_dt_s_xyz_m_rpy_rad': old_bounds.tolist(),
+            'new_bounds_dt_s_xyz_m_rpy_rad': bounds.tolist(),
+            'loss': loss, 'search': search,
+        })
+
+    final_loss, after = spatiotemporal_objective(
+        points, samples, stamps, body_T_camera, K, images, parameters,
+        edge_percentile=edge_percentile, max_distance=max_distance,
+        reference_edge_points=before['edge_points'])
+    after['loss'] = final_loss
+    audit_objective = level_objective(observability_scale, parameters)
+    observability = stc.finite_difference_observability(
+        audit_objective, parameters, base_steps * 0.5,
+        minimum_curvature=minimum_curvature,
+        maximum_condition=maximum_condition,
+        maximum_correlation=maximum_time_translation_correlation)
+    report = {
+        'mode': 'multi_resolution_production',
+        'pyramid_scales': list(scales),
+        'levels': levels,
+        'initial_bounds_dt_s_xyz_m_rpy_rad': initial_bounds.tolist(),
+        'final_bounds_dt_s_xyz_m_rpy_rad': bounds.tolist(),
+        'bound_expansions': expansions,
+        'boundary_tolerance_dt_s_xyz_m_rpy_rad':
+            boundary_tolerance.tolist(),
+        'boundary_axes': stc.boundary_axes(
+            parameters, bounds, tolerance=boundary_tolerance),
+        'observability_scale': observability_scale,
+        'observability': observability,
+    }
+    return parameters, before, after, report
+
+
 def calibration_acceptance(train_before: dict, train_after: dict,
                            heldout_before: dict, heldout_after: dict, *,
                            minimum_edge_points: int,
@@ -459,6 +579,9 @@ def main() -> int:
     optimization_mode = parser.add_mutually_exclusive_group()
     optimization_mode.add_argument('--optimize-extrinsic', action='store_true')
     optimization_mode.add_argument('--optimize-spatiotemporal', action='store_true')
+    parser.add_argument('--production-calibration', action='store_true',
+                        help='enable pyramid search, stratified holdout, bound '
+                             'expansion, and observability rejection')
     parser.add_argument('--trajectory', type=Path,
                         help='dense TUM world<-body trajectory; required for '
                              'spatiotemporal optimization')
@@ -471,6 +594,19 @@ def main() -> int:
     parser.add_argument('--max-rotation-deg', type=float, default=2.0)
     parser.add_argument('--holdout-modulo', type=int, default=5,
                         help='every Nth selected view is validation-only')
+    parser.add_argument('--holdout-fraction', type=float, default=0.2)
+    parser.add_argument('--spatial-segments', type=int, default=4)
+    parser.add_argument('--pyramid-scales', default='0.25,0.5,1.0')
+    parser.add_argument('--rounds-per-pyramid-level', type=int, default=2)
+    parser.add_argument('--auto-bound-expansions', type=int, default=2)
+    parser.add_argument('--bound-expansion-factor', type=float, default=2.0)
+    parser.add_argument('--observability-scale', type=float, default=1.0,
+                        help='audit resolution; must match the finest pyramid '
+                             'scale')
+    parser.add_argument('--minimum-curvature', type=float, default=1e-6)
+    parser.add_argument('--maximum-condition', type=float, default=1e6)
+    parser.add_argument('--maximum-time-translation-correlation', type=float,
+                        default=0.98)
     parser.add_argument('--minimum-edge-points', type=int, default=50)
     parser.add_argument('--minimum-heldout-improvement', type=float, default=0.0,
                         help='fractional held-out loss reduction required to '
@@ -482,11 +618,31 @@ def main() -> int:
             args.rotation_step_deg <= 0.0 or args.time_step <= 0.0 or
             args.max_time_offset < 0.0 or args.max_translation < 0.0 or
             args.max_rotation_deg < 0.0 or args.holdout_modulo < 2 or
+            not 0.0 < args.holdout_fraction < 0.5 or
+            args.spatial_segments < 1 or args.rounds_per_pyramid_level < 1 or
+            args.auto_bound_expansions < 0 or
+            args.bound_expansion_factor <= 1.0 or
+            not 0.0 < args.observability_scale <= 1.0 or
+            args.minimum_curvature <= 0.0 or args.maximum_condition <= 1.0 or
+            not 0.0 <= args.maximum_time_translation_correlation < 1.0 or
             args.minimum_edge_points < 1 or args.max_points < 0 or
             not 0.0 <= args.minimum_heldout_improvement < 1.0):
         raise SystemExit('stride, distance, rounds, and search steps must be > 0')
     if args.optimize_spatiotemporal and args.trajectory is None:
         raise SystemExit('--optimize-spatiotemporal requires --trajectory')
+    if args.production_calibration and not args.optimize_spatiotemporal:
+        raise SystemExit('--production-calibration requires '
+                         '--optimize-spatiotemporal')
+    try:
+        pyramid_scales = tuple(float(item) for item in
+                               args.pyramid_scales.split(','))
+    except ValueError as exc:
+        raise SystemExit('--pyramid-scales must be comma-separated numbers') \
+            from exc
+    if (args.production_calibration and pyramid_scales and
+            not np.isclose(args.observability_scale, pyramid_scales[-1])):
+        raise SystemExit('--observability-scale must match the finest '
+                         '--pyramid-scales value')
     import imageio.v3 as iio
     points, _ = pcio.read_ply_xyz(args.pointcloud)
     if args.max_points and len(points) > args.max_points:
@@ -518,24 +674,58 @@ def main() -> int:
             raise SystemExit(
                 'time offset is unobservable: selected views contain less than '
                 '0.05 m translation and 1 degree rotation')
-        heldout = [index for ordinal, index in enumerate(selected)
-                   if ordinal % args.holdout_modulo == 0]
-        train = [index for index in selected if index not in heldout]
+        split_report = None
+        if args.production_calibration:
+            selected_poses = np.asarray([
+                pi.interpolate_pose(samples, float(stamps[index]))
+                for index in selected])
+            train, heldout, split_report = stc.stratified_view_split(
+                stamps, selected_poses, selected,
+                holdout_fraction=args.holdout_fraction,
+                spatial_segments=args.spatial_segments)
+        else:
+            heldout = [index for ordinal, index in enumerate(selected)
+                       if ordinal % args.holdout_modulo == 0]
+            train = [index for index in selected if index not in heldout]
         if not train or not heldout:
             raise SystemExit('spatiotemporal calibration needs train and held-out views')
         image_by_index = dict(zip(selected, images))
         train_images = [image_by_index[index] for index in train]
         heldout_images = [image_by_index[index] for index in heldout]
-        parameters, train_before, train_after = optimize_spatiotemporal(
-            points, samples, stamps[train], body_T_camera, dataset['K'],
-            train_images, rounds=args.optimization_rounds,
-            time_step=args.time_step, translation_step=args.translation_step,
-            rotation_step_deg=args.rotation_step_deg,
-            max_time_offset=args.max_time_offset,
-            max_translation=args.max_translation,
-            max_rotation_deg=args.max_rotation_deg,
-            edge_percentile=args.edge_percentile,
-            max_distance=args.max_distance)
+        production_report = None
+        if args.production_calibration:
+            (parameters, train_before, train_after,
+             production_report) = optimize_spatiotemporal_production(
+                points, samples, stamps[train], body_T_camera, dataset['K'],
+                train_images, scales=pyramid_scales,
+                rounds_per_level=args.rounds_per_pyramid_level,
+                time_step=args.time_step,
+                translation_step=args.translation_step,
+                rotation_step_deg=args.rotation_step_deg,
+                max_time_offset=args.max_time_offset,
+                max_translation=args.max_translation,
+                max_rotation_deg=args.max_rotation_deg,
+                auto_bound_expansions=args.auto_bound_expansions,
+                bound_expansion_factor=args.bound_expansion_factor,
+                observability_scale=args.observability_scale,
+                minimum_curvature=args.minimum_curvature,
+                maximum_condition=args.maximum_condition,
+                maximum_time_translation_correlation=(
+                    args.maximum_time_translation_correlation),
+                edge_percentile=args.edge_percentile,
+                max_distance=args.max_distance)
+        else:
+            parameters, train_before, train_after = optimize_spatiotemporal(
+                points, samples, stamps[train], body_T_camera, dataset['K'],
+                train_images, rounds=args.optimization_rounds,
+                time_step=args.time_step,
+                translation_step=args.translation_step,
+                rotation_step_deg=args.rotation_step_deg,
+                max_time_offset=args.max_time_offset,
+                max_translation=args.max_translation,
+                max_rotation_deg=args.max_rotation_deg,
+                edge_percentile=args.edge_percentile,
+                max_distance=args.max_distance)
         zero = np.zeros(7)
         heldout_before_loss, heldout_before = spatiotemporal_objective(
             points, samples, stamps[heldout], body_T_camera, dataset['K'],
@@ -553,9 +743,6 @@ def main() -> int:
             train_before, train_after, heldout_before, heldout_after,
             minimum_edge_points=args.minimum_edge_points,
             minimum_heldout_improvement=args.minimum_heldout_improvement)
-        if accepted:
-            effective_viewmats = recompose_viewmats(
-                samples, stamps, body_T_camera, parameters)
         parameter_bounds = np.array([
             args.max_time_offset, args.max_translation,
             args.max_translation, args.max_translation,
@@ -569,6 +756,17 @@ def main() -> int:
             name for name, value, bound in zip(
                 names, reported_parameters, parameter_bounds)
             if bound > 0.0 and abs(value) >= bound - 1e-12]
+        if production_report is not None:
+            boundary_axes = production_report['boundary_axes']
+            if boundary_axes:
+                accepted = False
+                rejection_reason = 'search_boundary_reached'
+            if not production_report['observability']['observable']:
+                accepted = False
+                rejection_reason = 'calibration_not_observable'
+        if accepted:
+            effective_viewmats = recompose_viewmats(
+                samples, stamps, body_T_camera, parameters)
         optimization = {
             'accepted': accepted,
             'parameters_dt_s_xyz_m_rpy_deg': [float(parameters[0])] +
@@ -578,9 +776,11 @@ def main() -> int:
             'trajectory_excitation': excitation,
             'train_view_indices': train,
             'heldout_view_indices': heldout,
+            'validation_split': split_report,
             'minimum_edge_points': args.minimum_edge_points,
             'search_bounds_dt_s_xyz_m_rpy_deg': parameter_bounds.tolist(),
             'boundary_axes': boundary_axes,
+            'production_calibration': production_report,
             'train': {'before': train_before, 'after': train_after},
             'heldout': {'before': heldout_before, 'after': heldout_after},
             'rejection_reason': rejection_reason,

--- a/scripts/evaluate_lidar_camera_alignment.py
+++ b/scripts/evaluate_lidar_camera_alignment.py
@@ -522,7 +522,8 @@ def calibration_acceptance(train_before: dict, train_after: dict,
 
 
 def write_recomposed_transforms(source: Path, output: Path,
-                                viewmats: np.ndarray) -> Path:
+                                viewmats: np.ndarray, *,
+                                calibration: dict | None = None) -> Path:
     """Write continuous-time recomposed poses while preserving frame metadata."""
     source, output = Path(source).resolve(), Path(output).resolve()
     if source == output:
@@ -536,9 +537,34 @@ def write_recomposed_transforms(source: Path, output: Path,
         frame['transform_matrix'] = (
             np.linalg.inv(viewmat) @ pi.ROS_OPTICAL_TO_OPENGL).tolist()
         frame['file_path'] = os.path.relpath(image_path, output.parent)
+    if calibration is not None:
+        document['spatiotemporal_calibration'] = calibration
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(document, indent=2) + '\n')
     return output
+
+
+def calibration_metadata(optimization: dict) -> dict:
+    """Return the compact uncertainty contract consumed by RGB fusion."""
+    production = optimization.get('production_calibration')
+    observability = (production.get('observability')
+                     if production is not None else None)
+    metadata = {
+        'accepted': bool(optimization['accepted']),
+        'parameters_dt_s_xyz_m_rpy_deg':
+            optimization['parameters_dt_s_xyz_m_rpy_deg'],
+        'boundary_axes': optimization['boundary_axes'],
+    }
+    if observability is not None:
+        metadata.update({
+            'uncertainty_dt_s_xyz_m_rpy_rad':
+                observability['uncertainty_dt_s_xyz_m_rpy_rad'],
+            'condition_number': observability['condition_number'],
+            'maximum_abs_time_translation_correlation':
+                observability[
+                    'maximum_abs_time_translation_correlation'],
+        })
+    return metadata
 
 
 def write_corrected_transforms(source: Path, output: Path,
@@ -827,7 +853,8 @@ def main() -> int:
         if args.corrected_transforms_out is not None:
             corrected = write_recomposed_transforms(
                 args.transforms, args.corrected_transforms_out,
-                effective_viewmats)
+                effective_viewmats,
+                calibration=calibration_metadata(optimization))
             report['corrected_transforms'] = str(corrected)
     elif optimization is not None:
         report['extrinsic_optimization'] = optimization

--- a/tools/colored_map/COLORING_HANDOFF.md
+++ b/tools/colored_map/COLORING_HANDOFF.md
@@ -5,6 +5,9 @@
 > LiDAR depth edge と画像edgeの距離が改善した場合だけ
 > `transforms_spatiotemporal.json` を採用する。設計とRTK Seq1 smoke結果は
 > `docs/research/colored-map-spatiotemporal-calibration-2026-07.md` を参照。
+> production版では画像pyramid、移動距離×motion stratified held-out、探索幅を
+> 考慮したbound拡張、7軸曲率・条件数・時刻/並進相関の可観測性gateまで追加。
+> Seq1 200k点 smokeはtrain 9.20% / held-out 7.85%改善、可観測性PASS。
 
 BIM 枝の `BIM_HANDOFF.md` と同じ趣旨の引き継ぎ文書。README の
 camera-coloured flythrough の色が濁っていた問題を起点に、着色パイプライン・

--- a/tools/colored_map/colored_map_pipeline.py
+++ b/tools/colored_map/colored_map_pipeline.py
@@ -257,6 +257,7 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                 '--trajectory', str(trajectory),
                 '--out', str(calibration_report),
                 '--optimize-spatiotemporal',
+                '--production-calibration',
                 '--corrected-transforms-out', str(refined_transforms),
                 '--view-stride', str(args.calibration_view_stride),
                 '--max-points', str(args.calibration_max_points),
@@ -268,6 +269,23 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
                 '--max-translation', str(args.calibration_max_translation),
                 '--max-rotation-deg', str(args.calibration_max_rotation_deg),
                 '--holdout-modulo', str(args.calibration_holdout_modulo),
+                '--holdout-fraction', str(args.calibration_holdout_fraction),
+                '--spatial-segments', str(args.calibration_spatial_segments),
+                '--pyramid-scales', args.calibration_pyramid_scales,
+                '--rounds-per-pyramid-level',
+                str(args.calibration_rounds_per_pyramid_level),
+                '--auto-bound-expansions',
+                str(args.calibration_auto_bound_expansions),
+                '--bound-expansion-factor',
+                str(args.calibration_bound_expansion_factor),
+                '--observability-scale',
+                str(args.calibration_observability_scale),
+                '--minimum-curvature',
+                str(args.calibration_minimum_curvature),
+                '--maximum-condition',
+                str(args.calibration_maximum_condition),
+                '--maximum-time-translation-correlation',
+                str(args.calibration_maximum_time_translation_correlation),
                 '--minimum-edge-points',
                 str(args.calibration_minimum_edge_points),
                 '--minimum-heldout-improvement',
@@ -353,6 +371,11 @@ def build_commands(args) -> list[tuple[str, list[str]]]:
 def run_pipeline(args) -> dict:
     """Execute missing stages and return paths plus the stages that ran."""
     out_dir = Path(args.out)
+    try:
+        calibration_scales = tuple(
+            float(item) for item in args.calibration_pyramid_scales.split(','))
+    except ValueError as exc:
+        raise ValueError('calibration pyramid scales must be numbers') from exc
     if args.kalibr_camchain is not None and args.lidar_calibration is None:
         raise ValueError('--kalibr-camchain requires --lidar-calibration')
     if args.force_calibration and not args.refine_spatiotemporal_calibration:
@@ -369,9 +392,26 @@ def run_pipeline(args) -> dict:
             args.calibration_max_translation < 0.0 or
             args.calibration_max_rotation_deg < 0.0 or
             args.calibration_holdout_modulo < 2 or
+            not 0.0 < args.calibration_holdout_fraction < 0.5 or
+            args.calibration_spatial_segments < 1 or
+            args.calibration_rounds_per_pyramid_level < 1 or
+            args.calibration_auto_bound_expansions < 0 or
+            args.calibration_bound_expansion_factor <= 1.0 or
+            not 0.0 < args.calibration_observability_scale <= 1.0 or
+            args.calibration_minimum_curvature <= 0.0 or
+            args.calibration_maximum_condition <= 1.0 or
+            not 0.0 <= args.calibration_maximum_time_translation_correlation < 1.0 or
             args.calibration_minimum_edge_points < 1 or
             not 0.0 <= args.calibration_minimum_heldout_improvement < 1.0):
         raise ValueError('invalid spatiotemporal calibration search settings')
+    if (args.refine_spatiotemporal_calibration and
+            (not calibration_scales or
+             tuple(sorted(calibration_scales)) != calibration_scales or
+             any(not 0.0 < scale <= 1.0 for scale in calibration_scales) or
+             not np.isclose(args.calibration_observability_scale,
+                            calibration_scales[-1]))):
+        raise ValueError('calibration observability scale must match the '
+                         'finest valid pyramid scale')
     if not args.dry_run:
         out_dir.mkdir(parents=True, exist_ok=True)
         if args.kalibr_camchain is not None:
@@ -452,6 +492,19 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument('--calibration-max-translation', type=float, default=0.1)
     p.add_argument('--calibration-max-rotation-deg', type=float, default=2.0)
     p.add_argument('--calibration-holdout-modulo', type=int, default=5)
+    p.add_argument('--calibration-holdout-fraction', type=float, default=0.2)
+    p.add_argument('--calibration-spatial-segments', type=int, default=4)
+    p.add_argument('--calibration-pyramid-scales', default='0.25,0.5,1.0')
+    p.add_argument('--calibration-rounds-per-pyramid-level', type=int,
+                   default=2)
+    p.add_argument('--calibration-auto-bound-expansions', type=int, default=2)
+    p.add_argument('--calibration-bound-expansion-factor', type=float,
+                   default=2.0)
+    p.add_argument('--calibration-observability-scale', type=float, default=1.0)
+    p.add_argument('--calibration-minimum-curvature', type=float, default=1e-6)
+    p.add_argument('--calibration-maximum-condition', type=float, default=1e6)
+    p.add_argument('--calibration-maximum-time-translation-correlation',
+                   type=float, default=0.98)
     p.add_argument('--calibration-minimum-edge-points', type=int, default=50)
     p.add_argument('--calibration-minimum-heldout-improvement', type=float,
                    default=0.0)

--- a/tools/colored_map/spatiotemporal_calibration.py
+++ b/tools/colored_map/spatiotemporal_calibration.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Deterministic production helpers for LiDAR-camera calibration.
+
+The module deliberately depends on NumPy only.  Geometry projection and image
+edge objectives remain in ``evaluate_lidar_camera_alignment.py``; this file
+owns search policy, validation partitioning, and local identifiability so they
+can be tested without ROS, image codecs, or a real point cloud.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+import numpy as np
+
+
+PARAMETER_NAMES = ('dt', 'tx', 'ty', 'tz', 'roll', 'pitch', 'yaw')
+
+
+def downsample_nearest(image: np.ndarray, scale: float) -> np.ndarray:
+    """Return a deterministic nearest-neighbour image pyramid level."""
+    array = np.asarray(image)
+    if array.ndim not in (2, 3):
+        raise ValueError(f'image must be HxW or HxWxC, got {array.shape}')
+    if not 0.0 < scale <= 1.0:
+        raise ValueError('image scale must be in (0, 1]')
+    if scale == 1.0:
+        return array
+    height = max(2, int(round(array.shape[0] * scale)))
+    width = max(2, int(round(array.shape[1] * scale)))
+    rows = np.minimum(
+        (np.arange(height, dtype=np.float64) / scale).astype(np.int64),
+        array.shape[0] - 1)
+    columns = np.minimum(
+        (np.arange(width, dtype=np.float64) / scale).astype(np.int64),
+        array.shape[1] - 1)
+    return array[rows[:, None], columns[None, :]]
+
+
+def scale_intrinsics(K: np.ndarray, scale: float) -> np.ndarray:
+    """Scale pinhole intrinsics for one image pyramid level."""
+    if not 0.0 < scale <= 1.0:
+        raise ValueError('intrinsics scale must be in (0, 1]')
+    result = np.asarray(K, dtype=np.float64).copy()
+    if result.shape != (3, 3):
+        raise ValueError(f'K must be 3x3, got {result.shape}')
+    result[0, :] *= scale
+    result[1, :] *= scale
+    result[2, :] = [0.0, 0.0, 1.0]
+    return result
+
+
+def _rotation_angle_deg(first: np.ndarray, second: np.ndarray) -> float:
+    relative = first[:3, :3].T @ second[:3, :3]
+    cosine = np.clip((np.trace(relative) - 1.0) * 0.5, -1.0, 1.0)
+    return float(np.rad2deg(np.arccos(cosine)))
+
+
+def stratified_view_split(
+        stamps: np.ndarray, world_T_bodies: np.ndarray,
+        selected: Sequence[int], *, holdout_fraction: float = 0.2,
+        spatial_segments: int = 4) -> tuple[list[int], list[int], dict]:
+    """Split views across path position and local motion deterministically.
+
+    Spatial strata are equal travelled-distance segments (falling back to
+    temporal progress for a stationary path).  Each view is additionally
+    labelled ``static``, ``translation``, or ``rotation`` from its local motion.
+    Every non-singleton stratum contributes validation views, preventing a
+    periodic camera stride from placing the holdout in only one motion regime.
+    """
+    indices = np.asarray(list(selected), dtype=np.int64)
+    stamps = np.asarray(stamps, dtype=np.float64)
+    poses = np.asarray(world_T_bodies, dtype=np.float64)
+    if indices.size < 2:
+        raise ValueError('stratified split needs at least two selected views')
+    if poses.shape != (indices.size, 4, 4):
+        raise ValueError('world_T_bodies must match selected views')
+    if not 0.0 < holdout_fraction < 0.5:
+        raise ValueError('holdout_fraction must be in (0, 0.5)')
+    if spatial_segments < 1:
+        raise ValueError('spatial_segments must be positive')
+
+    translations = poses[:, :3, 3]
+    step_translation = np.linalg.norm(
+        np.diff(translations, axis=0), axis=1)
+    step_rotation = np.asarray([
+        _rotation_angle_deg(first, second)
+        for first, second in zip(poses, poses[1:])])
+    local_translation = np.r_[step_translation[0], step_translation]
+    local_rotation = np.r_[step_rotation[0], step_rotation]
+    translation_scale = max(float(np.median(
+        local_translation[local_translation > 1e-9]))
+        if np.any(local_translation > 1e-9) else 0.0, 1e-9)
+    rotation_scale = max(float(np.median(
+        local_rotation[local_rotation > 1e-6]))
+        if np.any(local_rotation > 1e-6) else 0.0, 1e-6)
+
+    motion_labels = []
+    for translation, rotation in zip(local_translation, local_rotation):
+        if translation < 0.1 * translation_scale and rotation < 0.1 * rotation_scale:
+            motion_labels.append('static')
+        elif rotation / rotation_scale >= translation / translation_scale:
+            motion_labels.append('rotation')
+        else:
+            motion_labels.append('translation')
+
+    progress = np.r_[0.0, np.cumsum(step_translation)]
+    if progress[-1] <= 1e-9:
+        duration = max(float(stamps[indices[-1]] - stamps[indices[0]]), 1e-9)
+        progress = (stamps[indices] - stamps[indices[0]]) / duration
+    else:
+        progress /= progress[-1]
+    segment_ids = np.minimum(
+        (progress * spatial_segments).astype(np.int64), spatial_segments - 1)
+
+    strata: dict[tuple[int, str], list[int]] = {}
+    for ordinal, (segment, motion) in enumerate(
+            zip(segment_ids, motion_labels)):
+        strata.setdefault((int(segment), motion), []).append(ordinal)
+
+    heldout_ordinals: set[int] = set()
+    report_strata = []
+    for key in sorted(strata):
+        members = strata[key]
+        count = (min(len(members) - 1,
+                     max(1, int(round(len(members) * holdout_fraction))))
+                 if len(members) > 1 else 0)
+        chosen = []
+        if count:
+            positions = np.linspace(
+                0, len(members) - 1, 2 * count + 1, dtype=np.float64)[1::2]
+            chosen = [members[int(round(position))] for position in positions]
+            heldout_ordinals.update(chosen)
+        report_strata.append({
+            'spatial_segment': key[0], 'motion': key[1],
+            'views': len(members), 'heldout': len(chosen),
+        })
+    if not heldout_ordinals:
+        heldout_ordinals.add(indices.size // 2)
+    if len(heldout_ordinals) >= indices.size:
+        heldout_ordinals.remove(max(heldout_ordinals))
+
+    heldout = [int(indices[item]) for item in sorted(heldout_ordinals)]
+    train = [int(index) for ordinal, index in enumerate(indices)
+             if ordinal not in heldout_ordinals]
+    report = {
+        'strategy': 'travelled_distance_x_motion',
+        'holdout_fraction_requested': holdout_fraction,
+        'holdout_fraction_actual': len(heldout) / len(indices),
+        'spatial_segments': spatial_segments,
+        'strata': report_strata,
+    }
+    return train, heldout, report
+
+
+def bounded_coordinate_search(
+        objective: Callable[[np.ndarray], float], initial: np.ndarray,
+        steps: np.ndarray, bounds: np.ndarray, *, rounds: int = 2,
+        maximum_sweeps: int = 100,
+        step_multipliers: Sequence[float] = (1.0, 2.0),
+        ) -> tuple[np.ndarray, float, dict]:
+    """Run deterministic bounded coordinate pattern search from ``initial``."""
+    parameters = np.asarray(initial, dtype=np.float64).copy()
+    current_steps = np.asarray(steps, dtype=np.float64).copy()
+    bounds = np.asarray(bounds, dtype=np.float64)
+    if parameters.shape != current_steps.shape or parameters.shape != bounds.shape:
+        raise ValueError('initial, steps, and bounds must have matching shapes')
+    multipliers = tuple(float(value) for value in step_multipliers)
+    if (rounds < 1 or maximum_sweeps < 1 or
+            np.any(current_steps <= 0.0) or not multipliers or
+            any(value <= 0.0 for value in multipliers)):
+        raise ValueError('rounds, sweeps, and steps must be positive')
+    if np.any(bounds < 0.0) or np.any(np.abs(parameters) > bounds + 1e-12):
+        raise ValueError('initial parameters must lie inside non-negative bounds')
+    best_loss = float(objective(parameters))
+    history = [{'round': 0, 'loss': best_loss,
+                'parameters': parameters.tolist()}]
+    evaluations = 1
+    sweeps = 0
+    for level in range(rounds):
+        changed = True
+        while changed:
+            changed = False
+            sweeps += 1
+            if sweeps > maximum_sweeps:
+                raise RuntimeError('coordinate search exceeded maximum sweeps')
+            for axis in range(parameters.size):
+                axis_parameters = parameters
+                axis_best_parameters = parameters
+                axis_best_loss = best_loss
+                for multiplier in multipliers:
+                    for direction in (-1.0, 1.0):
+                        candidate = axis_parameters.copy()
+                        candidate[axis] += (
+                            direction * multiplier * current_steps[axis])
+                        if abs(candidate[axis]) > bounds[axis] + 1e-12:
+                            continue
+                        loss = float(objective(candidate))
+                        evaluations += 1
+                        if loss + 1e-12 < axis_best_loss:
+                            axis_best_parameters = candidate
+                            axis_best_loss = loss
+                if axis_best_loss + 1e-12 < best_loss:
+                    parameters = axis_best_parameters
+                    best_loss = axis_best_loss
+                    changed = True
+            history.append({
+                'round': level + 1, 'sweep': sweeps, 'loss': best_loss,
+                'parameters': parameters.tolist(),
+            })
+        current_steps *= 0.5
+    return parameters, best_loss, {
+        'evaluations': evaluations, 'sweeps': sweeps,
+        'final_steps': current_steps.tolist(),
+        'step_multipliers': list(multipliers), 'history': history,
+    }
+
+
+def boundary_axes(parameters: np.ndarray, bounds: np.ndarray,
+                  *, tolerance: float | np.ndarray = 1e-9) -> list[str]:
+    """Return named parameters touching a nonzero search bound."""
+    values = np.asarray(parameters, dtype=np.float64)
+    limits = np.asarray(bounds, dtype=np.float64)
+    tolerances = np.broadcast_to(
+        np.asarray(tolerance, dtype=np.float64), values.shape)
+    if np.any(tolerances < 0.0):
+        raise ValueError('boundary tolerance must be non-negative')
+    return [name for name, value, limit, margin in zip(
+        PARAMETER_NAMES, values, limits, tolerances)
+        if limit > 0.0 and abs(value) >= limit - margin]
+
+
+def finite_difference_observability(
+        objective: Callable[[np.ndarray], float], parameters: np.ndarray,
+        perturbations: np.ndarray, *,
+        correlation_pairs: Sequence[tuple[int, int]] = ((0, 1), (0, 2), (0, 3)),
+        minimum_curvature: float = 1e-6,
+        maximum_condition: float = 1e6,
+        maximum_correlation: float = 0.98,
+        maximum_stationary_offset: float = 1.0) -> dict:
+    """Estimate local curvature, uncertainty, and clock/lever-arm coupling.
+
+    Each axis uses a five-point quadratic fit instead of a single second
+    difference.  This is less sensitive to pixel quantisation in the image-edge
+    objective and also checks that the fitted stationary point remains local.
+    Clock/translation pairs use a 3x3 quadratic surface.  A correlation is only
+    reported when that pair is positive definite; an invalid variance is never
+    converted into a synthetic perfect correlation.
+    """
+    values = np.asarray(parameters, dtype=np.float64)
+    steps = np.asarray(perturbations, dtype=np.float64)
+    if values.shape != (7,) or steps.shape != (7,) or np.any(steps <= 0.0):
+        raise ValueError('observability expects seven positive perturbations')
+    if maximum_stationary_offset <= 0.0:
+        raise ValueError('maximum_stationary_offset must be positive')
+    base = float(objective(values))
+    hessian = np.zeros((7, 7), dtype=np.float64)
+    evaluations = 1
+    finite = np.isfinite(base)
+    axis_fits = []
+    offsets = np.arange(-2.0, 3.0)
+    axis_design = np.column_stack((offsets ** 2, offsets,
+                                   np.ones(offsets.size)))
+    for axis in range(7):
+        losses = []
+        for offset in offsets:
+            if offset == 0.0:
+                losses.append(base)
+                continue
+            candidate = values.copy()
+            candidate[axis] += offset * steps[axis]
+            losses.append(float(objective(candidate)))
+            evaluations += 1
+        axis_finite = bool(np.all(np.isfinite(losses)))
+        finite &= axis_finite
+        if axis_finite:
+            coefficients = np.linalg.lstsq(
+                axis_design, np.asarray(losses), rcond=None)[0]
+            predicted = axis_design @ coefficients
+            residual = float(np.sum((np.asarray(losses) - predicted) ** 2))
+            total = float(np.sum((np.asarray(losses) - np.mean(losses)) ** 2))
+            fit_quality = 1.0 - residual / total if total > 1e-15 else 1.0
+            curvatures, stationary_offsets = [], []
+            for radius in (1, 2):
+                minus_loss = losses[2 - radius]
+                plus_loss = losses[2 + radius]
+                curvature_at_radius = float(
+                    (plus_loss + minus_loss - 2.0 * base) / radius ** 2)
+                gradient_at_radius = float(
+                    (plus_loss - minus_loss) / (2.0 * radius))
+                curvatures.append(curvature_at_radius)
+                stationary_offsets.append(
+                    float(-gradient_at_radius / curvature_at_radius)
+                    if abs(curvature_at_radius) > 1e-15 else None)
+            curvature = float(np.median(curvatures))
+            finite_offsets = [value for value in stationary_offsets
+                              if value is not None and np.isfinite(value)]
+            stationary_offset = (float(np.median(finite_offsets))
+                                 if finite_offsets else None)
+        else:
+            curvature, stationary_offset, fit_quality = np.nan, None, np.nan
+            curvatures, stationary_offsets = [np.nan, np.nan], [None, None]
+        hessian[axis, axis] = curvature
+        axis_fits.append({
+            'axis': PARAMETER_NAMES[axis],
+            'curvature': curvature,
+            'curvature_at_one_and_two_steps': curvatures,
+            'curvature_stable': bool(
+                all(value > minimum_curvature for value in curvatures)),
+            'stationary_offset_steps': stationary_offset,
+            'stationary_offset_at_one_and_two_steps': stationary_offsets,
+            'fit_r_squared': fit_quality,
+            'losses_at_offsets_minus2_to_plus2': losses,
+        })
+
+    correlations = []
+    pair_fits = []
+    pair_offsets = (-1.0, 0.0, 1.0)
+    for first, second in correlation_pairs:
+        rows, losses = [], []
+        for first_offset in pair_offsets:
+            for second_offset in pair_offsets:
+                if first_offset == 0.0 and second_offset == 0.0:
+                    loss = base
+                else:
+                    candidate = values.copy()
+                    candidate[first] += first_offset * steps[first]
+                    candidate[second] += second_offset * steps[second]
+                    loss = float(objective(candidate))
+                    evaluations += 1
+                rows.append((first_offset ** 2, second_offset ** 2,
+                             first_offset * second_offset, first_offset,
+                             second_offset, 1.0))
+                losses.append(loss)
+        pair_finite = bool(np.all(np.isfinite(losses)))
+        finite &= pair_finite
+        if pair_finite:
+            design = np.asarray(rows, dtype=np.float64)
+            coefficients = np.linalg.lstsq(
+                design, np.asarray(losses), rcond=None)[0]
+            cross = float(coefficients[2])
+            pair_hessian = np.array([
+                [2.0 * coefficients[0], cross],
+                [cross, 2.0 * coefficients[1]],
+            ])
+            determinant = float(np.linalg.det(pair_hessian))
+            pair_positive = bool(
+                pair_hessian[0, 0] > minimum_curvature and
+                pair_hessian[1, 1] > minimum_curvature and
+                determinant > minimum_curvature ** 2)
+            correlation = (float(-cross / np.sqrt(
+                pair_hessian[0, 0] * pair_hessian[1, 1]))
+                           if pair_positive else None)
+        else:
+            cross, determinant, pair_positive, correlation = (
+                np.nan, np.nan, False, None)
+        hessian[first, second] = hessian[second, first] = cross
+        correlations.append({
+            'first': PARAMETER_NAMES[first],
+            'second': PARAMETER_NAMES[second],
+            'correlation': correlation,
+        })
+        pair_fits.append({
+            'first': PARAMETER_NAMES[first],
+            'second': PARAMETER_NAMES[second],
+            'positive_definite': pair_positive,
+            'determinant': determinant,
+        })
+
+    eigenvalues = np.linalg.eigvalsh(hessian) if finite else np.full(7, np.nan)
+    positive = eigenvalues[eigenvalues > minimum_curvature]
+    condition = (float(positive[-1] / positive[0])
+                 if positive.size == 7 else float('inf'))
+    hessian_positive = bool(finite and positive.size == 7)
+    if hessian_positive:
+        covariance_normalized = np.linalg.inv(hessian) * max(base, 1e-6)
+        covariance = (np.diag(steps) @ covariance_normalized @
+                      np.diag(steps))
+        uncertainties = np.sqrt(np.diag(covariance)).tolist()
+    else:
+        uncertainties = [None] * 7
+    defined_correlations = [
+        abs(item['correlation']) for item in correlations
+        if item['correlation'] is not None]
+    max_correlation = (max(defined_correlations)
+                       if defined_correlations else None)
+    pairs_observable = all(item['positive_definite'] for item in pair_fits)
+    curvature_stable = all(item['curvature_stable'] for item in axis_fits)
+    stationary = all(
+        item['stationary_offset_steps'] is not None and
+        abs(item['stationary_offset_steps']) <= maximum_stationary_offset
+        for item in axis_fits)
+    observable = bool(
+        hessian_positive and curvature_stable and pairs_observable and stationary and
+        condition <= maximum_condition and max_correlation is not None and
+        max_correlation <= maximum_correlation)
+    reasons = []
+    if not finite:
+        reasons.append('non_finite_local_objective')
+    if positive.size != 7:
+        reasons.append('insufficient_positive_curvature')
+    if not curvature_stable:
+        reasons.append('unstable_multiscale_curvature')
+    if not pairs_observable:
+        reasons.append('unobservable_time_translation_pair')
+    if not stationary:
+        reasons.append('stationary_point_outside_local_neighborhood')
+    if condition > maximum_condition:
+        reasons.append('ill_conditioned')
+    if (max_correlation is not None and
+            max_correlation > maximum_correlation):
+        reasons.append('time_translation_correlation')
+    return {
+        'observable': observable,
+        'rejection_reasons': reasons,
+        'evaluations': evaluations,
+        'base_loss': base,
+        'perturbations_dt_s_xyz_m_rpy_rad': steps.tolist(),
+        'standardized_hessian': hessian.tolist(),
+        'eigenvalues': eigenvalues.tolist(),
+        'condition_number': condition,
+        'axis_quadratic_fits': axis_fits,
+        'pair_quadratic_fits': pair_fits,
+        'uncertainty_dt_s_xyz_m_rpy_rad': uncertainties,
+        'time_translation_correlations': correlations,
+        'maximum_abs_time_translation_correlation': max_correlation,
+    }


### PR DESCRIPTION
## Summary

- add deterministic multi-resolution 7DoF LiDAR-camera calibration with step-aware bound expansion
- replace periodic validation with travelled-distance x motion stratified held-out views
- gate adoption on multi-scale local curvature, Hessian conditioning, uncertainty, and clock/translation coupling
- embed accepted parameters and uncertainty in corrected transforms for downstream RGB fusion
- wire production calibration through the coloured-map pipeline and document the Seq1 result

## Why

The previous search demonstrated held-out improvement but could stop at tight bounds and had no production identifiability check. Pixel-quantized edge objectives require a wider pattern search and robust centred curvature estimates. Downstream fusion also needs the accepted uncertainty beside the corrected poses instead of an unrelated report lookup.

## RTK-SLAM Construction Seq1

200,000 deterministic points, 13/260 views, 9 train + 4 held out, pyramid 0.25/0.5/1.0:

- train loss: 6.5391 -> 5.9373 (9.20% better)
- held-out loss: 6.5225 -> 6.0103 (7.85% better)
- held-out out-of-range: 0.2406 -> 0.2158
- no final boundary axes
- all seven Hessian eigenvalues positive (0.0369-0.0827)
- condition number: 2.24
- maximum absolute clock/translation correlation: 0.105
- production acceptance: passed

## Validation

- `python3 -m pytest -q graph_based_slam/test` - 1229 passed, 13 skipped
- focused calibration/pipeline tests - 57 passed
- Jazzy `ament_flake8` on all changed Python files - no problems
- `git diff --check` - clean
