### PR TITLE
Make the canonical NTU benchmark lossless and pass its APE gate

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -174,8 +174,9 @@ That wrapper:
 - uses the bundled NTU VIRAL `rosbag2`
 - selects the validated `lidarslam/param/lidarslam_ntu_viral.yaml` graph profile
 - uses the official-calibration `rko_lio_ntu_viral.yaml` frontend profile with
-  the bounded tnp_01 voxel/gravity tuning
+  the bounded tnp_01 voxel/gravity tuning and offline output backpressure
 - runs `RKO-LIO + graph_based_slam`
+- waits for graph ingestion to become quiescent before the final map save
 - saves raw and corrected trajectories
 - computes APE against the Leica prism reference
 - verifies the Autoware map bundle when present

--- a/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
+++ b/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
@@ -89,8 +89,7 @@ def test_default_ntu_frontend_profile_keeps_calibration_and_tuned_resolution():
         0.0, 0.0, 0.0, 1.0, -0.05, 0.0, 0.055,
     ]
     assert profile['voxel_size'] == 1.5
-    assert profile['gravity_window_alignment'] is True
-    assert profile['gravity_alignment_gain'] == 0.2
+    assert profile['gravity_window_alignment'] is False
     assert profile['async.output_publish_delay_ms'] == 20
 
 

--- a/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
+++ b/graph_based_slam/test/test_rko_lio_graph_benchmark_script.py
@@ -91,6 +91,17 @@ def test_default_ntu_frontend_profile_keeps_calibration_and_tuned_resolution():
     assert profile['voxel_size'] == 1.5
     assert profile['gravity_window_alignment'] is True
     assert profile['gravity_alignment_gain'] == 0.2
+    assert profile['async.output_publish_delay_ms'] == 20
+
+
+def test_default_ntu_graph_profile_buffers_fast_offline_frontend_bursts():
+    """Loop search must not drop synchronized pairs from the 10x frontend."""
+    profile_path = REPO_ROOT / 'lidarslam' / 'param' / 'lidarslam_ntu_viral.yaml'
+    profile = yaml.safe_load(profile_path.read_text(encoding='utf-8'))
+    graph = profile['graph_based_slam']['ros__parameters']
+
+    assert graph['odom_cloud_sync_queue_size'] == 1024
+    assert graph['use_save_map_in_loop'] is False
 
 
 def test_trajectory_only_mode_uses_full_dump_as_explicit_passthrough():
@@ -140,6 +151,22 @@ def test_quiet_completion_requires_substantial_bag_progress():
     assert 'raw_tum_reached_fraction 0.8' in script
     assert '[[ -n "$end_stamp" ]]' in script
     assert 'aborted-but-scoreable' not in script
+
+
+def test_map_save_waits_for_graph_ingestion_to_be_quiet():
+    """Frontend completion must not race graph ingestion and map saving."""
+    script = BENCHMARK_SCRIPT.read_text(encoding='utf-8')
+
+    assert 'graph_progress_signature()' in script
+    assert 'wait_for_graph_drain()' in script
+    assert (
+        'wait_for_graph_drain "$QUIESCENCE_SECS" "$SAVE_TIMEOUT_SECS"'
+        in script
+    )
+    wait_pos = script.index('Waiting for graph input to drain')
+    save_pos = script.index('Calling /map_save ...')
+    assert wait_pos < save_pos
+    assert 'event-driven loop search, query submap' in script
 
 
 def test_signal_handlers_exit_instead_of_continuing_to_map_save():

--- a/graph_based_slam/test/test_rko_lio_offline_completion_source.py
+++ b/graph_based_slam/test/test_rko_lio_offline_completion_source.py
@@ -59,6 +59,16 @@ def test_offline_completion_does_not_wait_for_trailing_imu_buffer():
     assert 'imu_buffer.empty() && lidar_buffer.empty()' not in offline_node
 
 
+def test_threaded_node_supports_opt_in_output_backpressure():
+    threaded_header = (RKO_ROS_DIR / 'threaded_node.hpp').read_text(encoding='utf-8')
+    threaded_cpp = (RKO_ROS_DIR / 'threaded_node.cpp').read_text(encoding='utf-8')
+
+    assert 'std::chrono::milliseconds output_publish_delay{0}' in threaded_header
+    assert '"async.output_publish_delay_ms", 0' in threaded_cpp
+    assert 'async.output_publish_delay_ms must be non-negative' in threaded_cpp
+    assert 'std::this_thread::sleep_for(output_publish_delay)' in threaded_cpp
+
+
 def test_rko_lio_has_kidnap_relocalization_recovery_path():
     rko_core_dir = REPO_ROOT / 'Thirdparty' / 'rko_lio' / 'rko_lio' / 'core'
     config_path = (

--- a/lidarslam/param/lidarslam_ntu_viral.yaml
+++ b/lidarslam/param/lidarslam_ntu_viral.yaml
@@ -53,7 +53,16 @@ graph_based_slam:
       loop_overlap_large_correction_translation_m: 0.0
       loop_overlap_max_distance_m: 0.5
       num_adjacent_pose_cnstraints: 5
-      use_save_map_in_loop: true
+      # RKO-LIO processes this offline bag faster than sensor time. A long NDT
+      # loop query can therefore block the single graph executor long enough
+      # to overflow the generic 100-pair history. Pacing below plus a bounded
+      # 1024-pair history covers the measured worst burst; the benchmark drain
+      # barrier then waits until it is consumed.
+      odom_cloud_sync_queue_size: 1024
+      # The benchmark performs one explicit /map_save after graph quiescence.
+      # Synchronous PCD bundle writes inside each accepted loop closure block
+      # the subscription executor and can overflow even a deep input history.
+      use_save_map_in_loop: false
       map_leaf_size: 0.1
       adjacent_edge_info_weight: 1000.0
       use_gnss: false

--- a/lidarslam/param/rko_lio_ntu_viral.yaml
+++ b/lidarslam/param/rko_lio_ntu_viral.yaml
@@ -17,3 +17,6 @@ min_range: 1.0
 max_range: 100.0
 max_correspondence_distance: 0.5
 double_downsample: true
+# Keep the offline producer below the synchronous graph backend's sustained
+# consumption rate. This changes wall time only; pose computation is unchanged.
+async.output_publish_delay_ms: 20

--- a/lidarslam/param/rko_lio_ntu_viral.yaml
+++ b/lidarslam/param/rko_lio_ntu_viral.yaml
@@ -9,8 +9,10 @@ deskew: true
 # Clean tnp_01 sweep: 1.4 m regressed and 1.7 m became unstable; 1.5 m is the
 # bounded optimum while preserving the official body_T_lidar calibration.
 voxel_size: 1.5
-gravity_window_alignment: true
-gravity_alignment_gain: 0.2
+# The initial static IMU alignment is required, but continuous window
+# alignment mistakes this sequence's sustained motion acceleration for gravity
+# tilt (5,691/5,691 attempted corrections), regressing APE 0.983 -> 1.070 m.
+gravity_window_alignment: false
 icp_keypoint_voxel_multiplier: 1.5
 max_points_per_voxel: 20
 min_range: 1.0

--- a/scripts/run_rko_lio_graph_benchmark.sh
+++ b/scripts/run_rko_lio_graph_benchmark.sh
@@ -21,7 +21,8 @@ Options:
   --startup-timeout-secs <sec>   Timeout waiting for startup (default: 30)
   --save-timeout-secs <sec>      Timeout waiting for map outputs (default: 60)
   --offline-timeout-secs <sec>   Max wall-clock for the offline node to finish the bag (default: 1800)
-  --quiescence-secs <sec>        Treat the run as done after this many stable seconds (default: 20)
+  --quiescence-secs <sec>        Require this many stable seconds for completion
+                                 fallback and graph drain (default: 20)
   --completion-end-margin-secs <sec>
                                  Required trajectory proximity to bag end (default: 0.25)
   --skip-map-save                Do not call /map_save or verify the map bundle
@@ -558,6 +559,54 @@ wait_for_offline_completion() {
   return 1
 }
 
+graph_progress_signature() {
+  # The frontend completion marker can precede delivery of its final odometry
+  # and cloud messages to graph_based_slam. Track only graph ingestion events:
+  # unrelated TF warnings may keep the launch log growing indefinitely.
+  local latest_progress
+  latest_progress="$(
+    grep -E \
+      "event-driven loop search, query submap|best_loop_candidate|loop edge skipped|Map bundle artifacts:" \
+      "$LAUNCH_LOG" 2>/dev/null | tail -n 1
+  )" || true
+  if [[ -z "$latest_progress" ]]; then
+    latest_progress="no_graph_progress"
+  fi
+  printf '%s\n' "$latest_progress"
+}
+
+wait_for_graph_drain() {
+  local quiet_secs="$1"
+  local timeout_secs="$2"
+  local deadline=$((SECONDS + timeout_secs))
+  local last_signature=""
+  local stable_since=0
+
+  while (( SECONDS < deadline )); do
+    if [[ -n "$LAUNCH_PID" ]] && ! kill -0 "$LAUNCH_PID" 2>/dev/null; then
+      echo "SLAM launch exited while waiting for graph input to drain." >&2
+      return 1
+    fi
+
+    local current_signature
+    current_signature="$(graph_progress_signature)"
+    if [[ "$current_signature" == "$last_signature" ]]; then
+      if (( stable_since == 0 )); then
+        stable_since=$SECONDS
+      elif (( SECONDS - stable_since >= quiet_secs )); then
+        echo "Graph input stayed quiet for ${quiet_secs}s; map_save barrier satisfied"
+        return 0
+      fi
+    else
+      last_signature="$current_signature"
+      stable_since=$SECONDS
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
 call_map_save_with_retry() {
   local deadline=$((SECONDS + SAVE_TIMEOUT_SECS))
   while (( SECONDS < deadline )); do
@@ -732,6 +781,12 @@ if ! wait_for_offline_completion "$OFFLINE_TIMEOUT_SECS"; then
 fi
 
 if [[ "$SKIP_MAP_SAVE" == "false" ]]; then
+  echo "Waiting for graph input to drain ..."
+  if ! wait_for_graph_drain "$QUIESCENCE_SECS" "$SAVE_TIMEOUT_SECS"; then
+    echo "Timed out waiting for graph input to drain. Recent launch log:" >&2
+    tail -n 120 "$LAUNCH_LOG" >&2 || true
+    exit 1
+  fi
   echo "Calling /map_save ..."
   if ! call_map_save_with_retry; then
     echo "map_save service call failed. Recent launch log:" >&2


### PR DESCRIPTION
## What changed

- wait for graph-specific ingestion progress to become quiescent before `/map_save`
- pace the NTU offline frontend by 20 ms per published scan using merged RKO-LIO PR #10
- increase the NTU synchronized input history to a bounded 1024 pairs
- disable expensive in-loop map bundle saves; retain the explicit final save
- disable continuous gravity-window corrections for NTU while retaining required static initialization
- document and regression-test the canonical behavior

## Root cause

The offline frontend ran faster than the synchronous graph loop-search callback. DDS histories overflowed, so canonical runs varied between roughly 85 and 101 graph anchors. In-loop PCD saves increased callback stalls. After transport became lossless, the remaining APE error was dominated by Z: the continuous gravity window applied a correction on all 5,691 attempted scans and interpreted sustained motion acceleration as gravity tilt.

## Impact

The canonical official-calibration NTU VIRAL run is now repeatable and passes the blocking 1.0 m profile:

- raw RMSE: 0.9830169090 m
- dense graph-corrected RMSE: 0.9364228722 m
- 5,794 full-rate poses, 166 graph anchors, 13 loop edges
- optimized trajectory byte-identical across the candidate and clean committed rerun
- Autoware map verification: 8/8 PASS
- processing RTF: 0.379

The refreshed release audit reports `ntu_viral_tnp_01: PASS`; only the externally acquired Newer College profile remains blocking with `NO_DATA`.

## Validation

- `rko_lio` Release build passed
- clang-format dry-run and shell syntax checks passed
- focused regression suite: 23 passed
- project suite: 1,639 passed / 13 skipped; 8 ROS-environment failures reran 13/13 after sourcing Jazzy; 2 unrelated failures require the uninitialized `ndt_omp_ros2` submodule
- two paced/history runs produced identical optimized trajectory bytes and RMSE
- clean canonical run at `1b96695`: corrected RMSE 0.9364228722 m, map 8/8 PASS
