### PR TITLE
Add pinned real-data E2E gate

### DIFF
--- a/.github/workflows/real-data-e2e.yml
+++ b/.github/workflows/real-data-e2e.yml
@@ -1,0 +1,138 @@
+name: real-data-e2e
+
+on:
+  schedule:
+    - cron: '17 17 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: real-data-e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  driving-slam-mid360:
+    name: pinned MID-360 golden path
+    runs-on: ubuntu-24.04
+    container: ros:jazzy-ros-core
+    timeout-minutes: 45
+
+    steps:
+      - name: Install system dependencies
+        shell: bash
+        run: |
+          apt-get update
+          apt-get install -y \
+            git \
+            python3-colcon-common-extensions \
+            python3-rosdep \
+            tar \
+            zstd
+
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Initialize rosdep
+        shell: bash
+        run: |
+          if [[ ! -e /etc/ros/rosdep/sources.list.d/20-default.list ]]; then
+            rosdep init
+          fi
+          rosdep update --rosdistro jazzy
+
+      - name: Install product dependencies
+        shell: bash
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          rosdep install -r -y \
+            --from-paths \
+              lidarslam \
+              lidarslam_msgs \
+              scanmatcher \
+              graph_based_slam \
+              Thirdparty/ndt_omp_ros2 \
+              Thirdparty/rko_lio \
+            --ignore-src \
+            --rosdistro jazzy
+
+      - name: Restore pinned dataset archive
+        uses: actions/cache@v5
+        with:
+          path: datasets/real-data-e2e/driving_slam_mid360/archives/rosbag2_2024_04_16-14_17_01.zip
+          key: driving-slam-mid360-517088133-0836c50859bb1af591966b69da166186
+
+      - name: Build installed product
+        shell: bash
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          colcon build \
+            --symlink-install \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+      - name: Download and verify pinned real bag
+        shell: bash
+        run: |
+          python3 scripts/download_mid360_robot_public_dataset.py \
+            --dataset driving_slam_mid360 \
+            --dataset-root datasets/real-data-e2e \
+            --output-dir output/real-data-e2e/intake
+
+      - name: Run installed golden path
+        shell: bash
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          source install/setup.bash
+          bag="datasets/real-data-e2e/driving_slam_mid360/extracted/rosbag2_2024_04_16-14_17_01/rosbag2_2024_04_16-14_17_01"
+          mkdir -p output/real-data-e2e
+          lidarslam-map doctor "${bag}" --json \
+            > output/real-data-e2e/doctor.json
+          timeout --signal=TERM --kill-after=30s 20m \
+            lidarslam-map run "${bag}" \
+              --output-dir output/real-data-e2e/run
+
+      - name: Validate pinned E2E evidence
+        shell: bash
+        run: |
+          python3 scripts/validate_real_data_e2e.py \
+            --contract configs/real_data_e2e/driving_slam_mid360_v1.json \
+            --intake-manifest datasets/real-data-e2e/driving_slam_mid360/mid360_robot_public_dataset_intake.json \
+            --run-dir output/real-data-e2e/run \
+            --output-json output/real-data-e2e/evidence.json \
+            --output-markdown output/real-data-e2e/evidence.md
+
+      - name: Publish evidence summary
+        if: always()
+        shell: bash
+        run: |
+          if [[ -f output/real-data-e2e/evidence.md ]]; then
+            sed -n '1,120p' output/real-data-e2e/evidence.md \
+              >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "## Real-data E2E validation did not produce a report" \
+              >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload non-geometry evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: driving-slam-mid360-e2e-evidence
+          retention-days: 14
+          if-no-files-found: warn
+          path: |
+            configs/real_data_e2e/driving_slam_mid360_v1.json
+            datasets/real-data-e2e/driving_slam_mid360/mid360_robot_public_dataset_intake.json
+            datasets/real-data-e2e/driving_slam_mid360/mid360_robot_public_dataset_intake.md
+            output/real-data-e2e/doctor.json
+            output/real-data-e2e/evidence.json
+            output/real-data-e2e/evidence.md
+            output/real-data-e2e/run/run_manifest.json
+            output/real-data-e2e/run/autoware_map_diagnosis.json
+            output/real-data-e2e/run/autoware_map_diagnosis.md
+            output/real-data-e2e/run/verify_autoware_map.log
+            output/real-data-e2e/run/slam.launch.log
+            output/real-data-e2e/run/map_save.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,9 +84,10 @@ jobs:
         shell: bash
         run: |
           rm -rf release_bundle
-          mkdir -p release_bundle/docs/releases release_bundle/docs/social release_bundle/docs/assets release_bundle/docs/roadmap release_bundle/output release_bundle/lidarslam/images
+          mkdir -p release_bundle/docs/releases release_bundle/docs/social release_bundle/docs/assets release_bundle/docs/roadmap release_bundle/configs/real_data_e2e release_bundle/output release_bundle/lidarslam/images
           cp README.md CHANGELOG.md CONTRIBUTING.md RELEASING.md VERSION mkdocs.yml SECURITY.md SUPPORT.md CODE_OF_CONDUCT.md GOVERNANCE.md CITATION.cff release_bundle/
-          cp docs/index.md docs/getting-started.md docs/product-contract.md docs/golden-path-cli.md docs/operational-reliability.md docs/distribution.md docs/rosdistro-release.md docs/autoware-map-authoring.md docs/autoware-foxglove.md docs/autoware-quickstart.md docs/workflows.md docs/benchmarking.md docs/comparison.md release_bundle/docs/
+          cp docs/index.md docs/getting-started.md docs/product-contract.md docs/golden-path-cli.md docs/operational-reliability.md docs/real-data-e2e.md docs/distribution.md docs/rosdistro-release.md docs/autoware-map-authoring.md docs/autoware-foxglove.md docs/autoware-quickstart.md docs/workflows.md docs/benchmarking.md docs/comparison.md release_bundle/docs/
+          cp configs/real_data_e2e/driving_slam_mid360_v1.json release_bundle/configs/real_data_e2e/
           cp docs/roadmap/v0.9.md release_bundle/docs/roadmap/
           cp -r docs/assets/. release_bundle/docs/assets/
           cp docs/social/autoware_map_authoring_post_v0.2.2.md release_bundle/docs/social/

--- a/configs/real_data_e2e/driving_slam_mid360_v1.json
+++ b/configs/real_data_e2e/driving_slam_mid360_v1.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "id": "driving_slam_mid360_v1",
+  "dataset": {
+    "id": "driving_slam_mid360",
+    "title": "Driving SLAM Test with Livox MID360",
+    "source_url": "https://zenodo.org/records/14841855",
+    "doi": "10.5281/zenodo.14841855",
+    "file_id": "rosbag2_2024_04_16",
+    "filename": "rosbag2_2024_04_16-14_17_01.zip",
+    "size_bytes": 517088133,
+    "md5": "0836c50859bb1af591966b69da166186"
+  },
+  "input": {
+    "metadata_size_bytes": 5590,
+    "metadata_sha256": "65d66875f49248e38ff14d80e6e749fb50606f6f80bd4be337160e3752691e9a",
+    "storage_identifier": "sqlite3",
+    "storage_files": [
+      {
+        "path": "rosbag2_2024_04_16-14_17_01_0.db3",
+        "size_bytes": 1468932096,
+        "sha256": "3bbd390a97e57af47ad6699baa36eb4c5f39f61b35275505ecaf221c126354f5"
+      }
+    ],
+    "duration_sec": 277.16683667,
+    "duration_tolerance_sec": 0.001,
+    "message_count": 58217,
+    "topics": {
+      "/livox/lidar": {
+        "type": "sensor_msgs/msg/PointCloud2",
+        "message_count": 2772
+      },
+      "/livox/imu": {
+        "type": "sensor_msgs/msg/Imu",
+        "message_count": 55435
+      }
+    }
+  },
+  "execution": {
+    "profile_id": "rko_lio_graph_mid360_preset",
+    "ros_distro": "jazzy",
+    "required_argv_fragments": [
+      "--wait-for-offline-completion",
+      "--skip-viewer",
+      "lidarslam_mid360_rko_graph.yaml",
+      "rko_lio_mid360.yaml"
+    ],
+    "maximum_runtime_sec": 600
+  },
+  "output": {
+    "minimum_raw_poses": 2500,
+    "minimum_corrected_poses": 500,
+    "minimum_pointcloud_tiles": 300,
+    "minimum_pointcloud_bytes": 50000000,
+    "minimum_verify_passes": 8
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,10 @@
     <h3>Operational Reliability</h3>
     <p>Understand failure artifacts, termination handling, recovery, and open reliability gates.</p>
   </a>
+  <a class="link-card" href="real-data-e2e.html">
+    <h3>Pinned Real-data E2E</h3>
+    <p>Inspect the nightly Jazzy gate from a fixed public MID-360 bag to a verified map bundle.</p>
+  </a>
   <a class="link-card" href="autoware-map-authoring.html">
     <h3>Autoware-Compatible Map Authoring</h3>
     <p>The shortest product-level summary of the supported public path.</p>
@@ -119,6 +123,7 @@
 
 - [Product contract](product-contract.md)
 - [Operational reliability](operational-reliability.md)
+- [Pinned real-data E2E gate](real-data-e2e.md)
 - [Distribution and installed CLI](distribution.md)
 - [v0.9 product roadmap](roadmap/v0.9.md)
 - [Contributing](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/CONTRIBUTING.md)

--- a/docs/operational-reliability.md
+++ b/docs/operational-reliability.md
@@ -17,6 +17,7 @@ only marked covered when an automated test exercises the public behavior.
 | Termination after the workflow result is durable but before post-processing completes | Leave the last durable schema-v2 lifecycle stage in the final or `.partial` directory | Original input/software/command identity and map artifacts | Run the same command and output path with `--resume`; SLAM is not rerun | Automated |
 | Ambiguous or unsafe resume state | Exit `2`; refuse concurrent or pre-terminal post-processing | Both candidate directories and manifests remain unchanged | Verify no original process is active; resolve the ambiguity manually before retrying | Automated |
 | Missing TF connectivity observed in ROS logs | Diagnosis is `runtime_failed` with a TF connectivity hint | Launch log and diagnosis artifacts | Correct calibration/frame configuration and rerun | Automated diagnosis fixture |
+| Pinned public MID-360 bag → verified map | Nightly Jazzy workflow runs the installed CLI with exact archive/bag identity and bounded output thresholds | Non-geometry evidence report, manifests, diagnosis, verification, and logs | Inspect the failed assertion and retained evidence; do not move the contract without review | Automated real-data E2E |
 
 `run_manifest.json` is authoritative for terminal workflow status. Diagnosis
 uses its `failed` or `interrupted` state even when the workflow stopped before
@@ -45,7 +46,7 @@ the termination coverage:
 - controlled disk-exhaustion injection for manifest and map writes;
 - one-hour and eight-hour soak profiles with RSS, wall-time, output-size, and
   dropped-input counters;
-- nightly pinned real-bag E2E evidence;
 - output migration tooling and last-known-good rollback instructions.
 
-See the [v0.9 roadmap](roadmap/v0.9.md) for the full Phase 3 and v1.0 gates.
+See the [pinned real-data E2E contract](real-data-e2e.md) and the
+[v0.9 roadmap](roadmap/v0.9.md) for the remaining Phase 3 and v1.0 gates.

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -38,6 +38,8 @@ post-processing without rerunning SLAM or replacing map artifacts.
 Signal handling, preserved failure state, recovery actions, and still-open
 Phase 3 gates are tracked in
 [Operational reliability](operational-reliability.md).
+The flagship installed workflow is also exercised by the
+[pinned real-data E2E gate](real-data-e2e.md).
 
 ## Official entrypoints
 

--- a/docs/real-data-e2e.md
+++ b/docs/real-data-e2e.md
@@ -1,0 +1,77 @@
+# Pinned real-data E2E gate
+
+The scheduled `real-data-e2e` workflow proves that the installed golden path
+can turn one unchanged public rosbag into a verified Autoware-compatible map.
+It runs nightly on ROS 2 Jazzy and can also be started with
+`workflow_dispatch`. It is intentionally separate from pull-request CI because
+the source archive is 517 MB.
+
+## Pinned input
+
+The first contract is
+[`driving_slam_mid360_v1`](https://github.com/rsasaki0109/lidar_slam_ros2/blob/develop/configs/real_data_e2e/driving_slam_mid360_v1.json):
+
+- source: [Driving SLAM Test with Livox MID360](https://zenodo.org/records/14841855),
+  DOI `10.5281/zenodo.14841855`;
+- archive: `rosbag2_2024_04_16-14_17_01.zip`;
+- exact size: `517088133` bytes;
+- MD5: `0836c50859bb1af591966b69da166186`;
+- bag identity: exact `metadata.yaml` and sqlite3 SHA-256 values in the
+  contract;
+- public sensor payload: 2772 PointCloud2 records and 55435 IMU records over
+  277.16683667 seconds.
+
+The cache key includes the archive size and MD5. A restored cache is still
+hashed by the intake and again by the E2E validator, so a corrupt or replaced
+archive fails closed.
+
+The Zenodo record is open access but does not currently declare a license in
+its machine-readable record metadata. The workflow downloads from the
+publisher for validation and does not upload the source bag, trajectories, or
+map geometry. Its retained artifact contains only the contract, intake
+identity, run manifest, diagnosis, verification result, and logs.
+
+## Blocking assertions
+
+The run uses the installed `lidarslam-map doctor` and `lidarslam-map run`
+commands. `validate_real_data_e2e.py` then requires:
+
+- valid schema-v2 run manifest and diagnosis-v1 report;
+- exact archive, metadata, and sqlite3 identities;
+- the maintained `rko_lio_graph_mid360_preset` on ROS 2 Jazzy;
+- successful, finalized terminal state within 600 seconds;
+- exact preflight duration, message counts, types, and topics;
+- Autoware verification with at least eight passes and no failures;
+- at least 2500 raw poses, 500 corrected poses, 300 pointcloud tiles, and
+  50 MB of tiled pointcloud evidence.
+
+Any failed assertion exits non-zero. The workflow also has a 45-minute job
+limit and a 20-minute product-run limit. If the product run times out, its
+SIGTERM recovery path preserves terminal evidence before the job fails.
+
+## Reproduce locally
+
+From a built Jazzy workspace:
+
+```bash
+python3 scripts/download_mid360_robot_public_dataset.py \
+  --dataset driving_slam_mid360 \
+  --dataset-root datasets/real-data-e2e
+
+source /opt/ros/jazzy/setup.bash
+source install/setup.bash
+
+bag="datasets/real-data-e2e/driving_slam_mid360/extracted/rosbag2_2024_04_16-14_17_01/rosbag2_2024_04_16-14_17_01"
+lidarslam-map doctor "$bag" --json
+lidarslam-map run "$bag" --output-dir output/real-data-e2e/run
+
+python3 scripts/validate_real_data_e2e.py \
+  --contract configs/real_data_e2e/driving_slam_mid360_v1.json \
+  --intake-manifest datasets/real-data-e2e/driving_slam_mid360/mid360_robot_public_dataset_intake.json \
+  --run-dir output/real-data-e2e/run
+```
+
+The nightly gate proves one flagship real-data path. It does not replace
+Humble/Jazzy build CI, multi-dataset accuracy benchmarks, long-duration soak
+tests, disk-pressure injection, or independent third-party first-map
+validation.

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -3,7 +3,8 @@
 > Status: **direction approved 2026-07-27; Phase 0 and Phase 1 complete;
 > Phase 2 in progress (installed CLI and clean-prefix validation landed;
 > binary flagship packaging remains open); Phase 3 in progress (SIGINT/SIGTERM
-> process-group cleanup and recoverable terminal evidence landed)**.
+> process-group cleanup, recoverable terminal evidence, and the pinned nightly
+> MID-360 real-data E2E gate landed; soak and storage-pressure gates remain)**.
 > This roadmap
 > turns the existing benchmark-heavy map-authoring stack into a product-level
 > OSS project. It does not replace the evidence-driven capability roadmaps;

--- a/graph_based_slam/CMakeLists.txt
+++ b/graph_based_slam/CMakeLists.txt
@@ -980,6 +980,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_validate_real_data_e2e
+    test/test_validate_real_data_e2e.py
+    TIMEOUT 60
+  )
+  ament_add_pytest_test(
     test_lidarslam_product_cli
     test/test_lidarslam_product_cli.py
     TIMEOUT 120

--- a/graph_based_slam/test/test_autoware_dogfood_script.py
+++ b/graph_based_slam/test/test_autoware_dogfood_script.py
@@ -131,3 +131,16 @@ def test_dogfood_rejects_output_file_before_ros_launch(tmp_path: Path):
     assert result.returncode == 2
     assert 'error: output directory path is a file' in result.stderr
     assert 'ros2 not found' not in result.stderr
+
+
+def test_dogfood_omits_empty_optional_frame_launch_arguments():
+    script = DOGFOOD_SCRIPT.read_text(encoding='utf-8')
+
+    assert 'LAUNCH_ARGS=(' in script
+    assert 'if [[ -n "$LIDAR_FRAME" ]]; then' in script
+    assert 'LAUNCH_ARGS+=("lidar_frame:=${LIDAR_FRAME}")' in script
+    assert 'if [[ -n "$IMU_FRAME" ]]; then' in script
+    assert 'LAUNCH_ARGS+=("imu_frame:=${IMU_FRAME}")' in script
+    assert '"${LAUNCH_ARGS[@]}"' in script
+    assert '"lidar_frame:=${LIDAR_FRAME}" \\' not in script
+    assert '"imu_frame:=${IMU_FRAME}" \\' not in script

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -65,6 +65,7 @@ PRODUCT_CONTRACT_DOC = REPO_ROOT / 'docs' / 'product-contract.md'
 GOLDEN_PATH_CLI_DOC = REPO_ROOT / 'docs' / 'golden-path-cli.md'
 DISTRIBUTION_DOC = REPO_ROOT / 'docs' / 'distribution.md'
 OPERATIONAL_RELIABILITY_DOC = REPO_ROOT / 'docs' / 'operational-reliability.md'
+REAL_DATA_E2E_DOC = REPO_ROOT / 'docs' / 'real-data-e2e.md'
 PREFLIGHT_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'preflight-v1.schema.json'
 DIAGNOSIS_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'diagnosis-v1.schema.json'
 RUN_MANIFEST_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'run-manifest-v1.schema.json'
@@ -124,6 +125,7 @@ def test_docs_exist_and_are_linked_from_readme():
     assert GOLDEN_PATH_CLI_DOC.is_file()
     assert DISTRIBUTION_DOC.is_file()
     assert OPERATIONAL_RELIABILITY_DOC.is_file()
+    assert REAL_DATA_E2E_DOC.is_file()
     assert PREFLIGHT_SCHEMA.is_file()
     assert DIAGNOSIS_SCHEMA.is_file()
     assert RUN_MANIFEST_SCHEMA.is_file()
@@ -331,6 +333,8 @@ def test_release_metadata_and_core_package_versions_match():
     assert 'docs/getting-started.md' in release_workflow
     assert 'docs/golden-path-cli.md' in release_workflow
     assert 'docs/operational-reliability.md' in release_workflow
+    assert 'docs/real-data-e2e.md' in release_workflow
+    assert 'configs/real_data_e2e/driving_slam_mid360_v1.json' in release_workflow
     assert 'docs/distribution.md' in release_workflow
     assert 'docs/rosdistro-release.md' in release_workflow
     assert 'docs/roadmap/v0.9.md' in release_workflow
@@ -374,6 +378,7 @@ def test_release_metadata_and_core_package_versions_match():
     assert 'Golden-path CLI: golden-path-cli.md' in mkdocs_config
     assert 'Distribution and installed CLI: distribution.md' in mkdocs_config
     assert 'Operational reliability: operational-reliability.md' in mkdocs_config
+    assert 'Pinned real-data E2E: real-data-e2e.md' in mkdocs_config
     assert 'Autoware-Compatible Map Authoring: autoware-map-authoring.md' in mkdocs_config
     assert 'Autoware Foxglove: autoware-foxglove.md' in mkdocs_config
     assert 'Benchmarking And Release Gate: benchmarking.md' in mkdocs_config
@@ -398,6 +403,7 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     comparison_doc = COMPARISON_DOC.read_text(encoding='utf-8')
     distribution_doc = DISTRIBUTION_DOC.read_text(encoding='utf-8')
     reliability_doc = OPERATIONAL_RELIABILITY_DOC.read_text(encoding='utf-8')
+    real_data_e2e_doc = REAL_DATA_E2E_DOC.read_text(encoding='utf-8')
 
     assert 'lidarslam-map doctor' in getting_started_doc
     assert 'lidarslam-map run' in getting_started_doc
@@ -501,3 +507,30 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     assert '(operational-reliability.md)' in (
         PRODUCT_CONTRACT_DOC.read_text(encoding='utf-8')
     )
+    assert 'driving_slam_mid360_v1' in real_data_e2e_doc
+    assert '517088133' in real_data_e2e_doc
+    assert '0836c50859bb1af591966b69da166186' in real_data_e2e_doc
+    assert 'validate_real_data_e2e.py' in real_data_e2e_doc
+    assert '(real-data-e2e.md)' in (
+        PRODUCT_CONTRACT_DOC.read_text(encoding='utf-8')
+    )
+
+
+def test_real_data_e2e_workflow_is_pinned_bounded_and_non_geometry():
+    """The scheduled public-bag workflow must be pinned and bounded."""
+    workflow = (
+        REPO_ROOT / '.github' / 'workflows' / 'real-data-e2e.yml'
+    ).read_text(encoding='utf-8')
+
+    assert "cron: '17 17 * * *'" in workflow
+    assert 'workflow_dispatch:' in workflow
+    assert 'container: ros:jazzy-ros-core' in workflow
+    assert 'timeout-minutes: 45' in workflow
+    assert 'actions/cache@v5' in workflow
+    assert '0836c50859bb1af591966b69da166186' in workflow
+    assert 'timeout --signal=TERM --kill-after=30s 20m' in workflow
+    assert 'lidarslam-map doctor' in workflow
+    assert 'lidarslam-map run' in workflow
+    assert 'validate_real_data_e2e.py' in workflow
+    assert 'output/real-data-e2e/run/map.pcd' not in workflow
+    assert 'output/real-data-e2e/run/traj_raw.tum' not in workflow

--- a/graph_based_slam/test/test_validate_real_data_e2e.py
+++ b/graph_based_slam/test/test_validate_real_data_e2e.py
@@ -1,0 +1,249 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the pinned real-data E2E evidence validator."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / 'scripts' / 'validate_real_data_e2e.py'
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location('real_data_e2e', SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload), encoding='utf-8')
+    return path
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    archive = tmp_path / 'sample.zip'
+    archive.write_bytes(b'pinned-real-data-fixture')
+    archive_md5 = hashlib.md5(archive.read_bytes()).hexdigest()
+    storage = {
+        'path': 'sample.db3',
+        'size_bytes': 123,
+        'sha256': 'a' * 64,
+    }
+    source_url = 'https://example.test/records/1'
+    contract = {
+        'schema_version': 1,
+        'id': 'fixture_v1',
+        'dataset': {
+            'id': 'fixture',
+            'source_url': source_url,
+            'file_id': 'bag',
+            'filename': archive.name,
+            'size_bytes': archive.stat().st_size,
+            'md5': archive_md5,
+        },
+        'input': {
+            'metadata_size_bytes': 50,
+            'metadata_sha256': 'b' * 64,
+            'storage_identifier': 'sqlite3',
+            'storage_files': [storage],
+            'duration_sec': 12.5,
+            'duration_tolerance_sec': 0.001,
+            'message_count': 30,
+            'topics': {
+                '/points': {
+                    'type': 'sensor_msgs/msg/PointCloud2',
+                    'message_count': 10,
+                },
+                '/imu': {
+                    'type': 'sensor_msgs/msg/Imu',
+                    'message_count': 20,
+                },
+            },
+        },
+        'execution': {
+            'profile_id': 'fixture_profile',
+            'ros_distro': 'jazzy',
+            'required_argv_fragments': ['--skip-viewer', 'fixture.yaml'],
+            'maximum_runtime_sec': 60,
+        },
+        'output': {
+            'minimum_raw_poses': 2,
+            'minimum_corrected_poses': 1,
+            'minimum_pointcloud_tiles': 2,
+            'minimum_pointcloud_bytes': 6,
+            'minimum_verify_passes': 8,
+        },
+    }
+    intake = {
+        'status': 'READY',
+        'archive_path': str(archive),
+        'dataset': {'id': 'fixture', 'source_url': source_url},
+        'file': {
+            'id': 'bag',
+            'filename': archive.name,
+            'url': source_url + '/files/sample.zip',
+        },
+    }
+    run_dir = tmp_path / 'run'
+    pointcloud_dir = run_dir / 'pointcloud_map'
+    pointcloud_dir.mkdir(parents=True)
+    (pointcloud_dir / '0_0.pcd').write_bytes(b'abcd')
+    (pointcloud_dir / '0_1.pcd').write_bytes(b'efgh')
+    (run_dir / 'traj_raw.tum').write_text('raw1\nraw2\n', encoding='utf-8')
+    (run_dir / 'traj_corrected.tum').write_text(
+        'corrected\n',
+        encoding='utf-8',
+    )
+    manifest = {
+        'schema_version': 2,
+        'schema_uri': (
+            'https://rsasaki0109.github.io/lidar_slam_ros2/'
+            'schemas/run-manifest-v2.schema.json'
+        ),
+        'run_id': '12345678-1234-5678-9234-567812345678',
+        'status': 'succeeded',
+        'lifecycle': {
+            'stage': 'complete',
+            'resume_count': 0,
+            'verification_enabled': True,
+            'runner_exit_code': 0,
+            'last_error': None,
+        },
+        'input': {
+            'bag_path': '/tmp/bag',
+            'metadata_path': '/tmp/bag/metadata.yaml',
+            'metadata_size_bytes': 50,
+            'metadata_sha256': 'b' * 64,
+            'storage_identifier': 'sqlite3',
+            'storage_files': [storage],
+            'identity_algorithm': 'sha256',
+        },
+        'software': {
+            'product_version': '0.9.0',
+            'git_commit': 'c' * 40,
+            'git_dirty': False,
+            'package_versions': {'lidarslam': '0.9.0'},
+            'ros_distro': 'jazzy',
+        },
+        'profile': {'id': 'fixture_profile', 'label': 'Fixture'},
+        'execution': {
+            'argv': ['runner', '--skip-viewer', 'fixture.yaml'],
+            'command_shell': 'runner --skip-viewer fixture.yaml',
+            'started_at': '2026-07-27T00:00:00Z',
+            'finished_at': '2026-07-27T00:00:10Z',
+            'exit_code': 0,
+        },
+        'output': {
+            'requested_dir': str(run_dir),
+            'working_dir': str(run_dir) + '.partial',
+            'finalized': True,
+            'diagnosis_status': 'success',
+            'artifact_checksums': [],
+        },
+    }
+    diagnosis = {
+        'schema_version': 1,
+        'schema_uri': (
+            'https://rsasaki0109.github.io/lidar_slam_ros2/'
+            'schemas/diagnosis-v1.schema.json'
+        ),
+        'run_dir': str(run_dir),
+        'status': 'success',
+        'files': {},
+        'launch_flags': {},
+        'verify': {
+            'result': 'PASS',
+            'counts': {'pass': 8, 'warn': 0, 'fail': 0},
+        },
+        'projector_type': 'Local',
+        'bag_preflight': {
+            'summary': {
+                'duration_sec': 12.5,
+                'message_count': 30,
+                'topics': {
+                    'pointcloud2': [{
+                        'name': '/points',
+                        'msg_type': 'sensor_msgs/msg/PointCloud2',
+                        'message_count': 10,
+                    }],
+                    'imu': [{
+                        'name': '/imu',
+                        'msg_type': 'sensor_msgs/msg/Imu',
+                        'message_count': 20,
+                    }],
+                },
+            },
+        },
+        'problem_hints': [],
+        'suggested_next_steps': [],
+    }
+    _write_json(run_dir / 'run_manifest.json', manifest)
+    _write_json(run_dir / 'autoware_map_diagnosis.json', diagnosis)
+    return (
+        _write_json(tmp_path / 'contract.json', contract),
+        _write_json(tmp_path / 'intake.json', intake),
+        run_dir,
+    )
+
+
+def test_validator_accepts_complete_pinned_evidence(tmp_path: Path):
+    """Complete pinned artifacts should pass every evidence assertion."""
+    module = _load_module()
+    contract, intake, run_dir = _fixture(tmp_path)
+
+    report = module.validate(contract, intake, run_dir)
+
+    assert report['status'] == 'PASS'
+    assert report['summary']['fail'] == 0
+    assert report['summary']['raw_poses'] == 2
+    assert report['summary']['pointcloud_tiles'] == 2
+    assert '**PASS**' in module.render_markdown(report)
+
+
+def test_validator_rejects_tampered_cached_archive(tmp_path: Path):
+    """A cache entry whose content changed must fail archive identity."""
+    module = _load_module()
+    contract, intake, run_dir = _fixture(tmp_path)
+    intake_payload = json.loads(intake.read_text(encoding='utf-8'))
+    Path(intake_payload['archive_path']).write_bytes(b'tampered')
+
+    report = module.validate(contract, intake, run_dir)
+
+    assert report['status'] == 'FAIL'
+    archive_check = next(
+        row for row in report['checks'] if row['id'] == 'archive_identity'
+    )
+    assert archive_check['status'] == 'FAIL'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Product Contract: product-contract.md
   - Golden-path CLI: golden-path-cli.md
   - Operational reliability: operational-reliability.md
+  - Pinned real-data E2E: real-data-e2e.md
   - Distribution and installed CLI: distribution.md
   - Autoware-Compatible Map Authoring: autoware-map-authoring.md
   - Autoware Quickstart: autoware-quickstart.md

--- a/scripts/run_rko_lio_graph_autoware_dogfood.sh
+++ b/scripts/run_rko_lio_graph_autoware_dogfood.sh
@@ -580,39 +580,35 @@ echo "  output_dir:     $OUTPUT_DIR"
 echo "  run_name:       $RUN_NAME"
 echo "  rko_ros_param:  $RKO_ROS_PARAM_FILE"
 
+LAUNCH_ARGS=(
+  "main_param_dir:=${LIDARSLAM_PARAM}"
+  "rko_param_file:=${RKO_ROS_PARAM_FILE}"
+  "bag_path:=${BAG_PATH}"
+  "lidar_topic:=${LIDAR_TOPIC}"
+  "imu_topic:=${IMU_TOPIC}"
+  "base_frame:=${BASE_FRAME}"
+  "save_dir:=${OUTPUT_DIR}"
+  "results_dir:=${OUTPUT_DIR}"
+  "run_name:=${RUN_NAME}"
+  "dump_results:=true"
+  "use_rviz:=false"
+)
+if [[ -n "$LIDAR_FRAME" ]]; then
+  LAUNCH_ARGS+=("lidar_frame:=${LIDAR_FRAME}")
+fi
+if [[ -n "$IMU_FRAME" ]]; then
+  LAUNCH_ARGS+=("imu_frame:=${IMU_FRAME}")
+fi
+
 if command -v setsid >/dev/null 2>&1; then
   setsid ros2 launch lidarslam rko_lio_slam.launch.py \
-    "main_param_dir:=${LIDARSLAM_PARAM}" \
-    "rko_param_file:=${RKO_ROS_PARAM_FILE}" \
-    "bag_path:=${BAG_PATH}" \
-    "lidar_topic:=${LIDAR_TOPIC}" \
-    "imu_topic:=${IMU_TOPIC}" \
-    "base_frame:=${BASE_FRAME}" \
-    "lidar_frame:=${LIDAR_FRAME}" \
-    "imu_frame:=${IMU_FRAME}" \
-    "save_dir:=${OUTPUT_DIR}" \
-    "results_dir:=${OUTPUT_DIR}" \
-    "run_name:=${RUN_NAME}" \
-    "dump_results:=true" \
-    "use_rviz:=false" \
+    "${LAUNCH_ARGS[@]}" \
     >"${LAUNCH_LOG}" 2>&1 &
   LAUNCH_PID="$!"
   LAUNCH_PGID="$LAUNCH_PID"
 else
   ros2 launch lidarslam rko_lio_slam.launch.py \
-    "main_param_dir:=${LIDARSLAM_PARAM}" \
-    "rko_param_file:=${RKO_ROS_PARAM_FILE}" \
-    "bag_path:=${BAG_PATH}" \
-    "lidar_topic:=${LIDAR_TOPIC}" \
-    "imu_topic:=${IMU_TOPIC}" \
-    "base_frame:=${BASE_FRAME}" \
-    "lidar_frame:=${LIDAR_FRAME}" \
-    "imu_frame:=${IMU_FRAME}" \
-    "save_dir:=${OUTPUT_DIR}" \
-    "results_dir:=${OUTPUT_DIR}" \
-    "run_name:=${RUN_NAME}" \
-    "dump_results:=true" \
-    "use_rviz:=false" \
+    "${LAUNCH_ARGS[@]}" \
     >"${LAUNCH_LOG}" 2>&1 &
   LAUNCH_PID="$!"
 fi

--- a/scripts/validate_real_data_e2e.py
+++ b/scripts/validate_real_data_e2e.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Validate a pinned real-data golden-path run against its release contract."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'run-manifest-v2.schema.json'
+DIAGNOSIS_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'diagnosis-v1.schema.json'
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding='utf-8'))
+    if not isinstance(payload, dict):
+        raise ValueError(f'JSON root must be an object: {path}')
+    return payload
+
+
+def _digest(path: Path, algorithm: str) -> str:
+    value = hashlib.new(algorithm)
+    with path.open('rb') as stream:
+        for block in iter(lambda: stream.read(8 * 1024 * 1024), b''):
+            value.update(block)
+    return value.hexdigest()
+
+
+def _line_count(path: Path) -> int:
+    with path.open('rb') as stream:
+        return sum(1 for line in stream if line.strip())
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace('Z', '+00:00'))
+
+
+def validate(
+    contract_path: Path,
+    intake_path: Path,
+    run_dir: Path,
+) -> dict[str, Any]:
+    """Return a machine-readable PASS/FAIL report."""
+    contract = _load_json(contract_path)
+    intake = _load_json(intake_path)
+    run_manifest = _load_json(run_dir / 'run_manifest.json')
+    diagnosis = _load_json(run_dir / 'autoware_map_diagnosis.json')
+    checks: list[dict[str, str]] = []
+
+    def check(check_id: str, passed: bool, detail: str) -> None:
+        checks.append({
+            'id': check_id,
+            'status': 'PASS' if passed else 'FAIL',
+            'detail': detail,
+        })
+
+    check(
+        'contract_schema',
+        contract.get('schema_version') == 1,
+        f"schema_version={contract.get('schema_version')!r}",
+    )
+
+    dataset = contract['dataset']
+    intake_dataset = intake.get('dataset') or {}
+    intake_file = intake.get('file') or {}
+    check(
+        'dataset_identity',
+        intake_dataset.get('id') == dataset['id']
+        and intake_file.get('id') == dataset['file_id']
+        and intake_file.get('filename') == dataset['filename'],
+        (
+            f"dataset={intake_dataset.get('id')!r}, "
+            f"file={intake_file.get('id')!r}"
+        ),
+    )
+    check(
+        'intake_ready',
+        intake.get('status') == 'READY',
+        f"status={intake.get('status')!r}",
+    )
+    check(
+        'dataset_source',
+        intake_dataset.get('source_url') == dataset['source_url']
+        and intake_file.get('url', '').startswith(
+            dataset['source_url'] + '/files/'
+        ),
+        f"source={intake_dataset.get('source_url')!r}",
+    )
+
+    archive_path = Path(intake.get('archive_path', ''))
+    archive_exists = archive_path.is_file()
+    archive_size = archive_path.stat().st_size if archive_exists else -1
+    archive_md5 = _digest(archive_path, 'md5') if archive_exists else ''
+    check(
+        'archive_identity',
+        archive_exists
+        and archive_size == dataset['size_bytes']
+        and archive_md5 == dataset['md5'],
+        f'size_bytes={archive_size}, md5={archive_md5 or "missing"}',
+    )
+
+    try:
+        jsonschema.validate(run_manifest, _load_json(RUN_SCHEMA))
+    except jsonschema.ValidationError as exc:
+        check('run_manifest_schema', False, exc.message)
+    else:
+        check('run_manifest_schema', True, 'schema-v2 valid')
+    try:
+        jsonschema.validate(diagnosis, _load_json(DIAGNOSIS_SCHEMA))
+    except jsonschema.ValidationError as exc:
+        check('diagnosis_schema', False, exc.message)
+    else:
+        check('diagnosis_schema', True, 'diagnosis-v1 valid')
+
+    expected_input = contract['input']
+    actual_input = run_manifest.get('input') or {}
+    metadata_size_matches = (
+        actual_input.get('metadata_size_bytes')
+        == expected_input['metadata_size_bytes']
+    )
+    metadata_hash_matches = (
+        actual_input.get('metadata_sha256')
+        == expected_input['metadata_sha256']
+    )
+    storage_type_matches = (
+        actual_input.get('storage_identifier')
+        == expected_input['storage_identifier']
+    )
+    check(
+        'bag_metadata_identity',
+        metadata_size_matches
+        and metadata_hash_matches
+        and storage_type_matches,
+        (
+            f"size_bytes={actual_input.get('metadata_size_bytes')!r}, "
+            f"sha256={actual_input.get('metadata_sha256')!r}"
+        ),
+    )
+    check(
+        'bag_storage_identity',
+        actual_input.get('storage_files') == expected_input['storage_files'],
+        f"storage_files={actual_input.get('storage_files')!r}",
+    )
+
+    profile = run_manifest.get('profile') or {}
+    execution = run_manifest.get('execution') or {}
+    lifecycle = run_manifest.get('lifecycle') or {}
+    output = run_manifest.get('output') or {}
+    expected_execution = contract['execution']
+    check(
+        'terminal_success',
+        run_manifest.get('status') == 'succeeded'
+        and execution.get('exit_code') == 0
+        and lifecycle.get('stage') == 'complete'
+        and lifecycle.get('runner_exit_code') == 0
+        and lifecycle.get('last_error') is None
+        and output.get('finalized') is True
+        and output.get('diagnosis_status') == 'success',
+        (
+            f"status={run_manifest.get('status')!r}, "
+            f"stage={lifecycle.get('stage')!r}, "
+            f"exit={execution.get('exit_code')!r}"
+        ),
+    )
+    check(
+        'maintained_profile',
+        profile.get('id') == expected_execution['profile_id'],
+        f"profile_id={profile.get('id')!r}",
+    )
+    check(
+        'ros_distro',
+        (run_manifest.get('software') or {}).get('ros_distro')
+        == expected_execution['ros_distro'],
+        (
+            'ros_distro='
+            f"{(run_manifest.get('software') or {}).get('ros_distro')!r}"
+        ),
+    )
+    argv_text = '\n'.join(execution.get('argv') or [])
+    missing_argv = [
+        fragment
+        for fragment in expected_execution['required_argv_fragments']
+        if fragment not in argv_text
+    ]
+    check(
+        'execution_contract',
+        not missing_argv,
+        f'missing_fragments={missing_argv!r}',
+    )
+    try:
+        runtime_sec = (
+            _parse_timestamp(execution['finished_at'])
+            - _parse_timestamp(execution['started_at'])
+        ).total_seconds()
+    except (KeyError, TypeError, ValueError) as exc:
+        runtime_sec = -1.0
+        runtime_detail = str(exc)
+    else:
+        runtime_detail = f'runtime_sec={runtime_sec:.3f}'
+    check(
+        'runtime_budget',
+        0 < runtime_sec <= expected_execution['maximum_runtime_sec'],
+        runtime_detail,
+    )
+
+    preflight = diagnosis.get('bag_preflight') or {}
+    summary = preflight.get('summary') or {}
+    actual_topics = {}
+    for category in ('pointcloud2', 'imu'):
+        for topic in (summary.get('topics') or {}).get(category, []):
+            actual_topics[topic.get('name')] = {
+                'type': topic.get('msg_type'),
+                'message_count': topic.get('message_count'),
+            }
+    duration_sec = summary.get('duration_sec')
+    duration_ok = isinstance(duration_sec, (int, float)) and abs(
+        duration_sec - expected_input['duration_sec']
+    ) <= expected_input['duration_tolerance_sec']
+    check(
+        'preflight_identity',
+        summary.get('message_count') == expected_input['message_count']
+        and duration_ok
+        and all(
+            actual_topics.get(name) == expected
+            for name, expected in expected_input['topics'].items()
+        ),
+        (
+            f'duration_sec={duration_sec!r}, '
+            f"message_count={summary.get('message_count')!r}, "
+            f'topics={actual_topics!r}'
+        ),
+    )
+
+    verify = diagnosis.get('verify') or {}
+    verify_counts = verify.get('counts') or {}
+    check(
+        'diagnosis_success',
+        diagnosis.get('status') == 'success'
+        and verify.get('result') == 'PASS'
+        and verify_counts.get('fail') == 0
+        and verify_counts.get('pass', 0)
+        >= contract['output']['minimum_verify_passes'],
+        (
+            f"status={diagnosis.get('status')!r}, "
+            f"verify={verify.get('result')!r}, counts={verify_counts!r}"
+        ),
+    )
+
+    raw_path = run_dir / 'traj_raw.tum'
+    corrected_path = run_dir / 'traj_corrected.tum'
+    raw_poses = _line_count(raw_path) if raw_path.is_file() else 0
+    corrected_poses = (
+        _line_count(corrected_path) if corrected_path.is_file() else 0
+    )
+    check(
+        'trajectory_evidence',
+        raw_poses >= contract['output']['minimum_raw_poses']
+        and corrected_poses >= contract['output']['minimum_corrected_poses'],
+        f'raw_poses={raw_poses}, corrected_poses={corrected_poses}',
+    )
+
+    tiles = list((run_dir / 'pointcloud_map').glob('*.pcd'))
+    pointcloud_bytes = sum(path.stat().st_size for path in tiles)
+    check(
+        'pointcloud_evidence',
+        len(tiles) >= contract['output']['minimum_pointcloud_tiles']
+        and pointcloud_bytes >= contract['output']['minimum_pointcloud_bytes'],
+        f'tiles={len(tiles)}, bytes={pointcloud_bytes}',
+    )
+
+    failures = [row for row in checks if row['status'] == 'FAIL']
+    return {
+        'schema_version': 1,
+        'contract_id': contract.get('id'),
+        'status': 'PASS' if not failures else 'FAIL',
+        'contract_path': str(contract_path.resolve()),
+        'intake_manifest_path': str(intake_path.resolve()),
+        'run_dir': str(run_dir.resolve()),
+        'checks': checks,
+        'summary': {
+            'pass': len(checks) - len(failures),
+            'fail': len(failures),
+            'runtime_sec': runtime_sec,
+            'raw_poses': raw_poses,
+            'corrected_poses': corrected_poses,
+            'pointcloud_tiles': len(tiles),
+            'pointcloud_bytes': pointcloud_bytes,
+        },
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    """Render the validation report for Actions summaries and artifacts."""
+    lines = [
+        '# Real-data E2E validation',
+        '',
+        f"- contract: `{report['contract_id']}`",
+        f"- status: **{report['status']}**",
+        f"- run: `{report['run_dir']}`",
+        '',
+        '| Check | Status | Detail |',
+        '| --- | --- | --- |',
+    ]
+    for row in report['checks']:
+        detail = row['detail'].replace('|', '\\|').replace('\n', ' ')
+        lines.append(f"| `{row['id']}` | **{row['status']}** | {detail} |")
+    lines.extend([
+        '',
+        '## Evidence summary',
+        '',
+        f"- runtime: `{report['summary']['runtime_sec']:.3f} s`",
+        f"- raw poses: `{report['summary']['raw_poses']}`",
+        f"- corrected poses: `{report['summary']['corrected_poses']}`",
+        f"- pointcloud tiles: `{report['summary']['pointcloud_tiles']}`",
+        f"- pointcloud bytes: `{report['summary']['pointcloud_bytes']}`",
+    ])
+    return '\n'.join(lines) + '\n'
+
+
+def main() -> int:
+    """Validate CLI inputs, write evidence reports, and return gate status."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--contract', type=Path, required=True)
+    parser.add_argument('--intake-manifest', type=Path, required=True)
+    parser.add_argument('--run-dir', type=Path, required=True)
+    parser.add_argument('--output-json', type=Path)
+    parser.add_argument('--output-markdown', type=Path)
+    args = parser.parse_args()
+
+    try:
+        report = validate(
+            args.contract.resolve(),
+            args.intake_manifest.resolve(),
+            args.run_dir.resolve(),
+        )
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as exc:
+        print(
+            f'error: real-data E2E validation could not run: {exc}',
+            file=sys.stderr,
+        )
+        return 2
+
+    payload = json.dumps(report, indent=2, sort_keys=True) + '\n'
+    markdown = render_markdown(report)
+    if args.output_json:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(payload, encoding='utf-8')
+    if args.output_markdown:
+        args.output_markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.output_markdown.write_text(markdown, encoding='utf-8')
+    print(markdown, end='')
+    return 0 if report['status'] == 'PASS' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a nightly/manual Jazzy E2E workflow pinned to the official Zenodo MID-360 driving bag by archive and extracted-storage identities
- validate installed-product doctor/run evidence, runtime bounds, topic/message counts, pose counts, PCD output, and Autoware verification
- upload only non-geometry evidence with bounded retention
- fix the golden-path wrapper so omitted optional frame overrides are not passed as malformed empty ROS launch arguments
- document the real-data contract, operating procedure, and release/readiness integration

## Real-data evidence

Validated locally through the installed Jazzy product against `rosbag2_2024_04_16-14_17_01` (277.16683667 s, 58,217 messages):

- runtime: 89.584 s
- raw poses: 2,700
- corrected poses: 577
- PCD tiles: 366 (64,649,907 bytes)
- Autoware verification: 8/8 PASS, 0 WARN, 0 FAIL
- schema-v2 run manifest and diagnosis: valid, terminal success

The first real run exposed the empty `lidar_frame:=` / `imu_frame:=` launch-argument bug; this PR includes the regression fix and test.

## Validation

- `bash scripts/run_default_ci_checks.sh`: 2,571 tests, 0 errors, 0 failures, 125 skipped
- focused pytest suites: 60 passed
- `mkdocs build --strict`
- `bash -n scripts/run_rko_lio_graph_autoware_dogfood.sh`
- Python compile and strict flake8 for the new validator/tests
- `git diff --check`

After merge, the new workflow will be manually dispatched on `develop` to establish the first default-branch hosted-run evidence.