### PR TITLE
Add recoverable workflow termination

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
           rm -rf release_bundle
           mkdir -p release_bundle/docs/releases release_bundle/docs/social release_bundle/docs/assets release_bundle/docs/roadmap release_bundle/output release_bundle/lidarslam/images
           cp README.md CHANGELOG.md CONTRIBUTING.md RELEASING.md VERSION mkdocs.yml SECURITY.md SUPPORT.md CODE_OF_CONDUCT.md GOVERNANCE.md CITATION.cff release_bundle/
-          cp docs/index.md docs/getting-started.md docs/product-contract.md docs/golden-path-cli.md docs/distribution.md docs/rosdistro-release.md docs/autoware-map-authoring.md docs/autoware-foxglove.md docs/autoware-quickstart.md docs/workflows.md docs/benchmarking.md docs/comparison.md release_bundle/docs/
+          cp docs/index.md docs/getting-started.md docs/product-contract.md docs/golden-path-cli.md docs/operational-reliability.md docs/distribution.md docs/rosdistro-release.md docs/autoware-map-authoring.md docs/autoware-foxglove.md docs/autoware-quickstart.md docs/workflows.md docs/benchmarking.md docs/comparison.md release_bundle/docs/
           cp docs/roadmap/v0.9.md release_bundle/docs/roadmap/
           cp -r docs/assets/. release_bundle/docs/assets/
           cp docs/social/autoware_map_authoring_post_v0.2.2.md release_bundle/docs/social/

--- a/docs/golden-path-cli.md
+++ b/docs/golden-path-cli.md
@@ -33,7 +33,12 @@ The runner writes into `<output>.partial` and atomically renames that directory
 to the requested output name after the workflow stops. It refuses to start
 when either name already exists, so a new run never overwrites prior evidence.
 Completed, failed, and interrupted workflows retain their artifacts and
-terminal state for diagnosis.
+terminal state for diagnosis. The runner isolates the workflow in its own
+process group. `Ctrl-C` (`SIGINT`) and service/container termination
+(`SIGTERM`) are forwarded to that group, bounded by a ten-second graceful
+shutdown before forced cleanup. The manifest is then completed with
+`interrupted` status, exit `130` or `143`, and the terminating signal in
+`lifecycle.last_error`.
 
 If the workflow has stopped but verification, finalization, diagnosis, or
 checksum generation was interrupted, resume only those terminal
@@ -115,7 +120,8 @@ Each subcommand accepts the same options as its delegated tool:
 | `0` | Command completed successfully |
 | `2` | Invalid usage, input, profile, or output path |
 | `70` | Internal/tooling error prevented the command from starting |
-| `130` | Run was interrupted by the operator |
+| `130` | Run was interrupted by the operator (`SIGINT`) |
+| `143` | Run was terminated by a service or container manager (`SIGTERM`) |
 | other non-zero | Map-workflow exit code, propagated unchanged |
 
 ## Installed names and compatibility

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,10 @@
     <h3>Distribution</h3>
     <p>Install the CLI, understand supported platforms, and see the binary-release boundary.</p>
   </a>
+  <a class="link-card" href="operational-reliability.html">
+    <h3>Operational Reliability</h3>
+    <p>Understand failure artifacts, termination handling, recovery, and open reliability gates.</p>
+  </a>
   <a class="link-card" href="autoware-map-authoring.html">
     <h3>Autoware-Compatible Map Authoring</h3>
     <p>The shortest product-level summary of the supported public path.</p>
@@ -114,6 +118,7 @@
 ## Project
 
 - [Product contract](product-contract.md)
+- [Operational reliability](operational-reliability.md)
 - [Distribution and installed CLI](distribution.md)
 - [v0.9 product roadmap](roadmap/v0.9.md)
 - [Contributing](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/CONTRIBUTING.md)

--- a/docs/operational-reliability.md
+++ b/docs/operational-reliability.md
@@ -1,0 +1,51 @@
+# Operational reliability
+
+This page defines how the golden-path runner behaves when an input, workflow,
+or post-processing stage fails. It is the Phase 3 evidence ledger; a row is
+only marked covered when an automated test exercises the public behavior.
+
+## Failure and recovery matrix
+
+| Failure | Public behavior | Preserved state | Operator action | Coverage |
+| --- | --- | --- | --- | --- |
+| Missing or corrupt `metadata.yaml`, missing referenced storage file | Exit `2` before workflow launch | Existing output is untouched; a new output is not created | Correct or replace the bag, then rerun `lidarslam-map doctor` | Automated |
+| Incompatible topic/profile selection | Exit `2` with available profiles and missing requirements | Existing output is untouched | Choose a compatible profile or fix the input | Automated |
+| Final or `.partial` output collision | Exit `2`; no overwrite | Both existing paths remain immutable | Inspect the existing run or choose a new output name | Automated |
+| Workflow exits non-zero | Propagate the workflow exit code | Final output, diagnosis, checksums, and schema-v2 manifest with `failed` status | Inspect the diagnosis and launch log; rerun into a new directory after fixing the cause | Automated |
+| Operator `Ctrl-C` (`SIGINT`) | Forward `SIGINT` to the isolated workflow process group; force cleanup after ten seconds; exit `130` | Final output and manifest with `interrupted` status and signal reason | Inspect preserved evidence; rerun into a new directory if a map is still required | Automated |
+| Service/container stop (`SIGTERM`) | Forward `SIGTERM` to the isolated workflow process group; force cleanup after ten seconds; exit `143` | Final output, diagnosis, checksums, and manifest with `interrupted`, `143`, and `SIGTERM` | Inspect preserved evidence; rerun into a new directory if a map is still required | Automated failure injection |
+| Termination after the workflow result is durable but before post-processing completes | Leave the last durable schema-v2 lifecycle stage in the final or `.partial` directory | Original input/software/command identity and map artifacts | Run the same command and output path with `--resume`; SLAM is not rerun | Automated |
+| Ambiguous or unsafe resume state | Exit `2`; refuse concurrent or pre-terminal post-processing | Both candidate directories and manifests remain unchanged | Verify no original process is active; resolve the ambiguity manually before retrying | Automated |
+| Missing TF connectivity observed in ROS logs | Diagnosis is `runtime_failed` with a TF connectivity hint | Launch log and diagnosis artifacts | Correct calibration/frame configuration and rerun | Automated diagnosis fixture |
+
+`run_manifest.json` is authoritative for terminal workflow status. Diagnosis
+uses its `failed` or `interrupted` state even when the workflow stopped before
+writing a recognizable ROS log signature.
+
+## Termination boundary
+
+The runner starts the delegated workflow in a separate POSIX process group.
+For `SIGINT` and `SIGTERM`, it forwards the same signal to the entire group,
+waits up to ten seconds, then sends `SIGKILL` if the group leader has not
+exited. The leader is always reaped before terminal post-processing begins.
+
+An external `SIGKILL`, kernel panic, power loss, or storage device loss cannot
+be converted into a terminal manifest by user-space code. Such a run may
+remain at `workflow_running`; `--resume` deliberately refuses it because an
+original process could still own the artifacts. Confirm that no workflow
+process is alive, retain the directory as evidence, and start a new output.
+
+## Open Phase 3 gates
+
+The following readiness rows remain incomplete and must not be inferred from
+the termination coverage:
+
+- timestamp reversal detection against real rosbag records before launch;
+- an explicit free-space budget and deterministic disk-pressure refusal;
+- controlled disk-exhaustion injection for manifest and map writes;
+- one-hour and eight-hour soak profiles with RSS, wall-time, output-size, and
+  dropped-input counters;
+- nightly pinned real-bag E2E evidence;
+- output migration tooling and last-known-good rollback instructions.
+
+See the [v0.9 roadmap](roadmap/v0.9.md) for the full Phase 3 and v1.0 gates.

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -35,6 +35,9 @@ a new name, and in-progress work is isolated under a `.partial` sibling. The
 only exception is explicit `--resume` of an incomplete schema-v2 lifecycle:
 the runner revalidates the original execution identity and completes terminal
 post-processing without rerunning SLAM or replacing map artifacts.
+Signal handling, preserved failure state, recovery actions, and still-open
+Phase 3 gates are tracked in
+[Operational reliability](operational-reliability.md).
 
 ## Official entrypoints
 

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -2,7 +2,8 @@
 
 > Status: **direction approved 2026-07-27; Phase 0 and Phase 1 complete;
 > Phase 2 in progress (installed CLI and clean-prefix validation landed;
-> binary flagship packaging remains open)**.
+> binary flagship packaging remains open); Phase 3 in progress (SIGINT/SIGTERM
+> process-group cleanup and recoverable terminal evidence landed)**.
 > This roadmap
 > turns the existing benchmark-heavy map-authoring stack into a product-level
 > OSS project. It does not replace the evidence-driven capability roadmaps;

--- a/graph_based_slam/test/test_autoware_map_run_diagnosis.py
+++ b/graph_based_slam/test/test_autoware_map_run_diagnosis.py
@@ -132,6 +132,43 @@ def test_summary_reports_tf_issue_hints(tmp_path: Path):
     assert any('tail -n 120' in step for step in summary['suggested_next_steps'])
 
 
+def test_summary_uses_terminal_manifest_as_runtime_failure_evidence(
+    tmp_path: Path,
+):
+    module = _load_module()
+    run_dir = tmp_path / 'run'
+    run_dir.mkdir()
+    (run_dir / 'run_manifest.json').write_text(
+        json.dumps({
+            'status': 'interrupted',
+            'lifecycle': {
+                'last_error': 'map workflow interrupted by SIGTERM',
+            },
+        }),
+        encoding='utf-8',
+    )
+
+    summary = module.summarize_run(run_dir)
+
+    assert summary['status'] == 'runtime_failed'
+    assert 'map workflow interrupted by SIGTERM' in summary['problem_hints']
+
+
+def test_summary_reports_unreadable_manifest_without_traceback(tmp_path: Path):
+    module = _load_module()
+    run_dir = tmp_path / 'run'
+    run_dir.mkdir()
+    (run_dir / 'run_manifest.json').write_text('{not json', encoding='utf-8')
+
+    summary = module.summarize_run(run_dir)
+
+    assert summary['status'] == 'runtime_failed'
+    assert any(
+        hint.startswith('The run manifest is unreadable:')
+        for hint in summary['problem_hints']
+    )
+
+
 def test_cli_help_is_user_facing():
     result = subprocess.run(
         [sys.executable, str(SCRIPT_PATH), '--help'],

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -64,6 +64,7 @@ COMPARISON_DOC = REPO_ROOT / 'docs' / 'comparison.md'
 PRODUCT_CONTRACT_DOC = REPO_ROOT / 'docs' / 'product-contract.md'
 GOLDEN_PATH_CLI_DOC = REPO_ROOT / 'docs' / 'golden-path-cli.md'
 DISTRIBUTION_DOC = REPO_ROOT / 'docs' / 'distribution.md'
+OPERATIONAL_RELIABILITY_DOC = REPO_ROOT / 'docs' / 'operational-reliability.md'
 PREFLIGHT_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'preflight-v1.schema.json'
 DIAGNOSIS_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'diagnosis-v1.schema.json'
 RUN_MANIFEST_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'run-manifest-v1.schema.json'
@@ -122,6 +123,7 @@ def test_docs_exist_and_are_linked_from_readme():
     assert PRODUCT_CONTRACT_DOC.is_file()
     assert GOLDEN_PATH_CLI_DOC.is_file()
     assert DISTRIBUTION_DOC.is_file()
+    assert OPERATIONAL_RELIABILITY_DOC.is_file()
     assert PREFLIGHT_SCHEMA.is_file()
     assert DIAGNOSIS_SCHEMA.is_file()
     assert RUN_MANIFEST_SCHEMA.is_file()
@@ -328,6 +330,7 @@ def test_release_metadata_and_core_package_versions_match():
     assert 'docs/product-contract.md' in release_workflow
     assert 'docs/getting-started.md' in release_workflow
     assert 'docs/golden-path-cli.md' in release_workflow
+    assert 'docs/operational-reliability.md' in release_workflow
     assert 'docs/distribution.md' in release_workflow
     assert 'docs/rosdistro-release.md' in release_workflow
     assert 'docs/roadmap/v0.9.md' in release_workflow
@@ -370,6 +373,7 @@ def test_release_metadata_and_core_package_versions_match():
     assert 'Product Contract: product-contract.md' in mkdocs_config
     assert 'Golden-path CLI: golden-path-cli.md' in mkdocs_config
     assert 'Distribution and installed CLI: distribution.md' in mkdocs_config
+    assert 'Operational reliability: operational-reliability.md' in mkdocs_config
     assert 'Autoware-Compatible Map Authoring: autoware-map-authoring.md' in mkdocs_config
     assert 'Autoware Foxglove: autoware-foxglove.md' in mkdocs_config
     assert 'Benchmarking And Release Gate: benchmarking.md' in mkdocs_config
@@ -393,6 +397,7 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     benchmarking_doc = BENCHMARKING_DOC.read_text(encoding='utf-8')
     comparison_doc = COMPARISON_DOC.read_text(encoding='utf-8')
     distribution_doc = DISTRIBUTION_DOC.read_text(encoding='utf-8')
+    reliability_doc = OPERATIONAL_RELIABILITY_DOC.read_text(encoding='utf-8')
 
     assert 'lidarslam-map doctor' in getting_started_doc
     assert 'lidarslam-map run' in getting_started_doc
@@ -488,3 +493,11 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     assert 'Jazzy amd64' in distribution_doc
     assert 'There is currently no supported' in distribution_doc
     assert 'rko_lio' in distribution_doc
+    assert 'SIGTERM' in reliability_doc
+    assert 'exit `143`' in reliability_doc
+    assert 'Automated failure injection' in reliability_doc
+    assert 'timestamp reversal' in reliability_doc
+    assert 'disk-pressure' in reliability_doc
+    assert '(operational-reliability.md)' in (
+        PRODUCT_CONTRACT_DOC.read_text(encoding='utf-8')
+    )

--- a/lidarslam/test/test_autoware_map_runner_script.py
+++ b/lidarslam/test/test_autoware_map_runner_script.py
@@ -33,8 +33,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 from pathlib import Path
+import signal
 import subprocess
+import sys
+import time
 
 import jsonschema
 import pytest
@@ -342,18 +346,30 @@ def test_main_writes_success_manifest_and_rejects_collision(
 
 
 @pytest.mark.parametrize(
-    ('workflow_error', 'expected_status', 'expected_exit_code'),
+    ('workflow_result', 'expected_status', 'expected_exit_code', 'expected_error'),
     [
-        (subprocess.CompletedProcess([], 17), 'failed', 17),
-        (KeyboardInterrupt(), 'interrupted', 130),
+        ((17, False, None), 'failed', 17, 'map workflow exited with code 17'),
+        (
+            (130, True, 'map workflow interrupted by SIGINT'),
+            'interrupted',
+            130,
+            'map workflow interrupted by SIGINT',
+        ),
+        (
+            (143, True, 'map workflow interrupted by SIGTERM'),
+            'interrupted',
+            143,
+            'map workflow interrupted by SIGTERM',
+        ),
     ],
 )
 def test_main_retains_terminal_manifest_for_failed_and_interrupted_runs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    workflow_error,
+    workflow_result,
     expected_status: str,
     expected_exit_code: int,
+    expected_error: str,
 ):
     module = _load_module()
     bag_dir = _write_metadata(
@@ -379,13 +395,7 @@ def test_main_retains_terminal_manifest_for_failed_and_interrupted_runs(
     })
     monkeypatch.setattr(module, 'maybe_verify_map', lambda *args, **kwargs: None)
 
-    if isinstance(workflow_error, BaseException):
-        def fake_run(*args, **kwargs):
-            raise workflow_error
-    else:
-        def fake_run(*args, **kwargs):
-            return workflow_error
-    monkeypatch.setattr(module.subprocess, 'run', fake_run)
+    monkeypatch.setattr(module, '_run_workflow', lambda *args: workflow_result)
     monkeypatch.setattr(
         module.sys,
         'argv',
@@ -405,8 +415,199 @@ def test_main_retains_terminal_manifest_for_failed_and_interrupted_runs(
     assert manifest['execution']['exit_code'] == expected_exit_code
     assert manifest['lifecycle']['stage'] == 'complete'
     assert manifest['lifecycle']['runner_exit_code'] == expected_exit_code
+    assert manifest['lifecycle']['last_error'] == expected_error
     assert manifest['output']['finalized'] is True
     assert not output_dir.with_name('failed_map.partial').exists()
+
+
+def test_workflow_supervisor_forwards_sigterm_and_reaps_process_group(
+    tmp_path: Path,
+):
+    child_pid_path = tmp_path / 'child.pid'
+    child_code = '\n'.join([
+        'import os',
+        'from pathlib import Path',
+        'import time',
+        f'Path({str(child_pid_path)!r}).write_text(str(os.getpid()))',
+        'time.sleep(60)',
+    ])
+    probe_code = '\n'.join([
+        'import importlib.util',
+        'import json',
+        'from pathlib import Path',
+        'import sys',
+        f'script = Path({str(SCRIPT_PATH)!r})',
+        "spec = importlib.util.spec_from_file_location('runner_probe', script)",
+        'module = importlib.util.module_from_spec(spec)',
+        'spec.loader.exec_module(module)',
+        (
+            'result = module._run_workflow('
+            f'[sys.executable, "-c", {child_code!r}], Path.cwd())'
+        ),
+        'print(json.dumps(result))',
+    ])
+
+    probe = subprocess.Popen(
+        [sys.executable, '-c', probe_code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 5
+    while not child_pid_path.is_file() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert child_pid_path.is_file()
+    child_pid = int(child_pid_path.read_text(encoding='utf-8'))
+
+    os.kill(probe.pid, signal.SIGTERM)
+    stdout, stderr = probe.communicate(timeout=10)
+
+    assert probe.returncode == 0, stderr
+    assert json.loads(stdout) == [
+        143,
+        True,
+        'map workflow interrupted by SIGTERM',
+    ]
+    with pytest.raises(ProcessLookupError):
+        os.kill(child_pid, 0)
+
+
+def test_workflow_supervisor_forces_cleanup_after_grace_period(tmp_path: Path):
+    module = _load_module()
+    descendant_pid_path = tmp_path / 'descendant.pid'
+    descendant_code = '\n'.join([
+        'import signal',
+        'import time',
+        'signal.signal(signal.SIGTERM, signal.SIG_IGN)',
+        'time.sleep(60)',
+    ])
+    leader_code = '\n'.join([
+        'from pathlib import Path',
+        'import signal',
+        'import subprocess',
+        'import sys',
+        'import time',
+        'signal.signal(signal.SIGTERM, signal.SIG_IGN)',
+        (
+            'child = subprocess.Popen('
+            f'[sys.executable, "-c", {descendant_code!r}])'
+        ),
+        f'Path({str(descendant_pid_path)!r}).write_text(str(child.pid))',
+        'time.sleep(60)',
+    ])
+    leader = subprocess.Popen(
+        [sys.executable, '-c', leader_code],
+        start_new_session=True,
+    )
+    deadline = time.monotonic() + 5
+    while not descendant_pid_path.is_file() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert descendant_pid_path.is_file()
+    descendant_pid = int(descendant_pid_path.read_text(encoding='utf-8'))
+
+    module._terminate_process_group(
+        leader,
+        signal.SIGTERM,
+        grace_secs=0.1,
+    )
+
+    assert leader.returncode == -signal.SIGKILL
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        try:
+            os.kill(descendant_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.01)
+    else:
+        pytest.fail('forced process-group cleanup left a descendant alive')
+
+
+def test_sigterm_failure_injection_preserves_recoverable_terminal_run(
+    tmp_path: Path,
+):
+    bag_dir = _write_metadata(
+        tmp_path,
+        'termination_bag',
+        [
+            ('/points', 'sensor_msgs/msg/PointCloud2', 20),
+            ('/imu', 'sensor_msgs/msg/Imu', 180),
+        ],
+    )
+    output_dir = tmp_path / 'terminated_map'
+    working_dir = tmp_path / 'terminated_map.partial'
+    child_pid_path = tmp_path / 'workflow.pid'
+    child_code = '\n'.join([
+        'import os',
+        'from pathlib import Path',
+        'import time',
+        f'Path({str(child_pid_path)!r}).write_text(str(os.getpid()))',
+        'time.sleep(60)',
+    ])
+    probe_code = '\n'.join([
+        'import importlib.util',
+        'from pathlib import Path',
+        'import sys',
+        f'script = Path({str(SCRIPT_PATH)!r})',
+        "spec = importlib.util.spec_from_file_location('runner_e2e_probe', script)",
+        'module = importlib.util.module_from_spec(spec)',
+        'spec.loader.exec_module(module)',
+        'module.build_execution_plan = lambda **kwargs: {',
+        "    'payload': {},",
+        "    'profile_id': 'rko_lio_graph_public_path',",
+        "    'label': 'termination injection fixture',",
+        f"    'command': [sys.executable, '-c', {child_code!r}],",
+        f"    'output_dir': Path({str(working_dir)!r}),",
+        '}',
+        'sys.argv = [',
+        '    str(script),',
+        f'    {str(bag_dir)!r},',
+        "    '--output-dir',",
+        f'    {str(output_dir)!r},',
+        ']',
+        'raise SystemExit(module.main())',
+    ])
+
+    runner = subprocess.Popen(
+        [sys.executable, '-c', probe_code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 5
+    while not child_pid_path.is_file() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert child_pid_path.is_file()
+    child_pid = int(child_pid_path.read_text(encoding='utf-8'))
+
+    os.kill(runner.pid, signal.SIGTERM)
+    stdout, stderr = runner.communicate(timeout=15)
+
+    assert runner.returncode == 143, (stdout, stderr)
+    assert output_dir.is_dir()
+    assert not working_dir.exists()
+    assert (output_dir / 'autoware_map_diagnosis.md').is_file()
+    assert (output_dir / 'autoware_map_diagnosis.json').is_file()
+    manifest = json.loads(
+        (output_dir / 'run_manifest.json').read_text(encoding='utf-8')
+    )
+    schema = json.loads(
+        (
+            REPO_ROOT / 'docs' / 'schemas' / 'run-manifest-v2.schema.json'
+        ).read_text(encoding='utf-8')
+    )
+    jsonschema.validate(manifest, schema)
+    assert manifest['status'] == 'interrupted'
+    assert manifest['execution']['exit_code'] == 143
+    assert manifest['lifecycle']['stage'] == 'complete'
+    assert manifest['lifecycle']['runner_exit_code'] == 143
+    assert manifest['lifecycle']['last_error'] == (
+        'map workflow interrupted by SIGTERM'
+    )
+    assert manifest['output']['finalized'] is True
+    assert manifest['output']['diagnosis_status'] == 'runtime_failed'
+    with pytest.raises(ProcessLookupError):
+        os.kill(child_pid, 0)
 
 
 def test_main_preserves_failed_manifest_when_post_finalize_diagnosis_fails(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Getting Started: getting-started.md
   - Product Contract: product-contract.md
   - Golden-path CLI: golden-path-cli.md
+  - Operational reliability: operational-reliability.md
   - Distribution and installed CLI: distribution.md
   - Autoware-Compatible Map Authoring: autoware-map-authoring.md
   - Autoware Quickstart: autoware-quickstart.md

--- a/scripts/diagnose_autoware_map_run.py
+++ b/scripts/diagnose_autoware_map_run.py
@@ -42,6 +42,19 @@ def _find_first(run_dir: Path, candidates: list[str]) -> Path | None:
     return None
 
 
+def _read_run_manifest(run_dir: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    manifest_path = run_dir / 'run_manifest.json'
+    if not manifest_path.is_file():
+        return None, []
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, [f'The run manifest is unreadable: {exc}']
+    if not isinstance(manifest, dict):
+        return None, ['The run manifest root is not a JSON object.']
+    return manifest, []
+
+
 def _parse_verify_log(text: str) -> dict[str, Any]:
     result = 'unknown'
     if 'RESULT: PASS' in text:
@@ -157,13 +170,33 @@ def summarize_run(run_dir: Path, bag_path: Path | None = None) -> dict[str, Any]
     verify_summary = _parse_verify_log(verify_log)
     launch_flags = _extract_launch_flags(launch_log)
     problem_hints = _extract_problem_hints(launch_log, map_save_log, verify_summary)
+    run_manifest, manifest_hints = _read_run_manifest(run_dir)
+    problem_hints.extend(manifest_hints)
+    manifest_status = run_manifest.get('status') if run_manifest else None
+    manifest_lifecycle = run_manifest.get('lifecycle') if run_manifest else None
+    if not isinstance(manifest_lifecycle, dict):
+        manifest_lifecycle = {}
+    if manifest_status == 'interrupted':
+        terminal_error = manifest_lifecycle.get('last_error')
+        problem_hints.append(
+            terminal_error
+            or 'The map workflow was interrupted before successful completion.'
+        )
+    elif manifest_status == 'failed':
+        terminal_error = manifest_lifecycle.get('last_error')
+        problem_hints.append(
+            terminal_error
+            or 'The map workflow recorded a terminal failure.'
+        )
 
     pointcloud_map_exists = pointcloud_metadata_path.is_file()
     map_projector_exists = map_projector_path.is_file()
     projector_type = _parse_projector_type(run_dir)
 
     status = 'incomplete'
-    if pointcloud_map_exists and map_projector_exists and verify_summary['result'] == 'PASS':
+    if manifest_status in ('failed', 'interrupted'):
+        status = 'runtime_failed'
+    elif pointcloud_map_exists and map_projector_exists and verify_summary['result'] == 'PASS':
         status = 'success'
     elif verify_summary['result'] == 'FAIL':
         status = 'verify_failed'

--- a/scripts/run_autoware_map_from_bag.py
+++ b/scripts/run_autoware_map_from_bag.py
@@ -13,8 +13,10 @@ import json
 import os
 from pathlib import Path
 import shlex
+import signal
 import subprocess
 import sys
+import time
 import uuid
 import xml.etree.ElementTree as ET
 
@@ -51,6 +53,7 @@ PROFILE_HELP = (
     ('pointcloud_gnss_smoke', 'PointCloud2 + NavSatFix smoke workflow.'),
     ('packet_applanix_smoke', 'VelodyneScan + Applanix GSOF49 smoke workflow.'),
 )
+WORKFLOW_SHUTDOWN_GRACE_SECS = 10.0
 PACKAGE_XML_PATHS = (
     SHARE_ROOT / 'lidarslam' / 'package.xml',
     SHARE_ROOT / 'graph_based_slam' / 'package.xml',
@@ -62,6 +65,98 @@ PACKAGE_XML_PATHS = (
         else SHARE_ROOT / 'rko_lio' / 'package.xml'
     ),
 )
+
+
+class _TerminationRequested(Exception):
+    """Represent an external termination signal while the workflow is active."""
+
+    def __init__(self, signum: int):
+        super().__init__(signum)
+        self.signum = signum
+
+
+def _terminate_process_group(
+    process: subprocess.Popen,
+    signum: int,
+    grace_secs: float = WORKFLOW_SHUTDOWN_GRACE_SECS,
+) -> None:
+    """Forward a signal to the isolated workflow group and reap its leader."""
+    try:
+        os.killpg(process.pid, signum)
+    except ProcessLookupError:
+        process.wait()
+        return
+
+    deadline = time.monotonic() + grace_secs
+    while time.monotonic() < deadline:
+        process.poll()
+        try:
+            os.killpg(process.pid, 0)
+        except ProcessLookupError:
+            process.wait()
+            return
+        except PermissionError:
+            pass
+        time.sleep(0.05)
+
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    process.wait()
+
+
+def _run_workflow(
+    command: list[str],
+    cwd: Path,
+) -> tuple[int, bool, str | None]:
+    """Run a workflow in an isolated process group with durable signal results."""
+    process: subprocess.Popen | None = None
+
+    def request_termination(signum, _frame):
+        raise _TerminationRequested(signum)
+
+    previous_sigterm = signal.signal(signal.SIGTERM, request_termination)
+    requested_signal = None
+    try:
+        process = subprocess.Popen(command, cwd=cwd, start_new_session=True)
+        try:
+            return process.wait(), False, None
+        except KeyboardInterrupt:
+            requested_signal = signal.SIGINT
+        except _TerminationRequested as exc:
+            requested_signal = exc.signum
+    finally:
+        signal.signal(signal.SIGTERM, previous_sigterm)
+
+    if process is None or requested_signal is None:
+        raise RuntimeError('workflow supervision ended without a process result')
+    _terminate_process_group(process, requested_signal)
+    signal_name = signal.Signals(requested_signal).name
+    return (
+        128 + requested_signal,
+        True,
+        f'map workflow interrupted by {signal_name}',
+    )
+
+
+def _terminal_workflow_error(
+    status: str,
+    exit_code: int,
+) -> str | None:
+    """Return the stable terminal error recorded after post-processing."""
+    if status == 'interrupted':
+        signal_names = {
+            130: 'SIGINT',
+            143: 'SIGTERM',
+        }
+        signal_name = signal_names.get(exit_code)
+        if signal_name:
+            return f'map workflow interrupted by {signal_name}'
+        return f'map workflow interrupted with exit code {exit_code}'
+    if exit_code != 0:
+        return f'map workflow exited with code {exit_code}'
+    return None
 
 
 def _load_script_module(script_name: str, module_name: str):
@@ -559,9 +654,12 @@ def _validate_resume_state(
     if not isinstance(resume_count, int) or isinstance(resume_count, bool):
         raise ValueError('resume manifest lifecycle.resume_count must be an integer')
     lifecycle['resume_count'] = resume_count + 1
-    lifecycle['last_error'] = None
     workflow_exit_code = execution['exit_code']
-    if manifest.get('status') == 'interrupted' and workflow_exit_code == 130:
+    if manifest.get('status') == 'interrupted':
+        if workflow_exit_code not in (130, 143):
+            raise ValueError(
+                'interrupted resume state requires workflow exit code 130 or 143'
+            )
         manifest['status'] = 'interrupted'
     else:
         manifest['status'] = 'succeeded' if workflow_exit_code == 0 else 'failed'
@@ -730,9 +828,9 @@ def _postprocess_run(
         lifecycle['stage'] = 'diagnosed'
         _write_manifest(current_dir, manifest)
 
-        interrupted = manifest['status'] == 'interrupted' and workflow_exit_code == 130
+        interrupted = manifest['status'] == 'interrupted'
         if interrupted:
-            runner_exit_code = 130
+            runner_exit_code = workflow_exit_code
         elif workflow_exit_code != 0:
             runner_exit_code = workflow_exit_code
             manifest['status'] = 'failed'
@@ -748,7 +846,10 @@ def _postprocess_run(
         manifest['output']['artifact_checksums'] = _artifact_checksums(current_dir)
         lifecycle['stage'] = 'complete'
         lifecycle['runner_exit_code'] = runner_exit_code
-        lifecycle['last_error'] = None
+        lifecycle['last_error'] = _terminal_workflow_error(
+            manifest['status'],
+            workflow_exit_code,
+        )
         _write_manifest(current_dir, manifest)
         return runner_exit_code
     except (OSError, RuntimeError, ValueError, KeyError, TypeError) as exc:
@@ -992,15 +1093,16 @@ def main() -> int:
 
     exit_code = 0
     interrupted = False
+    workflow_error = None
     try:
-        result = subprocess.run(plan['command'], check=False, cwd=WORK_ROOT)
-        exit_code = result.returncode
-    except KeyboardInterrupt:
-        interrupted = True
-        exit_code = 130
+        exit_code, interrupted, workflow_error = _run_workflow(
+            plan['command'],
+            WORK_ROOT,
+        )
     except OSError as exc:
         print(f'error: failed to start map workflow: {exc}', file=sys.stderr)
         exit_code = 70
+        workflow_error = f'failed to start map workflow: {exc}'
 
     manifest['execution']['exit_code'] = exit_code
     manifest['execution']['finished_at'] = _utc_now()
@@ -1008,6 +1110,10 @@ def main() -> int:
         'interrupted' if interrupted else ('succeeded' if exit_code == 0 else 'failed')
     )
     manifest['lifecycle']['stage'] = 'workflow_finished'
+    manifest['lifecycle']['last_error'] = (
+        workflow_error
+        or _terminal_workflow_error(manifest['status'], exit_code)
+    )
     exit_code = _postprocess_with_lock(
         args,
         manifest,


### PR DESCRIPTION
## What changed

- supervise the delegated map workflow in an isolated process group
- forward SIGINT and SIGTERM, wait up to ten seconds, then force cleanup and reap the leader
- persist interrupted terminal state with exit 130/143 and a stable lifecycle error
- make diagnosis treat failed/interrupted manifests as authoritative runtime evidence
- add real subprocess failure-injection tests, forced descendant cleanup coverage, and operational reliability documentation

## Why

A service or container stop could previously terminate the runner without a durable, diagnosable product result, while child processes could outlive the public CLI. Product-level operation needs bounded shutdown, explicit terminal semantics, and preserved recovery evidence.

## User impact

`lidarslam-map run` now exits 130 for SIGINT and 143 for SIGTERM, preserves the finalized run bundle and diagnosis, records the terminating signal in the schema-v2 manifest, and safely supports terminal post-processing resume. Remaining Phase 3 gates are explicitly documented rather than implied.

## Validation

- `bash scripts/run_default_ci_checks.sh` — 2565 tests, 0 errors, 0 failures, 125 skipped
- focused runner/diagnosis/product/docs tests — 48 passed
- forced process-group failure subset — 6 passed
- `mkdocs build --strict`
- Python bytecode compilation and `git diff --check`
