### PR TITLE
Make first-map receipt submission public

### DIFF
--- a/.github/ISSUE_TEMPLATE/first-map-validation.yml
+++ b/.github/ISSUE_TEMPLATE/first-map-validation.yml
@@ -81,6 +81,15 @@ body:
       required: true
 
   - type: textarea
+    id: receipt
+    attributes:
+      label: Privacy-bounded JSON receipt
+      description: Review first_map_validation_receipt.json, then drag and drop that file here. GitHub uploads it as a public attachment. The generated receipt excludes map geometry, private paths, and the exact command; do not attach any other run artifact.
+      placeholder: Drag and drop first_map_validation_receipt.json here.
+    validations:
+      required: true
+
+  - type: textarea
     id: findings
     attributes:
       label: Findings
@@ -94,6 +103,8 @@ body:
       label: Privacy and reproducibility
       options:
         - label: I removed credentials, private location data, and map geometry.
+          required: true
+        - label: I reviewed the attached JSON receipt and confirmed that it contains no information I need to keep private.
           required: true
         - label: The report contains enough version, command, environment, and verification identity for maintainers to review it.
           required: true

--- a/docs/contracts/v1-readiness.json
+++ b/docs/contracts/v1-readiness.json
@@ -116,6 +116,7 @@
       "state": "incomplete",
       "evidence": [
         "docs/external-first-map-validation.md",
+        ".github/ISSUE_TEMPLATE/first-map-validation.yml",
         "docs/evidence/external-first-map-validations.json",
         "scripts/prepare_external_first_map_acceptance.py",
         "docs/schemas/external-first-map-acceptance-v1.schema.json"

--- a/docs/external-first-map-validation.md
+++ b/docs/external-first-map-validation.md
@@ -36,9 +36,12 @@ An empty ledger is an honest `0 / 3`, not missing evidence.
 
 4. Open the
    [Independent First-map Validation issue form](https://github.com/rsasaki0109/lidar_slam_ros2/issues/new?template=first-map-validation.yml).
-   Paste the receipt's `Verification summary` block into the form. Keep the
-   JSON receipt until review; it contains evidence hashes but no map geometry,
-   private paths, or exact command.
+   Paste the receipt's `Verification summary` block into the form. Review
+   `first_map_validation_receipt.json`, then drag and drop that file into the
+   form's **Privacy-bounded JSON receipt** field. GitHub stores issue
+   attachments publicly. The generated JSON contains evidence hashes but no
+   map geometry, private paths, or exact command; do not attach any other run
+   artifact.
 
 Both passing and failing reports are useful. A failed attempt is an onboarding
 finding, not an accepted validation, and must be resolved or explicitly
@@ -48,10 +51,10 @@ documented before v1.0.
 
     Remove credentials, private paths, precise locations, rosbag payloads,
     point-cloud tiles, trajectories, and screenshots that reveal private
-    places. The issue form asks only for command, environment, status,
-    verifier summary, and a manifest checksum. The generated receipt is
-    privacy-bounded, but you must still review it and redact private paths
-    from the separately pasted command.
+    places. The issue form asks for command, environment, status, verifier
+    summary, and the privacy-bounded JSON receipt. You must still review the
+    receipt before attaching it and redact private paths from the separately
+    pasted command.
 
 ## What the receipt proves
 
@@ -102,8 +105,10 @@ as passing evidence.
 Do not hand-edit the tracked ledger first. After resolving any onboarding
 findings:
 
-1. Download the reporter's JSON receipt privately and confirm the public issue
-   contains the matching verification summary.
+1. Download `first_map_validation_receipt.json` from the public issue. Confirm
+   it is the generated privacy-bounded receipt—not a manifest, map, log, or
+   other run artifact—and that the issue contains its matching verification
+   summary.
 2. Create `/tmp/validation-entry.json` with one `validation` object matching
    the
    [`external-first-map-validations-v1` schema](schemas/external-first-map-validations-v1.schema.json).
@@ -120,7 +125,8 @@ findings:
 
 4. Review the proposed file and its diff, then copy that reviewed proposal to
    `docs/evidence/external-first-map-validations.json` in a normal pull
-   request. Do not commit the reporter's receipt.
+   request. Do not commit a second copy of the reporter's receipt; the public
+   issue attachment remains its review source.
 
 The intake command is fail-closed. It requires a schema-valid PASS receipt,
 all seven receipt checks, exact verification-field and manifest-hash binding,

--- a/graph_based_slam/test/test_docs_entrypoints.py
+++ b/graph_based_slam/test/test_docs_entrypoints.py
@@ -417,11 +417,15 @@ def test_contributing_and_issue_templates_exist():
         'command',
         'result',
         'verification',
+        'receipt',
         'findings',
         'privacy',
     ):
         assert f'id: {field_id}' in first_map_form
     assert 'Do not upload map geometry.' in first_map_form
+    assert 'drag and drop that file here' in first_map_form
+    assert 'GitHub uploads it as a public attachment' in first_map_form
+    assert 'do not attach any other run artifact' in first_map_form
 
 
 def test_product_contract_has_bounded_official_surface():
@@ -672,6 +676,12 @@ def test_docs_cover_autoware_and_release_gate_keywords():
     assert 'create_first_map_validation_receipt.py' in first_map_program
     assert 'first-map-validation-receipt-v1' in first_map_program
     assert 'Do not publish map geometry' in first_map_program
+    assert 'Privacy-bounded JSON receipt' in first_map_program
+    assert 'GitHub stores issue' in first_map_program
+    assert 'attachments publicly' in first_map_program
+    assert 'Download `first_map_validation_receipt.json` from the public issue' in (
+        first_map_program
+    )
     assert first_map_ledger['schema_version'] == 1
     assert first_map_ledger['required_validations'] == 3
     assert isinstance(first_map_ledger['validations'], list)

--- a/lidarslam/test/test_first_map_validation_receipt.py
+++ b/lidarslam/test/test_first_map_validation_receipt.py
@@ -245,7 +245,11 @@ def test_cli_writes_both_receipts_and_uses_stable_exit_codes(tmp_path: Path):
     assert passing.returncode == 0, passing.stderr
     assert json.loads(passing.stdout)['status'] == 'PASS'
     assert (run_dir / 'first_map_validation_receipt.json').is_file()
-    assert (run_dir / 'first_map_validation_receipt.md').is_file()
+    markdown_path = run_dir / 'first_map_validation_receipt.md'
+    assert markdown_path.is_file()
+    markdown = markdown_path.read_text(encoding='utf-8')
+    assert 'attach that JSON file to the public' in markdown
+    assert 'Do not attach the manifest, map, logs, bag' in markdown
 
     missing = subprocess.run(
         ['python3', str(CLI_PATH), str(tmp_path / 'missing')],

--- a/scripts/first_map_validation_receipt.py
+++ b/scripts/first_map_validation_receipt.py
@@ -284,6 +284,10 @@ def render_markdown(receipt: dict[str, Any]) -> str:
         'This receipt intentionally excludes map geometry, private paths, and '
         'the exact command. Review the receipt before sharing it and redact '
         'the separately reported command if it contains a private path.',
+        '',
+        'After reviewing `first_map_validation_receipt.json`, attach that JSON '
+        'file to the public Independent First-map Validation issue. Do not '
+        'attach the manifest, map, logs, bag, or any other run artifact.',
     ])
     return '\n'.join(lines) + '\n'
 


### PR DESCRIPTION
## What changed

- add a required privacy-bounded JSON receipt attachment field to the independent first-map issue form
- require reporters to confirm that they reviewed the public attachment for private information
- make the participant and reviewer runbooks use the same public issue attachment
- print the public-submission instruction in every generated Markdown receipt
- track the issue form itself as v1 external-adoption evidence

## Why

The generated JSON receipt was intentionally safe to share, but the public
runbook only told reporters to retain it until review and told maintainers to
download it privately. It never defined how the reporter should deliver the
file. That hidden coordination step prevented a third party from completing
the submission using public documentation alone.

## User and maintainer impact

Reporters now review and attach only
`first_map_validation_receipt.json` to the structured public issue. The form
warns that attachments are public and prohibits other run artifacts.
Maintainers can download the same schema-validated evidence directly from the
issue and feed it into the existing fail-closed acceptance command.

## Validation

- external-adoption, receipt, runner, docs, and v1 readiness tests: 98 passed
- issue-form YAML parsed successfully with unique field IDs and a required receipt field
- `python3 scripts/check_v1_readiness.py --json`
- `git diff --check`
