### PR TITLE
Tune the NTU frontend profile

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -173,6 +173,8 @@ That wrapper:
 
 - uses the bundled NTU VIRAL `rosbag2`
 - selects the validated `lidarslam/param/lidarslam_ntu_viral.yaml` graph profile
+- uses the official-calibration `rko_lio_ntu_viral.yaml` frontend profile with
+  the bounded tnp_01 voxel/gravity tuning
 - runs `RKO-LIO + graph_based_slam`
 - saves raw and corrected trajectories
 - computes APE against the Leica prism reference

--- a/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
+++ b/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
@@ -34,9 +34,12 @@ from __future__ import annotations
 from pathlib import Path
 import subprocess
 
+import yaml
+
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BENCHMARK_SCRIPT = REPO_ROOT / 'scripts' / 'run_rko_lio_graph_benchmark.sh'
+NTU_RKO_PROFILE = REPO_ROOT / 'lidarslam' / 'param' / 'rko_lio_ntu_viral.yaml'
 
 
 def _run_benchmark(*args: str) -> subprocess.CompletedProcess[str]:
@@ -77,6 +80,17 @@ def test_default_graph_profile_is_the_validated_ntu_configuration():
         'DEFAULT_LIDARSLAM_PARAM="${REPO_ROOT}/lidarslam/param/'
         'lidarslam_ntu_viral.yaml"'
     ) in script
+
+
+def test_default_ntu_frontend_profile_keeps_calibration_and_tuned_resolution():
+    """The golden profile must combine official extrinsics with bounded tuning."""
+    profile = yaml.safe_load(NTU_RKO_PROFILE.read_text(encoding='utf-8'))
+    assert profile['extrinsic_lidar2base_quat_xyzw_xyz'] == [
+        0.0, 0.0, 0.0, 1.0, -0.05, 0.0, 0.055,
+    ]
+    assert profile['voxel_size'] == 1.5
+    assert profile['gravity_window_alignment'] is True
+    assert profile['gravity_alignment_gain'] == 0.2
 
 
 def test_trajectory_only_mode_uses_full_dump_as_explicit_passthrough():

--- a/lidarslam/param/rko_lio_ntu_viral.yaml
+++ b/lidarslam/param/rko_lio_ntu_viral.yaml
@@ -6,7 +6,11 @@ extrinsic_lidar2base_quat_xyzw_xyz: [0.0, 0.0, 0.0, 1.0, -0.05, 0.0, 0.055]
 lidar_timestamps.offset_seconds: 0.0
 initialization_phase: true
 deskew: true
-voxel_size: 0.35
+# Clean tnp_01 sweep: 1.4 m regressed and 1.7 m became unstable; 1.5 m is the
+# bounded optimum while preserving the official body_T_lidar calibration.
+voxel_size: 1.5
+gravity_window_alignment: true
+gravity_alignment_gain: 0.2
 icp_keypoint_voxel_multiplier: 1.5
 max_points_per_voxel: 20
 min_range: 1.0


### PR DESCRIPTION
## What changed

- tune the maintained NTU RKO-LIO profile to `voxel_size: 1.5`
- enable bounded sliding-window gravity alignment at gain 0.2
- preserve and regression-test the official NTU `body_T_lidar` calibration
- document the validated frontend profile in the recommended benchmark

## Why

The previous maintained profile produced roughly 2.03 m raw APE on tnp_01.
A bounded voxel/gravity sweep reduced this substantially. A calibration audit
also found that an early diagnostic candidate had used the inverse lever arm;
this PR deliberately keeps the official calibration even though the
calibration-correct result does not yet meet the blocking 1.0 m target.

## Evidence

With official `body_T_lidar`, voxel 1.5, gravity gain 0.2, and the merged NTU
graph profile:

- raw APE RMSE: 1.0697216394 m
- dense corrected APE RMSE: 1.0637680548 m
- 5794/5795 output poses
- Autoware map verification: PASS
- git provenance: clean at `8c39817`

Bounded rejects:

- voxel 1.4: 1.1248805014 m raw
- voxel 1.7: 4.0404384554 m raw (unstable)
- gravity gain 0.3: 1.2045269880 m raw

The <=1.0 m release gate remains open and is not weakened by this PR.

## Validation

- `source /opt/ros/jazzy/setup.bash && python3 -m pytest -q graph_based_slam/test` — 1353 passed, 13 skipped
- focused benchmark/densification/metrics tests — 29 passed
- `bash -n scripts/run_rko_lio_graph_benchmark.sh`
- `git diff --check`
