### PR TITLE
Add attested versioned release images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ on:
       - docker/**
       - scripts/run_docker_demo.sh
       - .github/workflows/docker.yml
+      - .github/workflows/release.yml
   workflow_dispatch:
 
 concurrency:
@@ -20,11 +21,19 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  attestations: write
+  id-token: write
 
 jobs:
   build:
-    name: build${{ (github.event_name != 'pull_request') && ' and push' || '' }} (humble)
-    runs-on: ubuntu-22.04
+    name: build${{ (github.event_name != 'pull_request') && ' and push' || '' }} (${{ matrix.ros_distro }})
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distro:
+          - humble
+          - jazzy
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -32,27 +41,79 @@ jobs:
           submodules: recursive
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Pull requests only validate that the image builds; pushes to develop
-      # (and manual dispatches) publish ghcr.io/<repo>:humble + :latest.
+      - name: Resolve OCI metadata
+        id: image_meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ matrix.ros_distro }}
+            type=raw,value=latest,enable=${{ matrix.ros_distro == 'humble' }}
+          labels: |
+            org.opencontainers.image.title=lidarslam_ros2
+            org.opencontainers.image.description=Installed ROS 2 LiDAR SLAM map-authoring product
+            org.opencontainers.image.licenses=BSD-2-Clause
+
+      # Pull requests load and smoke-test both supported images. Pushes to
+      # develop (and manual dispatches) publish moving distro convenience tags;
+      # tagged releases publish exact v<VERSION>-<distro> tags in release.yml.
       - name: Build (and push) image
-        uses: docker/build-push-action@v6
+        id: image
+        uses: docker/build-push-action@v7
         with:
           context: .
           build-args: |
-            ROS_DISTRO=humble
+            ROS_DISTRO=${{ matrix.ros_distro }}
+          platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ghcr.io/${{ github.repository }}:humble
-            ghcr.io/${{ github.repository }}:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          load: ${{ github.event_name == 'pull_request' }}
+          tags: ${{ steps.image_meta.outputs.tags }}
+          labels: ${{ steps.image_meta.outputs.labels }}
+          sbom: ${{ github.event_name != 'pull_request' }}
+          provenance: ${{ github.event_name != 'pull_request' && 'mode=max' || 'false' }}
+          cache-from: type=gha,scope=convenience-${{ matrix.ros_distro }}
+          cache-to: type=gha,mode=max,scope=convenience-${{ matrix.ros_distro }}
+
+      - name: Attest published image
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Smoke-test installed CLI
+        shell: bash
+        env:
+          EXPECTED_DIGEST: ${{ steps.image.outputs.digest }}
+          IMAGE_TAG: ghcr.io/${{ github.repository }}:${{ matrix.ros_distro }}
+        run: |
+          VERSION="$(tr -d '\n' < VERSION)"
+          IMAGE_REF="${IMAGE_TAG}"
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            IMAGE_REF="ghcr.io/${{ github.repository }}@${EXPECTED_DIGEST}"
+            docker pull "${IMAGE_REF}"
+          fi
+          OBSERVED_VERSION="$(docker run --rm "${IMAGE_REF}" lidarslam-map --version)"
+          if [[ "${OBSERVED_VERSION}" != "lidarslam_ros2 ${VERSION}" ]]; then
+            echo "unexpected CLI version: ${OBSERVED_VERSION}" >&2
+            exit 1
+          fi
+          {
+            echo "## ${{ matrix.ros_distro }} convenience image"
+            echo
+            echo "- CLI: \`${OBSERVED_VERSION}\`"
+            if [[ -n "${EXPECTED_DIGEST}" ]]; then
+              echo "- Digest: \`${EXPECTED_DIGEST}\`"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,25 @@ on:
 
 permissions:
   contents: write
+  packages: write
+  attestations: write
+  id-token: write
 
 concurrency:
   group: release-${{ github.event.inputs.tag_name || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: publish release
+  metadata:
+    name: validate release metadata
     runs-on: ubuntu-24.04
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    outputs:
+      bundle_name: ${{ steps.meta.outputs.bundle_name }}
+      release_notes: ${{ steps.meta.outputs.release_notes }}
+      tag_name: ${{ steps.meta.outputs.tag_name }}
+      version: ${{ steps.meta.outputs.version }}
 
     steps:
       - name: Check out repository
@@ -31,11 +39,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag_name || github.ref }}
-
-      - name: Install Python test dependency
-        shell: bash
-        run: |
-          python3 -m pip install --upgrade pytest
 
       - name: Resolve release metadata
         id: meta
@@ -71,6 +74,159 @@ jobs:
           echo "release_notes=${RELEASE_NOTES}" >> "${GITHUB_OUTPUT}"
           echo "bundle_name=${BUNDLE_NAME}" >> "${GITHUB_OUTPUT}"
 
+  images:
+    name: publish ${{ matrix.ros_distro }} amd64 image
+    needs: metadata
+    runs-on: ubuntu-24.04
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distro:
+          - humble
+          - jazzy
+
+    steps:
+      - name: Check out tagged repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.metadata.outputs.tag_name }}
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve OCI metadata
+        id: image_meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ needs.metadata.outputs.tag_name }}-${{ matrix.ros_distro }}
+          labels: |
+            org.opencontainers.image.title=lidarslam_ros2
+            org.opencontainers.image.description=Installed ROS 2 LiDAR SLAM map-authoring product
+            org.opencontainers.image.licenses=BSD-2-Clause
+
+      - name: Build and publish versioned image
+        id: image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          build-args: |
+            ROS_DISTRO=${{ matrix.ros_distro }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.image_meta.outputs.tags }}
+          labels: ${{ steps.image_meta.outputs.labels }}
+          sbom: true
+          provenance: mode=max
+          cache-from: type=gha,scope=release-${{ matrix.ros_distro }}
+          cache-to: type=gha,mode=max,scope=release-${{ matrix.ros_distro }}
+
+      - name: Attest published image
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Pull and smoke-test published digest
+        id: smoke
+        shell: bash
+        env:
+          EXPECTED_DIGEST: ${{ steps.image.outputs.digest }}
+          EXPECTED_VERSION: ${{ needs.metadata.outputs.version }}
+          IMAGE_TAG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.metadata.outputs.tag_name }}-${{ matrix.ros_distro }}
+        run: |
+          TAG_DIGEST="$(
+            docker buildx imagetools inspect "${IMAGE_TAG}" \
+              --format '{{json .Manifest}}' | jq -r '.digest'
+          )"
+          if [[ "${TAG_DIGEST}" != "${EXPECTED_DIGEST}" ]]; then
+            echo "tag digest ${TAG_DIGEST} != build digest ${EXPECTED_DIGEST}" >&2
+            exit 1
+          fi
+
+          IMAGE_REF="${REGISTRY}/${IMAGE_NAME}@${EXPECTED_DIGEST}"
+          docker pull "${IMAGE_REF}"
+          OBSERVED_VERSION="$(docker run --rm "${IMAGE_REF}" lidarslam-map --version)"
+          EXPECTED_OUTPUT="lidarslam_ros2 ${EXPECTED_VERSION}"
+          if [[ "${OBSERVED_VERSION}" != "${EXPECTED_OUTPUT}" ]]; then
+            echo "CLI version '${OBSERVED_VERSION}' != '${EXPECTED_OUTPUT}'" >&2
+            exit 1
+          fi
+
+          EVIDENCE_FILE="release-image-${{ matrix.ros_distro }}.json"
+          TAG_COMMIT="$(git rev-parse HEAD)"
+          jq -n \
+            --arg schema_version "1" \
+            --arg ros_distro "${{ matrix.ros_distro }}" \
+            --arg platform "linux/amd64" \
+            --arg tag "${IMAGE_TAG}" \
+            --arg digest "${EXPECTED_DIGEST}" \
+            --arg git_commit "${TAG_COMMIT}" \
+            --arg product_version "${EXPECTED_VERSION}" \
+            --arg cli_version "${OBSERVED_VERSION}" \
+            '{
+              schema_version: ($schema_version | tonumber),
+              status: "PASS",
+              ros_distro: $ros_distro,
+              platform: $platform,
+              tag: $tag,
+              digest: $digest,
+              git_commit: $git_commit,
+              product_version: $product_version,
+              cli_version: $cli_version
+            }' > "${EVIDENCE_FILE}"
+          echo "evidence_file=${EVIDENCE_FILE}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "## ${{ matrix.ros_distro }} release image"
+            echo
+            echo "- Tag: \`${IMAGE_TAG}\`"
+            echo "- Digest: \`${EXPECTED_DIGEST}\`"
+            echo "- CLI: \`${OBSERVED_VERSION}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload release-image evidence
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-image-${{ matrix.ros_distro }}
+          path: ${{ steps.smoke.outputs.evidence_file }}
+          if-no-files-found: error
+
+  publish:
+    name: publish release
+    needs:
+      - metadata
+      - images
+    runs-on: ubuntu-24.04
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.metadata.outputs.tag_name }}
+
+      - name: Install Python test dependency
+        shell: bash
+        run: |
+          python3 -m pip install --upgrade pytest
+
       - name: Validate release docs
         shell: bash
         run: |
@@ -95,7 +251,7 @@ jobs:
           cp lidarslam/images/dynamic_object_filter_bag6_summary.svg release_bundle/lidarslam/images/
           cp lidarslam/images/social_autoware_map_authoring.png release_bundle/lidarslam/images/
           cp lidarslam/images/social_autoware_map_authoring_demo.mp4 release_bundle/lidarslam/images/
-          cp "${{ steps.meta.outputs.release_notes }}" release_bundle/docs/releases/
+          cp "${{ needs.metadata.outputs.release_notes }}" release_bundle/docs/releases/
           for artifact in \
             output/benchmark_summary.md \
             output/benchmark_summary.csv \
@@ -107,19 +263,33 @@ jobs:
               cp "${artifact}" release_bundle/output/
             fi
           done
-          tar -czf "${{ steps.meta.outputs.bundle_name }}" release_bundle
+          tar -czf "${{ needs.metadata.outputs.bundle_name }}" release_bundle
 
       - name: Upload release bundle artifact
         uses: actions/upload-artifact@v6
         with:
-          name: ${{ steps.meta.outputs.tag_name }}-release-bundle
-          path: ${{ steps.meta.outputs.bundle_name }}
+          name: ${{ needs.metadata.outputs.tag_name }}-release-bundle
+          path: ${{ needs.metadata.outputs.bundle_name }}
+
+      - name: Attest release bundle
+        uses: actions/attest@v4
+        with:
+          subject-path: ${{ needs.metadata.outputs.bundle_name }}
+
+      - name: Download release-image evidence
+        uses: actions/download-artifact@v7
+        with:
+          pattern: release-image-*
+          path: release_image_evidence
+          merge-multiple: true
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.meta.outputs.tag_name }}
-          name: lidarslam_ros2 v${{ steps.meta.outputs.version }}
-          body_path: ${{ steps.meta.outputs.release_notes }}
+          tag_name: ${{ needs.metadata.outputs.tag_name }}
+          name: lidarslam_ros2 v${{ needs.metadata.outputs.version }}
+          body_path: ${{ needs.metadata.outputs.release_notes }}
           prerelease: true
-          files: ${{ steps.meta.outputs.bundle_name }}
+          files: |
+            ${{ needs.metadata.outputs.bundle_name }}
+            release_image_evidence/*.json

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,6 +33,10 @@ bash scripts/run_autoware_quickstart.sh
    of this).
 5. Review README, `docs/autoware-quickstart.md`, `docs/benchmarking.md`,
    `docs/comparison.md`, and `CONTRIBUTING.md` for operator-facing accuracy.
+6. Confirm the tagged checkout can build both `ROS_DISTRO=humble` and
+   `ROS_DISTRO=jazzy` Docker targets. The release workflow will refuse to
+   create the GitHub Release unless both published digests pass the installed
+   `lidarslam-map --version` smoke test.
 
 ## Automated Publication
 
@@ -40,8 +44,22 @@ Two GitHub Actions workflows matter for release:
 
 - `.github/workflows/main.yml` runs the continuing CI matrix, release-readiness
   fixture checks, and weekly scheduled validation.
-- `.github/workflows/release.yml` publishes a prerelease when `v*` tags are
-  pushed and uses `docs/releases/v<version>.md` as the release body.
+- `.github/workflows/release.yml` validates the tag, publishes and attests
+  `v<version>-humble` and `v<version>-jazzy` GHCR images, smoke-tests both by
+  registry digest, then publishes the prerelease using
+  `docs/releases/v<version>.md` as the release body. The release assets include
+  the source bundle plus one `release-image-<distro>.json` installation
+  evidence file per image.
+
+The image build emits an OCI SBOM and maximum-mode BuildKit provenance.
+GitHub artifact attestations cover each image digest and the source release
+bundle. Verify an image after publication:
+
+```bash
+gh attestation verify \
+  "oci://ghcr.io/rsasaki0109/lidar_slam_ros2:v${VERSION}-jazzy" \
+  -R rsasaki0109/lidar_slam_ros2
+```
 
 ## Tagging
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,7 +1,8 @@
 # Distribution and installed CLI
 
-This page describes what can be installed reproducibly today and what remains
-before `lidarslam_ros2` can claim a complete binary-distribution path.
+This page describes the supported source and container installation paths and
+the remaining boundary before `lidarslam_ros2` can publish ROS buildfarm
+packages.
 
 ## Supported source install
 
@@ -73,6 +74,62 @@ that `ros2 run lidarslam lidarslam` was not replaced.
 The Docker image is likewise built without `--symlink-install` and verifies
 `lidarslam-map --version` before its build tree is removed.
 
+## Container install
+
+GHCR is the supported prebuilt amd64 delivery path for both ROS distributions.
+The moving convenience tags track `develop` and are useful for evaluation:
+
+```bash
+docker pull ghcr.io/rsasaki0109/lidar_slam_ros2:humble
+docker run --rm ghcr.io/rsasaki0109/lidar_slam_ros2:humble \
+  lidarslam-map --version
+
+docker pull ghcr.io/rsasaki0109/lidar_slam_ros2:jazzy
+docker run --rm ghcr.io/rsasaki0109/lidar_slam_ros2:jazzy \
+  lidarslam-map --version
+```
+
+`latest` remains an alias of the Humble convenience image for compatibility.
+It is not a release identifier.
+
+Every tagged release publishes exact
+`ghcr.io/rsasaki0109/lidar_slam_ros2:v<VERSION>-<distro>` images only after
+the repository tag matches `VERSION`. For example:
+
+```bash
+IMAGE=ghcr.io/rsasaki0109/lidar_slam_ros2:v0.7.0-jazzy
+docker pull "$IMAGE"
+docker run --rm "$IMAGE" lidarslam-map --version
+```
+
+Use an exact digest for deployment or rollback. Each GitHub Release attaches
+`release-image-humble.json` and `release-image-jazzy.json`; they record the
+tested tag, digest, tag commit, platform, product version, and observed CLI
+version:
+
+```bash
+DIGEST="$(jq -r .digest release-image-jazzy.json)"
+docker run --rm \
+  "ghcr.io/rsasaki0109/lidar_slam_ros2@${DIGEST}" \
+  lidarslam-map --version
+```
+
+The release workflow builds from the tagged recursive checkout, publishes an
+SBOM and maximum-mode BuildKit provenance with each image, creates a signed
+GitHub artifact attestation, then pulls and smoke-tests the registry digest.
+The GitHub Release is created only after both distro images pass. Verify the
+GitHub provenance with:
+
+```bash
+gh attestation verify \
+  oci://ghcr.io/rsasaki0109/lidar_slam_ros2:v0.7.0-jazzy \
+  -R rsasaki0109/lidar_slam_ros2
+```
+
+The version examples illustrate the tag contract; use a tag listed on the
+GitHub Releases page. Convenience tags are intentionally moving, so recording
+their current digest is mandatory when they are used in evaluation evidence.
+
 ## Profile-specific extras
 
 The flagship PointCloud2 + IMU profile is complete after the recursive source
@@ -97,7 +154,7 @@ module is absent. This extra is not required by the default RKO-LIO path.
 | Delivery | Humble amd64 | Jazzy amd64 | arm64 / Jetson | Flagship RKO-LIO path |
 | --- | --- | --- | --- | --- |
 | Recursive source checkout + `colcon` | Tested in CI | Tested in CI | Evaluation; use the Jetson runbook | Included from the maintained submodule |
-| GHCR image | Published convenience image for Humble | Not yet published | Not yet published | Included |
+| GHCR image | Moving and versioned amd64 images | Moving and versioned amd64 images | Not yet published | Included |
 | ROS buildfarm / apt | Not released | Not released | Not released | Packaging decision unresolved |
 
 `amd64` is the tested product target. Jetson/MID-360 workflows have real-device
@@ -122,6 +179,8 @@ that fact only proves buildability; it does not make the installed flagship
 workflow complete. See the [rosdistro release runbook](rosdistro-release.md)
 for the maintainer procedure and remaining prerequisites.
 
-Versioned GHCR tags, release-image SBOM/provenance, upgrade tests, and attached
-release-candidate installation evidence remain Phase 2 work. Until those land,
-use the recursive source install or the documented Humble convenience image.
+Versioned Humble/Jazzy GHCR tags, release-image SBOM/provenance, digest smoke
+tests, and attached installation evidence are automated for the next tagged
+release. ROS buildfarm packages remain blocked by the dependency decisions
+above. Upgrade testing across two released product versions and arm64 image
+publication also remain Phase 2 work.

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -1,8 +1,10 @@
 # lidarslam_ros2 v0.9 roadmap — product foundation
 
 > Status: **direction approved 2026-07-27; Phase 0 and Phase 1 complete;
-> Phase 2 in progress (installed CLI and clean-prefix validation landed;
-> binary flagship packaging remains open); Phase 3 in progress (SIGINT/SIGTERM
+> Phase 2 in progress (installed CLI, clean-prefix validation, and versioned
+> Humble/Jazzy GHCR release images with attestations landed; ROS buildfarm
+> flagship packaging and cross-version upgrades remain open); Phase 3 in
+> progress (SIGINT/SIGTERM
 > process-group cleanup, recoverable terminal evidence, and the pinned nightly
 > MID-360 real-data E2E gate landed; soak and storage-pressure gates remain)**.
 > This roadmap

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -77,6 +77,7 @@ SOCIAL_POST_DOC = REPO_ROOT / 'docs' / 'social' / 'autoware_map_authoring_post_v
 ISSUE_TEMPLATE_DIR = REPO_ROOT / '.github' / 'ISSUE_TEMPLATE'
 PUBLIC_AUTOWARE_ENTRYPOINT = REPO_ROOT / 'scripts' / 'run_autoware_quickstart.sh'
 RELEASE_WORKFLOW = REPO_ROOT / '.github' / 'workflows' / 'release.yml'
+DOCKER_WORKFLOW = REPO_ROOT / '.github' / 'workflows' / 'docker.yml'
 DOCS_SITE_WORKFLOW = REPO_ROOT / '.github' / 'workflows' / 'docs-site.yml'
 README_LOOP_IMAGE_PATH = REPO_ROOT / 'lidarslam' / 'images' / 'mid360_loop_closure_zoom.png'
 README_AUTOWARE_PROOF_IMAGE_PATH = (
@@ -132,6 +133,7 @@ def test_docs_exist_and_are_linked_from_readme():
     assert RUN_MANIFEST_V2_SCHEMA.is_file()
     assert V09_ROADMAP_DOC.is_file()
     assert SOCIAL_POST_DOC.is_file()
+    assert DOCKER_WORKFLOW.is_file()
     assert DOCS_SITE_WORKFLOW.is_file()
     assert README_LOOP_IMAGE_PATH.is_file()
     assert README_AUTOWARE_PROOF_IMAGE_PATH.is_file()
@@ -324,6 +326,16 @@ def test_release_metadata_and_core_package_versions_match():
     assert 'git tag "v${VERSION}"' in releasing
     assert 'RTK-SLAM' in release_notes
     assert 'action-gh-release@v2' in release_workflow
+    assert 'docker/setup-buildx-action@v4' in release_workflow
+    assert 'docker/login-action@v4' in release_workflow
+    assert 'docker/metadata-action@v6' in release_workflow
+    assert 'docker/build-push-action@v7' in release_workflow
+    assert 'actions/attest@v4' in release_workflow
+    assert 'actions/download-artifact@v7' in release_workflow
+    assert 'release-image-${{ matrix.ros_distro }}.json' in release_workflow
+    assert 'v<VERSION>-<distro>' in (
+        DISTRIBUTION_DOC.read_text(encoding='utf-8')
+    )
     assert 'mkdocs.yml' in release_workflow
     assert 'docs/index.md' in release_workflow
     assert 'docs/assets/' in release_workflow
@@ -497,6 +509,11 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     assert 'ros2 run lidarslam lidarslam-cli' in distribution_doc
     assert 'Humble amd64' in distribution_doc
     assert 'Jazzy amd64' in distribution_doc
+    assert ':v<VERSION>-<distro>' in distribution_doc
+    assert 'release-image-humble.json' in distribution_doc
+    assert 'release-image-jazzy.json' in distribution_doc
+    assert 'gh attestation verify' in distribution_doc
+    assert 'BuildKit provenance' in distribution_doc
     assert 'There is currently no supported' in distribution_doc
     assert 'rko_lio' in distribution_doc
     assert 'SIGTERM' in reliability_doc
@@ -534,3 +551,35 @@ def test_real_data_e2e_workflow_is_pinned_bounded_and_non_geometry():
     assert 'validate_real_data_e2e.py' in workflow
     assert 'output/real-data-e2e/run/map.pcd' not in workflow
     assert 'output/real-data-e2e/run/traj_raw.tum' not in workflow
+
+
+def test_container_distribution_builds_and_attests_both_supported_distros():
+    """Container CI and releases must prove both supported binary paths."""
+    docker_workflow = DOCKER_WORKFLOW.read_text(encoding='utf-8')
+    release_workflow = RELEASE_WORKFLOW.read_text(encoding='utf-8')
+
+    for workflow in (docker_workflow, release_workflow):
+        assert '- humble' in workflow
+        assert '- jazzy' in workflow
+        assert 'linux/amd64' in workflow or workflow == docker_workflow
+        assert 'docker/build-push-action@v7' in workflow
+        assert 'actions/attest@v4' in workflow
+        assert 'attestations: write' in workflow
+        assert 'id-token: write' in workflow
+        assert 'sbom:' in workflow
+        assert 'provenance:' in workflow
+        assert 'lidarslam-map --version' in workflow
+
+    assert "load: ${{ github.event_name == 'pull_request' }}" in docker_workflow
+    assert '.github/workflows/release.yml' in docker_workflow
+    assert 'needs:' in release_workflow
+    assert '- images' in release_workflow
+    assert 'v<VERSION>-<distro>' in (
+        DISTRIBUTION_DOC.read_text(encoding='utf-8')
+    )
+    assert '${{ needs.metadata.outputs.tag_name }}-${{ matrix.ros_distro }}' in (
+        release_workflow
+    )
+    assert 'subject-digest: ${{ steps.image.outputs.digest }}' in release_workflow
+    assert 'docker buildx imagetools inspect' in release_workflow
+    assert 'release_image_evidence/*.json' in release_workflow


### PR DESCRIPTION
## What changed

- build and smoke-test amd64 convenience images for both ROS 2 Humble and Jazzy
- publish exact `v<VERSION>-<distro>` images before a tagged GitHub Release
- emit BuildKit SBOM/provenance and GitHub artifact attestations
- verify the registry tag digest, run the installed CLI by digest, and attach machine-readable evidence for both images
- document image tags, digest pinning, attestation verification, and the remaining apt/arm64/upgrade boundaries

## Why

The product-level OSS distribution path needs reproducible artifacts whose source, platform, installed version, and tested registry digest can be independently checked. A GitHub Release now depends on both supported ROS image paths succeeding.

## User impact

Users can consume moving Humble/Jazzy evaluation images today and, from the next release tag, pin exact versioned images or immutable digests with attached smoke evidence and provenance.

## Validation

- clean local Jazzy Docker build and independent installed-CLI smoke (`lidarslam_ros2 0.6.0`, amd64)
- `python3 -m pytest graph_based_slam/test/test_docs_entrypoints.py -q` (9 passed)
- `ament_flake8 graph_based_slam` (164 files, no problems)
- default CI functional suite completed; after the one quote-style lint fix, aggregated results report 2,409 tests, 0 failures, 125 skipped
- workflow YAML parsed successfully (Docker: 1 job; release: 3 jobs)
- `python3 -m mkdocs build --strict`
- `git diff --check`