### PR TITLE
docs: record published Docker first-map evidence

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,7 @@ jobs:
           cp README.md CHANGELOG.md CONTRIBUTING.md RELEASING.md VERSION mkdocs.yml SECURITY.md SUPPORT.md CODE_OF_CONDUCT.md GOVERNANCE.md CITATION.cff release_bundle/
           cp docs/index.md docs/getting-started.md docs/product-contract.md docs/golden-path-cli.md docs/operational-reliability.md docs/real-data-e2e.md docs/distribution.md docs/rosdistro-release.md docs/autoware-map-authoring.md docs/autoware-foxglove.md docs/autoware-quickstart.md docs/workflows.md docs/benchmarking.md docs/comparison.md release_bundle/docs/
           cp configs/real_data_e2e/driving_slam_mid360_v1.json release_bundle/configs/real_data_e2e/
-          cp docs/evidence/real-data-soak-2026-07-28.md docs/evidence/real-data-soak-2026-07-28.json release_bundle/docs/evidence/
+          cp docs/evidence/real-data-soak-2026-07-28.md docs/evidence/real-data-soak-2026-07-28.json docs/evidence/docker-first-map-2026-07-28.md release_bundle/docs/evidence/
           cp docs/roadmap/v0.9.md release_bundle/docs/roadmap/
           cp docs/schemas/*.json release_bundle/docs/schemas/
           cp -r docs/assets/. release_bundle/docs/assets/

--- a/docs/evidence/docker-first-map-2026-07-28.md
+++ b/docs/evidence/docker-first-map-2026-07-28.md
@@ -1,0 +1,145 @@
+# Docker first-map trial — 2026-07-28
+
+## Result
+
+A maintainer-operated fresh-environment trial of the README Docker command
+completed the tracked MID-360 workflow and produced the versioned product
+artifacts after two onboarding defects were corrected:
+
+1. the demo selected an outer extraction directory instead of the nested
+   rosbag2 directory that contained `metadata.yaml`;
+2. the Docker default bypassed `lidarslam-map`, so a usable map lacked the
+   product manifest, verification log and diagnosis artifacts.
+
+The fixes landed in
+[PR #406](https://github.com/rsasaki0109/lidar_slam_ros2/pull/406) and
+[PR #407](https://github.com/rsasaki0109/lidar_slam_ros2/pull/407).
+The final published-image rerun passed.
+
+This is one maintainer-operated usability trial. It is direct evidence for the
+Docker first-success path, but it does not count as any of the three
+independent-user validations required before v1.0.
+
+## Trial environment
+
+| Item | Recorded value |
+| --- | --- |
+| Host | `sasaki-pc`, x86_64 |
+| Host OS | Ubuntu 24.04.4 LTS |
+| Kernel | `6.17.0-35-generic` |
+| Docker client/server | `29.4.3` / `29.4.3` |
+| ROS distribution in image | Humble |
+| Publish workflow | [develop docker image run 30340468419](https://github.com/rsasaki0109/lidar_slam_ros2/actions/runs/30340468419) |
+| Final image revision | `1fe7e20ce4f1cc60b07eb5066d1347e96abe2bf6` |
+| Final image digest | `sha256:9db1a467c99d69bd3a6d8d7a71e6555874f2a0e1e6f7d062ab2297dd7828c061` |
+| Input archive | `rosbag2_2024_04_16-14_17_01.zip`, 517,088,133 bytes |
+| Input MD5 | `0836c50859bb1af591966b69da166186` |
+| Source | Koide, *Driving SLAM Test with Livox MID360*, Zenodo DOI `10.5281/zenodo.14841855`, CC-BY 4.0 |
+
+The output directory was empty before each attempt. The first attempt also
+started without a cached dataset. The final acceptance attempt used the
+published image by digest and the README command shape:
+
+```bash
+docker run --rm \
+  -v "$PWD/lidarslam_output:/lidarslam_ws/output" \
+  ghcr.io/rsasaki0109/lidar_slam_ros2@sha256:9db1a467c99d69bd3a6d8d7a71e6555874f2a0e1e6f7d062ab2297dd7828c061
+```
+
+The moving `:humble` tag was resolved to the recorded digest before acceptance.
+
+## Failure and correction sequence
+
+### Attempt 1 — README command failed after download
+
+The initial image was revision
+`0ec55575ffc16eb008e9f24bd6c6f24700bf2f8a`, digest
+`sha256:782b5d92794f03fedc272c0ee632bca23a429769d05d3d481fc652a9f35df809`.
+It downloaded the 517.1 MB archive, verified MD5
+`0836c50859bb1af591966b69da166186`, and extracted the bag. It then exited:
+
+```text
+error: demo bag not found under /lidarslam_ws/datasets/mid360_public
+```
+
+The archive contains an outer directory and an inner rosbag2 directory with
+the same name. `run_docker_demo.sh` selected the first matching directory
+instead of selecting the directory that actually contained `metadata.yaml`.
+PR #406 changed discovery to use the metadata file and added a regression
+fixture with the same nested layout.
+
+### Attempt 2 — first map exposed a contract split
+
+With the discovery fix mounted read-only, the same image completed mapping:
+
+- 577 corrected poses and 2,687 raw poses;
+- 365 point-cloud tiles;
+- 42 Lanelet2 lanelets;
+- 127 MB output;
+- independent Autoware verification: 8 pass, 0 warn, 0 fail.
+
+The output did not contain `run_manifest.json`,
+`autoware_map_diagnosis.json`, `autoware_map_diagnosis.md`, or
+`verify_autoware_map.log`. The Docker entrypoint was calling the lower-level
+dogfood runner instead of the official product CLI, contrary to the common
+successful-output contract.
+
+PR #407 routes the default through:
+
+```bash
+lidarslam-map run "$bag" \
+  --profile rko_lio_graph_mid360_preset \
+  --output-dir /lidarslam_ws/output/mid360_demo
+```
+
+### Attempt 3 — unified candidate passed
+
+The candidate wrapper completed the installed golden path in 83.530 seconds.
+It produced a schema-v2 `run_manifest.json` with status `succeeded`, lifecycle
+stage `complete`, runner exit code `0`, and diagnosis status `success`.
+Verification reported 8 pass, 0 warn and 0 fail. Atomic finalization removed
+the `.partial` sibling.
+
+## Final published-image acceptance
+
+| Check | Result |
+| --- | --- |
+| OCI revision contains merged PR #407 | PASS — `git merge-base --is-ancestor` exit 0 |
+| Registry attestation verification | PASS — GitHub CLI 2.87.1 `gh attestation verify` exit 0 |
+| Installed `run --help` option groups | PASS — product usage plus five option groups, with no internal Python entrypoint |
+| Demo process exit code | `0` |
+| Manifest schema/status | schema `2`, status `succeeded`, profile `rko_lio_graph_mid360_preset` |
+| Lifecycle stage/runner exit | `complete` / `0`, verification enabled |
+| Diagnosis | `success` |
+| Autoware verification | PASS — 8 pass, 0 warn, 0 fail |
+| Corrected/raw poses | 576 / 2,689 |
+| Point-cloud tiles | 363 |
+| Lanelets | 42 relations |
+| Output size | 127 MB |
+| `.partial` sibling absent | PASS — 0 matching directories |
+
+Selected final artifact identities:
+
+| Artifact | SHA-256 |
+| --- | --- |
+| `run_manifest.json` | `0b5f7f01b830d77aabd97a09bb2d26054b3b6b4a2c2ad8a14cd9b1421fc2941b` |
+| `autoware_map_diagnosis.json` | `696236c2f237458c62aec959b63673c4583c1458ed0c6466595de053c0ba8270` |
+| `verify_autoware_map.log` | `f8d9a43f88615dbf2421bf1c42d303457f65e338f4836a267f6958149fbbdee5` |
+| `pointcloud_map/pointcloud_map_metadata.yaml` | `d92eeefc4b068c2cf121bb7664851a2fb03b5a100dd43c2e56347dc541355710` |
+| `traj_corrected.tum` | `001afc405f18b36c9aefb17983ca985da734fed7b2358e9d2d20c7a678eb0338` |
+
+## Findings that remain open
+
+- The first 517.1 MB download has no periodic progress display between start
+  and completion. On the trial network this looked idle for several minutes.
+- Files written to the bind mount are owned by container UID/GID `0:0`.
+  They are readable on the host but inconvenient to remove or modify without
+  an ownership-aware Docker invocation or post-run handling.
+- A moving convenience tag is appropriate for evaluation, but evidence and
+  deployment must continue to record an immutable digest.
+- This trial covers one amd64 host and Humble image. It does not replace the
+  Jazzy gate, source-workspace usability trial, arm64 evaluation, or three
+  independent-user first-map reports.
+
+These findings do not invalidate the generated map, but progress visibility
+and host-file ownership remain onboarding work before v1.0.

--- a/docs/real-data-e2e.md
+++ b/docs/real-data-e2e.md
@@ -25,11 +25,11 @@ The cache key includes the archive size and MD5. A restored cache is still
 hashed by the intake and again by the E2E validator, so a corrupt or replaced
 archive fails closed.
 
-The Zenodo record is open access but does not currently declare a license in
-its machine-readable record metadata. The workflow downloads from the
-publisher for validation and does not upload the source bag, trajectories, or
-map geometry. Its retained artifact contains only the contract, intake
-identity, run manifest, diagnosis, verification result, and logs.
+The Zenodo record declares the dataset under Creative Commons Attribution 4.0
+International. The workflow downloads from the publisher for validation and
+does not upload the source bag, trajectories, or map geometry. Its retained
+artifact contains only the contract, intake identity, run manifest, diagnosis,
+verification result, and logs.
 
 ## Blocking assertions
 

--- a/docs/roadmap/v0.9.md
+++ b/docs/roadmap/v0.9.md
@@ -103,6 +103,12 @@ Gate:
 - fixed demo and own-bag dry-run exercise the same product core;
 - clean Docker and source-workspace usability trials are recorded.
 
+The maintainer-operated
+[Docker first-map trial](../evidence/docker-first-map-2026-07-28.md) found and
+closed the nested-bag discovery blocker and unified the default container
+command with the versioned product CLI. It does not count toward the three
+independent-user reports required in Phase 4.
+
 ## 4. Phase 2 — Distribution and compatibility
 
 Deliverables:

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -72,6 +72,9 @@ SOAK_EVIDENCE_DOC = (
 SOAK_EVIDENCE_JSON = (
     REPO_ROOT / 'docs' / 'evidence' / 'real-data-soak-2026-07-28.json'
 )
+DOCKER_FIRST_MAP_EVIDENCE_DOC = (
+    REPO_ROOT / 'docs' / 'evidence' / 'docker-first-map-2026-07-28.md'
+)
 REAL_DATA_E2E_DOC = REPO_ROOT / 'docs' / 'real-data-e2e.md'
 PREFLIGHT_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'preflight-v2.schema.json'
 DIAGNOSIS_SCHEMA = REPO_ROOT / 'docs' / 'schemas' / 'diagnosis-v1.schema.json'
@@ -407,6 +410,10 @@ def test_release_metadata_and_core_package_versions_match():
         'Named-hardware soak evidence: evidence/real-data-soak-2026-07-28.md'
         in mkdocs_config
     )
+    assert (
+        'Docker first-map evidence: evidence/docker-first-map-2026-07-28.md'
+        in mkdocs_config
+    )
     assert 'Pinned real-data E2E: real-data-e2e.md' in mkdocs_config
     assert 'Autoware-Compatible Map Authoring: autoware-map-authoring.md' in mkdocs_config
     assert 'Autoware Foxglove: autoware-foxglove.md' in mkdocs_config
@@ -437,6 +444,15 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     assert 'lidarslam-map doctor' in getting_started_doc
     assert 'lidarslam-map run' in getting_started_doc
     assert 'lidarslam-map inspect' in getting_started_doc
+    assert 'Creative Commons Attribution 4.0' in real_data_e2e_doc
+    first_map_evidence = DOCKER_FIRST_MAP_EVIDENCE_DOC.read_text(encoding='utf-8')
+    assert 'FINAL_' not in first_map_evidence
+    assert 'PR #406' in first_map_evidence
+    assert 'PR #407' in first_map_evidence
+    assert 'independent-user validations' in first_map_evidence
+    assert 'docs/evidence/docker-first-map-2026-07-28.md' in (
+        RELEASE_WORKFLOW.read_text(encoding='utf-8')
+    )
     assert (
         'git clone --recursive https://github.com/rsasaki0109/lidar_slam_ros2.git'
         in getting_started_doc

--- a/graph_based_slam/test/test_mid360_robot_public_datasets.py
+++ b/graph_based_slam/test/test_mid360_robot_public_datasets.py
@@ -62,6 +62,9 @@ def test_public_dataset_registry_contains_recommended_mid360_sources():
     assert datasets['driving_slam_mid360'].file_by_id().md5 == (
         '0836c50859bb1af591966b69da166186'
     )
+    assert datasets['driving_slam_mid360'].license == (
+        'Creative Commons Attribution 4.0 International.'
+    )
     assert datasets['hard_pointcloud_mid360_outdoor_kidnap_a'].profile[
         'expected_pointcloud_topic'
     ] == '/livox/points'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Golden-path CLI: golden-path-cli.md
   - Operational reliability: operational-reliability.md
   - Named-hardware soak evidence: evidence/real-data-soak-2026-07-28.md
+  - Docker first-map evidence: evidence/docker-first-map-2026-07-28.md
   - Pinned real-data E2E: real-data-e2e.md
   - Distribution and installed CLI: distribution.md
   - Autoware-Compatible Map Authoring: autoware-map-authoring.md

--- a/scripts/mid360_robot_public_datasets.py
+++ b/scripts/mid360_robot_public_datasets.py
@@ -99,7 +99,7 @@ PUBLIC_MID360_DATASETS: dict[str, PublicDataset] = {
         title='Driving SLAM Test with Livox MID360',
         source_url='https://zenodo.org/records/14841855',
         description='Small ROS2 bag for LiDAR-IMU SLAM testing with a Livox MID-360.',
-        license='See Zenodo record.',
+        license='Creative Commons Attribution 4.0 International.',
         citation='Koide, Kenji. Driving SLAM Test with Livox MID360. Zenodo. DOI: 10.5281/zenodo.14841855',
         files=(
             PublicDatasetFile(


### PR DESCRIPTION
## Summary
- record the clean-environment first-map trial against the published Humble image digest
- connect the evidence to the product roadmap, documentation navigation, and release bundle
- align the tracked Zenodo dataset license with its current CC-BY 4.0 record

## Published-image acceptance
- digest: `sha256:9db1a467c99d69bd3a6d8d7a71e6555874f2a0e1e6f7d062ab2297dd7828c061`
- revision: `1fe7e20ce4f1cc60b07eb5066d1347e96abe2bf6`
- provenance attestation: verified
- manifest: schema 2, succeeded, lifecycle complete, runner exit 0
- map verification: 8 pass, 0 warn, 0 fail
- outputs: 576 corrected poses, 2,689 raw poses, 363 PCD tiles, 42 Lanelets

## Validation
- `python3 -m pytest -q graph_based_slam/test/test_docs_entrypoints.py graph_based_slam/test/test_mid360_robot_public_datasets.py` (15 passed)
- `python3 -m pytest -q graph_based_slam/test/test_docker_demo_script.py` (2 passed)
- `python3 -m compileall -q scripts graph_based_slam/test`
- `python3 -m mkdocs build --strict`
- `git diff --check`