### PR TITLE
Add validated NTU graph profile

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -172,6 +172,7 @@ errors are compared, matching the position-only public-suite ATE semantics.
 That wrapper:
 
 - uses the bundled NTU VIRAL `rosbag2`
+- selects the validated `lidarslam/param/lidarslam_ntu_viral.yaml` graph profile
 - runs `RKO-LIO + graph_based_slam`
 - saves raw and corrected trajectories
 - computes APE against the Leica prism reference

--- a/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
+++ b/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
@@ -70,6 +70,15 @@ def test_rko_lio_benchmark_help_exits_successfully():
     assert '--skip-reference-gen' in result.stderr
 
 
+def test_default_graph_profile_is_the_validated_ntu_configuration():
+    """The zero-option golden benchmark must use the NTU release profile."""
+    script = BENCHMARK_SCRIPT.read_text(encoding='utf-8')
+    assert (
+        'DEFAULT_LIDARSLAM_PARAM="${REPO_ROOT}/lidarslam/param/'
+        'lidarslam_ntu_viral.yaml"'
+    ) in script
+
+
 def test_trajectory_only_mode_uses_full_dump_as_explicit_passthrough():
     script = BENCHMARK_SCRIPT.read_text(encoding='utf-8')
     assert 'find "$OUTPUT_DIR" -mindepth 2 -maxdepth 2' in script

--- a/lidarslam/param/lidarslam_ntu_viral.yaml
+++ b/lidarslam/param/lidarslam_ntu_viral.yaml
@@ -1,0 +1,79 @@
+scan_matcher:
+  ros__parameters:
+    global_frame_id: "map"
+    robot_frame_id: "base_link"
+    registration_method: "NDT"
+    ndt_resolution: 2.0
+    ndt_num_threads: 2
+    gicp_corr_dist_threshold: 5.0
+    trans_for_mapupdate: 1.5
+    vg_size_for_input: 0.5
+    vg_size_for_map: 0.1
+    use_min_max_filter: true
+    scan_min_range: 1.0
+    scan_max_range: 200.0
+    scan_period: 0.2
+    map_publish_period: 15.0
+    num_targeted_cloud: 20
+    set_initial_pose: true
+    initial_pose_x: 0.0
+    initial_pose_y: 0.0
+    initial_pose_z: 0.0
+    initial_pose_qx: 0.0
+    initial_pose_qy: 0.0
+    initial_pose_qz: 0.0
+    initial_pose_qw: 1.0
+    use_imu: false
+    use_odom: false
+    odom_prior_planar: false
+    odom_prior_translation_only: false
+    odom_prior_suspect_recovery_only: false
+    odom_prior_weight: 1.0
+    debug_flag: false
+
+graph_based_slam:
+    ros__parameters:
+      registration_method: "NDT"
+      ndt_resolution: 1.0
+      ndt_num_threads: 2
+      voxel_leaf_size: 0.1
+      threshold_loop_closure_score: 0.7
+      distance_loop_closure: 100.0
+      range_of_searching_loop_closure: 20.0
+      search_submap_num: 2
+      loop_search_query_stride: 1
+      max_loop_candidate_count: 3
+      loop_edge_dedup_index_window: 8
+      # Tnp_01 clean validation rejects larger mainly-vertical corrections:
+      # raw 0.99685 m -> dense graph-corrected 0.96421 m with this cap.
+      loop_max_translation_delta: 0.3
+      loop_max_rotation_delta_deg: 2.0
+      loop_min_overlap_ratio: 0.76
+      loop_min_overlap_ratio_large_correction: 0.0
+      loop_overlap_large_correction_translation_m: 0.0
+      loop_overlap_max_distance_m: 0.5
+      num_adjacent_pose_cnstraints: 5
+      use_save_map_in_loop: true
+      map_leaf_size: 0.1
+      adjacent_edge_info_weight: 1000.0
+      use_gnss: false
+      gnss_topic: "/gnss/fix"
+      gnss_info_weight: 1.0
+      gnss_use_covariance_weighting: true
+      gnss_covariance_min_variance_m2: 0.01
+      gnss_covariance_max_variance_m2: 25.0
+      gnss_rtk_fix_max_horizontal_stddev_m: 0.3
+      gnss_rtk_fix_weight_scale: 3.0
+      gnss_non_rtk_weight_scale: 1.0
+      use_dynamic_object_filter: false
+      dynamic_object_filter_voxel_size: 0.3
+      dynamic_object_filter_min_observations: 2
+      dynamic_object_filter_temporal_window: 5
+      dynamic_object_filter_max_range_from_sensor_m: 30.0
+      use_planar_map_filter: true
+      planar_map_filter_voxel_size: 0.1
+      planar_map_filter_min_neighbors: 3
+      planar_map_filter_max_small_eigenvalue_ratio: 0.24
+      planar_map_filter_min_middle_eigenvalue_ratio: 0.0
+      planar_map_filter_min_retained_ratio: 0.90
+      debug_flag: true

--- a/scripts/run_rko_lio_graph_benchmark.sh
+++ b/scripts/run_rko_lio_graph_benchmark.sh
@@ -95,7 +95,7 @@ DEFAULT_REFERENCE_META="${REPO_ROOT}/output/ntu_viral_tnp01_reference.json"
 DEFAULT_LIDAR_TOPIC="/os1_cloud_node1/points"
 DEFAULT_IMU_TOPIC="/imu/imu"
 DEFAULT_BASE_FRAME="base_link"
-DEFAULT_LIDARSLAM_PARAM="${REPO_ROOT}/lidarslam/param/lidarslam.yaml"
+DEFAULT_LIDARSLAM_PARAM="${REPO_ROOT}/lidarslam/param/lidarslam_ntu_viral.yaml"
 DEFAULT_RKO_PARAM="${REPO_ROOT}/lidarslam/param/rko_lio_ntu_viral.yaml"
 
 BAG_PATH="$DEFAULT_BAG"


### PR DESCRIPTION
## What changed

- add `lidarslam_ntu_viral.yaml` as a dataset-specific graph profile
- set its loop translation correction cap to the validated 0.3 m
- make the zero-option NTU benchmark select that profile by default
- retain the shared 0.5 m profile required by Construction Seq2
- document and regression-test the default profile contract

## Why

Full-rate corrected scoring exposed that NTU tnp_01 loop candidates with
roughly 0.4–0.5 m, mainly vertical corrections degraded APE. A bounded clean
A/B showed that 0.3 m rejects the harmful corrections while retaining useful
loop closure. This belongs in a dataset profile rather than the shared graph
configuration because Construction Seq2 has validated loops up to 0.432 m.

## Validation

- clean NTU tnp_01 run at merge commit `004b1b1`
- raw APE RMSE: 0.9968498414 m
- dense corrected APE RMSE: 0.9642061352 m
- 5794 corrected poses from 91 graph anchors
- Autoware map verification: PASS (8 pass, 0 warn, 0 fail)
- git provenance: clean
- `source /opt/ros/jazzy/setup.bash && python3 -m pytest -q graph_based_slam/test` — 1352 passed, 13 skipped
- focused benchmark/densification/metrics tests — 28 passed
- YAML semantic diff against the shared profile contains only `loop_max_translation_delta: 0.5 -> 0.3`
- `bash -n scripts/run_rko_lio_graph_benchmark.sh`
- `git diff --check`
