### PR TITLE
Add bounded map soak telemetry

### DIFF
--- a/docs/operational-reliability.md
+++ b/docs/operational-reliability.md
@@ -60,16 +60,52 @@ remain at `workflow_running`; `--resume` deliberately refuses it because an
 original process could still own the artifacts. Confirm that no workflow
 process is alive, retain the directory as evidence, and start a new output.
 
+## Soak profiles
+
+The operator-only soak harness exercises the same `lidarslam-map run` contract
+as the golden path. It is deliberately not a fourth beginner entrypoint.
+Choose a fixed one-hour or eight-hour profile and supply budgets tied to a
+named machine. The `lidarslam` package declares GNU `time` as a runtime
+dependency because it supplies the peak-RSS evidence:
+
+```bash
+python3 scripts/run_map_soak.py /data/bags/mid360 \
+  --output-root /data/soak/one-hour-20260727 \
+  --soak-profile one-hour \
+  --hardware-label 'lab-amd64-7950x-64GiB' \
+  --map-profile mid360_livox_smoke \
+  --max-peak-rss-mib 4096 \
+  --max-output-gib 40 \
+  --max-dropped-inputs 0
+```
+
+The harness repeats complete, collision-safe map runs until the profile
+duration is reached. Each iteration records its command, exit code, GNU time
+wall duration and peak RSS, output size, remaining free space, console log and
+raw GNU time report. `soak_report.json` is updated atomically after every
+iteration and validated by
+[`soak-report-v1.schema.json`](schemas/soak-report-v1.schema.json).
+
+The drop counter is a conservative count of documented console signatures for
+message-filter drops, scan drops and queue/buffer overflow. One line can match
+more than one signature, so the total can over-count; a zero only proves those
+signatures were absent from the captured logs. A failed iteration, unreadable
+telemetry, or exceeded RSS/output/drop budget stops the profile immediately
+and preserves failed evidence. The duration gate passes only after the full
+3,600 or 28,800 seconds have elapsed.
+
 ## Open Phase 3 gates
 
 The following readiness rows remain incomplete and must not be inferred from
 the termination coverage:
 
 - timestamp reversal detection against real rosbag records before launch;
-- long-running free-space telemetry and a bounded-filesystem live exhaustion
-  test in the scheduled real-data environment;
-- one-hour and eight-hour soak profiles with RSS, wall-time, output-size, and
-  dropped-input counters;
+- execute and archive the one-hour and eight-hour soak profiles on named
+  release hardware; the harness and machine-readable thresholds are automated,
+  but real-duration evidence is not yet recorded;
+- periodic free-space telemetry within a long-running iteration and a
+  bounded-filesystem live exhaustion test in the scheduled real-data
+  environment;
 - output migration tooling and last-known-good rollback instructions.
 
 See the [pinned real-data E2E contract](real-data-e2e.md) and the

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -7,8 +7,9 @@
 > progress (SIGINT/SIGTERM
 > process-group cleanup, recoverable terminal evidence, and the pinned nightly
 > MID-360 real-data E2E gate landed; deterministic storage refusal and
-> disk-exhaustion failure injection landed; scheduled live exhaustion and soak
-> gates remain)**.
+> disk-exhaustion failure injection landed; fixed-duration soak profiles and
+> their telemetry contract landed, while named-hardware executions and
+> scheduled live exhaustion remain)**.
 > This roadmap
 > turns the existing benchmark-heavy map-authoring stack into a product-level
 > OSS project. It does not replace the evidence-driven capability roadmaps;

--- a/docs/schemas/soak-report-v1.schema.json
+++ b/docs/schemas/soak-report-v1.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/soak-report-v1.schema.json",
+  "title": "lidarslam_ros2 soak report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "schema_uri",
+    "status",
+    "last_error",
+    "profile",
+    "target_duration_sec",
+    "started_at",
+    "completed_at",
+    "hardware_label",
+    "bag_path",
+    "map_profile",
+    "product_cli",
+    "thresholds",
+    "metrics",
+    "checks",
+    "iterations"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "schema_uri": {
+      "const": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/soak-report-v1.schema.json"
+    },
+    "status": {"enum": ["running", "passed", "failed"]},
+    "last_error": {"type": ["string", "null"]},
+    "profile": {"enum": ["one-hour", "eight-hour"]},
+    "target_duration_sec": {"enum": [3600.0, 28800.0]},
+    "started_at": {"type": "string", "format": "date-time"},
+    "completed_at": {"type": ["string", "null"], "format": "date-time"},
+    "hardware_label": {"type": "string", "minLength": 1},
+    "bag_path": {"type": "string", "minLength": 1},
+    "map_profile": {"type": ["string", "null"]},
+    "product_cli": {"type": "string", "minLength": 1},
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_peak_rss_mib",
+        "max_output_bytes",
+        "max_dropped_inputs"
+      ],
+      "properties": {
+        "max_peak_rss_mib": {"type": "number", "exclusiveMinimum": 0},
+        "max_output_bytes": {"type": "integer", "minimum": 1},
+        "max_dropped_inputs": {"type": "integer", "minimum": 0}
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "wall_time_sec",
+        "iterations_completed",
+        "iterations_failed",
+        "peak_rss_mib",
+        "output_size_bytes",
+        "dropped_inputs_total",
+        "minimum_free_space_bytes"
+      ],
+      "properties": {
+        "wall_time_sec": {"type": "number", "minimum": 0},
+        "iterations_completed": {"type": "integer", "minimum": 0},
+        "iterations_failed": {"type": "integer", "minimum": 0},
+        "peak_rss_mib": {"type": "number", "minimum": 0},
+        "output_size_bytes": {"type": "integer", "minimum": 0},
+        "dropped_inputs_total": {"type": "integer", "minimum": 0},
+        "minimum_free_space_bytes": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        }
+      }
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target_duration_reached": {"type": "boolean"},
+        "all_iterations_succeeded": {"type": "boolean"},
+        "peak_rss_within_budget": {"type": "boolean"},
+        "output_size_within_budget": {"type": "boolean"},
+        "dropped_inputs_within_budget": {"type": "boolean"}
+      }
+    },
+    "iterations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "started_at",
+          "completed_at",
+          "command",
+          "command_display",
+          "exit_code",
+          "wall_time_sec",
+          "peak_rss_mib",
+          "output_size_bytes",
+          "free_space_bytes",
+          "dropped_input_signatures",
+          "log",
+          "time_report"
+        ],
+        "properties": {
+          "id": {"type": "string", "pattern": "^iteration-[0-9]{4,}$"},
+          "started_at": {"type": "string", "format": "date-time"},
+          "completed_at": {"type": "string", "format": "date-time"},
+          "command": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string"}
+          },
+          "command_display": {"type": "string", "minLength": 1},
+          "exit_code": {"type": "integer"},
+          "wall_time_sec": {"type": "number", "minimum": 0},
+          "peak_rss_mib": {"type": "number", "minimum": 0},
+          "output_size_bytes": {"type": "integer", "minimum": 0},
+          "free_space_bytes": {"type": "integer", "minimum": 0},
+          "dropped_input_signatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["message_filter", "scan_drop", "queue_overflow"],
+            "properties": {
+              "message_filter": {"type": "integer", "minimum": 0},
+              "scan_drop": {"type": "integer", "minimum": 0},
+              "queue_overflow": {"type": "integer", "minimum": 0}
+            }
+          },
+          "log": {"type": "string", "minLength": 1},
+          "time_report": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  }
+}

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -524,6 +524,13 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     assert '--min-free-space-gib' in reliability_doc
     assert '5 GiB' in reliability_doc
     assert 'No space left on device' in reliability_doc
+    assert 'scripts/run_map_soak.py' in reliability_doc
+    assert '--soak-profile one-hour' in reliability_doc
+    assert '--hardware-label' in reliability_doc
+    assert '--max-peak-rss-mib' in reliability_doc
+    assert 'soak-report-v1.schema.json' in reliability_doc
+    assert 'GNU `time`' in reliability_doc
+    assert '3,600 or 28,800 seconds' in reliability_doc
     assert '(operational-reliability.md)' in (
         PRODUCT_CONTRACT_DOC.read_text(encoding='utf-8')
     )

--- a/lidarslam/CMakeLists.txt
+++ b/lidarslam/CMakeLists.txt
@@ -159,6 +159,11 @@ if(BUILD_TESTING)
     TIMEOUT 120
   )
   ament_add_pytest_test(
+    test_map_soak_runner
+    test/test_map_soak_runner.py
+    TIMEOUT 120
+  )
+  ament_add_pytest_test(
     test_sparse_trajectory_scoring
     test/test_sparse_trajectory_scoring.py
     TIMEOUT 120

--- a/lidarslam/package.xml
+++ b/lidarslam/package.xml
@@ -25,6 +25,7 @@
   <exec_depend>python3-yaml</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rosbag2</exec_depend>
+  <exec_depend>time</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>

--- a/lidarslam/product-runtime-files.txt
+++ b/lidarslam/product-runtime-files.txt
@@ -1,6 +1,7 @@
 lidarslam_cli.py
 preflight_autoware_map_bag.py
 run_autoware_map_from_bag.py
+run_map_soak.py
 diagnose_autoware_map_run.py
 verify_autoware_map.py
 run_rko_lio_graph_autoware_dogfood.sh

--- a/lidarslam/test/test_installed_product_cli_contract.py
+++ b/lidarslam/test/test_installed_product_cli_contract.py
@@ -52,6 +52,7 @@ def test_product_runtime_manifest_is_curated_and_complete():
     assert len(names) == len(set(names))
     assert 'lidarslam_cli.py' in names
     assert 'run_autoware_map_from_bag.py' in names
+    assert 'run_map_soak.py' in names
     assert 'verify_autoware_map.py' in names
     assert 'gaussian_splatting_train.py' not in names
     for name in names:

--- a/lidarslam/test/test_map_soak_runner.py
+++ b/lidarslam/test/test_map_soak_runner.py
@@ -1,0 +1,239 @@
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Tests for the bounded product map soak harness."""
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location(
+    'run_map_soak',
+    ROOT / 'scripts/run_map_soak.py',
+)
+SOAK = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(SOAK)
+
+
+def _args(tmp_path: Path, **overrides) -> argparse.Namespace:
+    bag = tmp_path / 'bag'
+    bag.mkdir(exist_ok=True)
+    (bag / 'metadata.yaml').write_text(
+        'rosbag2_bagfile_information: {}\n',
+        encoding='utf-8',
+    )
+    cli = tmp_path / 'lidarslam-map'
+    cli.write_text('#!/bin/sh\n', encoding='utf-8')
+    cli.chmod(0o755)
+    values = {
+        'bag': str(bag),
+        'output_root': str(tmp_path / 'soak'),
+        'soak_profile': 'one-hour',
+        'hardware_label': 'ci-amd64-test-host',
+        'map_profile': 'mid360_livox_smoke',
+        'cli': str(cli),
+        'max_peak_rss_mib': 512.0,
+        'max_output_gib': 1.0,
+        'max_dropped_inputs': 0,
+        'min_free_space_gib': 0.01,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_profiles_are_exactly_one_and_eight_hours():
+    assert SOAK.PROFILE_DURATIONS == {
+        'one-hour': 3600.0,
+        'eight-hour': 28800.0,
+    }
+
+
+def test_parse_gnu_time_reports_wall_rss_and_exit():
+    report = SOAK.parse_gnu_time(
+        'Elapsed (wall clock) time (h:mm:ss or m:ss): 1:02:03.50\n'
+        'Maximum resident set size (kbytes): 262144\n'
+        'Exit status: 7\n'
+    )
+
+    assert report == {
+        'wall_time_sec': 3723.5,
+        'peak_rss_mib': 256.0,
+        'exit_code': 7,
+    }
+
+
+def test_parse_gnu_time_rejects_incomplete_evidence():
+    with pytest.raises(ValueError, match='peak_rss'):
+        SOAK.parse_gnu_time(
+            'Elapsed (wall clock) time (h:mm:ss or m:ss): 2:00.00\n'
+            'Exit status: 0\n'
+        )
+
+
+def test_drop_counters_are_explicit_and_conservative():
+    counts = SOAK.count_dropped_inputs(
+        'Message Filter dropping message because its queue is full\n'
+        'Dropping scan during kidnap recovery\n'
+        'unrelated warning\n'
+    )
+
+    assert counts == {
+        'message_filter': 1,
+        'scan_drop': 1,
+        'queue_overflow': 1,
+    }
+
+
+def test_successful_soak_writes_schema_valid_threshold_evidence(tmp_path):
+    args = _args(tmp_path)
+    ticks = iter([0.0, 0.0, 3600.0, 3600.0])
+
+    def fake_iteration(command, log_path, time_path):
+        run_dir = Path(command[command.index('--output-dir') + 1])
+        run_dir.mkdir(parents=True)
+        (run_dir / 'map.pcd').write_bytes(b'x' * 1024)
+        log_path.write_text('', encoding='utf-8')
+        time_path.write_text('fake GNU time evidence\n', encoding='utf-8')
+        return (
+            0,
+            {'wall_time_sec': 30.0, 'peak_rss_mib': 128.0, 'exit_code': 0},
+            {'message_filter': 0, 'scan_drop': 0, 'queue_overflow': 0},
+        )
+
+    exit_code, report = SOAK.run_soak(
+        args,
+        clock=lambda: next(ticks),
+        run_iteration=fake_iteration,
+    )
+
+    assert exit_code == 0
+    assert report['status'] == 'passed'
+    assert report['metrics']['iterations_completed'] == 1
+    assert report['metrics']['wall_time_sec'] == 3600.0
+    assert all(report['checks'].values())
+    saved = json.loads((Path(args.output_root) / SOAK.REPORT_NAME).read_text())
+    schema = json.loads(
+        (ROOT / 'docs/schemas/soak-report-v1.schema.json').read_text()
+    )
+    jsonschema.Draft7Validator.check_schema(schema)
+    jsonschema.validate(saved, schema)
+
+
+def test_failed_iteration_stops_and_preserves_failed_report(tmp_path):
+    args = _args(tmp_path)
+    ticks = iter([0.0, 0.0, 12.0])
+
+    def fake_iteration(command, log_path, time_path):
+        log_path.write_text('Dropping scan: queue full\n', encoding='utf-8')
+        time_path.write_text('fake GNU time evidence\n', encoding='utf-8')
+        return (
+            9,
+            {'wall_time_sec': 12.0, 'peak_rss_mib': 64.0, 'exit_code': 9},
+            {'message_filter': 0, 'scan_drop': 1, 'queue_overflow': 1},
+        )
+
+    exit_code, report = SOAK.run_soak(
+        args,
+        clock=lambda: next(ticks),
+        run_iteration=fake_iteration,
+    )
+
+    assert exit_code == 1
+    assert report['status'] == 'failed'
+    assert report['metrics']['iterations_failed'] == 1
+    assert report['metrics']['dropped_inputs_total'] == 2
+    assert report['checks']['target_duration_reached'] is False
+    assert report['checks']['all_iterations_succeeded'] is False
+    assert (Path(args.output_root) / SOAK.REPORT_NAME).is_file()
+
+
+def test_telemetry_failure_becomes_terminal_evidence(tmp_path):
+    args = _args(tmp_path)
+    ticks = iter([0.0, 0.0, 3.0])
+
+    def broken_iteration(command, log_path, time_path):
+        raise ValueError('GNU time report lacks fields')
+
+    exit_code, report = SOAK.run_soak(
+        args,
+        clock=lambda: next(ticks),
+        run_iteration=broken_iteration,
+    )
+
+    assert exit_code == 1
+    assert report['status'] == 'failed'
+    assert report['completed_at'] is not None
+    assert 'lacks fields' in report['last_error']
+    saved = json.loads((Path(args.output_root) / SOAK.REPORT_NAME).read_text())
+    assert saved['status'] == 'failed'
+    assert saved['last_error'] == report['last_error']
+
+
+def test_resource_budget_failure_stops_before_another_iteration(tmp_path):
+    args = _args(tmp_path, max_peak_rss_mib=100.0)
+    ticks = iter([0.0, 0.0, 10.0])
+    calls = []
+
+    def over_budget_iteration(command, log_path, time_path):
+        calls.append(command)
+        return (
+            0,
+            {'wall_time_sec': 10.0, 'peak_rss_mib': 101.0, 'exit_code': 0},
+            {'message_filter': 0, 'scan_drop': 0, 'queue_overflow': 0},
+        )
+
+    exit_code, report = SOAK.run_soak(
+        args,
+        clock=lambda: next(ticks),
+        run_iteration=over_budget_iteration,
+    )
+
+    assert exit_code == 1
+    assert len(calls) == 1
+    assert report['checks']['peak_rss_within_budget'] is False
+    assert report['last_error'].endswith('failed peak_rss_within_budget')
+
+
+def test_existing_output_is_never_overwritten(tmp_path):
+    args = _args(tmp_path)
+    output_root = Path(args.output_root)
+    output_root.mkdir()
+    marker = output_root / 'owned'
+    marker.write_text('keep', encoding='utf-8')
+
+    with pytest.raises(ValueError, match='already exists'):
+        SOAK.run_soak(args)
+
+    assert marker.read_text(encoding='utf-8') == 'keep'

--- a/scripts/run_map_soak.py
+++ b/scripts/run_map_soak.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+# Copyright 2026 Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD 2-Clause Simplified License)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Run the product map command repeatedly under a bounded soak contract."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+import math
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import subprocess
+import time
+from typing import Callable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILE_DURATIONS = {
+    'one-hour': 3600.0,
+    'eight-hour': 28800.0,
+}
+REPORT_NAME = 'soak_report.json'
+SCHEMA_URI = (
+    'https://rsasaki0109.github.io/lidar_slam_ros2/'
+    'schemas/soak-report-v1.schema.json'
+)
+DROP_SIGNATURES = {
+    'message_filter': re.compile(r'Message Filter.*dropp', re.IGNORECASE),
+    'scan_drop': re.compile(r'dropp(?:ed|ing).*scan', re.IGNORECASE),
+    'queue_overflow': re.compile(r'(?:queue|buffer).*(?:overflow|full)', re.IGNORECASE),
+}
+GNU_TIME_KEYS = {
+    'elapsed': 'Elapsed (wall clock) time (h:mm:ss or m:ss)',
+    'peak_rss': 'Maximum resident set size (kbytes)',
+    'exit_status': 'Exit status',
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def _positive_finite(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError('must be a positive number') from exc
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise argparse.ArgumentTypeError('must be finite and greater than zero')
+    return parsed
+
+
+def _nonnegative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError('must be a non-negative integer') from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError('must be a non-negative integer')
+    return parsed
+
+
+def _nonempty(value: str) -> str:
+    parsed = value.strip()
+    if not parsed:
+        raise argparse.ArgumentTypeError('must not be empty')
+    return parsed
+
+
+def _elapsed_seconds(value: str) -> float:
+    fields = value.strip().split(':')
+    if len(fields) == 2:
+        return float(fields[0]) * 60.0 + float(fields[1])
+    if len(fields) == 3:
+        return (
+            float(fields[0]) * 3600.0
+            + float(fields[1]) * 60.0
+            + float(fields[2])
+        )
+    raise ValueError(f'invalid GNU time elapsed value: {value!r}')
+
+
+def parse_gnu_time(text: str) -> dict[str, float | int]:
+    """Parse the stable fields used by the soak evidence contract."""
+    fields: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        for name, key in GNU_TIME_KEYS.items():
+            prefix = f'{key}:'
+            if stripped.startswith(prefix):
+                fields[name] = stripped[len(prefix):].strip()
+    missing = sorted(set(GNU_TIME_KEYS) - set(fields))
+    if missing:
+        raise ValueError(f'GNU time report lacks fields: {", ".join(missing)}')
+    return {
+        'wall_time_sec': _elapsed_seconds(fields['elapsed']),
+        'peak_rss_mib': float(fields['peak_rss']) / 1024.0,
+        'exit_code': int(fields['exit_status']),
+    }
+
+
+def count_dropped_inputs(text: str) -> dict[str, int]:
+    """Count documented log signatures without treating silence as proof."""
+    return {
+        name: sum(1 for line in text.splitlines() if pattern.search(line))
+        for name, pattern in DROP_SIGNATURES.items()
+    }
+
+
+def directory_size_bytes(path: Path) -> int:
+    total = 0
+    if not path.exists():
+        return total
+    for candidate in path.rglob('*'):
+        if candidate.is_file():
+            try:
+                total += candidate.stat().st_size
+            except FileNotFoundError:
+                continue
+    return total
+
+
+def _write_report_atomic(output_root: Path, report: dict[str, object]) -> None:
+    destination = output_root / REPORT_NAME
+    temporary = output_root / f'.{REPORT_NAME}.tmp'
+    try:
+        temporary.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + '\n',
+            encoding='utf-8',
+        )
+        os.replace(temporary, destination)
+    except OSError:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def evaluate_report(report: dict[str, object]) -> dict[str, bool]:
+    thresholds = report['thresholds']
+    metrics = report['metrics']
+    return {
+        'target_duration_reached': (
+            metrics['wall_time_sec'] >= report['target_duration_sec']
+        ),
+        'all_iterations_succeeded': (
+            metrics['iterations_completed'] > 0
+            and metrics['iterations_failed'] == 0
+        ),
+        'peak_rss_within_budget': (
+            metrics['peak_rss_mib'] <= thresholds['max_peak_rss_mib']
+        ),
+        'output_size_within_budget': (
+            metrics['output_size_bytes'] <= thresholds['max_output_bytes']
+        ),
+        'dropped_inputs_within_budget': (
+            metrics['dropped_inputs_total'] <= thresholds['max_dropped_inputs']
+        ),
+    }
+
+
+def _resolve_cli(value: str | None) -> Path:
+    if value:
+        candidate = Path(value).expanduser().resolve()
+    else:
+        installed = shutil.which('lidarslam-map')
+        candidate = Path(installed) if installed else ROOT / 'scripts/lidarslam'
+    if not candidate.is_file():
+        raise ValueError(f'product CLI not found: {candidate}')
+    if not os.access(candidate, os.X_OK):
+        raise ValueError(f'product CLI is not executable: {candidate}')
+    return candidate
+
+
+def _run_iteration(
+    command: list[str],
+    log_path: Path,
+    time_path: Path,
+) -> tuple[int, dict[str, float | int], dict[str, int]]:
+    gnu_time = Path('/usr/bin/time')
+    if not gnu_time.is_file():
+        raise ValueError('GNU /usr/bin/time is required for soak telemetry')
+    environment = os.environ.copy()
+    environment['LC_ALL'] = 'C'
+    timed_command = [
+        str(gnu_time),
+        '--verbose',
+        '--output',
+        str(time_path),
+        *command,
+    ]
+    with log_path.open('w', encoding='utf-8') as stream:
+        completed = subprocess.run(
+            timed_command,
+            stdout=stream,
+            stderr=subprocess.STDOUT,
+            check=False,
+            env=environment,
+        )
+    log_text = log_path.read_text(encoding='utf-8', errors='replace')
+    metrics = parse_gnu_time(time_path.read_text(encoding='utf-8'))
+    return completed.returncode, metrics, count_dropped_inputs(log_text)
+
+
+def _initial_report(args: argparse.Namespace, cli: Path) -> dict[str, object]:
+    return {
+        'schema_version': 1,
+        'schema_uri': SCHEMA_URI,
+        'status': 'running',
+        'last_error': None,
+        'profile': args.soak_profile,
+        'target_duration_sec': PROFILE_DURATIONS[args.soak_profile],
+        'started_at': _utc_now(),
+        'completed_at': None,
+        'hardware_label': args.hardware_label,
+        'bag_path': str(Path(args.bag).expanduser().resolve()),
+        'map_profile': args.map_profile,
+        'product_cli': str(cli),
+        'thresholds': {
+            'max_peak_rss_mib': args.max_peak_rss_mib,
+            'max_output_bytes': math.ceil(args.max_output_gib * 1024**3),
+            'max_dropped_inputs': args.max_dropped_inputs,
+        },
+        'metrics': {
+            'wall_time_sec': 0.0,
+            'iterations_completed': 0,
+            'iterations_failed': 0,
+            'peak_rss_mib': 0.0,
+            'output_size_bytes': 0,
+            'dropped_inputs_total': 0,
+            'minimum_free_space_bytes': None,
+        },
+        'checks': {},
+        'iterations': [],
+    }
+
+
+def run_soak(
+    args: argparse.Namespace,
+    *,
+    clock: Callable[[], float] = time.monotonic,
+    run_iteration: Callable[
+        [list[str], Path, Path],
+        tuple[int, dict[str, float | int], dict[str, int]],
+    ] = _run_iteration,
+) -> tuple[int, dict[str, object]]:
+    """Execute iterations until the profile duration or first failed run."""
+    cli = _resolve_cli(args.cli)
+    bag = Path(args.bag).expanduser().resolve()
+    if not (bag / 'metadata.yaml').is_file():
+        raise ValueError(f'rosbag2 metadata.yaml not found under: {bag}')
+    output_root = Path(args.output_root).expanduser().resolve()
+    if output_root.exists():
+        raise ValueError(f'soak output already exists: {output_root}')
+    if run_iteration is _run_iteration and not Path('/usr/bin/time').is_file():
+        raise ValueError('GNU /usr/bin/time is required for soak telemetry')
+    output_root.mkdir(parents=True)
+    logs_dir = output_root / 'logs'
+    runs_dir = output_root / 'runs'
+    logs_dir.mkdir()
+    runs_dir.mkdir()
+
+    report = _initial_report(args, cli)
+    target = report['target_duration_sec']
+    start = clock()
+    _write_report_atomic(output_root, report)
+    iteration_number = 0
+    while clock() - start < target:
+        iteration_number += 1
+        iteration_id = f'iteration-{iteration_number:04d}'
+        run_dir = runs_dir / iteration_id
+        log_path = logs_dir / f'{iteration_id}.log'
+        time_path = logs_dir / f'{iteration_id}.time'
+        command = [
+            str(cli),
+            'run',
+            str(bag),
+            '--output-dir',
+            str(run_dir),
+            '--min-free-space-gib',
+            str(args.min_free_space_gib),
+        ]
+        if args.map_profile:
+            command.extend(['--profile', args.map_profile])
+        iteration_started = _utc_now()
+        try:
+            return_code, resources, dropped = run_iteration(
+                command,
+                log_path,
+                time_path,
+            )
+        except (OSError, ValueError) as exc:
+            report['metrics']['wall_time_sec'] = clock() - start
+            report['status'] = 'failed'
+            report['last_error'] = (
+                f'{iteration_id} telemetry or execution failed: {exc}'
+            )
+            report['completed_at'] = _utc_now()
+            report['checks'] = evaluate_report(report)
+            _write_report_atomic(output_root, report)
+            return 1, report
+        elapsed = clock() - start
+        output_size = directory_size_bytes(run_dir)
+        free_bytes = shutil.disk_usage(output_root).free
+        dropped_total = sum(dropped.values())
+        iteration = {
+            'id': iteration_id,
+            'started_at': iteration_started,
+            'completed_at': _utc_now(),
+            'command': command,
+            'command_display': shlex.join(command),
+            'exit_code': return_code,
+            'wall_time_sec': resources['wall_time_sec'],
+            'peak_rss_mib': resources['peak_rss_mib'],
+            'output_size_bytes': output_size,
+            'free_space_bytes': free_bytes,
+            'dropped_input_signatures': dropped,
+            'log': str(log_path.relative_to(output_root)),
+            'time_report': str(time_path.relative_to(output_root)),
+        }
+        report['iterations'].append(iteration)
+        metrics = report['metrics']
+        metrics['wall_time_sec'] = elapsed
+        metrics['iterations_completed'] += int(return_code == 0)
+        metrics['iterations_failed'] += int(return_code != 0)
+        metrics['peak_rss_mib'] = max(
+            metrics['peak_rss_mib'],
+            resources['peak_rss_mib'],
+        )
+        metrics['output_size_bytes'] = directory_size_bytes(runs_dir)
+        metrics['dropped_inputs_total'] += dropped_total
+        previous_minimum = metrics['minimum_free_space_bytes']
+        metrics['minimum_free_space_bytes'] = (
+            free_bytes
+            if previous_minimum is None
+            else min(previous_minimum, free_bytes)
+        )
+        report['checks'] = evaluate_report(report)
+        _write_report_atomic(output_root, report)
+        if return_code != 0:
+            report['last_error'] = (
+                f'{iteration_id} exited with code {return_code}'
+            )
+            break
+        budget_checks = (
+            'peak_rss_within_budget',
+            'output_size_within_budget',
+            'dropped_inputs_within_budget',
+        )
+        failed_budget = next(
+            (name for name in budget_checks if not report['checks'][name]),
+            None,
+        )
+        if failed_budget is not None:
+            report['last_error'] = f'{iteration_id} failed {failed_budget}'
+            break
+
+    report['completed_at'] = _utc_now()
+    report['checks'] = evaluate_report(report)
+    report['status'] = (
+        'passed' if all(report['checks'].values()) else 'failed'
+    )
+    _write_report_atomic(output_root, report)
+    return (0 if report['status'] == 'passed' else 1), report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('bag', help='rosbag2 directory containing metadata.yaml')
+    parser.add_argument('--output-root', required=True)
+    parser.add_argument(
+        '--soak-profile',
+        choices=tuple(PROFILE_DURATIONS),
+        required=True,
+    )
+    parser.add_argument(
+        '--hardware-label',
+        type=_nonempty,
+        required=True,
+        help='Stable operator-defined hardware identity recorded in evidence',
+    )
+    parser.add_argument('--map-profile')
+    parser.add_argument('--cli', help='Product CLI path (default: lidarslam-map)')
+    parser.add_argument(
+        '--max-peak-rss-mib',
+        type=_positive_finite,
+        required=True,
+    )
+    parser.add_argument(
+        '--max-output-gib',
+        type=_positive_finite,
+        required=True,
+    )
+    parser.add_argument(
+        '--max-dropped-inputs',
+        type=_nonnegative_int,
+        required=True,
+    )
+    parser.add_argument(
+        '--min-free-space-gib',
+        type=_positive_finite,
+        default=5.0,
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    try:
+        exit_code, report = run_soak(parse_args())
+    except (OSError, ValueError) as exc:
+        print(f'error: {exc}', file=os.sys.stderr)
+        return 2
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return exit_code
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add fixed one-hour and eight-hour operator soak profiles over the product map command
- record atomic schema-v1 evidence for wall time, peak RSS, cumulative output size, free space, and conservative dropped-input signatures
- require named hardware and explicit RSS/output/drop budgets, stopping on the first run or budget failure
- document the contract without expanding the three beginner-facing entrypoints

## Validation
- default workflow aggregate after targeted rerun: 2584 tests, 0 errors, 0 failures, 125 skipped
- `python3 -m pytest lidarslam/test/test_map_soak_runner.py graph_based_slam/test/test_docs_entrypoints.py -q` (18 passed)
- targeted `ament_flake8` (3 files, no problems)
- targeted `ament_copyright` (2 files, no problems)
- Draft 7 schema validation
- `python3 -m mkdocs build --strict`
- `git diff --check`