### PR TITLE
Score dense graph-corrected trajectories

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -247,10 +247,17 @@ bash scripts/run_rko_lio_mid360_crossval_benchmark.sh \
 Typical outputs are written under:
 
 - `output/bench_rko_lio_ntu_viral_<name>/traj_raw_prism.tum`
+- `output/bench_rko_lio_ntu_viral_<name>/traj_corrected_sparse.tum`
 - `output/bench_rko_lio_ntu_viral_<name>/traj_corrected_prism.tum`
 - `output/bench_rko_lio_ntu_viral_<name>/ape_raw_vs_gt.txt`
 - `output/bench_rko_lio_ntu_viral_<name>/ape_corrected_vs_gt.txt`
 - `output/bench_rko_lio_ntu_viral_<name>/metrics.json`
+
+`traj_corrected_sparse.tum` preserves the optimized graph-node poses emitted
+by `/modified_path`. The canonical `traj_corrected.tum` and
+`traj_corrected_prism.tum` propagate those corrections onto every raw pose, so
+the corrected APE and `metrics.json` describe a full-rate trajectory rather
+than sparse nearest-neighbour samples.
 
 ## Loop Cloud-Overlap Gate
 

--- a/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
+++ b/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
@@ -77,6 +77,21 @@ def test_trajectory_only_mode_uses_full_dump_as_explicit_passthrough():
     assert 'cp "${BACKEND_TUMS[0]}" "$RAW_TUM"' in script
 
 
+def test_sparse_graph_corrections_are_propagated_to_full_rate_trajectory():
+    """The scored corrected artifact must retain the raw pose sampling rate."""
+    script = BENCHMARK_SCRIPT.read_text(encoding='utf-8')
+    assert (
+        'CORRECTED_SPARSE_TUM="${OUTPUT_DIR}/traj_corrected_sparse.tum"'
+        in script
+    )
+    assert 'CORRECTED_TUM="${OUTPUT_DIR}/traj_corrected.tum"' in script
+    assert '"${SCRIPT_DIR}/densify_corrected_trajectory.py"' in script
+    assert '--corrected "$CORRECTED_SPARSE_TUM"' in script
+    assert '--output "$CORRECTED_TUM"' in script
+    assert '--est "$CORRECTED_TUM_PRISM"' in script
+    assert '--sparse-match' not in script
+
+
 def test_reference_offset_failure_is_not_masked_by_process_substitution():
     script = BENCHMARK_SCRIPT.read_text(encoding='utf-8')
     assert 'if ! PRISM_TRANSFORM_OUTPUT="$(python3' in script

--- a/scripts/run_rko_lio_graph_benchmark.sh
+++ b/scripts/run_rko_lio_graph_benchmark.sh
@@ -315,6 +315,7 @@ PY
 LAUNCH_LOG="${OUTPUT_DIR}/slam.launch.log"
 MAP_SAVE_LOG="${OUTPUT_DIR}/map_save.log"
 RAW_TUM="${OUTPUT_DIR}/traj_raw.tum"
+CORRECTED_SPARSE_TUM="${OUTPUT_DIR}/traj_corrected_sparse.tum"
 CORRECTED_TUM="${OUTPUT_DIR}/traj_corrected.tum"
 RAW_TUM_PRISM="${OUTPUT_DIR}/traj_raw_prism.tum"
 CORRECTED_TUM_PRISM="${OUTPUT_DIR}/traj_corrected_prism.tum"
@@ -479,7 +480,7 @@ run_state_signature() {
   # Trajectory files only: the launch log keeps growing with TF warnings on
   # some bags, which would starve a log-based quiescence check forever and
   # burn the whole --offline-timeout-secs budget after the bag is processed.
-  python3 - "$RAW_TUM" "$CORRECTED_TUM" <<'PY'
+  python3 - "$RAW_TUM" "$CORRECTED_SPARSE_TUM" <<'PY'
 import os
 import sys
 
@@ -707,7 +708,7 @@ RAW_LOGGER_PID="$!"
 
 python3 "${SCRIPT_DIR}/path_to_tum.py" \
   --topic /modified_path \
-  --output "$CORRECTED_TUM" \
+  --output "$CORRECTED_SPARSE_TUM" \
   --use-sim-time false \
   >"${CORRECTED_LOG}" 2>&1 &
 CORRECTED_LOGGER_PID="$!"
@@ -768,14 +769,19 @@ if [[ "$SKIP_MAP_SAVE" == "true" ]]; then
   )
   if [[ "${#BACKEND_TUMS[@]}" -eq 1 && -s "${BACKEND_TUMS[0]}" ]]; then
     cp "${BACKEND_TUMS[0]}" "$RAW_TUM"
-    cp "${BACKEND_TUMS[0]}" "$CORRECTED_TUM"
+    cp "${BACKEND_TUMS[0]}" "$CORRECTED_SPARSE_TUM"
     echo "Trajectory-only passthrough from full-rate dump: ${BACKEND_TUMS[0]}"
   else
     die "trajectory-only run expected exactly one full-rate TUM dump"
   fi
-elif [[ ! -s "$CORRECTED_TUM" ]]; then
+elif [[ ! -s "$CORRECTED_SPARSE_TUM" ]]; then
   die "corrected trajectory missing after map_save"
 fi
+
+python3 "${SCRIPT_DIR}/densify_corrected_trajectory.py" \
+  --raw "$RAW_TUM" \
+  --corrected "$CORRECTED_SPARSE_TUM" \
+  --output "$CORRECTED_TUM"
 
 python3 "${SCRIPT_DIR}/apply_tum_frame_offset.py" \
   --in "$RAW_TUM" \
@@ -799,7 +805,6 @@ python3 "${SCRIPT_DIR}/ape_from_tum.py" \
 python3 "${SCRIPT_DIR}/ape_from_tum.py" \
   --ref "$REFERENCE_TUM" \
   --est "$CORRECTED_TUM_PRISM" \
-  --sparse-match \
   --out "$CORRECTED_APE"
 
 BENCH_T1="$(python3 - <<'PY'


### PR DESCRIPTION
## What changed

- preserve `/modified_path` graph-node poses as `traj_corrected_sparse.tum`
- propagate graph corrections onto every raw pose with the existing `densify_corrected_trajectory.py`
- score and publish the dense corrected trajectory as the canonical `traj_corrected.tum` / `traj_corrected_prism.tum`
- document the sparse and dense artifact contract and add wrapper regression coverage

## Why

The RKO graph benchmark previously scored sparse submap poses with
nearest-neighbour matching. On dense references this rejected large portions
of the reference and compared current reference positions with graph poses up
to several seconds old, so corrected APE did not represent the delivered
trajectory.

## Impact

Corrected APE and `metrics.json` now describe a full-rate trajectory with the
same sampling timestamps as raw odometry. The original sparse graph output
remains available for diagnostics.

## Validation

- `source /opt/ros/jazzy/setup.bash && python3 -m pytest -q graph_based_slam/test` — 1347 passed, 13 skipped
- focused benchmark/densification/metrics tests — 27 passed
- `bash -n scripts/run_rko_lio_graph_benchmark.sh`
- `git diff --check`
- NTU tnp_01 diagnostic: 90 sparse anchors propagated to 5794 corrected poses; dense corrected APE 1.09984 m (reveals a separate loop-policy regression, versus the misleading sparse score 1.56743 m)
