### PR TITLE
Enforce live publication in v1 readiness

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,9 +51,11 @@ mutating GitHub or rosdistro:
 python3 scripts/check_ndt_omp_release_readiness.py
 ```
 
-Only `READY_TO_TAG` authorizes proceeding to the separately documented
-maintainer commands; `LOCAL_READY` is the offline CI result, not remote
-publication proof.
+`LOCAL_READY` is the offline CI result, not remote publication proof.
+`READY_TO_TAG` authorizes the initial source-tag and Bloom procedure.
+The current 0.1.0 publication is `IN_PROGRESS`; do not recreate its immutable
+tag or rerun Bloom while the generated Humble and Jazzy rosdistro PRs remain
+current. Only `RELEASED` satisfies this part of the distribution gate.
 
 After Bloom packages enter ROS testing, run
 `.github/workflows/package-manager-install-upgrade.yml` for both Humble and

--- a/docs/contracts/v1-readiness.json
+++ b/docs/contracts/v1-readiness.json
@@ -55,6 +55,7 @@
         "docs/distribution.md",
         "docs/evidence/official-rko-binary-compatibility-2026-07-29.json",
         "docs/evidence/ndt-omp-release-preflight-2026-07-29.md",
+        "docs/evidence/ndt-omp-release-progress-2026-07-30.md",
         "docs/rosdistro-release.md",
         "scripts/check_ndt_omp_release_readiness.py",
         "docs/schemas/ndt-omp-release-readiness-v1.schema.json",
@@ -63,7 +64,7 @@
         "docs/schemas/package-manager-install-v1.schema.json"
       ],
       "blockers": [
-        "Release ndt_omp_ros2 0.1.0 into Humble and Jazzy rosdistro.",
+        "Merge ros/rosdistro PR #52949 for Humble and #52950 for Jazzy.",
         "Wait for rko_lio 0.3.2 to sync from testing to the normal apt repository.",
         "Run the package-manager install and upgrade E2E for lidarslam_ros2."
       ]

--- a/docs/evidence/ndt-omp-release-progress-2026-07-30.md
+++ b/docs/evidence/ndt-omp-release-progress-2026-07-30.md
@@ -1,0 +1,27 @@
+# ndt_omp_ros2 0.1.0 release progress — 2026-07-30
+
+The read-only release audit was rerun from the pinned lidarslam_ros2 checkout:
+
+```bash
+python3 scripts/check_ndt_omp_release_readiness.py --json
+```
+
+It reported `IN_PROGRESS` with no remote-inspection errors:
+
+- the local candidate is the reviewed commit
+  `8b77fa5a6cdcad45bf35918361c892b6d94a287e`;
+- source tag `0.1.0` exists;
+- `rsasaki0109/ndt_omp_ros2-release` exists with generated Humble and Jazzy
+  release tracks;
+- neither public rosdistro distribution file contains `ndt_omp_ros2` yet.
+
+The generated registration pull requests are:
+
+- Humble: [ros/rosdistro#52949](https://github.com/ros/rosdistro/pull/52949)
+- Jazzy: [ros/rosdistro#52950](https://github.com/ros/rosdistro/pull/52950)
+
+Both PRs were mergeable and all automated checks were passing when reviewed
+on 2026-07-30. They remain external maintainer actions. This evidence records
+progress only; the distribution gate stays incomplete until the live audit
+reports `RELEASED`, RKO-LIO 0.3.2 is present in the normal apt repository,
+and the package-manager install/upgrade E2E passes.

--- a/docs/rosdistro-release.md
+++ b/docs/rosdistro-release.md
@@ -55,9 +55,14 @@ The dependency is consumed as the submodule
 `https://github.com/rsasaki0109/ndt_omp_ros2` (branch `humble`) — a fork
 maintained by the same owner, BSD licensed, with a unique name in rosdistro.
 Before the first lidarslam release, use the following maintainer sequence.
-The source repository currently has no `0.1.0` tag and
-`rsasaki0109/ndt_omp_ros2-release` does not exist (checked 2026-07-30), so
-all first-release steps below are required.
+The `0.1.0` source tag and
+[`rsasaki0109/ndt_omp_ros2-release`](https://github.com/rsasaki0109/ndt_omp_ros2-release)
+now exist. Bloom generated both distribution tracks, and the remaining
+publication work is the maintainer review and merge of
+[Humble PR #52949](https://github.com/ros/rosdistro/pull/52949) and
+[Jazzy PR #52950](https://github.com/ros/rosdistro/pull/52950). The live
+preflight therefore reports `IN_PROGRESS`, not `READY_TO_TAG` or `RELEASED`
+(checked 2026-07-30).
 
 Run the read-only preflight immediately before doing any publication work:
 
@@ -90,14 +95,13 @@ The checker is read-only; it never creates a tag, repository, or PR.
    [CI run 30369808717](https://github.com/rsasaki0109/ndt_omp_ros2/actions/runs/30369808717)
    passed the Humble and Jazzy build/test plus Bloom-generated Debian package
    gate.
-2. Create and push source tag `0.1.0`, then create the separate
-   `ndt_omp_ros2-release` repository.
-3. Run one new Bloom track for each ROS distribution. Since the repository is
-   not yet in either distribution file, pass the release repository URL
-   explicitly.
-4. Wait for the rosdistro PR to merge; the lidarslam release can be submitted
-   as soon as the key exists in the distribution file (it does not need to be
-   built yet).
+2. The source tag `0.1.0` and separate `ndt_omp_ros2-release` repository are
+   complete. Do not recreate or move the tag.
+3. The Humble and Jazzy Bloom tracks are complete. Do not rerun Bloom while
+   the generated rosdistro PRs are current and green.
+4. Wait for both rosdistro PRs to merge; the lidarslam release can be
+   submitted as soon as the keys exist in both distribution files (the
+   packages do not need to be built yet).
 
 #### NDT 0.1.0 exact commands
 

--- a/docs/schemas/v1-readiness-report-v1.schema.json
+++ b/docs/schemas/v1-readiness-report-v1.schema.json
@@ -13,6 +13,7 @@
     "minimum_release_candidate_version",
     "summary",
     "release",
+    "publication_audits",
     "external_first_map",
     "gates"
   ],
@@ -79,6 +80,39 @@
         },
         "tag_present": {
           "type": "boolean"
+        }
+      }
+    },
+    "publication_audits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "inspected",
+        "ndt_omp_ros2_status",
+        "lidarslam_release_status"
+      ],
+      "properties": {
+        "inspected": {
+          "type": "boolean"
+        },
+        "ndt_omp_ros2_status": {
+          "enum": [
+            null,
+            "LOCAL_READY",
+            "READY_TO_TAG",
+            "IN_PROGRESS",
+            "RELEASED",
+            "BLOCKED"
+          ]
+        },
+        "lidarslam_release_status": {
+          "enum": [
+            null,
+            "NOT_PUBLISHED",
+            "IN_PROGRESS",
+            "PUBLISHED",
+            "BLOCKED"
+          ]
         }
       }
     },

--- a/docs/v1-readiness.md
+++ b/docs/v1-readiness.md
@@ -15,13 +15,18 @@ For automation:
 
 ```bash
 python3 scripts/check_v1_readiness.py --json
+python3 scripts/check_v1_readiness.py --live --json
 python3 scripts/check_v1_readiness.py --require-complete
 ```
 
 The normal command reports an honest snapshot and exits zero when the
-contract is valid, even while product work remains. `--require-complete`
-exits 1 unless every gate is complete. An invalid contract, schema, evidence
-path, adoption ledger, version, or git-tag query exits 2.
+contract is valid, even while product work remains. It is deterministic and
+does not contact remote services. `--live` additionally runs the read-only
+NDT rosdistro and stable-release publication audits. `--require-complete`
+exits 1 unless every gate is complete; if local evidence could otherwise
+produce `READY`, it automatically runs those live audits before accepting
+the result. An invalid contract, schema, evidence path, adoption ledger,
+version, git-tag query, or untrustworthy live inspection exits 2.
 
 ## Authoritative inputs
 
@@ -40,8 +45,10 @@ path, adoption ledger, version, or git-tag query exits 2.
   [`ndt-omp-release-readiness-v1.schema.json`](schemas/ndt-omp-release-readiness-v1.schema.json)
   contract. It distinguishes a locally reviewed candidate from
   `READY_TO_TAG`, partial publication, and a completed rosdistro release.
-  The reviewed live result is preserved in
-  [`ndt-omp-release-preflight-2026-07-29.md`](evidence/ndt-omp-release-preflight-2026-07-29.md).
+  The initial and current reviewed results are preserved in
+  [`ndt-omp-release-preflight-2026-07-29.md`](evidence/ndt-omp-release-preflight-2026-07-29.md)
+  and
+  [`ndt-omp-release-progress-2026-07-30.md`](evidence/ndt-omp-release-progress-2026-07-30.md).
 - The package-manager distribution evidence has a versioned
   [`package-manager-install-v1.schema.json`](schemas/package-manager-install-v1.schema.json)
   contract and Humble/Jazzy clean-install/upgrade workflow. It remains an
@@ -55,9 +62,13 @@ path, adoption ledger, version, or git-tag query exits 2.
 The checker verifies that all ten expected gate IDs are present exactly once,
 that evidence paths remain inside the repository and exist, that semantic
 versions and tags align, and that the independent-user ledger passes its own
-schema and uniqueness rules. A tracked `complete` state is therefore an
-audited attestation backed by named evidence—not a substitute for rerunning
-the wider CI, real-data, or release workflows cited by that evidence.
+schema and uniqueness rules. Live evaluation additionally requires
+`ndt_omp_ros2` to report `RELEASED` before the distribution gate can complete,
+and the stable release to report `PUBLISHED` before the reliability or
+release-publication gates can complete. A tracked `complete` state is
+therefore an audited attestation backed by named evidence—not a substitute
+for rerunning the wider CI, real-data, or release workflows cited by that
+evidence.
 
 ## Current snapshot
 
@@ -65,7 +76,7 @@ The tracked state is **NOT_READY: 6/10 gates complete**.
 
 | Open gate | Remaining proof |
 | --- | --- |
-| Distribution | `ndt_omp_ros2` preflight is currently `READY_TO_TAG`; publish it to both rosdistros, wait for official RKO-LIO 0.3.2 to reach the normal apt repository, then run package-manager install/upgrade E2E |
+| Distribution | `ndt_omp_ros2` publication is `IN_PROGRESS`; merge rosdistro PRs [#52949](https://github.com/ros/rosdistro/pull/52949) and [#52950](https://github.com/ros/rosdistro/pull/52950), wait for official RKO-LIO 0.3.2 to reach the normal apt repository, then run package-manager install/upgrade E2E |
 | Reliability | Publish the first tagged release and pass the recovery-asset publication audit |
 | External adoption | Accept three distinct independent first-map validations; current ledger is 0/3 |
 | Release publication | v0.9.0 metadata and notes are aligned; create its immutable tag and pass the stable publication audit |

--- a/lidarslam/test/test_v1_readiness.py
+++ b/lidarslam/test/test_v1_readiness.py
@@ -75,6 +75,11 @@ def test_tracked_contract_reports_exact_open_product_gates():
         'minimum_version_met': True,
         'tag_present': False,
     }
+    assert report['publication_audits'] == {
+        'inspected': False,
+        'ndt_omp_ros2_status': None,
+        'lidarslam_release_status': None,
+    }
 
 
 def test_require_complete_exits_one_for_tracked_state():
@@ -132,6 +137,127 @@ def test_every_complete_gate_can_produce_ready_report(tmp_path):
     assert report['status'] == 'READY'
     assert report['summary']['complete'] == 10
     assert all(gate['blockers'] == [] for gate in report['gates'])
+
+
+@pytest.mark.parametrize(
+    ('ndt_status', 'release_status', 'incomplete'),
+    [
+        ('RELEASED', 'PUBLISHED', set()),
+        ('IN_PROGRESS', 'PUBLISHED', {'distribution'}),
+        (
+            'RELEASED',
+            'NOT_PUBLISHED',
+            {'reliability', 'release-publication'},
+        ),
+    ],
+)
+def test_live_publication_reports_are_required_for_claimed_complete_gates(
+    tmp_path,
+    ndt_status,
+    release_status,
+    incomplete,
+):
+    contract = json.loads(
+        READINESS.DEFAULT_CONTRACT.read_text(encoding='utf-8'))
+    for gate in contract['gates']:
+        gate['state'] = 'complete'
+        gate['blockers'] = []
+        for evidence in gate['evidence']:
+            path = tmp_path / evidence
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+    (tmp_path / 'VERSION').write_text('0.9.0\n', encoding='utf-8')
+    contract_path = tmp_path / 'v1-readiness.json'
+    contract_path.write_text(json.dumps(contract), encoding='utf-8')
+    external = {
+        'status': 'READY',
+        'accepted_validations': 3,
+        'required_validations': 3,
+        'remaining_validations': 0,
+    }
+
+    report = READINESS.evaluate_readiness(
+        repo_root=tmp_path,
+        contract_path=contract_path,
+        tags={'v0.9.0'},
+        external_report=external,
+        require_live_publication=True,
+        ndt_release_report={'status': ndt_status},
+        published_release_report={'status': release_status},
+    )
+
+    observed = {
+        gate['id']
+        for gate in report['gates']
+        if gate['status'] == 'INCOMPLETE'
+    }
+    assert observed == incomplete
+    assert report['status'] == ('NOT_READY' if incomplete else 'READY')
+    assert report['publication_audits'] == {
+        'inspected': True,
+        'ndt_omp_ros2_status': ndt_status,
+        'lidarslam_release_status': release_status,
+    }
+
+
+def test_live_evaluation_fails_without_both_publication_reports(tmp_path):
+    with pytest.raises(
+        READINESS.ReadinessError,
+        match='live publication reports are required',
+    ):
+        READINESS.evaluate_readiness(
+            require_live_publication=True,
+            ndt_release_report={'status': 'RELEASED'},
+        )
+
+
+def test_require_complete_escalates_a_locally_ready_report_to_live(
+    monkeypatch,
+    capsys,
+):
+    reports = [
+        {'status': 'READY', 'product_version': '0.9.0'},
+        {
+            'status': 'NOT_READY',
+            'publication_audits': {
+                'inspected': True,
+                'ndt_omp_ros2_status': 'IN_PROGRESS',
+                'lidarslam_release_status': 'NOT_PUBLISHED',
+            },
+        },
+    ]
+    evaluation_calls = []
+
+    def fake_evaluate(**kwargs):
+        evaluation_calls.append(kwargs)
+        return reports.pop(0)
+
+    monkeypatch.setattr(READINESS, 'evaluate_readiness', fake_evaluate)
+    monkeypatch.setattr(
+        READINESS,
+        'inspect_live_publication',
+        lambda **kwargs: (
+            {'status': 'IN_PROGRESS'},
+            {'status': 'NOT_PUBLISHED'},
+        ),
+    )
+    monkeypatch.setattr(
+        READINESS,
+        'render_markdown',
+        lambda report: f"{report['status']}\n",
+    )
+
+    result = READINESS.main(['--require-complete'])
+
+    assert result == 1
+    assert capsys.readouterr().out == 'NOT_READY\n'
+    assert len(evaluation_calls) == 2
+    assert evaluation_calls[1]['require_live_publication'] is True
+    assert evaluation_calls[1]['ndt_release_report']['status'] == 'IN_PROGRESS'
+    assert (
+        evaluation_calls[1]['published_release_report']['status']
+        == 'NOT_PUBLISHED'
+    )
 
 
 def test_evidence_cannot_escape_repository(tmp_path):

--- a/lidarslam/test/test_v1_readiness.py
+++ b/lidarslam/test/test_v1_readiness.py
@@ -211,6 +211,19 @@ def test_live_evaluation_fails_without_both_publication_reports(tmp_path):
         )
 
 
+def test_checker_load_failure_is_normalized_as_readiness_error(tmp_path):
+    scripts = tmp_path / 'scripts'
+    scripts.mkdir()
+    checker = scripts / 'broken.py'
+    checker.write_text('this is not valid Python !!!\n', encoding='utf-8')
+
+    with pytest.raises(
+        READINESS.ReadinessError,
+        match='cannot load readiness checker',
+    ):
+        READINESS._load_checker(tmp_path, 'broken.py', 'broken_for_v1')
+
+
 def test_require_complete_escalates_a_locally_ready_report_to_live(
     monkeypatch,
     capsys,

--- a/scripts/check_v1_readiness.py
+++ b/scripts/check_v1_readiness.py
@@ -118,7 +118,7 @@ def _load_checker(repo_root: Path, filename: str, module_name: str) -> Any:
     module = importlib.util.module_from_spec(spec)
     try:
         spec.loader.exec_module(module)
-    except (ImportError, OSError) as exc:
+    except Exception as exc:
         raise ReadinessError(
             f'cannot load readiness checker {path}: {exc}') from exc
     return module

--- a/scripts/check_v1_readiness.py
+++ b/scripts/check_v1_readiness.py
@@ -57,6 +57,19 @@ EXPECTED_GATE_IDS = {
     'external-adoption',
     'release-publication',
 }
+NDT_RELEASE_STATUSES = {
+    'LOCAL_READY',
+    'READY_TO_TAG',
+    'IN_PROGRESS',
+    'RELEASED',
+    'BLOCKED',
+}
+PUBLISHED_RELEASE_STATUSES = {
+    'NOT_PUBLISHED',
+    'IN_PROGRESS',
+    'PUBLISHED',
+    'BLOCKED',
+}
 SEMVER_PATTERN = re.compile(r'^[0-9]+\.[0-9]+\.[0-9]+$')
 
 
@@ -94,17 +107,58 @@ def _version_tuple(value: str) -> tuple[int, int, int]:
     return tuple(int(part) for part in value.split('.'))  # type: ignore[return-value]
 
 
-def _external_checker() -> Any:
-    path = REPO_ROOT / 'scripts' / 'check_external_first_map_readiness.py'
+def _load_checker(repo_root: Path, filename: str, module_name: str) -> Any:
+    path = repo_root / 'scripts' / filename
     spec = importlib.util.spec_from_file_location(
-        'external_first_map_readiness_for_v1',
+        module_name,
         path,
     )
     if spec is None or spec.loader is None:
-        raise ReadinessError(f'cannot load external readiness checker: {path}')
+        raise ReadinessError(f'cannot load readiness checker: {path}')
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except (ImportError, OSError) as exc:
+        raise ReadinessError(
+            f'cannot load readiness checker {path}: {exc}') from exc
     return module
+
+
+def _external_checker(repo_root: Path) -> Any:
+    return _load_checker(
+        repo_root,
+        'check_external_first_map_readiness.py',
+        'external_first_map_readiness_for_v1',
+    )
+
+
+def inspect_live_publication(
+    *,
+    repo_root: Path,
+    product_version: str,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Run both authoritative, read-only publication audits."""
+    ndt_checker = _load_checker(
+        repo_root,
+        'check_ndt_omp_release_readiness.py',
+        'ndt_omp_release_readiness_for_v1',
+    )
+    release_checker = _load_checker(
+        repo_root,
+        'check_published_release.py',
+        'published_release_for_v1',
+    )
+    try:
+        ndt_report = ndt_checker.evaluate_readiness(repo_root=repo_root)
+        snapshot = release_checker.inspect_remote(product_version)
+        published_report = release_checker.evaluate_publication(
+            version=product_version,
+            snapshot=snapshot,
+        )
+    except Exception as exc:
+        raise ReadinessError(
+            f'live publication audit could not be trusted: {exc}') from exc
+    return ndt_report, published_report
 
 
 def _git_tags(repo_root: Path) -> set[str]:
@@ -153,6 +207,9 @@ def evaluate_readiness(
     ledger_schema_path: Path = DEFAULT_LEDGER_SCHEMA,
     tags: set[str] | None = None,
     external_report: dict[str, Any] | None = None,
+    require_live_publication: bool = False,
+    ndt_release_report: dict[str, Any] | None = None,
+    published_release_report: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Validate the contract and return one deterministic readiness report."""
     repo_root = repo_root.resolve()
@@ -184,7 +241,7 @@ def evaluate_readiness(
     tag_present = expected_tag in available_tags
 
     if external_report is None:
-        checker = _external_checker()
+        checker = _external_checker(repo_root)
         try:
             external_report = checker.validate_ledger(
                 ledger_path,
@@ -193,6 +250,24 @@ def evaluate_readiness(
         except checker.LedgerError as exc:
             raise ReadinessError(
                 f'external first-map ledger invalid: {exc}') from exc
+
+    if require_live_publication:
+        if ndt_release_report is None or published_release_report is None:
+            raise ReadinessError(
+                'live publication reports are required for strict evaluation')
+        ndt_status = ndt_release_report.get('status')
+        published_status = published_release_report.get('status')
+        if ndt_status not in NDT_RELEASE_STATUSES:
+            raise ReadinessError(
+                f'NDT live publication report has invalid status: {ndt_status!r}')
+        if published_status not in PUBLISHED_RELEASE_STATUSES:
+            raise ReadinessError(
+                'lidarslam live publication report has invalid status: '
+                f'{published_status!r}'
+            )
+    else:
+        ndt_status = None
+        published_status = None
 
     gate_reports: list[dict[str, Any]] = []
     for gate in contract['gates']:
@@ -226,6 +301,34 @@ def evaluate_readiness(
                 if dynamic not in blockers:
                     blockers.append(dynamic)
 
+        if gate['id'] == 'distribution' and require_live_publication:
+            complete = complete and ndt_status == 'RELEASED'
+            detail = (
+                f'Tracked distribution attestation; live ndt_omp_ros2 '
+                f'release status={ndt_status}.'
+            )
+            if ndt_status != 'RELEASED':
+                dynamic = (
+                    'Live ndt_omp_ros2 release audit must report RELEASED; '
+                    f'observed {ndt_status}.'
+                )
+                if dynamic not in blockers:
+                    blockers.append(dynamic)
+
+        if gate['id'] == 'reliability' and require_live_publication:
+            complete = complete and published_status == 'PUBLISHED'
+            detail = (
+                'Tracked reliability attestation; live stable-release '
+                f'status={published_status}.'
+            )
+            if published_status != 'PUBLISHED':
+                dynamic = (
+                    'Live stable-release audit must report PUBLISHED; '
+                    f'observed {published_status}.'
+                )
+                if dynamic not in blockers:
+                    blockers.append(dynamic)
+
         if gate['id'] == 'release-publication':
             complete = (
                 gate['state'] == 'complete'
@@ -233,10 +336,14 @@ def evaluate_readiness(
                 and tag_present
                 and not missing
             )
+            if require_live_publication:
+                complete = complete and published_status == 'PUBLISHED'
             detail = (
                 f'VERSION={product_version}; minimum={minimum_version}; '
                 f'expected local tag={expected_tag}; '
-                f'tag_present={str(tag_present).lower()}.'
+                f'tag_present={str(tag_present).lower()}; '
+                'live stable-release status='
+                f'{published_status if require_live_publication else "not inspected"}.'
             )
             if not minimum_version_met:
                 blockers.append(
@@ -245,6 +352,13 @@ def evaluate_readiness(
             if not tag_present:
                 blockers.append(
                     f'Immutable release tag {expected_tag} is not present.')
+            if require_live_publication and published_status != 'PUBLISHED':
+                dynamic = (
+                    'Live stable-release audit must report PUBLISHED; '
+                    f'observed {published_status}.'
+                )
+                if dynamic not in blockers:
+                    blockers.append(dynamic)
 
         gate_reports.append({
             'id': gate['id'],
@@ -278,6 +392,11 @@ def evaluate_readiness(
             'minimum_version_met': minimum_version_met,
             'tag_present': tag_present,
         },
+        'publication_audits': {
+            'inspected': require_live_publication,
+            'ndt_omp_ros2_status': ndt_status,
+            'lidarslam_release_status': published_status,
+        },
         'external_first_map': external_report,
         'gates': gate_reports,
     }
@@ -296,6 +415,16 @@ def render_markdown(report: dict[str, Any]) -> str:
             '- Complete gates: '
             f"**{report['summary']['complete']} / "
             f"{report['summary']['total']}**"
+        ),
+        (
+            '- Live publication audits: '
+            '**'
+            + (
+                'inspected'
+                if report['publication_audits']['inspected']
+                else 'not inspected'
+            )
+            + '**'
         ),
         '',
         '| Gate | Status | Detail |',
@@ -349,9 +478,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument('--output-json', type=Path)
     parser.add_argument('--output-markdown', type=Path)
     parser.add_argument(
+        '--live',
+        action='store_true',
+        help='Run the read-only NDT and stable-release publication audits.',
+    )
+    parser.add_argument(
         '--require-complete',
         action='store_true',
-        help='Exit 1 unless every v1.0 readiness gate is complete.',
+        help=(
+            'Exit 1 unless every gate is complete; automatically run live '
+            'publication audits before reporting READY.'
+        ),
     )
     return parser.parse_args(argv)
 
@@ -371,6 +508,21 @@ def main(argv: list[str] | None = None) -> int:
             ledger_path=args.ledger,
             ledger_schema_path=args.ledger_schema,
         )
+        if args.live or (args.require_complete and report['status'] == 'READY'):
+            ndt_report, published_report = inspect_live_publication(
+                repo_root=REPO_ROOT,
+                product_version=report['product_version'],
+            )
+            report = evaluate_readiness(
+                contract_path=args.contract,
+                contract_schema_path=args.contract_schema,
+                report_schema_path=args.report_schema,
+                ledger_path=args.ledger,
+                ledger_schema_path=args.ledger_schema,
+                require_live_publication=True,
+                ndt_release_report=ndt_report,
+                published_release_report=published_report,
+            )
     except ReadinessError as exc:
         print(f'v1 readiness audit invalid: {exc}', file=sys.stderr)
         return 2


### PR DESCRIPTION
## What changed

- add `--live` to the v1 readiness checker for read-only NDT rosdistro and stable GitHub Release audits
- make `--require-complete` automatically escalate to live inspection before it can report `READY`
- require `ndt_omp_ros2=RELEASED` for distribution and `lidarslam_ros2=PUBLISHED` for reliability/release publication
- expose schema-validated publication audit statuses in JSON and Markdown reports
- record the current NDT 0.1.0 Bloom/rosdistro PR progress and update release guidance

## Why

The previous strict checker trusted tracked gate state, local evidence paths,
and a local tag. If those fields were changed to complete, it could report
`READY` without verifying that NDT was registered in both rosdistros or that
the stable GitHub Release and recovery assets actually existed. This change
makes those external publication facts necessary conditions while keeping
normal CI deterministic and offline.

## User and maintainer impact

Normal `check_v1_readiness.py` runs remain network-free. Maintainers can use
`--live` for an explicit current snapshot. `--require-complete` only contacts
remote services when local state could otherwise claim full readiness, and
fails closed if the live inspection cannot be trusted.

## Validation

- related CI Python suite: 76 passed
- `python3 scripts/check_v1_readiness.py --live --json`: `NOT_READY`, NDT `IN_PROGRESS`, release `NOT_PUBLISHED`
- `python3 scripts/check_v1_readiness.py --require-complete --json`: exits 1 at the tracked 6/10 state without remote-state drift
- `git diff --check`
