### PR TITLE
Add live soak storage telemetry

### DIFF
--- a/docs/operational-reliability.md
+++ b/docs/operational-reliability.md
@@ -76,15 +76,32 @@ python3 scripts/run_map_soak.py /data/bags/mid360 \
   --map-profile mid360_livox_smoke \
   --max-peak-rss-mib 4096 \
   --max-output-gib 40 \
-  --max-dropped-inputs 0
+  --max-dropped-inputs 0 \
+  --telemetry-interval-secs 30
 ```
 
 The harness repeats complete, collision-safe map runs until the profile
 duration is reached. Each iteration records its command, exit code, GNU time
 wall duration and peak RSS, output size, remaining free space, console log and
-raw GNU time report. `soak_report.json` is updated atomically after every
-iteration and validated by
-[`soak-report-v1.schema.json`](schemas/soak-report-v1.schema.json).
+raw GNU time report. While an iteration is still running, it samples free
+space and cumulative output size every 30 seconds by default. The interval
+must be positive and cannot exceed 60 seconds.
+
+Every sample is appended to `telemetry_samples` and atomically checkpoints
+`soak_report.json`. If free space falls below `--min-free-space-gib` or output
+growth exceeds `--max-output-gib`, the harness stops the entire timed process
+group with `SIGTERM` and a bounded `SIGKILL` fallback, then attempts to
+finalize a failed report. The last successful sample remains available even
+when the iteration never produces normal GNU time evidence. Schema v2 defines
+the periodic evidence; schema v1 remains published for existing reports:
+
+- [`soak-report-v2.schema.json`](schemas/soak-report-v2.schema.json)
+- [`soak-report-v1.schema.json`](schemas/soak-report-v1.schema.json)
+
+Operator `Ctrl-C` and service `SIGTERM` use the same process-group cleanup and
+return `130` and `143`, respectively. Their terminal v2 report has
+`interrupted` status. If the filesystem refuses the final atomic update, the
+last successfully written running-state sample remains as recovery evidence.
 
 The drop counter is a conservative count of documented console signatures for
 message-filter drops, scan drops and queue/buffer overflow. One line can match
@@ -103,8 +120,7 @@ the termination coverage:
 - execute and archive the one-hour and eight-hour soak profiles on named
   release hardware; the harness and machine-readable thresholds are automated,
   but real-duration evidence is not yet recorded;
-- periodic free-space telemetry within a long-running iteration and a
-  bounded-filesystem live exhaustion test in the scheduled real-data
+- a bounded-filesystem live exhaustion test in the scheduled real-data
   environment;
 - output migration tooling and last-known-good rollback instructions.
 

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -7,9 +7,9 @@
 > progress (SIGINT/SIGTERM
 > process-group cleanup, recoverable terminal evidence, and the pinned nightly
 > MID-360 real-data E2E gate landed; deterministic storage refusal and
-> disk-exhaustion failure injection landed; fixed-duration soak profiles and
-> their telemetry contract landed, while named-hardware executions and
-> scheduled live exhaustion remain)**.
+> disk-exhaustion failure injection, fixed-duration soak profiles, and
+> periodic in-iteration storage telemetry landed, while named-hardware
+> executions and scheduled live exhaustion remain)**.
 > This roadmap
 > turns the existing benchmark-heavy map-authoring stack into a product-level
 > OSS project. It does not replace the evidence-driven capability roadmaps;

--- a/docs/schemas/soak-report-v2.schema.json
+++ b/docs/schemas/soak-report-v2.schema.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/soak-report-v2.schema.json",
+  "title": "lidarslam_ros2 soak report v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "schema_uri",
+    "status",
+    "last_error",
+    "active_iteration_id",
+    "profile",
+    "target_duration_sec",
+    "telemetry_interval_sec",
+    "started_at",
+    "completed_at",
+    "hardware_label",
+    "bag_path",
+    "map_profile",
+    "product_cli",
+    "thresholds",
+    "metrics",
+    "checks",
+    "telemetry_samples",
+    "iterations"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {"enum": ["passed", "failed", "interrupted"]}
+        }
+      },
+      "then": {
+        "properties": {
+          "checks": {
+            "required": [
+              "target_duration_reached",
+              "all_iterations_succeeded",
+              "peak_rss_within_budget",
+              "output_size_within_budget",
+              "dropped_inputs_within_budget",
+              "free_space_within_budget"
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "schema_version": {"const": 2},
+    "schema_uri": {
+      "const": "https://rsasaki0109.github.io/lidar_slam_ros2/schemas/soak-report-v2.schema.json"
+    },
+    "status": {"enum": ["running", "passed", "failed", "interrupted"]},
+    "last_error": {"type": ["string", "null"]},
+    "active_iteration_id": {
+      "type": ["string", "null"],
+      "pattern": "^iteration-[0-9]{4,}$"
+    },
+    "profile": {"enum": ["one-hour", "eight-hour"]},
+    "target_duration_sec": {"enum": [3600.0, 28800.0]},
+    "telemetry_interval_sec": {
+      "type": "number",
+      "exclusiveMinimum": 0,
+      "maximum": 60
+    },
+    "started_at": {"type": "string", "format": "date-time"},
+    "completed_at": {"type": ["string", "null"], "format": "date-time"},
+    "hardware_label": {"type": "string", "minLength": 1},
+    "bag_path": {"type": "string", "minLength": 1},
+    "map_profile": {"type": ["string", "null"]},
+    "product_cli": {"type": "string", "minLength": 1},
+    "thresholds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "max_peak_rss_mib",
+        "max_output_bytes",
+        "max_dropped_inputs",
+        "minimum_free_space_bytes"
+      ],
+      "properties": {
+        "max_peak_rss_mib": {"type": "number", "exclusiveMinimum": 0},
+        "max_output_bytes": {"type": "integer", "minimum": 1},
+        "max_dropped_inputs": {"type": "integer", "minimum": 0},
+        "minimum_free_space_bytes": {"type": "integer", "minimum": 1}
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "wall_time_sec",
+        "iterations_completed",
+        "iterations_failed",
+        "peak_rss_mib",
+        "output_size_bytes",
+        "dropped_inputs_total",
+        "minimum_free_space_bytes"
+      ],
+      "properties": {
+        "wall_time_sec": {"type": "number", "minimum": 0},
+        "iterations_completed": {"type": "integer", "minimum": 0},
+        "iterations_failed": {"type": "integer", "minimum": 0},
+        "peak_rss_mib": {"type": "number", "minimum": 0},
+        "output_size_bytes": {"type": "integer", "minimum": 0},
+        "dropped_inputs_total": {"type": "integer", "minimum": 0},
+        "minimum_free_space_bytes": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        }
+      }
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target_duration_reached": {"type": "boolean"},
+        "all_iterations_succeeded": {"type": "boolean"},
+        "peak_rss_within_budget": {"type": "boolean"},
+        "output_size_within_budget": {"type": "boolean"},
+        "dropped_inputs_within_budget": {"type": "boolean"},
+        "free_space_within_budget": {"type": "boolean"}
+      }
+    },
+    "telemetry_samples": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "captured_at",
+          "iteration_id",
+          "iteration_elapsed_sec",
+          "soak_elapsed_sec",
+          "output_size_bytes",
+          "free_space_bytes"
+        ],
+        "properties": {
+          "captured_at": {"type": "string", "format": "date-time"},
+          "iteration_id": {
+            "type": "string",
+            "pattern": "^iteration-[0-9]{4,}$"
+          },
+          "iteration_elapsed_sec": {"type": "number", "minimum": 0},
+          "soak_elapsed_sec": {"type": "number", "minimum": 0},
+          "output_size_bytes": {"type": "integer", "minimum": 0},
+          "free_space_bytes": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "iterations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "started_at",
+          "completed_at",
+          "command",
+          "command_display",
+          "exit_code",
+          "wall_time_sec",
+          "peak_rss_mib",
+          "output_size_bytes",
+          "free_space_bytes",
+          "dropped_input_signatures",
+          "log",
+          "time_report"
+        ],
+        "properties": {
+          "id": {"type": "string", "pattern": "^iteration-[0-9]{4,}$"},
+          "started_at": {"type": "string", "format": "date-time"},
+          "completed_at": {"type": "string", "format": "date-time"},
+          "command": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"type": "string"}
+          },
+          "command_display": {"type": "string", "minLength": 1},
+          "exit_code": {"type": "integer"},
+          "wall_time_sec": {"type": "number", "minimum": 0},
+          "peak_rss_mib": {"type": "number", "minimum": 0},
+          "output_size_bytes": {"type": "integer", "minimum": 0},
+          "free_space_bytes": {"type": "integer", "minimum": 0},
+          "dropped_input_signatures": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["message_filter", "scan_drop", "queue_overflow"],
+            "properties": {
+              "message_filter": {"type": "integer", "minimum": 0},
+              "scan_drop": {"type": "integer", "minimum": 0},
+              "queue_overflow": {"type": "integer", "minimum": 0}
+            }
+          },
+          "log": {"type": "string", "minLength": 1},
+          "time_report": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  }
+}

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -528,7 +528,10 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     assert '--soak-profile one-hour' in reliability_doc
     assert '--hardware-label' in reliability_doc
     assert '--max-peak-rss-mib' in reliability_doc
-    assert 'soak-report-v1.schema.json' in reliability_doc
+    assert '--telemetry-interval-secs' in reliability_doc
+    assert 'soak-report-v2.schema.json' in reliability_doc
+    assert 'schema v1 remains published' in reliability_doc
+    assert 'SIGKILL' in reliability_doc
     assert 'GNU `time`' in reliability_doc
     assert '3,600 or 28,800 seconds' in reliability_doc
     assert '(operational-reliability.md)' in (

--- a/lidarslam/test/test_map_soak_runner.py
+++ b/lidarslam/test/test_map_soak_runner.py
@@ -32,7 +32,13 @@
 import argparse
 import importlib.util
 import json
+import os
 from pathlib import Path
+import signal
+import sys
+import threading
+import time
+from types import SimpleNamespace
 
 import jsonschema
 import pytest
@@ -45,6 +51,12 @@ SPEC = importlib.util.spec_from_file_location(
 )
 SOAK = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(SOAK)
+
+
+def _schema_v2() -> dict:
+    return json.loads(
+        (ROOT / 'docs/schemas/soak-report-v2.schema.json').read_text()
+    )
 
 
 def _args(tmp_path: Path, **overrides) -> argparse.Namespace:
@@ -68,6 +80,7 @@ def _args(tmp_path: Path, **overrides) -> argparse.Namespace:
         'max_output_gib': 1.0,
         'max_dropped_inputs': 0,
         'min_free_space_gib': 0.01,
+        'telemetry_interval_secs': 30.0,
     }
     values.update(overrides)
     return argparse.Namespace(**values)
@@ -78,6 +91,13 @@ def test_profiles_are_exactly_one_and_eight_hours():
         'one-hour': 3600.0,
         'eight-hour': 28800.0,
     }
+
+
+def test_telemetry_interval_is_positive_and_at_most_sixty_seconds():
+    assert SOAK._telemetry_interval('0.25') == 0.25
+    assert SOAK._telemetry_interval('60') == 60.0
+    with pytest.raises(argparse.ArgumentTypeError, match='exceed'):
+        SOAK._telemetry_interval('60.01')
 
 
 def test_parse_gnu_time_reports_wall_rss_and_exit():
@@ -120,10 +140,27 @@ def test_successful_soak_writes_schema_valid_threshold_evidence(tmp_path):
     args = _args(tmp_path)
     ticks = iter([0.0, 0.0, 3600.0, 3600.0])
 
-    def fake_iteration(command, log_path, time_path):
+    def fake_iteration(
+        command,
+        log_path,
+        time_path,
+        *,
+        telemetry_interval_sec,
+        on_sample,
+    ):
+        assert telemetry_interval_sec == 30.0
+        on_sample(0.0)
         run_dir = Path(command[command.index('--output-dir') + 1])
         run_dir.mkdir(parents=True)
         (run_dir / 'map.pcd').write_bytes(b'x' * 1024)
+        on_sample(15.0)
+        checkpoint = json.loads(
+            (Path(args.output_root) / SOAK.REPORT_NAME).read_text()
+        )
+        assert checkpoint['status'] == 'running'
+        assert checkpoint['active_iteration_id'] == 'iteration-0001'
+        assert len(checkpoint['telemetry_samples']) == 2
+        jsonschema.validate(checkpoint, _schema_v2())
         log_path.write_text('', encoding='utf-8')
         time_path.write_text('fake GNU time evidence\n', encoding='utf-8')
         return (
@@ -142,11 +179,12 @@ def test_successful_soak_writes_schema_valid_threshold_evidence(tmp_path):
     assert report['status'] == 'passed'
     assert report['metrics']['iterations_completed'] == 1
     assert report['metrics']['wall_time_sec'] == 3600.0
+    assert len(report['telemetry_samples']) == 2
+    assert report['telemetry_samples'][1]['output_size_bytes'] == 1024
+    assert report['active_iteration_id'] is None
     assert all(report['checks'].values())
     saved = json.loads((Path(args.output_root) / SOAK.REPORT_NAME).read_text())
-    schema = json.loads(
-        (ROOT / 'docs/schemas/soak-report-v1.schema.json').read_text()
-    )
+    schema = _schema_v2()
     jsonschema.Draft7Validator.check_schema(schema)
     jsonschema.validate(saved, schema)
 
@@ -155,7 +193,15 @@ def test_failed_iteration_stops_and_preserves_failed_report(tmp_path):
     args = _args(tmp_path)
     ticks = iter([0.0, 0.0, 12.0])
 
-    def fake_iteration(command, log_path, time_path):
+    def fake_iteration(
+        command,
+        log_path,
+        time_path,
+        *,
+        telemetry_interval_sec,
+        on_sample,
+    ):
+        on_sample(0.0)
         log_path.write_text('Dropping scan: queue full\n', encoding='utf-8')
         time_path.write_text('fake GNU time evidence\n', encoding='utf-8')
         return (
@@ -183,7 +229,14 @@ def test_telemetry_failure_becomes_terminal_evidence(tmp_path):
     args = _args(tmp_path)
     ticks = iter([0.0, 0.0, 3.0])
 
-    def broken_iteration(command, log_path, time_path):
+    def broken_iteration(
+        command,
+        log_path,
+        time_path,
+        *,
+        telemetry_interval_sec,
+        on_sample,
+    ):
         raise ValueError('GNU time report lacks fields')
 
     exit_code, report = SOAK.run_soak(
@@ -206,7 +259,15 @@ def test_resource_budget_failure_stops_before_another_iteration(tmp_path):
     ticks = iter([0.0, 0.0, 10.0])
     calls = []
 
-    def over_budget_iteration(command, log_path, time_path):
+    def over_budget_iteration(
+        command,
+        log_path,
+        time_path,
+        *,
+        telemetry_interval_sec,
+        on_sample,
+    ):
+        on_sample(0.0)
         calls.append(command)
         return (
             0,
@@ -224,6 +285,205 @@ def test_resource_budget_failure_stops_before_another_iteration(tmp_path):
     assert len(calls) == 1
     assert report['checks']['peak_rss_within_budget'] is False
     assert report['last_error'].endswith('failed peak_rss_within_budget')
+
+
+def test_periodic_low_space_sample_aborts_and_preserves_evidence(
+    tmp_path,
+    monkeypatch,
+):
+    args = _args(tmp_path, min_free_space_gib=1.0)
+    ticks = iter([0.0, 0.0, 4.0])
+    monkeypatch.setattr(
+        SOAK.shutil,
+        'disk_usage',
+        lambda path: SimpleNamespace(free=512 * 1024**2),
+    )
+
+    def sample_iteration(
+        command,
+        log_path,
+        time_path,
+        *,
+        telemetry_interval_sec,
+        on_sample,
+    ):
+        on_sample(4.0)
+        raise AssertionError('low-space callback must abort the iteration')
+
+    exit_code, report = SOAK.run_soak(
+        args,
+        clock=lambda: next(ticks),
+        run_iteration=sample_iteration,
+    )
+
+    assert exit_code == 1
+    assert report['status'] == 'failed'
+    assert report['metrics']['iterations_failed'] == 1
+    assert report['metrics']['minimum_free_space_bytes'] == 512 * 1024**2
+    assert len(report['telemetry_samples']) == 1
+    assert report['checks']['free_space_within_budget'] is False
+    assert 'fell below minimum_free_space_bytes' in report['last_error']
+    saved = json.loads((Path(args.output_root) / SOAK.REPORT_NAME).read_text())
+    assert saved['telemetry_samples'] == report['telemetry_samples']
+
+
+def test_periodic_output_growth_aborts_before_iteration_finishes(tmp_path):
+    args = _args(tmp_path, max_output_gib=1.0 / 1024**3)
+    ticks = iter([0.0, 0.0, 2.0])
+
+    def growing_iteration(
+        command,
+        log_path,
+        time_path,
+        *,
+        telemetry_interval_sec,
+        on_sample,
+    ):
+        run_dir = Path(command[command.index('--output-dir') + 1])
+        run_dir.mkdir(parents=True)
+        (run_dir / 'growing.map').write_bytes(b'xx')
+        on_sample(2.0)
+        raise AssertionError('output-budget callback must abort the iteration')
+
+    exit_code, report = SOAK.run_soak(
+        args,
+        clock=lambda: next(ticks),
+        run_iteration=growing_iteration,
+    )
+
+    assert exit_code == 1
+    assert report['metrics']['output_size_bytes'] == 2
+    assert report['checks']['output_size_within_budget'] is False
+    assert 'failed output_size_within_budget' in report['last_error']
+
+
+def test_iteration_callback_failure_terminates_process_group(tmp_path):
+    log_path = tmp_path / 'iteration.log'
+    time_path = tmp_path / 'iteration.time'
+    started = time.monotonic()
+
+    with pytest.raises(RuntimeError, match='stop now'):
+        SOAK._run_iteration(
+            [sys.executable, '-c', 'import time; time.sleep(30)'],
+            log_path,
+            time_path,
+            telemetry_interval_sec=0.01,
+            on_sample=lambda elapsed: (_ for _ in ()).throw(
+                RuntimeError('stop now')
+            ),
+        )
+
+    assert time.monotonic() - started < 2.0
+
+
+def test_real_iteration_emits_periodic_and_final_samples(tmp_path):
+    log_path = tmp_path / 'iteration.log'
+    time_path = tmp_path / 'iteration.time'
+    samples = []
+
+    return_code, resources, dropped = SOAK._run_iteration(
+        [sys.executable, '-c', 'import time; time.sleep(0.08)'],
+        log_path,
+        time_path,
+        telemetry_interval_sec=0.02,
+        on_sample=samples.append,
+    )
+
+    assert return_code == 0
+    assert resources['exit_code'] == 0
+    assert resources['wall_time_sec'] >= 0.08
+    assert dropped == {
+        'message_filter': 0,
+        'scan_drop': 0,
+        'queue_overflow': 0,
+    }
+    assert samples[0] == 0.0
+    assert len(samples) >= 3
+    assert samples == sorted(samples)
+
+
+def test_real_iteration_forwards_sigterm_and_restores_handler(tmp_path):
+    log_path = tmp_path / 'iteration.log'
+    time_path = tmp_path / 'iteration.time'
+    previous_handler = signal.getsignal(signal.SIGTERM)
+    timer = threading.Timer(
+        0.1,
+        lambda: os.kill(os.getpid(), signal.SIGTERM),
+    )
+    started = time.monotonic()
+    timer.start()
+    try:
+        with pytest.raises(SOAK.TerminationSignal) as raised:
+            SOAK._run_iteration(
+                [sys.executable, '-c', 'import time; time.sleep(30)'],
+                log_path,
+                time_path,
+                telemetry_interval_sec=0.02,
+                on_sample=lambda elapsed: None,
+            )
+    finally:
+        timer.cancel()
+
+    assert raised.value.signum == signal.SIGTERM
+    assert signal.getsignal(signal.SIGTERM) == previous_handler
+    assert time.monotonic() - started < 2.0
+
+
+def test_keyboard_interrupt_is_terminal_and_returns_130(tmp_path):
+    args = _args(tmp_path)
+    ticks = iter([0.0, 0.0, 2.0])
+
+    def interrupted_iteration(
+        command,
+        log_path,
+        time_path,
+        *,
+        telemetry_interval_sec,
+        on_sample,
+    ):
+        on_sample(1.0)
+        raise KeyboardInterrupt
+
+    exit_code, report = SOAK.run_soak(
+        args,
+        clock=lambda: next(ticks),
+        run_iteration=interrupted_iteration,
+    )
+
+    assert exit_code == 130
+    assert report['status'] == 'interrupted'
+    assert report['metrics']['iterations_failed'] == 1
+    assert report['active_iteration_id'] is None
+    assert report['last_error'].endswith('interrupted by SIGINT')
+
+
+def test_sigterm_is_terminal_and_returns_143(tmp_path):
+    args = _args(tmp_path)
+    ticks = iter([0.0, 0.0, 2.0])
+
+    def terminated_iteration(
+        command,
+        log_path,
+        time_path,
+        *,
+        telemetry_interval_sec,
+        on_sample,
+    ):
+        on_sample(1.0)
+        raise SOAK.TerminationSignal(signal.SIGTERM)
+
+    exit_code, report = SOAK.run_soak(
+        args,
+        clock=lambda: next(ticks),
+        run_iteration=terminated_iteration,
+    )
+
+    assert exit_code == 143
+    assert report['status'] == 'interrupted'
+    assert report['metrics']['iterations_failed'] == 1
+    assert report['active_iteration_id'] is None
+    assert report['last_error'].endswith('interrupted by SIGTERM')
+    jsonschema.validate(report, _schema_v2())
 
 
 def test_existing_output_is_never_overwritten(tmp_path):

--- a/scripts/run_map_soak.py
+++ b/scripts/run_map_soak.py
@@ -41,6 +41,7 @@ from pathlib import Path
 import re
 import shlex
 import shutil
+import signal
 import subprocess
 import time
 from typing import Callable
@@ -54,8 +55,10 @@ PROFILE_DURATIONS = {
 REPORT_NAME = 'soak_report.json'
 SCHEMA_URI = (
     'https://rsasaki0109.github.io/lidar_slam_ros2/'
-    'schemas/soak-report-v1.schema.json'
+    'schemas/soak-report-v2.schema.json'
 )
+DEFAULT_TELEMETRY_INTERVAL_SECS = 30.0
+PROCESS_SHUTDOWN_GRACE_SECS = 10.0
 DROP_SIGNATURES = {
     'message_filter': re.compile(r'Message Filter.*dropp', re.IGNORECASE),
     'scan_drop': re.compile(r'dropp(?:ed|ing).*scan', re.IGNORECASE),
@@ -66,6 +69,18 @@ GNU_TIME_KEYS = {
     'peak_rss': 'Maximum resident set size (kbytes)',
     'exit_status': 'Exit status',
 }
+
+
+class TerminationSignal(RuntimeError):
+    """Represent a service termination delivered while an iteration runs."""
+
+    def __init__(self, signum: int):
+        self.signum = signum
+        super().__init__(signal.Signals(signum).name)
+
+
+def _raise_termination_signal(signum: int, _frame: object) -> None:
+    raise TerminationSignal(signum)
 
 
 def _utc_now() -> str:
@@ -79,6 +94,13 @@ def _positive_finite(value: str) -> float:
         raise argparse.ArgumentTypeError('must be a positive number') from exc
     if not math.isfinite(parsed) or parsed <= 0:
         raise argparse.ArgumentTypeError('must be finite and greater than zero')
+    return parsed
+
+
+def _telemetry_interval(value: str) -> float:
+    parsed = _positive_finite(value)
+    if parsed > 60.0:
+        raise argparse.ArgumentTypeError('must not exceed 60 seconds')
     return parsed
 
 
@@ -189,6 +211,11 @@ def evaluate_report(report: dict[str, object]) -> dict[str, bool]:
         'dropped_inputs_within_budget': (
             metrics['dropped_inputs_total'] <= thresholds['max_dropped_inputs']
         ),
+        'free_space_within_budget': (
+            metrics['minimum_free_space_bytes'] is not None
+            and metrics['minimum_free_space_bytes']
+            >= thresholds['minimum_free_space_bytes']
+        ),
     }
 
 
@@ -209,6 +236,10 @@ def _run_iteration(
     command: list[str],
     log_path: Path,
     time_path: Path,
+    *,
+    telemetry_interval_sec: float,
+    on_sample: Callable[[float], None],
+    clock: Callable[[], float] = time.monotonic,
 ) -> tuple[int, dict[str, float | int], dict[str, int]]:
     gnu_time = Path('/usr/bin/time')
     if not gnu_time.is_file():
@@ -223,26 +254,71 @@ def _run_iteration(
         *command,
     ]
     with log_path.open('w', encoding='utf-8') as stream:
-        completed = subprocess.run(
+        process = subprocess.Popen(
             timed_command,
             stdout=stream,
             stderr=subprocess.STDOUT,
-            check=False,
             env=environment,
+            start_new_session=True,
         )
+        previous_sigterm_handler = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGTERM, _raise_termination_signal)
+        iteration_start = clock()
+        last_sample_elapsed: float | None = None
+        try:
+            on_sample(0.0)
+            last_sample_elapsed = 0.0
+            while True:
+                try:
+                    process.wait(timeout=telemetry_interval_sec)
+                    break
+                except subprocess.TimeoutExpired:
+                    elapsed = clock() - iteration_start
+                    on_sample(elapsed)
+                    last_sample_elapsed = elapsed
+            final_elapsed = clock() - iteration_start
+            if last_sample_elapsed is None or final_elapsed > last_sample_elapsed:
+                on_sample(final_elapsed)
+        except BaseException:
+            _terminate_process_group(process)
+            raise
+        finally:
+            signal.signal(signal.SIGTERM, previous_sigterm_handler)
     log_text = log_path.read_text(encoding='utf-8', errors='replace')
     metrics = parse_gnu_time(time_path.read_text(encoding='utf-8'))
-    return completed.returncode, metrics, count_dropped_inputs(log_text)
+    return process.returncode, metrics, count_dropped_inputs(log_text)
+
+
+def _terminate_process_group(process: subprocess.Popen) -> None:
+    """Stop and reap the timed command and every descendant in its session."""
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        process.wait(timeout=PROCESS_SHUTDOWN_GRACE_SECS)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    process.wait()
 
 
 def _initial_report(args: argparse.Namespace, cli: Path) -> dict[str, object]:
     return {
-        'schema_version': 1,
+        'schema_version': 2,
         'schema_uri': SCHEMA_URI,
         'status': 'running',
         'last_error': None,
+        'active_iteration_id': None,
         'profile': args.soak_profile,
         'target_duration_sec': PROFILE_DURATIONS[args.soak_profile],
+        'telemetry_interval_sec': args.telemetry_interval_secs,
         'started_at': _utc_now(),
         'completed_at': None,
         'hardware_label': args.hardware_label,
@@ -253,6 +329,9 @@ def _initial_report(args: argparse.Namespace, cli: Path) -> dict[str, object]:
             'max_peak_rss_mib': args.max_peak_rss_mib,
             'max_output_bytes': math.ceil(args.max_output_gib * 1024**3),
             'max_dropped_inputs': args.max_dropped_inputs,
+            'minimum_free_space_bytes': math.ceil(
+                args.min_free_space_gib * 1024**3
+            ),
         },
         'metrics': {
             'wall_time_sec': 0.0,
@@ -264,6 +343,7 @@ def _initial_report(args: argparse.Namespace, cli: Path) -> dict[str, object]:
             'minimum_free_space_bytes': None,
         },
         'checks': {},
+        'telemetry_samples': [],
         'iterations': [],
     }
 
@@ -273,7 +353,7 @@ def run_soak(
     *,
     clock: Callable[[], float] = time.monotonic,
     run_iteration: Callable[
-        [list[str], Path, Path],
+        ...,
         tuple[int, dict[str, float | int], dict[str, int]],
     ] = _run_iteration,
 ) -> tuple[int, dict[str, object]]:
@@ -316,18 +396,74 @@ def run_soak(
         if args.map_profile:
             command.extend(['--profile', args.map_profile])
         iteration_started = _utc_now()
+        report['active_iteration_id'] = iteration_id
+        _write_report_atomic(output_root, report)
+        iteration_base_elapsed = report['metrics']['wall_time_sec']
+
+        def record_sample(iteration_elapsed_sec: float) -> None:
+            free_bytes = shutil.disk_usage(output_root).free
+            output_size = directory_size_bytes(runs_dir)
+            soak_elapsed_sec = iteration_base_elapsed + iteration_elapsed_sec
+            report['telemetry_samples'].append({
+                'captured_at': _utc_now(),
+                'iteration_id': iteration_id,
+                'iteration_elapsed_sec': iteration_elapsed_sec,
+                'soak_elapsed_sec': soak_elapsed_sec,
+                'output_size_bytes': output_size,
+                'free_space_bytes': free_bytes,
+            })
+            metrics = report['metrics']
+            metrics['wall_time_sec'] = soak_elapsed_sec
+            metrics['output_size_bytes'] = output_size
+            previous_minimum = metrics['minimum_free_space_bytes']
+            metrics['minimum_free_space_bytes'] = (
+                free_bytes
+                if previous_minimum is None
+                else min(previous_minimum, free_bytes)
+            )
+            report['checks'] = evaluate_report(report)
+            _write_report_atomic(output_root, report)
+            if free_bytes < report['thresholds']['minimum_free_space_bytes']:
+                raise RuntimeError(
+                    f'{iteration_id} fell below minimum_free_space_bytes'
+                )
+            if output_size > report['thresholds']['max_output_bytes']:
+                raise RuntimeError(
+                    f'{iteration_id} failed output_size_within_budget'
+                )
+
         try:
             return_code, resources, dropped = run_iteration(
                 command,
                 log_path,
                 time_path,
+                telemetry_interval_sec=args.telemetry_interval_secs,
+                on_sample=record_sample,
             )
-        except (OSError, ValueError) as exc:
+        except (KeyboardInterrupt, TerminationSignal) as exc:
+            if isinstance(exc, TerminationSignal):
+                runner_exit_code = 128 + exc.signum
+                reason = signal.Signals(exc.signum).name
+            else:
+                runner_exit_code = 130
+                reason = 'SIGINT'
             report['metrics']['wall_time_sec'] = clock() - start
+            report['metrics']['iterations_failed'] += 1
+            report['status'] = 'interrupted'
+            report['last_error'] = f'{iteration_id} interrupted by {reason}'
+            report['active_iteration_id'] = None
+            report['completed_at'] = _utc_now()
+            report['checks'] = evaluate_report(report)
+            _write_report_atomic(output_root, report)
+            return runner_exit_code, report
+        except (OSError, RuntimeError, ValueError) as exc:
+            report['metrics']['wall_time_sec'] = clock() - start
+            report['metrics']['iterations_failed'] += 1
             report['status'] = 'failed'
             report['last_error'] = (
                 f'{iteration_id} telemetry or execution failed: {exc}'
             )
+            report['active_iteration_id'] = None
             report['completed_at'] = _utc_now()
             report['checks'] = evaluate_report(report)
             _write_report_atomic(output_root, report)
@@ -352,6 +488,7 @@ def run_soak(
             'time_report': str(time_path.relative_to(output_root)),
         }
         report['iterations'].append(iteration)
+        report['active_iteration_id'] = None
         metrics = report['metrics']
         metrics['wall_time_sec'] = elapsed
         metrics['iterations_completed'] += int(return_code == 0)
@@ -379,6 +516,7 @@ def run_soak(
             'peak_rss_within_budget',
             'output_size_within_budget',
             'dropped_inputs_within_budget',
+            'free_space_within_budget',
         )
         failed_budget = next(
             (name for name in budget_checks if not report['checks'][name]),
@@ -433,6 +571,16 @@ def parse_args() -> argparse.Namespace:
         '--min-free-space-gib',
         type=_positive_finite,
         default=5.0,
+    )
+    parser.add_argument(
+        '--telemetry-interval-secs',
+        type=_telemetry_interval,
+        default=DEFAULT_TELEMETRY_INTERVAL_SECS,
+        help=(
+            'Checkpoint free-space and output telemetry while an iteration '
+            f'is running (default: {DEFAULT_TELEMETRY_INTERVAL_SECS:g}; '
+            'maximum: 60 seconds).'
+        ),
     )
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary

- sample free space and cumulative output size throughout each running soak iteration
- atomically checkpoint schema-v2 telemetry at a configurable interval capped at 60 seconds
- stop and reap the isolated timed process group when live storage budgets fail
- preserve terminal SIGINT/SIGTERM evidence with exit codes 130/143 while keeping schema v1 published

## Why

The v1 soak report only observed storage at iteration boundaries. A single long map run could therefore exhaust its filesystem without a recent soak checkpoint or an early budget stop.

## User and operator impact

Operators get 30-second storage checkpoints by default, may tune the interval with `--telemetry-interval-secs`, and receive recoverable failed/interrupted evidence when a live storage or termination boundary is crossed. The beginner-facing three-command surface is unchanged.

## Validation

- `bash scripts/run_default_ci_checks.sh` (2590 tests, 0 errors, 0 failures, 125 skipped before the final signal additions)
- targeted `colcon test --packages-select lidarslam` and aggregate result (2592 tests, 0 errors, 0 failures, 125 skipped)
- `python3 -m pytest lidarslam/test/test_map_soak_runner.py graph_based_slam/test/test_docs_entrypoints.py -q` (26 passed)
- targeted `ament_flake8` (3 files, no problems)
- Draft 7 validation for soak-report v1 and v2
- `python3 -m mkdocs build --strict`
- `git diff --check`
