### PR TITLE
Add deterministic storage-pressure handling

### DIFF
--- a/docs/golden-path-cli.md
+++ b/docs/golden-path-cli.md
@@ -32,6 +32,10 @@ Use `--dry-run` to inspect the plan without creating the output directory.
 The runner writes into `<output>.partial` and atomically renames that directory
 to the requested output name after the workflow stops. It refuses to start
 when either name already exists, so a new run never overwrites prior evidence.
+It also refuses to launch when the output filesystem has less than 5 GiB free.
+Use `--min-free-space-gib <GiB>` to set a larger reserve after sizing the
+expected map; the configured reserve is a refusal boundary, not an output-size
+prediction.
 Completed, failed, and interrupted workflows retain their artifacts and
 terminal state for diagnosis. The runner isolates the workflow in its own
 process group. `Ctrl-C` (`SIGINT`) and service/container termination

--- a/docs/operational-reliability.md
+++ b/docs/operational-reliability.md
@@ -11,7 +11,9 @@ only marked covered when an automated test exercises the public behavior.
 | Missing or corrupt `metadata.yaml`, missing referenced storage file | Exit `2` before workflow launch | Existing output is untouched; a new output is not created | Correct or replace the bag, then rerun `lidarslam-map doctor` | Automated |
 | Incompatible topic/profile selection | Exit `2` with available profiles and missing requirements | Existing output is untouched | Choose a compatible profile or fix the input | Automated |
 | Final or `.partial` output collision | Exit `2`; no overwrite | Both existing paths remain immutable | Inspect the existing run or choose a new output name | Automated |
+| Output filesystem below the configured reserve | Exit `2` before workflow launch with required and observed GiB | Existing output is untouched; a new output is not created | Free storage, choose another output filesystem, or set a deliberately sized `--min-free-space-gib` budget | Automated |
 | Workflow exits non-zero | Propagate the workflow exit code | Final output, diagnosis, checksums, and schema-v2 manifest with `failed` status | Inspect the diagnosis and launch log; rerun into a new directory after fixing the cause | Automated |
+| Storage exhaustion during a manifest or map write | Preserve the previous atomic manifest when possible; return the workflow or runner failure code; diagnose `ENOSPC`, quota, and “No space left on device” signatures | Final or `.partial` evidence that was already durable; incomplete manifest temp files are removed | Preserve evidence, free storage, and rerun into a new output directory | Automated failure injection |
 | Operator `Ctrl-C` (`SIGINT`) | Forward `SIGINT` to the isolated workflow process group; force cleanup after ten seconds; exit `130` | Final output and manifest with `interrupted` status and signal reason | Inspect preserved evidence; rerun into a new directory if a map is still required | Automated |
 | Service/container stop (`SIGTERM`) | Forward `SIGTERM` to the isolated workflow process group; force cleanup after ten seconds; exit `143` | Final output, diagnosis, checksums, and manifest with `interrupted`, `143`, and `SIGTERM` | Inspect preserved evidence; rerun into a new directory if a map is still required | Automated failure injection |
 | Termination after the workflow result is durable but before post-processing completes | Leave the last durable schema-v2 lifecycle stage in the final or `.partial` directory | Original input/software/command identity and map artifacts | Run the same command and output path with `--resume`; SLAM is not rerun | Automated |
@@ -22,6 +24,28 @@ only marked covered when an automated test exercises the public behavior.
 `run_manifest.json` is authoritative for terminal workflow status. Diagnosis
 uses its `failed` or `interrupted` state even when the workflow stopped before
 writing a recognizable ROS log signature.
+
+## Output storage boundary
+
+`lidarslam-map run` requires at least 5 GiB free on the filesystem that will
+contain the output directory. It checks the nearest existing parent before
+workflow launch and prints the probe path, required GiB, and observed GiB.
+This reserve is a deterministic disk-pressure refusal boundary, not an
+output-size prediction: large bags and dense maps can require substantially
+more.
+
+Override the reserve only after sizing the expected map:
+
+```bash
+lidarslam-map run /path/to/rosbag2 \
+  --output-dir /data/maps/session-01 \
+  --min-free-space-gib 20
+```
+
+The value must be finite and greater than zero. When capacity is below the
+budget, no output or `.partial` directory is created. Atomic manifest updates
+remove an incomplete temporary file on write failure, so the previous durable
+manifest is not replaced by truncated JSON.
 
 ## Termination boundary
 
@@ -42,8 +66,8 @@ The following readiness rows remain incomplete and must not be inferred from
 the termination coverage:
 
 - timestamp reversal detection against real rosbag records before launch;
-- an explicit free-space budget and deterministic disk-pressure refusal;
-- controlled disk-exhaustion injection for manifest and map writes;
+- long-running free-space telemetry and a bounded-filesystem live exhaustion
+  test in the scheduled real-data environment;
 - one-hour and eight-hour soak profiles with RSS, wall-time, output-size, and
   dropped-input counters;
 - output migration tooling and last-known-good rollback instructions.

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -67,7 +67,9 @@ The general product path accepts a rosbag2 directory containing
 - `sensor_msgs/msg/Imu`;
 - valid, monotonic timestamps;
 - a known transform between LiDAR, IMU and base frames;
-- enough free disk space for the input bag, intermediate clouds and output map.
+- enough free disk space for the input bag, intermediate clouds and output map;
+  `run` enforces a 5 GiB output-filesystem reserve by default and accepts a
+  deliberately sized `--min-free-space-gib` override.
 
 Topic presence is necessary but not sufficient. A bag with the right message
 types can still require a sensor-specific point-time field, calibration,

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -6,7 +6,9 @@
 > flagship packaging and cross-version upgrades remain open); Phase 3 in
 > progress (SIGINT/SIGTERM
 > process-group cleanup, recoverable terminal evidence, and the pinned nightly
-> MID-360 real-data E2E gate landed; soak and storage-pressure gates remain)**.
+> MID-360 real-data E2E gate landed; deterministic storage refusal and
+> disk-exhaustion failure injection landed; scheduled live exhaustion and soak
+> gates remain)**.
 > This roadmap
 > turns the existing benchmark-heavy map-authoring stack into a product-level
 > OSS project. It does not replace the evidence-driven capability roadmaps;

--- a/graph_based_slam/test/test_autoware_map_run_diagnosis.py
+++ b/graph_based_slam/test/test_autoware_map_run_diagnosis.py
@@ -132,6 +132,23 @@ def test_summary_reports_tf_issue_hints(tmp_path: Path):
     assert any('tail -n 120' in step for step in summary['suggested_next_steps'])
 
 
+def test_summary_reports_map_write_disk_exhaustion(tmp_path: Path):
+    module = _load_module()
+    run_dir = tmp_path / 'run'
+    run_dir.mkdir()
+    (run_dir / 'map_save.log').write_text(
+        'write failed: [Errno 28] No space left on device\n',
+        encoding='utf-8',
+    )
+
+    summary = module.summarize_run(run_dir)
+    hints = '\n'.join(summary['problem_hints'])
+
+    assert summary['status'] == 'runtime_failed'
+    assert 'output filesystem ran out of writable space or quota' in hints
+    assert 'free storage' in hints
+
+
 def test_summary_uses_terminal_manifest_as_runtime_failure_evidence(
     tmp_path: Path,
 ):

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -521,6 +521,9 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     assert 'Automated failure injection' in reliability_doc
     assert 'timestamp reversal' in reliability_doc
     assert 'disk-pressure' in reliability_doc
+    assert '--min-free-space-gib' in reliability_doc
+    assert '5 GiB' in reliability_doc
+    assert 'No space left on device' in reliability_doc
     assert '(operational-reliability.md)' in (
         PRODUCT_CONTRACT_DOC.read_text(encoding='utf-8')
     )

--- a/lidarslam/test/test_autoware_map_runner_script.py
+++ b/lidarslam/test/test_autoware_map_runner_script.py
@@ -31,6 +31,7 @@
 
 from __future__ import annotations
 
+import errno
 import importlib.util
 import json
 import os
@@ -122,7 +123,159 @@ def test_runner_help_is_user_facing():
     assert 'Workflow profiles:' in result.stdout
     assert 'Expected successful outputs:' in result.stdout
     assert '--output-dir <dir>' in result.stdout
+    assert '--min-free-space-gib <GiB>' in result.stdout
     assert '--resume' in result.stdout
+
+
+def test_storage_preflight_records_budget_and_refuses_low_space(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _load_module()
+    output_dir = tmp_path / 'nested' / 'map_output'
+    usage_type = type('DiskUsage', (), {})
+
+    enough = usage_type()
+    enough.free = 7 * 1024**3
+    monkeypatch.setattr(module.shutil, 'disk_usage', lambda path: enough)
+    evidence = module.check_output_storage(output_dir, 5.0)
+
+    assert evidence == {
+        'probe_path': str(tmp_path.resolve()),
+        'required_free_bytes': 5 * 1024**3,
+        'observed_free_bytes': 7 * 1024**3,
+    }
+
+    low = usage_type()
+    low.free = 256 * 1024**2
+    monkeypatch.setattr(module.shutil, 'disk_usage', lambda path: low)
+    with pytest.raises(ValueError, match='insufficient free space for map output'):
+        module.check_output_storage(output_dir, 5.0)
+
+
+@pytest.mark.parametrize('value', ['0', '-1', 'nan', 'inf'])
+def test_storage_preflight_rejects_unsafe_budget_values(value: str):
+    module = _load_module()
+
+    with pytest.raises(
+        module.argparse.ArgumentTypeError,
+        match='finite number greater than zero',
+    ):
+        module._minimum_free_space_gib(value)
+
+
+def test_main_refuses_low_space_before_creating_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+):
+    module = _load_module()
+    bag_dir = _write_metadata(
+        tmp_path,
+        'demo_bag',
+        [
+            ('/points', 'sensor_msgs/msg/PointCloud2', 20),
+            ('/imu', 'sensor_msgs/msg/Imu', 180),
+        ],
+    )
+    output_dir = tmp_path / 'map_output'
+    usage_type = type('DiskUsage', (), {})
+    usage = usage_type()
+    usage.free = 1024
+    monkeypatch.setattr(module.shutil, 'disk_usage', lambda path: usage)
+    monkeypatch.setattr(
+        module,
+        'build_execution_plan',
+        lambda **kwargs: pytest.fail('workflow planning must follow storage refusal'),
+    )
+    monkeypatch.setattr(
+        module.sys,
+        'argv',
+        [
+            str(SCRIPT_PATH),
+            str(bag_dir),
+            '--output-dir',
+            str(output_dir),
+            '--dry-run',
+        ],
+    )
+
+    assert module.main() == 2
+    assert 'insufficient free space for map output' in capsys.readouterr().err
+    assert not output_dir.exists()
+    assert not output_dir.with_name('map_output.partial').exists()
+
+
+def test_atomic_manifest_write_preserves_previous_file_on_enospc(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _load_module()
+    run_dir = tmp_path / 'run'
+    run_dir.mkdir()
+    destination = run_dir / 'run_manifest.json'
+    destination.write_text('{"status":"durable"}\n', encoding='utf-8')
+
+    def fail_replace(source, target):
+        del source, target
+        raise OSError(errno.ENOSPC, 'No space left on device')
+
+    monkeypatch.setattr(module.os, 'replace', fail_replace)
+    with pytest.raises(OSError) as error:
+        module._write_manifest(run_dir, {'status': 'new'})
+
+    assert error.value.errno == errno.ENOSPC
+    assert destination.read_text(encoding='utf-8') == '{"status":"durable"}\n'
+    assert not (run_dir / '.run_manifest.json.tmp').exists()
+
+
+def test_initial_manifest_enospc_removes_empty_partial_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture,
+):
+    module = _load_module()
+    bag_dir = _write_metadata(
+        tmp_path,
+        'demo_bag',
+        [
+            ('/points', 'sensor_msgs/msg/PointCloud2', 20),
+            ('/imu', 'sensor_msgs/msg/Imu', 180),
+        ],
+    )
+    output_dir = tmp_path / 'map_output'
+    working_dir = tmp_path / 'map_output.partial'
+    plan = {
+        'payload': {},
+        'profile_id': 'rko_lio_graph_public_path',
+        'label': 'RKO-LIO + graph_based_slam public path',
+        'command': ['map-workflow'],
+        'output_dir': working_dir,
+    }
+    monkeypatch.setattr(module, 'build_execution_plan', lambda **kwargs: plan)
+
+    def fail_manifest_write(*args, **kwargs):
+        del args, kwargs
+        raise OSError(errno.ENOSPC, 'No space left on device')
+
+    monkeypatch.setattr(module, '_write_manifest', fail_manifest_write)
+    monkeypatch.setattr(
+        module.sys,
+        'argv',
+        [
+            str(SCRIPT_PATH),
+            str(bag_dir),
+            '--output-dir',
+            str(output_dir),
+            '--min-free-space-gib',
+            '0.001',
+        ],
+    )
+
+    assert module.main() == 2
+    assert 'No space left on device' in capsys.readouterr().err
+    assert not output_dir.exists()
+    assert not working_dir.exists()
 
 
 def test_runner_rejects_db3_file_without_traceback(tmp_path: Path):
@@ -418,6 +571,71 @@ def test_main_retains_terminal_manifest_for_failed_and_interrupted_runs(
     assert manifest['lifecycle']['last_error'] == expected_error
     assert manifest['output']['finalized'] is True
     assert not output_dir.with_name('failed_map.partial').exists()
+
+
+def test_map_write_enospc_is_preserved_and_diagnosed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = _load_module()
+    bag_dir = _write_metadata(
+        tmp_path,
+        'disk_pressure_bag',
+        [
+            ('/points', 'sensor_msgs/msg/PointCloud2', 20),
+            ('/imu', 'sensor_msgs/msg/Imu', 180),
+        ],
+    )
+    output_dir = tmp_path / 'disk_pressure_map'
+    working_dir = tmp_path / 'disk_pressure_map.partial'
+    plan = {
+        'payload': {},
+        'profile_id': 'rko_lio_graph_public_path',
+        'label': 'disk-pressure injection fixture',
+        'command': ['map-workflow'],
+        'output_dir': working_dir,
+    }
+
+    def inject_map_write_enospc(*args):
+        del args
+        (working_dir / 'map_save.log').write_text(
+            'write failed: [Errno 28] No space left on device\n',
+            encoding='utf-8',
+        )
+        return 28, False, None
+
+    monkeypatch.setattr(module, 'build_execution_plan', lambda **kwargs: plan)
+    monkeypatch.setattr(module, '_run_workflow', inject_map_write_enospc)
+    monkeypatch.setattr(module, 'maybe_verify_map', lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        module.sys,
+        'argv',
+        [
+            str(SCRIPT_PATH),
+            str(bag_dir),
+            '--output-dir',
+            str(output_dir),
+            '--min-free-space-gib',
+            '0.001',
+        ],
+    )
+
+    assert module.main() == 28
+    manifest = json.loads(
+        (output_dir / 'run_manifest.json').read_text(encoding='utf-8')
+    )
+    diagnosis = json.loads(
+        (output_dir / 'autoware_map_diagnosis.json').read_text(encoding='utf-8')
+    )
+    assert manifest['status'] == 'failed'
+    assert manifest['execution']['exit_code'] == 28
+    assert manifest['lifecycle']['runner_exit_code'] == 28
+    assert manifest['output']['finalized'] is True
+    assert diagnosis['status'] == 'runtime_failed'
+    assert any(
+        'output filesystem ran out of writable space or quota' in hint
+        for hint in diagnosis['problem_hints']
+    )
 
 
 def test_workflow_supervisor_forwards_sigterm_and_reaps_process_group(

--- a/scripts/diagnose_autoware_map_run.py
+++ b/scripts/diagnose_autoware_map_run.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import argparse
 import json
+from pathlib import Path
 import re
 import sys
-from pathlib import Path
 from typing import Any
 
 import yaml
@@ -100,12 +100,19 @@ def _extract_launch_flags(launch_log: str) -> dict[str, bool]:
     }
 
 
-def _extract_problem_hints(launch_log: str, map_save_log: str, verify_summary: dict[str, Any]) -> list[str]:
+def _extract_problem_hints(
+    launch_log: str,
+    map_save_log: str,
+    verify_summary: dict[str, Any],
+) -> list[str]:
     hints: list[str] = []
     combined = '\n'.join([launch_log, map_save_log])
 
     if 'process has died' in combined:
-        hints.append('A ROS node died during the run. Check the launch log tail for the crashing process.')
+        hints.append(
+            'A ROS node died during the run. '
+            'Check the launch log tail for the crashing process.'
+        )
     if 'failed to initialize rcl' in combined or "Couldn't parse params file" in combined:
         hints.append('The run hit a ROS parameter-file parsing error.')
     if 'TF_NO_FRAME_ID' in combined or 'TF_NO_CHILD_FRAME_ID' in combined:
@@ -114,6 +121,15 @@ def _extract_problem_hints(launch_log: str, map_save_log: str, verify_summary: d
         hints.append('TF tree connectivity was missing for the requested frames.')
     if 'map_save service call failed' in combined:
         hints.append('The /map_save service call failed or timed out.')
+    if (
+        'No space left on device' in combined
+        or 'ENOSPC' in combined
+        or 'Disk quota exceeded' in combined
+    ):
+        hints.append(
+            'The output filesystem ran out of writable space or quota. '
+            'Preserve the run evidence, free storage, and rerun into a new output directory.'
+        )
     if 'Added 0 GNSS position constraint edges' in combined:
         hints.append('GNSS was enabled but the backend accepted zero GNSS edges.')
     if verify_summary['result'] == 'FAIL':
@@ -219,7 +235,9 @@ def summarize_run(run_dir: Path, bag_path: Path | None = None) -> dict[str, Any]
             'launch_log': str(launch_log_path) if launch_log_path else None,
             'map_save_log': str(map_save_log_path) if map_save_log_path else None,
             'verify_log': str(verify_log_path) if verify_log_path else None,
-            'pointcloud_map_metadata': str(pointcloud_metadata_path) if pointcloud_map_exists else None,
+            'pointcloud_map_metadata': (
+                str(pointcloud_metadata_path) if pointcloud_map_exists else None
+            ),
             'map_projector_info': str(map_projector_path) if map_projector_exists else None,
         },
         'launch_flags': launch_flags,

--- a/scripts/run_autoware_map_from_bag.py
+++ b/scripts/run_autoware_map_from_bag.py
@@ -10,9 +10,11 @@ import fcntl
 import hashlib
 import importlib.util
 import json
+import math
 import os
 from pathlib import Path
 import shlex
+import shutil
 import signal
 import subprocess
 import sys
@@ -54,6 +56,7 @@ PROFILE_HELP = (
     ('packet_applanix_smoke', 'VelodyneScan + Applanix GSOF49 smoke workflow.'),
 )
 WORKFLOW_SHUTDOWN_GRACE_SECS = 10.0
+DEFAULT_MIN_FREE_SPACE_GIB = 5.0
 PACKAGE_XML_PATHS = (
     SHARE_ROOT / 'lidarslam' / 'package.xml',
     SHARE_ROOT / 'graph_based_slam' / 'package.xml',
@@ -333,6 +336,56 @@ def validate_output_dir(output_dir: Path) -> None:
             return
 
 
+def _minimum_free_space_gib(value: str) -> float:
+    """Parse a positive finite output-storage reserve."""
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError('must be a number greater than zero') from exc
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError('must be a finite number greater than zero')
+    return parsed
+
+
+def check_output_storage(
+    output_dir: Path,
+    minimum_free_space_gib: float,
+) -> dict[str, object]:
+    """Refuse a run whose output filesystem is below the configured reserve."""
+    probe_path = output_dir
+    while not probe_path.exists():
+        parent = probe_path.parent
+        if parent == probe_path:
+            raise ValueError(
+                f'cannot find an existing parent for output directory: {output_dir}'
+            )
+        probe_path = parent
+    if not probe_path.is_dir():
+        raise ValueError(f'output storage probe path is not a directory: {probe_path}')
+
+    required_free_bytes = math.ceil(minimum_free_space_gib * 1024**3)
+    try:
+        observed_free_bytes = shutil.disk_usage(probe_path).free
+    except OSError as exc:
+        raise ValueError(
+            f'cannot inspect free space for output directory {output_dir}: {exc}'
+        ) from exc
+    if observed_free_bytes < required_free_bytes:
+        observed_gib = observed_free_bytes / 1024**3
+        raise ValueError(
+            'insufficient free space for map output: '
+            f'require at least {minimum_free_space_gib:.2f} GiB under '
+            f'{probe_path}, but only {observed_gib:.2f} GiB is available. '
+            'Free storage or choose another --output-dir; lower '
+            '--min-free-space-gib only after sizing the expected map.'
+        )
+    return {
+        'probe_path': str(probe_path.resolve()),
+        'required_free_bytes': required_free_bytes,
+        'observed_free_bytes': observed_free_bytes,
+    }
+
+
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
 
@@ -482,11 +535,18 @@ def _bag_identity(bag_path: Path) -> dict[str, object]:
 def _write_manifest(run_dir: Path, manifest: dict[str, object]) -> None:
     destination = run_dir / MANIFEST_NAME
     temporary = run_dir / f'.{MANIFEST_NAME}.tmp'
-    temporary.write_text(
-        json.dumps(manifest, indent=2, sort_keys=True) + '\n',
-        encoding='utf-8',
-    )
-    os.replace(temporary, destination)
+    try:
+        temporary.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + '\n',
+            encoding='utf-8',
+        )
+        os.replace(temporary, destination)
+    except OSError:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
 
 
 def _artifact_checksums(run_dir: Path) -> list[dict[str, object]]:
@@ -961,6 +1021,16 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        '--min-free-space-gib',
+        type=_minimum_free_space_gib,
+        default=DEFAULT_MIN_FREE_SPACE_GIB,
+        metavar='<GiB>',
+        help=(
+            'Refuse to start when the output filesystem has less than this '
+            f'reserve (default: {DEFAULT_MIN_FREE_SPACE_GIB:g} GiB).'
+        ),
+    )
+    parser.add_argument(
         '--viewer',
         choices=['none', 'autoware', 'foxglove'],
         default='none',
@@ -1021,11 +1091,16 @@ def main() -> int:
         WORK_ROOT / 'output' / f'autoware_map_authoring_{bag_path.stem}_{timestamp}'
     )
     working_dir = output_dir.with_name(f'{output_dir.name}.partial')
+    storage_preflight = None
     try:
         validate_bag_path(bag_path)
         if not args.resume:
             validate_output_dir(output_dir)
             validate_output_dir(working_dir)
+        storage_preflight = check_output_storage(
+            output_dir,
+            args.min_free_space_gib,
+        )
         plan = build_execution_plan(
             bag_path=bag_path,
             profile_id=args.profile,
@@ -1039,6 +1114,12 @@ def main() -> int:
     print(f"Selected profile: {plan['label']}")
     print(f'Output directory: {output_dir}')
     print(f'Atomic working directory: {working_dir}')
+    print(
+        'Storage preflight: '
+        f"{storage_preflight['observed_free_bytes'] / 1024**3:.2f} GiB free; "
+        f"{storage_preflight['required_free_bytes'] / 1024**3:.2f} GiB required "
+        f"under {storage_preflight['probe_path']}"
+    )
     print('Command:')
     print('  ' + shlex.join(plan['command']))
 
@@ -1071,6 +1152,7 @@ def main() -> int:
             return 70
         return _finish_run(args, plan, output_dir, exit_code)
 
+    created_working_dir = False
     try:
         manifest = _build_manifest(
             bag_path,
@@ -1080,11 +1162,17 @@ def main() -> int:
             verify_map=not args.no_verify_map,
         )
         working_dir.mkdir(parents=True, exist_ok=False)
+        created_working_dir = True
         manifest['status'] = 'running'
         manifest['lifecycle']['stage'] = 'workflow_running'
         manifest['execution']['started_at'] = _utc_now()
         _write_manifest(working_dir, manifest)
     except (OSError, RuntimeError, ValueError, ET.ParseError, yaml.YAMLError) as exc:
+        if created_working_dir and not (working_dir / MANIFEST_NAME).exists():
+            try:
+                working_dir.rmdir()
+            except OSError:
+                pass
         print(
             f'error: failed to initialize output directory {working_dir}: {exc}',
             file=sys.stderr,


### PR DESCRIPTION
## Summary
- refuse map runs before launch when the output filesystem is below a configurable 5 GiB reserve
- preserve durable manifests and clean temporary evidence when storage writes fail
- diagnose ENOSPC/quota map failures with actionable recovery guidance
- document the operational boundary and remaining live exhaustion/soak work

## Validation
- `bash scripts/run_default_ci_checks.sh` (2572 tests, 0 errors, 0 failures, 125 skipped)
- `python3 -m pytest lidarslam/test/test_autoware_map_runner_script.py graph_based_slam/test/test_autoware_map_run_diagnosis.py graph_based_slam/test/test_docs_entrypoints.py -q` (57 passed)
- targeted `ament_flake8` (5 files, no problems)
- `python3 -m mkdocs build --strict`
- run-manifest-v2 schema validation
- `git diff --check`